### PR TITLE
[OF-1015] fix: Handle changelog before tags exist

### DIFF
--- a/teamcity/GenerateReadMe.py
+++ b/teamcity/GenerateReadMe.py
@@ -266,10 +266,15 @@ def main():
 
     if git_repo:
         if input_args.initial_commit == '':
-            # Get commit ID of latest tag
-            latest_tag = git_repo.git.describe(tags=True, abbrev=0)
-            tag_commit_id = git_repo.git.rev_list(latest_tag, n=1)
-            input_args.initial_commit = tag_commit_id
+            # If there are no tags we go back to the first commit on the branch
+            if len(git_repo.tags) > 0:
+                # Get commit ID of latest tag
+                latest_tag = git_repo.git.describe(tags=True, abbrev=0)
+                tag_commit_id = git_repo.git.rev_list(latest_tag, n=1)
+                input_args.initial_commit = tag_commit_id
+            else:
+                first_commit = list(git_repo.iter_commits())[-1]
+                input_args.initial_commit = first_commit.hexsha
 
         commit_list = get_commits(input_args, git_repo)
 


### PR DESCRIPTION
Previously in the changelog generate script it would crash if there were no previous tags. This fixes that by setting the initial commit to the first commit on the branch and generating the changelog from then on.

Olympus Foundation Pull  Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
