### PR TITLE
[OB-2722] fix: portable timegm

### DIFF
--- a/Tests/src/PublicAPITests/DateTimeTests.cpp
+++ b/Tests/src/PublicAPITests/DateTimeTests.cpp
@@ -40,6 +40,40 @@ CSP_PUBLIC_TEST(CSPEngine, DateTimeTests, UTCStringConversion)
 	}
 
 	{
+		// testing the very start of a leap year
+		const csp::common::String UTCString("2004-01-01T00:00:00+00:00");
+		const csp::common::DateTime Date(UTCString);
+
+		auto TimePoint				 = Date.GetTimePoint();
+		auto Time					 = std::chrono::system_clock::to_time_t(TimePoint);
+		const std::tm* const UTCTime = std::gmtime(&Time);
+
+		EXPECT_EQ(UTCTime->tm_year, 2004 - 1900);
+		EXPECT_EQ(UTCTime->tm_mon, 0);
+		EXPECT_EQ(UTCTime->tm_mday, 1);
+		EXPECT_EQ(UTCTime->tm_hour, 0);
+		EXPECT_EQ(UTCTime->tm_min, 0);
+		EXPECT_EQ(UTCTime->tm_sec, 00);
+	}
+
+	{
+		// testing the very end of a year
+		const csp::common::String UTCString("1999-12-31T23:59:59+00:00");
+		const csp::common::DateTime Date(UTCString);
+
+		auto TimePoint				 = Date.GetTimePoint();
+		auto Time					 = std::chrono::system_clock::to_time_t(TimePoint);
+		const std::tm* const UTCTime = std::gmtime(&Time);
+
+		EXPECT_EQ(UTCTime->tm_year, 1999 - 1900);
+		EXPECT_EQ(UTCTime->tm_mon, 11);
+		EXPECT_EQ(UTCTime->tm_mday, 31);
+		EXPECT_EQ(UTCTime->tm_hour, 23);
+		EXPECT_EQ(UTCTime->tm_min, 59);
+		EXPECT_EQ(UTCTime->tm_sec, 59);
+	}
+
+	{
 		// this UTC date is out of the int32-representable range since the 1980 epoch.
 		// We expect this to pass, as we expect our code to work with 64bit date/time representations.
 		const csp::common::String UTCString("2122-04-30T02:30:54+00:00");


### PR DESCRIPTION
So it was recently found that there is [a bug](https://chromium.googlesource.com/external/github.com/emscripten-core/emscripten/+/3ce924feb86511ca2bf1e9caaf21762e1b0ee652) in even the latest versions of emscripten where `timegm` will not work for date/times that exceed what a 32-bit int can represent (which runs up to some time in 2038 I think).

I had an idea for writing a CSP-bespoke implementation of `timegm`, so that we have a portable version that we can rely on working both for WASM right now, but also for any platform we support in the future.

I'm not an expert on the inner workings of `timegm`, so full-disclusure, I adapted a sample found on stackoverflow. But I have written unit tests against the C `timegm` implementation and validated that this portable version also passes.

@MAG-ME would you mind taking a look, and if it all possible, validating whether this fixes the WASM issue you found?

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
