### PR TITLE
[OW-1349] fix: pass string arguments to callback functions in typescript wrapper

### DIFF
--- a/Tools/WrapperGenerator/Templates/TypeScript/Partials/Method/ClassMethod.mustache
+++ b/Tools/WrapperGenerator/Templates/TypeScript/Partials/Method/ClassMethod.mustache
@@ -61,10 +61,14 @@
         );
 {{/ type.is_class_or_interface }}
 {{/ type.function_signature.parameters }}
-
+    {{# type.function_signature.parameters }}
+        {{# type.is_string }}
+            const _{{ name }} = Module.UTF8ToString({{ name }});
+        {{/ type.is_string }}
+    {{/ type.function_signature.parameters }}
         {{ name }}(
 {{# type.function_signature.parameters }}
-        {{# type.is_class_or_interface }}_{{/ type.is_class_or_interface }}{{ name }}{{> Comma }}
+        {{# type.is_class_or_interface }}_{{/ type.is_class_or_interface }}{{# type.is_string }}_{{/ type.is_string }}{{ name }}{{> Comma }}
 {{/ type.function_signature.parameters }}
         );
     };


### PR DESCRIPTION
- ensure that string arguments pass their value to callbacks in the typescript wrapper

Olympus Foundation Pull  Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
