### PR TITLE
[NT-0] doc: reuploaded readme gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ _"An interoperable communication library for the spatial internet."_
 - [Tenant Keys](#-tenant-keys)
 - [Api Documentation](#-api-documentation)
 - [Contributions](#%EF%B8%8F-contributions)
-- [Work In Progress](#woman_factory_worker-work-in-progress)
 - [License](#%EF%B8%8F-license)
 
 ****
@@ -31,7 +30,7 @@ _"An interoperable communication library for the spatial internet."_
 Interoperability is the foundation of the spatial internet. We need experiences to work across multiple technologies in harmony, bridging applications and devices so that we can move beyond a series of disconnected islands.
 
 <p align="center">
-    <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/bfd58061-613d-4aa6-9adf-35a4d8e53434">
+    <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/e618ed91-fd61-4b3a-a77b-416e9c4a521a">
 </p>
 
 The Connected Spaces Platform provides developers across a range of languages and platforms with a means to build *interoperable, cross-reality, multi-user applications*.
@@ -102,15 +101,6 @@ You can always find up-to-date documentation on the API here.
 PRs are welcome! If have any ideas you would like to contribute please see our contribution page.
 
  - [Contribution](/CONTRIBUTING.md)
-
-
-****
-
-## :woman_factory_worker: Work In Progress
-
-Our Work In Progress page details future planned work.
-
- - [Work In Progress](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Work-In-Progress)
 
 
 ****


### PR DESCRIPTION
Making the repo public has broken all GitHub-hosted assets that we've uploaded. Fixing this first and most important one by reuploading the gif again.

I also took the liberty of removing the WIP section of the readme, as the page it links to is empty. We can revive it when content exists there.
