### PR TITLE
[OF-1073] feat: Adds Update to EventTicketing

### DIFF
--- a/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
+++ b/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
@@ -47,6 +47,26 @@ public:
 											  bool IsTicketingActive,
 											  TicketedEventResultCallback Callback);
 
+	/// @brief Updates a ticketed event in the given space.
+	///
+	/// All parameters should be provided even if they are not new values. Empty values will overwrite
+	/// existing values to be empty.
+	///
+	/// @param SpaceId csp::common::String : ID of the space the event belongs to.
+	/// @param EventId csp::common::String : ID of the Event to update.
+	/// @param Vendor csp::systems::EventTicketingVendor : Enum representing the vendor that the event is created with.
+	/// @param VendorEventId csp::common::String : Specifies the event ID in the vendors system.
+	/// @param VendorEventUri csp::common::String : Specifies the URI for the event in the vendors system.
+	/// @param IsTicketingActive bool : Specifies whether ticketing is currently active for this event.
+	/// @param Callback TicketedEventResultCallback : Callback providing the TicketedEvent once created.
+	CSP_ASYNC_RESULT void UpdateTicketedEvent(const csp::common::String& SpaceId,
+											  const csp::common::String& EventId,
+											  EventTicketingVendor Vendor,
+											  const csp::common::String& VendorEventId,
+											  const csp::common::String& VendorEventUri,
+											  bool IsTicketingActive,
+											  TicketedEventResultCallback Callback);
+
 	/// @brief Creates a ticketed event for the given space.
 	/// @param SpaceIds csp::common::Array<csp::common::String> : IDs of the spaces to get the events for.
 	/// @param Skip csp::common::Optional<int> : Optional number of results that will be skipped from the result.

