### PR TITLE
[OF-1078] fix: spelling correction

### DIFF
--- a/Library/include/CSP/Systems/EventTicketing/EventTicketing.h
+++ b/Library/include/CSP/Systems/EventTicketing/EventTicketing.h
@@ -142,6 +142,6 @@ typedef std::function<void(const TicketedEventResult& Result)> TicketedEventResu
 typedef std::function<void(const TicketedEventCollectionResult& Result)> TicketedEventCollectionResultCallback;
 
 // @brief Callback providing the ticketed event vendor information necessary for authenticating with the vendor's platform.
-typedef std::function<void(const TicketedEventVendorAuthInfoResult& Result)> TicketedEventVendorAuthoriseInfoCallback;
+typedef std::function<void(const TicketedEventVendorAuthInfoResult& Result)> TicketedEventVendorAuthorizeInfoCallback;
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
+++ b/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
@@ -62,7 +62,7 @@ public:
 	/// @param UserId csp::common::String : The ID of the user to obtain authentication info for.
 	/// @param Callback TicketedEventVendorInfoResultCallback : Callback providing the oauth2 information.
 	CSP_ASYNC_RESULT void
-		GetVendorAuthoriseInfo(EventTicketingVendor Vendor, const csp::common::String& UserId, TicketedEventVendorAuthoriseInfoCallback Callback);
+		GetVendorAuthorizeInfo(EventTicketingVendor Vendor, const csp::common::String& UserId, TicketedEventVendorAuthorizeInfoCallback Callback);
 
 private:
 	EventTicketingSystem(); // This constructor is only provided to appease the wrapper generator and should not be used

--- a/Library/src/CSP/Systems/EventTicketing/EventTicketingSystem.cpp
+++ b/Library/src/CSP/Systems/EventTicketing/EventTicketingSystem.cpp
@@ -98,13 +98,13 @@ void EventTicketingSystem::GetTicketedEvents(const csp::common::Array<csp::commo
 		->apiV1SpacesEventsGet(std::nullopt, std::nullopt, RequestSpaceIds, RequestSkip, RequestLimit, ResponseHandler);
 }
 
-void EventTicketingSystem::GetVendorAuthoriseInfo(EventTicketingVendor Vendor,
+void EventTicketingSystem::GetVendorAuthorizeInfo(EventTicketingVendor Vendor,
 												  const csp::common::String& UserId,
-												  TicketedEventVendorAuthoriseInfoCallback Callback)
+												  TicketedEventVendorAuthorizeInfoCallback Callback)
 {
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= EventTicketingAPI
-			  ->CreateHandler<TicketedEventVendorAuthoriseInfoCallback, TicketedEventVendorAuthInfoResult, void, chs::VendorProviderInfo>(
+			  ->CreateHandler<TicketedEventVendorAuthorizeInfoCallback, TicketedEventVendorAuthInfoResult, void, chs::VendorProviderInfo>(
 				  Callback,
 				  nullptr,
 				  csp::web::EResponseCodes::ResponseCreated);

--- a/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
+++ b/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
@@ -622,7 +622,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthoriseInfoTest
 	LogIn(UserSystem, UserId);
 
 	auto [TicketedEventVendorAuthInfoResult]
-		= AWAIT_PRE(EventTicketingSystem, GetVendorAuthoriseInfo, RequestPredicate, csp::systems::EventTicketingVendor::Eventbrite, UserId);
+		= AWAIT_PRE(EventTicketingSystem, GetVendorAuthorizeInfo, RequestPredicate, csp::systems::EventTicketingVendor::Eventbrite, UserId);
 
 	EXPECT_EQ(TicketedEventVendorAuthInfoResult.GetResultCode(), csp::services::EResultCode::Success);
 
@@ -652,7 +652,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthoriseInfoBadD
 	// 1. Invalid vendor test
 	{
 		auto [TicketedEventVendorAuthInfoResult]
-			= AWAIT_PRE(EventTicketingSystem, GetVendorAuthoriseInfo, RequestPredicate, csp::systems::EventTicketingVendor::Unknown, UserId);
+			= AWAIT_PRE(EventTicketingSystem, GetVendorAuthorizeInfo, RequestPredicate, csp::systems::EventTicketingVendor::Unknown, UserId);
 
 		// specifying an unknown vendor when attempting to get auth info should return a fail and an empty vendor auth info object
 		EXPECT_EQ(TicketedEventVendorAuthInfoResult.GetResultCode(), csp::services::EResultCode::Failed);
@@ -668,7 +668,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthoriseInfoBadD
 	// 2. Invalid user ID
 	{
 		auto [TicketedEventVendorAuthInfoResult] = AWAIT_PRE(EventTicketingSystem,
-															 GetVendorAuthoriseInfo,
+															 GetVendorAuthorizeInfo,
 															 RequestPredicate,
 															 csp::systems::EventTicketingVendor::Eventbrite,
 															 "n0taR3alC1ien7");
@@ -687,7 +687,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthoriseInfoBadD
 	// 3. Invalid vendor ID and user ID
 	{
 		auto [TicketedEventVendorAuthInfoResult] = AWAIT_PRE(EventTicketingSystem,
-															 GetVendorAuthoriseInfo,
+															 GetVendorAuthorizeInfo,
 															 RequestPredicate,
 															 csp::systems::EventTicketingVendor::Unknown,
 															 "n0taR3alC1ien7");


### PR DESCRIPTION
CSP seeks to adopt American English. Updating the term 'authorise' to 'authorize' within the event ticketing API accordingly.