### PR TITLE
CSP 4.5.1 - prepping a patch version to address a deallocator issue found in CSP

### DIFF
--- a/Library/include/CSP/Common/StringFormat.h
+++ b/Library/include/CSP/Common/StringFormat.h
@@ -50,6 +50,7 @@ template <typename... Args> static String StringFormat(const String& Format, Arg
 	std::unique_ptr<char[], csp::memory::DllDeleter<char>> Buf((char*) csp::memory::DllAlloc(Size));
 
 	std::snprintf(Buf.get(), Size, Format.c_str(), args...);
+
 	return String(Buf.get(), Size - 1); // We don't want the '\0' inside
 };
 

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -404,7 +404,7 @@ void CSPFoundation::SetClientUserAgentInfo(const csp::ClientUserAgent& ClientUse
 
 void Free(void* Pointer)
 {
-	csp::memory::DllFree(Pointer);
+	CSP_FREE(Pointer);
 }
 
 void* ModuleHandle = nullptr;

--- a/Tests/src/InternalTests/CommonTypeTests/StringFormat.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/StringFormat.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_STRINGFORMAT_TESTS)
+
+	#include "CSP/Common/StringFormat.h"
+	#include "CSP/Common/List.h"
+
+	#include "TestHelpers.h"
+
+	#include <gtest/gtest.h>
+
+
+using namespace csp::common;
+
+
+CSP_INTERNAL_TEST(CSPEngine, CommonStringFormatTests, StringFormatTest)
+{
+	try
+	{
+		String Instance = StringFormat("%c %d %i %.1f %s", '1', 2, 3, 4.0f, "five");
+
+		EXPECT_FALSE(Instance.IsEmpty());
+		EXPECT_NE(Instance.c_str(), nullptr);
+		EXPECT_EQ(Instance, "1 2 3 4.0 five");
+	}
+	catch (...)
+	{
+		FAIL();
+	}
+}
+
+#endif

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -445,7 +445,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
 
 	InitialiseTestingConnection();
 
-	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, true);
+	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
 	EXPECT_EQ(EnterResult.GetResultCode(), csp::services::EResultCode::Success);
 	Connection	 = EnterResult.GetConnection();
 	EntitySystem = Connection->GetSpaceEntitySystem();
@@ -2070,7 +2070,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 	csp::systems::Space Space;
 	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
 
-	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, true);
+	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
 	EXPECT_EQ(EnterResult.GetResultCode(), csp::services::EResultCode::Success);
 	Connection	 = EnterResult.GetConnection();
 	EntitySystem = Connection->GetSpaceEntitySystem();

--- a/Tools/WrapperGenerator/Templates/C/Partials/Class/Method/Method.mustache
+++ b/Tools/WrapperGenerator/Templates/C/Partials/Class/Method/Method.mustache
@@ -390,7 +390,7 @@
           auto _cstr = _result.c_str();
         {{/ is_pointer }}
 
-        auto _resultCopy = CSP_NEW char[_result.Length() + 1];
+        auto _resultCopy = (char*)CSP_ALLOC(_result.Length() + 1);
         std::memcpy(_resultCopy, _cstr, _result.Length());
         _resultCopy[_result.Length()] = '\0';
 


### PR DESCRIPTION
We're looking to cut a new release of CSP, primarily to immediately address an issue found and fixed by @MAG-MichaelK over in https://github.com/magnopus-opensource/connected-spaces-platform/pull/107, where strings were being incorrectly deallocated.

There's one other change coming along for the ride, but it purely relates to tests, so no impact on the CSP binaries themselves.