--- a/Library/src/CSP/Systems/EventTicketing/EventTicketing.cpp
+++ b/Library/src/CSP/Systems/EventTicketing/EventTicketing.cpp
@@ -38,12 +38,48 @@ csp::systems::EventTicketingVendor VendorNameToEnum(const csp::common::String& V
 
 void SpaceEventDtoToTicketedEvent(const chs::SpaceEventDto& Dto, csp::systems::TicketedEvent& Event)
 {
-	Event.Id				= Dto.GetId();
-	Event.SpaceId			= Dto.GetSpaceId();
-	Event.Vendor			= VendorNameToEnum(Dto.GetVendorName());
-	Event.VendorEventId		= Dto.GetVendorEventId();
-	Event.VendorEventUri	= Dto.GetVendorEventUri();
-	Event.IsTicketingActive = Dto.GetIsTicketingActive();
+	Event.Id	  = Dto.GetId();
+	Event.SpaceId = Dto.GetSpaceId();
+
+	if (Dto.HasVendorName())
+	{
+		Event.Vendor = VendorNameToEnum(Dto.GetVendorName());
+	}
+	else
+	{
+		FOUNDATION_LOG_WARN_MSG("SpaceEventDto missing VendorName");
+		Event.Vendor = csp::systems::EventTicketingVendor::Unknown;
+	}
+
+	if (Dto.HasVendorEventId())
+	{
+		Event.VendorEventId = Dto.GetVendorEventId();
+	}
+	else
+	{
+		FOUNDATION_LOG_WARN_MSG("SpaceEventDto missing VendorEventId");
+		Event.VendorEventId = "";
+	}
+
+	if (Dto.HasVendorEventUri())
+	{
+		Event.VendorEventUri = Dto.GetVendorEventUri();
+	}
+	else
+	{
+		FOUNDATION_LOG_WARN_MSG("SpaceEventDto missing VendorEventUri");
+		Event.VendorEventUri = "";
+	}
+
+	if (Dto.HasIsTicketingActive())
+	{
+		Event.IsTicketingActive = Dto.GetIsTicketingActive();
+	}
+	else
+	{
+		FOUNDATION_LOG_WARN_MSG("SpaceEventDto missing IsTicketingActive");
+		Event.IsTicketingActive = false;
+	}
 }
 
 void VendorInfoDtoToVendorInfo(const chs::VendorProviderInfo& Dto, csp::systems::TicketedEventVendorAuthInfo& VendorInfo)

--- a/Library/src/CSP/Systems/EventTicketing/EventTicketingSystem.cpp
+++ b/Library/src/CSP/Systems/EventTicketing/EventTicketingSystem.cpp
@@ -37,7 +37,6 @@ csp::common::String GetVendorNameString(const csp::systems::EventTicketingVendor
 namespace csp::systems
 {
 
-
 EventTicketingSystem::EventTicketingSystem(csp::web::WebClient* InWebClient) : SystemBase(InWebClient)
 {
 	EventTicketingAPI = CSP_NEW chs::TicketedSpaceApi(InWebClient);
@@ -70,6 +69,30 @@ void EventTicketingSystem::CreateTicketedEvent(const csp::common::String& SpaceI
 			csp::web::EResponseCodes::ResponseCreated);
 
 	static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->apiV1SpacesSpaceIdEventsPost(SpaceId, Request, ResponseHandler);
+}
+
+void EventTicketingSystem::UpdateTicketedEvent(const csp::common::String& SpaceId,
+											   const csp::common::String& EventId,
+											   EventTicketingVendor Vendor,
+											   const csp::common::String& VendorEventId,
+											   const csp::common::String& VendorEventUri,
+											   bool IsTicketingActive,
+											   TicketedEventResultCallback Callback)
+{
+	auto Request = std::make_shared<chs::SpaceEventDto>();
+
+	Request->SetVendorName(GetVendorNameString(Vendor));
+	Request->SetVendorEventId(VendorEventId);
+	Request->SetVendorEventUri(VendorEventUri);
+	Request->SetIsTicketingActive(IsTicketingActive);
+
+	csp::services::ResponseHandlerPtr ResponseHandler
+		= EventTicketingAPI->CreateHandler<TicketedEventResultCallback, TicketedEventResult, void, chs::SpaceEventDto>(
+			Callback,
+			nullptr,
+			csp::web::EResponseCodes::ResponseCreated);
+
+	static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->apiV1SpacesSpaceIdEventsEventIdPut(SpaceId, EventId, Request, ResponseHandler);
 }
 
 void EventTicketingSystem::GetTicketedEvents(const csp::common::Array<csp::common::String>& SpaceIds,

--- a/Tests/CSharp/src/Tests/EventTicketingSystemTests.cs
+++ b/Tests/CSharp/src/Tests/EventTicketingSystemTests.cs
@@ -123,6 +123,128 @@ namespace CSPEngine
         }
 #endif
 
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_TEST
+        [Test]
+        public static void UpdateTicketedEventTest()
+        {
+            GetFoundationSystems(out var userSystem, out var spaceSystem, out var assetSystem, out _, out var anchorSystem, out _, out _, out _, out var eventTicketingSystem);
+
+            string testSpaceName = GenerateUniqueString("OLY-UNITTEST");
+            string testSpaceDescription = "OLY-UNITTEST-DESC";
+
+            string initialVendorEventId = "InitialVendorEventId";
+            string initialVendorEventUri = "InitialVendorEventUri";
+
+            string updatedVendorEventId = "UpdatedVendorEventId";
+            string updatedVendorEventUri = "UpdatedVendorEventUri";
+
+            // Log in
+            _ = UserSystemTests.LogIn(userSystem);
+
+            var space = SpaceSystemTests.CreateSpace(spaceSystem, testSpaceName, testSpaceDescription, Systems.SpaceAttributes.Private, null, null, null);
+
+            using var createResult = eventTicketingSystem.CreateTicketedEvent(space.Id, Csp.Systems.EventTicketingVendor.Eventbrite, initialVendorEventId, initialVendorEventUri, false).Result;
+            Assert.AreEqual(createResult.GetResultCode(), Csp.Services.EResultCode.Success);
+
+            using var createdEvent = createResult.GetTicketedEvent();
+
+            Assert.AreEqual(createdEvent.SpaceId, space.Id);
+            Assert.AreEqual(createdEvent.Vendor, Csp.Systems.EventTicketingVendor.Eventbrite);
+            Assert.AreEqual(createdEvent.VendorEventId, initialVendorEventId);
+            Assert.AreEqual(createdEvent.VendorEventUri, initialVendorEventUri);
+            Assert.IsFalse(createdEvent.IsTicketingActive);
+
+            using var updateResult = eventTicketingSystem.UpdateTicketedEvent(space.Id, createdEvent.Id, Csp.Systems.EventTicketingVendor.Eventbrite, updatedVendorEventId, updatedVendorEventUri, true).Result;
+
+            Assert.AreEqual(updateResult.GetResultCode(), Csp.Services.EResultCode.Success);
+
+            using var updatedEvent = updateResult.GetTicketedEvent();
+
+            Assert.AreEqual(updatedEvent.Id, createdEvent.Id);
+            Assert.AreEqual(updatedEvent.SpaceId, space.Id);
+            Assert.AreEqual(updatedEvent.Vendor, Csp.Systems.EventTicketingVendor.Eventbrite);
+            Assert.AreEqual(updatedEvent.VendorEventId, updatedVendorEventId);
+            Assert.AreEqual(updatedEvent.VendorEventUri, updatedVendorEventUri);
+            Assert.IsTrue(updatedEvent.IsTicketingActive);
+        }
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_BADSPACE_TEST
+        [Test]
+        public static void UpdateTicketedEventBadSpaceTest()
+        {
+            GetFoundationSystems(out var userSystem, out var spaceSystem, out var assetSystem, out _, out var anchorSystem, out _, out _, out _, out var eventTicketingSystem);
+
+            string testSpaceName = GenerateUniqueString("OLY-UNITTEST");
+            string testSpaceDescription = "OLY-UNITTEST-DESC";
+
+            string initialVendorEventId = "InitialVendorEventId";
+            string initialVendorEventUri = "InitialVendorEventUri";
+
+            string updatedVendorEventId = "UpdatedVendorEventId";
+            string updatedVendorEventUri = "UpdatedVendorEventUri";
+
+            // Log in
+            _ = UserSystemTests.LogIn(userSystem);
+
+            var space = SpaceSystemTests.CreateSpace(spaceSystem, testSpaceName, testSpaceDescription, Systems.SpaceAttributes.Private, null, null, null);
+
+            using var createResult = eventTicketingSystem.CreateTicketedEvent(space.Id, Csp.Systems.EventTicketingVendor.Eventbrite, initialVendorEventId, initialVendorEventUri, false).Result;
+            Assert.AreEqual(createResult.GetResultCode(), Csp.Services.EResultCode.Success);
+
+            using var createdEvent = createResult.GetTicketedEvent();
+
+            Assert.AreEqual(createdEvent.SpaceId, space.Id);
+            Assert.AreEqual(createdEvent.Vendor, Csp.Systems.EventTicketingVendor.Eventbrite);
+            Assert.AreEqual(createdEvent.VendorEventId, initialVendorEventId);
+            Assert.AreEqual(createdEvent.VendorEventUri, initialVendorEventUri);
+            Assert.IsFalse(createdEvent.IsTicketingActive);
+
+            using var updateResult = eventTicketingSystem.UpdateTicketedEvent("12a345678b9cdd01ef23456a", createdEvent.Id, Csp.Systems.EventTicketingVendor.Eventbrite, updatedVendorEventId, updatedVendorEventUri, true).Result;
+
+            Assert.AreEqual(updateResult.GetResultCode(), Csp.Services.EResultCode.Failed);
+            Assert.AreEqual(updateResult.GetHttpResultCode(), 404);
+        }
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_BADEVENTID_TEST
+        [Test]
+        public static void UpdateTicketedEventBadEventIdTest()
+        {
+            GetFoundationSystems(out var userSystem, out var spaceSystem, out var assetSystem, out _, out var anchorSystem, out _, out _, out _, out var eventTicketingSystem);
+
+            string testSpaceName = GenerateUniqueString("OLY-UNITTEST");
+            string testSpaceDescription = "OLY-UNITTEST-DESC";
+
+            string initialVendorEventId = "InitialVendorEventId";
+            string initialVendorEventUri = "InitialVendorEventUri";
+
+            string updatedVendorEventId = "UpdatedVendorEventId";
+            string updatedVendorEventUri = "UpdatedVendorEventUri";
+
+            // Log in
+            _ = UserSystemTests.LogIn(userSystem);
+
+            var space = SpaceSystemTests.CreateSpace(spaceSystem, testSpaceName, testSpaceDescription, Systems.SpaceAttributes.Private, null, null, null);
+
+            using var createResult = eventTicketingSystem.CreateTicketedEvent(space.Id, Csp.Systems.EventTicketingVendor.Eventbrite, initialVendorEventId, initialVendorEventUri, false).Result;
+            Assert.AreEqual(createResult.GetResultCode(), Csp.Services.EResultCode.Success);
+
+            using var createdEvent = createResult.GetTicketedEvent();
+
+            Assert.AreEqual(createdEvent.SpaceId, space.Id);
+            Assert.AreEqual(createdEvent.Vendor, Csp.Systems.EventTicketingVendor.Eventbrite);
+            Assert.AreEqual(createdEvent.VendorEventId, initialVendorEventId);
+            Assert.AreEqual(createdEvent.VendorEventUri, initialVendorEventUri);
+            Assert.IsFalse(createdEvent.IsTicketingActive);
+
+            using var updateResult = eventTicketingSystem.UpdateTicketedEvent(space.Id, "12a345678b9cdd01ef23456a", Csp.Systems.EventTicketingVendor.Eventbrite, updatedVendorEventId, updatedVendorEventUri, true).Result;
+
+            Assert.AreEqual(updateResult.GetResultCode(), Csp.Services.EResultCode.Failed);
+            Assert.AreEqual(updateResult.GetHttpResultCode(), 404);
+        }
+#endif
+
 #if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_NO_EVENTS_TES
         [Test]
         public static void GetTicketedEventsNoEventsTest()

--- a/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
+++ b/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
@@ -36,7 +36,7 @@ bool RequestPredicate(const csp::services::ResultBase& Result)
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_CREATETICKETEDEVENT_ACTIVE_TRUE_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_CREATETICKETEDEVENT_ACTIVE_TRUE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveTrueTest)
 {
 	SetRandSeed();
@@ -85,7 +85,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveT
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_CREATETICKETEDEVENT_ACTIVE_FALSE_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_CREATETICKETEDEVENT_ACTIVE_FALSE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveFalseTest)
 {
 	SetRandSeed();
@@ -134,7 +134,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveF
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_CREATETICKETEDEVENT_TWICE_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_CREATETICKETEDEVENT_TWICE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventTwiceTest)
 {
 	SetRandSeed();
@@ -207,7 +207,195 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventTwiceTe
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETTICKETEDEVENTS_NO_EVENTS_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_TEST
+CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager	   = csp::systems::SystemsManager::Get();
+	auto* UserSystem		   = SystemsManager.GetUserSystem();
+	auto* SpaceSystem		   = SystemsManager.GetSpaceSystem();
+	auto* EventTicketingSystem = SystemsManager.GetEventTicketingSystem();
+
+	csp::common::String InitialVendorEventId  = "InitialVendorEventId";
+	csp::common::String InitialVendorEventUri = "InitialVendorEventUri";
+	csp::common::String UpdatedVendorEventId  = "UpdatedVendorEventId";
+	csp::common::String UpdatedVendorEventUri = "UpdatedVendorEventUri";
+
+	const char* TestSpaceName		 = "CSP-UNITTEST-SPACE";
+	const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueHexString().c_str());
+
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	auto [CreatedResult] = AWAIT_PRE(EventTicketingSystem,
+									 CreateTicketedEvent,
+									 RequestPredicate,
+									 Space.Id,
+									 csp::systems::EventTicketingVendor::Eventbrite,
+									 InitialVendorEventId,
+									 InitialVendorEventUri,
+									 false);
+
+	EXPECT_EQ(CreatedResult.GetResultCode(), csp::services::EResultCode::Success);
+
+	auto CreatedEvent = CreatedResult.GetTicketedEvent();
+
+	EXPECT_EQ(CreatedEvent.SpaceId, Space.Id);
+	EXPECT_EQ(CreatedEvent.Vendor, csp::systems::EventTicketingVendor::Eventbrite);
+	EXPECT_EQ(CreatedEvent.VendorEventId, InitialVendorEventId);
+	EXPECT_EQ(CreatedEvent.VendorEventUri, InitialVendorEventUri);
+	EXPECT_FALSE(CreatedEvent.IsTicketingActive);
+
+	auto [UpdatedResult] = AWAIT_PRE(EventTicketingSystem,
+									 UpdateTicketedEvent,
+									 RequestPredicate,
+									 Space.Id,
+									 CreatedEvent.Id,
+									 csp::systems::EventTicketingVendor::Eventbrite,
+									 UpdatedVendorEventId,
+									 UpdatedVendorEventUri,
+									 true);
+
+	EXPECT_EQ(UpdatedResult.GetResultCode(), csp::services::EResultCode::Success);
+
+	auto UpdatedEvent = UpdatedResult.GetTicketedEvent();
+
+	EXPECT_EQ(UpdatedEvent.Id, CreatedEvent.Id);
+	EXPECT_EQ(UpdatedEvent.SpaceId, Space.Id);
+	EXPECT_EQ(UpdatedEvent.Vendor, csp::systems::EventTicketingVendor::Eventbrite);
+	EXPECT_EQ(UpdatedEvent.VendorEventId, UpdatedVendorEventId);
+	EXPECT_EQ(UpdatedEvent.VendorEventUri, UpdatedVendorEventUri);
+	EXPECT_TRUE(UpdatedEvent.IsTicketingActive);
+
+	DeleteSpace(SpaceSystem, Space.Id);
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_BADSPACE_TEST
+CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventBadSpaceTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager	   = csp::systems::SystemsManager::Get();
+	auto* UserSystem		   = SystemsManager.GetUserSystem();
+	auto* SpaceSystem		   = SystemsManager.GetSpaceSystem();
+	auto* EventTicketingSystem = SystemsManager.GetEventTicketingSystem();
+
+	csp::common::String InitialVendorEventId  = "InitialVendorEventId";
+	csp::common::String InitialVendorEventUri = "InitialVendorEventUri";
+	csp::common::String UpdatedVendorEventId  = "UpdatedVendorEventId";
+	csp::common::String UpdatedVendorEventUri = "UpdatedVendorEventUri";
+
+	const char* TestSpaceName		 = "CSP-UNITTEST-SPACE";
+	const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueHexString().c_str());
+
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	auto [CreatedResult] = AWAIT_PRE(EventTicketingSystem,
+									 CreateTicketedEvent,
+									 RequestPredicate,
+									 Space.Id,
+									 csp::systems::EventTicketingVendor::Eventbrite,
+									 InitialVendorEventId,
+									 InitialVendorEventUri,
+									 false);
+
+	EXPECT_EQ(CreatedResult.GetResultCode(), csp::services::EResultCode::Success);
+
+	auto CreatedEvent = CreatedResult.GetTicketedEvent();
+
+	auto [UpdatedResult] = AWAIT_PRE(EventTicketingSystem,
+									 UpdateTicketedEvent,
+									 RequestPredicate,
+									 "12a345678b9cdd01ef23456a",
+									 CreatedEvent.Id,
+									 csp::systems::EventTicketingVendor::Eventbrite,
+									 UpdatedVendorEventId,
+									 UpdatedVendorEventUri,
+									 true);
+
+	EXPECT_EQ(UpdatedResult.GetResultCode(), csp::services::EResultCode::Failed);
+	EXPECT_EQ(UpdatedResult.GetHttpResultCode(), 404);
+
+	DeleteSpace(SpaceSystem, Space.Id);
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_BADEVENTID_TEST
+CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventBadEventIdTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager	   = csp::systems::SystemsManager::Get();
+	auto* UserSystem		   = SystemsManager.GetUserSystem();
+	auto* SpaceSystem		   = SystemsManager.GetSpaceSystem();
+	auto* EventTicketingSystem = SystemsManager.GetEventTicketingSystem();
+
+	csp::common::String InitialVendorEventId  = "InitialVendorEventId";
+	csp::common::String InitialVendorEventUri = "InitialVendorEventUri";
+	csp::common::String UpdatedVendorEventId  = "UpdatedVendorEventId";
+	csp::common::String UpdatedVendorEventUri = "UpdatedVendorEventUri";
+
+	const char* TestSpaceName		 = "CSP-UNITTEST-SPACE";
+	const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueHexString().c_str());
+
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	auto [CreatedResult] = AWAIT_PRE(EventTicketingSystem,
+									 CreateTicketedEvent,
+									 RequestPredicate,
+									 Space.Id,
+									 csp::systems::EventTicketingVendor::Eventbrite,
+									 InitialVendorEventId,
+									 InitialVendorEventUri,
+									 false);
+
+	EXPECT_EQ(CreatedResult.GetResultCode(), csp::services::EResultCode::Success);
+
+	auto CreatedEvent = CreatedResult.GetTicketedEvent();
+
+	auto [UpdatedResult] = AWAIT_PRE(EventTicketingSystem,
+									 UpdateTicketedEvent,
+									 RequestPredicate,
+									 Space.Id,
+									 "12a345678b9cdd01ef23456a",
+									 csp::systems::EventTicketingVendor::Eventbrite,
+									 UpdatedVendorEventId,
+									 UpdatedVendorEventUri,
+									 true);
+
+	EXPECT_EQ(UpdatedResult.GetResultCode(), csp::services::EResultCode::Failed);
+	EXPECT_EQ(UpdatedResult.GetHttpResultCode(), 404);
+
+	DeleteSpace(SpaceSystem, Space.Id);
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_NO_EVENTS_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsNoEventsTest)
 {
 	SetRandSeed();
@@ -243,7 +431,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsNoEventsT
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETTICKETEDEVENTS_ONE_EVENT_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_ONE_EVENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsOneEventTest)
 {
 	SetRandSeed();
@@ -299,7 +487,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsOneEventT
 #endif
 
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETTICKETEDEVENTS_TWO_EVENTS_SAME_SPACE_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_TWO_EVENTS_SAME_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEventsSameSpaceTest)
 {
 	SetRandSeed();
@@ -397,7 +585,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEvents
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETTICKETEDEVENTS_TWO_EVENTS_TWO_SPACES_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_TWO_EVENTS_TWO_SPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEventsTwoSpacesTest)
 {
 	SetRandSeed();
@@ -501,7 +689,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEvents
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETTICKETEDEVENTS_PAGINATION_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_PAGINATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsPaginationTest)
 {
 	SetRandSeed();
@@ -609,7 +797,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsPaginatio
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETVENDORAUTHORISEINFO_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETVENDORAUTHORISEINFO_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthoriseInfoTest)
 {
 	SetRandSeed();
@@ -637,7 +825,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthoriseInfoTest
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETVENDORAUTHORISEINFO_BADDATA_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETVENDORAUTHORISEINFO_BADDATA_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthoriseInfoBadDataTest)
 {
 	SetRandSeed();


### PR DESCRIPTION
Add functionality to EventTicketingSystem to enable updating ticketed events to change the third party vendor details and whether ticketing is active for the event.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
