### PR TITLE
[NT-0] feat: PR reviewers default to the team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 ## code changes will send PR to following users
 
-* @magnopus/foundation
+* @magnopus-opensource/connectedspacesplatformteam


### PR DESCRIPTION
PR reviewers will now default to @magnopus-opensource/connectedspacesplatformteam 