### PR TITLE
[NT-0] doc: URLS in docs point to repo

### DIFF
--- a/Library/docs/source/index.md
+++ b/Library/docs/source/index.md
@@ -14,51 +14,43 @@ This is the Connected Spaces Platform client API documentation. The API affords 
 ****
 
 ## 📦 Install
-NPM packages are available for Web and Unity and can be found in [Packages](https://github.com/orgs/magnopus-opensource/packages?repo_name=csp-foundation)
+NPM packages are available for Web and Unity and can be found in [Packages](https://github.com/orgs/magnopus-opensource/packages?repo_name=connected-spaces-platform)
 
-- Web Installation:  `npm install @magnopus/com.magnopus.csp.foundation.web`
+- Web Installation:  `npm install @magnopus-opensource/connected-spaces-platform.web`
 
-- Unity Installation: `npm install @magnopus/com.magnopus.csp.foundation.unity.core`
+- Unity Installation: `npm install @magnopus-opensource/connected-spaces-platform.unity.core`
 
-For C++ based applications, you can find headers and precompiled binaries for all platforms in [Releases](https://github.com/magnopus-opensource/csp-foundation/releases).
+For C++ based applications, you can find headers and precompiled binaries for all platforms in [Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
 ****
 
 ## 🔨 Build Instructions
 Build instructions for each language supported are below.
 
-- WebAssembly 
-    - [Building for Web](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-Web)
-- C++
-    - [Building for C++](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-CPP)
-
-- C#
-    - [Building for C#](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-CSharp)
-
-- Android
-    - [Building for Android](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-Android)
-
-- MacOS
-    - [Building for MacOS](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-MacOS)
-
-- IOS
-    - [Building for IOS](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-IOS)
+- [Building for Web](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-Web)
+- [Building for C++](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-CPP)
+- [Building for C#](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-CSharp)
+- [Building for Android](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-Android)
+- [Building for MacOS](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-MacOS)
+- [Building for IOS](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-IOS)
 
 ****
+
 ## 🖥️ Usage
-HelloWorld Examples for each language supported are below.
+Examples for each language supported are below.
 
 - WebAssembly 
-    - [Web Initialising Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/Web)
-    - [Web Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/Web)
+- WebAssembly 
+    - [Web Initialising Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Initialising%20Foundation/Web)
+    - [Web Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/Web)
 - C++
-    - [C++ Initialising Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/CPlusPlus/InitialisingFoundation)
-    - [C++ Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/CPlusPlus/BasicFramework)
+    - [C++ Initialising Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Initialising%20Foundation/CPlusPlus/InitialisingFoundation)
+    - [C++ Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/CPlusPlus/BasicFramework)
 
-- C#
-    - [Unity C# Initialising Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/CSharp/Foundation-Unity-Example)
-    - [Unity C# Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/CSharp/Foundation-Unity-Example)
-  
+- Unity C#
+    - [Unity C# Initialising Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Initialising%20Foundation/CSharp/Foundation-Unity-Example)
+    - [Unity C# Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/CSharp/Foundation-Unity-Example)
+
 ****
  ## 📖 Api Documentation
 ```eval_rst
@@ -71,4 +63,4 @@ HelloWorld Examples for each language supported are below.
 ****
  ## ©️ License
 
- [Apache-2.0](https://github.com/magnopus-opensource/csp-foundation/blob/main/LICENSE)
+ [Apache-2.0](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # 🌎 Connected Spaces Platform
 
-[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/magnopus-opensource/csp-foundation/blob/main/LICENSE)
-[![](https://img.shields.io/badge/License-Apache2.0-blue)](https://github.com/magnopus-opensource/csp-foundation/blob/main/LICENSE)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+[![](https://img.shields.io/badge/License-Apache2.0-blue)](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/LICENSE)
 
 
 _"An interoperable communication library for the next generation of the internet."_
 
-⚡️ Current Supported Languages : C++, C#, Web Assembly
+⚡️ Current Supported Languages : C++, C#, WebAssembly
 
 🖥️ Current Supported Platforms : Windows, Android, IOS and MacOS
 
@@ -18,19 +18,7 @@ _"An interoperable communication library for the next generation of the internet
 - [Background](#background)
 - [Install](#-install)
 - [Build Instructions](#-build-instructions)
-  - [Web Build Instructions](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-Web)
-  - [C++ Build Instructions](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-CPP)
-  - [C# Build Instructions](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-CSharp)
-  - [Android Build Instructions](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-Android)
-  - [MacOS Build Instructions](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-MacOS)
-  - [IOS Build Instructions](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-IOS)
 - [Usage](#%EF%B8%8F-usage)
-    - [Web Initialising CSP Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/Web)
-    - [Web Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/Web)
-    - [C++ Initialising CSP Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/CPlusPlus/InitialisingFoundation)
-    - [C++ Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/CPlusPlus/BasicFramework)
-    - [Unity C# Initialising CSP Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/CSharp/Foundation-Unity-Example)
-    - [Unity C# Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/CSharp/Foundation-Unity-Example)
 - [Tenant Keys](#-tenant-keys)
 - [Api Documentation](#-api-documentation)
 - [Contributions](#%EF%B8%8F-contributions)
@@ -46,65 +34,56 @@ This is the Connected Spaces Platform client API, affording client application d
 ****
 
 ## 📦 Install
-NPM packages are available for Web and Unity and can be found in [Packages](https://github.com/orgs/magnopus-opensource/packages?repo_name=csp-foundation)
+NPM packages are available for Web and Unity and can be found in [Packages](https://github.com/orgs/magnopus-opensource/packages?repo_name=connected-spaces-platform)
 
-- Web Installation:  `npm install @magnopus/com.magnopus.csp.foundation.web`
+- Web Installation:  `npm install @magnopus-opensource/connected-spaces-platform.web`
 
-- Unity Installation: `npm install @magnopus/com.magnopus.csp.foundation.unity.core`
+- Unity Installation: `npm install @magnopus-opensource/connected-spaces-platform.unity.core`
 
-For C++ based applications, you can find headers and precompiled binaries for all platforms in [Releases](https://github.com/magnopus-opensource/csp-foundation/releases).
+For C++ based applications, you can find headers and precompiled binaries for all platforms in [Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
 ****
 
 ## 🔨 Build Instructions
 Build instructions for each language supported are below.
 
-- WebAssembly 
-    - [Building for Web](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-Web)
-- C++
-    - [Building for C++](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-CPP)
-
-- C#
-    - [Building for C#](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-CSharp)
-
-- Android
-    - [Building for Android](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-Android)
-
-- MacOS
-    - [Building for MacOS](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-MacOS)
-
-- IOS
-    - [Building for IOS](https://github.com/magnopus-opensource/csp-foundation/wiki/Building-Foundation-for-IOS)
+- [Building for Web](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-Web)
+- [Building for C++](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-CPP)
+- [Building for C#](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-CSharp)
+- [Building for Android](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-Android)
+- [Building for MacOS](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-MacOS)
+- [Building for IOS](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-IOS)
 
 ****
 
 ## 🔑 Tenant Keys
 
-For information on how to obtain a Tenant Key please see our Tenant page:
+For information on how to obtain a Tenant Key, head over here.
 
-[Obtaining a Tenant Key](https://github.com/magnopus-opensource/csp-foundation/wiki) (WIP)
+[Obtaining a Tenant Key](https://www.magnopus.com/platform)
 ****
+
 ## 🖥️ Usage
-HelloWorld Examples for each language supported are below.
+Examples for each language supported are below.
 
 - WebAssembly 
-    - [Web Initialising Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/Web)
-    - [Web Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/Web)
+    - [Web Initialising Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Initialising%20Foundation/Web)
+    - [Web Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/Web)
 - C++
-    - [C++ Initialising Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/CPlusPlus/InitialisingFoundation)
-    - [C++ Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/CPlusPlus/BasicFramework)
+    - [C++ Initialising Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Initialising%20Foundation/CPlusPlus/InitialisingFoundation)
+    - [C++ Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/CPlusPlus/BasicFramework)
 
-- C#
-    - [Unity C# Initialising Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Initialising%20Foundation/CSharp/Foundation-Unity-Example)
-    - [Unity C# Basic Framework Example](https://github.com/magnopus-opensource/csp-foundation/tree/main/Examples/Basic%20Framework/CSharp/Foundation-Unity-Example)
+- Unity C#
+    - [Unity C# Initialising Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Initialising%20Foundation/CSharp/Foundation-Unity-Example)
+    - [Unity C# Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/CSharp/Foundation-Unity-Example)
 
 ****
 
  ## 📖 Api Documentation
 
- Our Api Documentation Page:
+You can always find up-to-date documentation on the API here.
 
- - [CSP Api Documentation](https://builds.magnoboard.com/foundation-docs/index.html)
+ - [CSP API Documentation](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/LICENSE)
 
 
 ****
@@ -120,14 +99,14 @@ PRs are welcome! If have any ideas you would like to contribute please see our c
 
 ## :woman_factory_worker: Work In Progress
 
-Our Work In Progress page details future planned work:
+Our Work In Progress page details future planned work.
 
- - [Work In Progress](https://github.com/magnopus-opensource/csp-foundation/wiki/Work-In-Progress)
+ - [Work In Progress](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Work-In-Progress)
 
 
 ****
 
  ## ©️ License
 
- [Apache-2.0](https://github.com/magnopus-opensource/csp-foundation/blob/main/LICENSE)
+ [Apache-2.0](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/LICENSE)
 


### PR DESCRIPTION
Responding to the repo rename, here we are updating URLs referenced by the README and the API docs `md` to reference the new repo URL.

Olympus Foundation Pull  Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
