### PR TITLE
[NT-0] doc: Tenant key request form URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you choose to use the Connected Spaces Platform in conjunction with Magnopus 
 
 For information on how to obtain one, head over here.
 
- - [Obtaining a Tenant Key](https://www.magnopus.com/platform)
+ - [Obtaining a Tenant Key](https://www.magnopus.com/csp/for-developers#tenant-key)
 ****
 
 ## 🖥️ Usage


### PR DESCRIPTION
- We've now got a confirmed URL for the tenant key request form.
- So in this change, the readme is updated to direct users to the URL when they click through the `Obtaining a Tenant Key` link