### PR TITLE
[OF-1028] refac: Refac DeviceIdPath Code

### DIFF
--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -133,7 +133,7 @@ EM_JS(void, set_device_id, (const char* cDeviceId), {
 // clang-format on
 #endif
 
-#if defined(!CSP_WASM)
+#if !defined(CSP_WASM)
 std::string DeviceIdPath()
 {
 	// For all platforms, we want to guarantee the current user has read/write access and to reduce public visibility of the file that holds the


### PR DESCRIPTION
connected-spaces-platform Pull Request

After a search through the codebase the main section of code needing to be split was DeviceId. This cannot be tested independently but if a failure occurs initialisation will not occur.

**For the reviewer**

* [x] If required, are the changes covered by appropriate tests?
* [x] Are any public-facing API changes well documented?
* [x] Is the code easily readable and extensible and/or follow existing conventions?
