### PR TITLE
[OB-2795] fix: properly allocate and free strings

### DIFF
--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -404,7 +404,7 @@ void CSPFoundation::SetClientUserAgentInfo(const csp::ClientUserAgent& ClientUse
 
 void Free(void* Pointer)
 {
-	csp::memory::DllFree(Pointer);
+	CSP_FREE(Pointer);
 }
 
 void* ModuleHandle = nullptr;

--- a/Tools/WrapperGenerator/Templates/C/Partials/Class/Method/Method.mustache
+++ b/Tools/WrapperGenerator/Templates/C/Partials/Class/Method/Method.mustache
@@ -390,7 +390,7 @@
           auto _cstr = _result.c_str();
         {{/ is_pointer }}
 
-        auto _resultCopy = CSP_NEW char[_result.Length() + 1];
+        auto _resultCopy = (char*)CSP_ALLOC(_result.Length() + 1);
         std::memcpy(_resultCopy, _cstr, _result.Length());
         _resultCopy[_result.Length()] = '\0';
 


### PR DESCRIPTION
String copies were incorrectly pairing `CSP_NEW` with `DllFree` in the C interface, which was causing OOB errors when freeing strings returned from to any of our wrappers.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
