### PR TITLE
[OF-1056] doc: Modified readme generation

### DIFF
--- a/teamcity/GenerateReadMe.py
+++ b/teamcity/GenerateReadMe.py
@@ -179,8 +179,10 @@ def create_summary_list(commit_title, commit_id, jira_job_id, feature_commit_lis
             else:
                 breaking_commit_list.append("No Ticket - " + commit_description.capitalize() + " - " + commit_id )
         
+        # Case to cover situations where the commit has been modified in a bad format that still contains a tag but not a recognised one
         else:
             misc_commit_list.append("No Ticket - " + commit_description.capitalize() + " - " + commit_id )
+    # Case to cover situations where the commit has been modified to not comply to our standard format, with the tag. We want to avoid printing merge commits from internal branches, however.
     else:
         if 'magnopus-opensource/develop' not in raw_commit_title and 'magnopus-opensource/main' not in raw_commit_title and 'magnopus-opensource/staging' not in raw_commit_title:
             misc_commit_list.append("No Ticket - " + raw_commit_title.capitalize() + " - " + commit_id )
@@ -315,6 +317,7 @@ def main():
                     
                     jira_job_id = get_jira_id(message)
                     
+                    # Only include merge commits as these are the commits that are the results of a PR. We do further screening inside the create_summary_list method to ensure we only print the merges we want to.
                     if (cleanhtml(commit_title).startswith("merge pull request")):
                         create_summary_list(change_desc, hexsha, jira_job_id, feature_commit_list, fix_commit_list, style_commit_list, refactor_commit_list, test_commit_list, doc_commit_list, breaking_commit_list, misc_commit_list)
                     write_file_line(hexsha, author.name, change_desc, file_out)


### PR DESCRIPTION
- Made readme generation more in-line with the bullet points generated for package releases.
- Added a 'Misc Changes' section for any commits that come through without the prefix modifier we normally parse.
	- While these can't occur through natural commit pipeline, they could happen if a developer modifies their merge commit description during a PR. This catches those edge cases.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
