### PR TITLE
[NT-0] fix: address stability issues

### DIFF
--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -205,7 +205,7 @@ public:
 
 	/// @brief Appends an element to the end of the list.
 	/// @param Item T&&
-	void Append(T&& Item)
+	CSP_NO_EXPORT void Append(T&& Item)
 	{
 		if (CurrentSize == MaximumSize)
 		{

--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -197,7 +197,26 @@ public:
 			ReallocList(Size);
 		}
 
+		// Instantiate element first to allow copy assignment
+		T* ObjectPtr = &ObjectArray[CurrentSize];
+		new (ObjectPtr) T;
 		ObjectArray[CurrentSize++] = Item;
+	}
+
+	/// @brief Appends an element to the end of the list.
+	/// @param Item T&&
+	void Append(T&& Item)
+	{
+		if (CurrentSize == MaximumSize)
+		{
+			auto Size = next_pow2(MaximumSize + 1);
+			ReallocList(Size);
+		}
+
+		// Instantiate element first to allow move assignment
+		T* ObjectPtr = &ObjectArray[CurrentSize];
+		new (ObjectPtr) T;
+		ObjectArray[CurrentSize++] = std::move(Item);
 	}
 
 	/// @brief Appends an element at the given index of the list.

--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -90,8 +90,26 @@ public:
 
 		for (size_t i = 0; i < CurrentSize; ++i)
 		{
+			T* ObjectPtr = &ObjectArray[i];
+			new (ObjectPtr) T;
 			ObjectArray[i] = Other.ObjectArray[i];
 		}
+	}
+
+	CSP_NO_EXPORT List(List<T>&& Other) : CurrentSize(0), MaximumSize(0), ObjectArray(nullptr)
+	{
+		if (Other.CurrentSize == 0)
+		{
+			AllocList(LIST_DEFAULT_SIZE);
+
+			return;
+		}
+
+		CurrentSize = Other.CurrentSize;
+		MaximumSize = Other.MaximumSize;
+		ObjectArray = Other.ObjectArray;
+
+		Other.ObjectArray = nullptr;
 	}
 
 	/// @brief Constructs a list from an initializer_list.
@@ -111,6 +129,8 @@ public:
 
 		for (size_t i = 0; i < CurrentSize; ++i)
 		{
+			T* ObjectPtr = &ObjectArray[i];
+			new (ObjectPtr) T;
 			ObjectArray[i] = *(List.begin() + i);
 		}
 	}
@@ -234,6 +254,8 @@ public:
 		std::memmove(ObjectArray + (Index + 1), ObjectArray + Index, sizeof(T) * After);
 		++CurrentSize;
 
+		T* ObjectPtr = &ObjectArray[0];
+		new (ObjectPtr) T;
 		ObjectArray[Index] = Item;
 	}
 

--- a/Library/include/CSP/Common/String.h
+++ b/Library/include/CSP/Common/String.h
@@ -61,10 +61,18 @@ public:
 	/// @param Other String const&
 	String(String const& Other);
 
+	/// @brief Move constructor
+	String(String&& Other);
+
 	/// @brief Copy assignment.
 	/// @param Rhs const String&
 	/// @return String&
 	String& operator=(const String& Rhs);
+
+	/// @brief Move assignment.
+	/// @param Rhs const String&
+	/// @return String&
+	String& operator=(String&& Rhs);
 
 	/// @brief Assigns a cstring to the string.
 	/// @param Text const char* : Pointer to a string buffer to copy data from

--- a/Library/include/CSP/Systems/Assets/Asset.h
+++ b/Library/include/CSP/Systems/Assets/Asset.h
@@ -332,14 +332,10 @@ public:
 	~AssetDataResult();
 
 	/// @brief Retrieves the data from the result.
-	void* GetData();
-	/// @brief Retrieves the data from the result.
 	const void* GetData() const;
 
 	/// @brief Gets the length of data returned.
-	size_t GetDataLength();
-	/// @brief Gets the length of data returned.
-	const size_t GetDataLength() const;
+	size_t GetDataLength() const;
 
 protected:
 	AssetDataResult() = delete;
@@ -347,9 +343,6 @@ protected:
 
 private:
 	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
-
-	void* Data;
-	size_t DataLength;
 };
 
 

--- a/Library/src/Common/String.cpp
+++ b/Library/src/Common/String.cpp
@@ -198,6 +198,12 @@ String::String(String const& Other) : ImplPtr(Other.ImplPtr->Clone())
 {
 }
 
+String::String(String&& Other)
+{
+	ImplPtr		  = Other.ImplPtr;
+	Other.ImplPtr = nullptr;
+}
+
 List<String> String::Split(char Separator) const
 {
 	return ImplPtr->Split(Separator);
@@ -211,13 +217,24 @@ String& String::swap(String& Other)
 
 String& String::operator=(const String& Rhs)
 {
+	CSP_DELETE(ImplPtr);
 	ImplPtr = Rhs.ImplPtr->Clone();
+	return *this;
+}
+
+String& String::operator=(String&& Rhs)
+{
+	CSP_DELETE(ImplPtr);
+	ImplPtr		= Rhs.ImplPtr;
+	Rhs.ImplPtr = nullptr;
 	return *this;
 }
 
 String& String::operator=(char const* const Text)
 {
-	return *this = String(Text);
+	CSP_DELETE(ImplPtr);
+	ImplPtr = CSP_NEW Impl(Text);
+	return *this;
 }
 
 const char* String::Get() const
@@ -289,7 +306,10 @@ bool String::operator<(const String& Other) const
 
 String::~String()
 {
-	CSP_DELETE(ImplPtr);
+	if (ImplPtr != nullptr)
+	{
+		CSP_DELETE(ImplPtr);
+	}
 }
 
 void String::Append(const String& Other)

--- a/Library/src/Multiplayer/SignalR/SignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRClient.cpp
@@ -134,11 +134,13 @@ public:
 	SignalRResponseReceiver() : ResponseReceived(false), ThreadId(std::this_thread::get_id())
 	{
 	}
-	void OnHttpResponse(const csp::web::HttpResponse& InResponse) override
+
+	void OnHttpResponse(csp::web::HttpResponse& InResponse) override
 	{
 		Response		 = InResponse;
 		ResponseReceived = true;
 	}
+
 	bool WaitForResponse()
 	{
 		return WaitFor(
@@ -148,10 +150,12 @@ public:
 			},
 			std::chrono::seconds(5));
 	}
+
 	bool IsResponseReceived() const
 	{
 		return ResponseReceived;
 	}
+
 	csp::web::HttpResponse& GetResponse()
 	{
 		return Response;

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -339,7 +339,8 @@ ComponentBase* SpaceEntity::AddComponent(ComponentType Type)
 
 	auto ComponentId = GenerateComponentId();
 	auto* Component	 = InstantiateComponent(ComponentId, Type);
-	// if Component != nullptr component has not been Instantiate, so is skipped.
+
+	// If Component is null, component has not been instantiated, so is skipped.
 	if (Component != nullptr)
 	{
 		DirtyComponents[ComponentId] = DirtyComponent {Component, ComponentUpdateType::Add};

--- a/Library/src/Services/ApiBase/ApiBase.cpp
+++ b/Library/src/Services/ApiBase/ApiBase.cpp
@@ -32,9 +32,14 @@ DtoBase* ApiResponseBase::GetDto() const
 	return Dto;
 }
 
-void ApiResponseBase::SetResponse(const csp::web::HttpResponse* InResponse)
+void ApiResponseBase::SetResponse(csp::web::HttpResponse* InResponse)
 {
 	Response = InResponse;
+}
+
+csp::web::HttpResponse* ApiResponseBase::GetMutableResponse()
+{
+	return Response;
 }
 
 const csp::web::HttpResponse* ApiResponseBase::GetResponse() const

--- a/Library/src/Services/ApiBase/ApiBase.h
+++ b/Library/src/Services/ApiBase/ApiBase.h
@@ -51,7 +51,8 @@ public:
 	EResponseCode GetResponseCode() const;
 	DtoBase* GetDto() const;
 
-	void SetResponse(const csp::web::HttpResponse* Response);
+	void SetResponse(csp::web::HttpResponse* Response);
+	csp::web::HttpResponse* GetMutableResponse();
 	const csp::web::HttpResponse* GetResponse() const;
 
 	void SetResponseCode(csp::web::EResponseCodes InResponseCode, csp::web::EResponseCodes InValidResponseCode);
@@ -60,7 +61,7 @@ protected:
 	EResponseCode ResponseCode				  = EResponseCode::ResponseFailed;
 	csp::web::EResponseCodes HttpResponseCode = csp::web::EResponseCodes::ResponseInit;
 	DtoBase* Dto;
-	const csp::web::HttpResponse* Response = nullptr;
+	csp::web::HttpResponse* Response = nullptr;
 
 private:
 	bool IsValidResponseCode(int ResponseCodeA, int ResponseCodeB);
@@ -159,8 +160,8 @@ public:
 	ApiResponseHandlerBase();
 	virtual ~ApiResponseHandlerBase();
 
-	virtual void OnHttpProgress(const csp::web::HttpRequest& Request) override	 = 0;
-	virtual void OnHttpResponse(const csp::web::HttpResponse& Response) override = 0;
+	virtual void OnHttpProgress(csp::web::HttpRequest& Request) override   = 0;
+	virtual void OnHttpResponse(csp::web::HttpResponse& Response) override = 0;
 
 	// Make sure these get deleted with the request
 	bool ShouldDelete() const override
@@ -188,9 +189,9 @@ public:
 	{
 	}
 
-	void OnHttpProgress(const csp::web::HttpRequest& Request) override
+	void OnHttpProgress(csp::web::HttpRequest& Request) override
 	{
-		ApiResp.SetResponse(&Request.GetResponse());
+		ApiResp.SetResponse(&Request.GetMutableResponse());
 
 		ResponseObjectPtr->OnProgress(&ApiResp);
 
@@ -198,7 +199,7 @@ public:
 		Callback(ResponseObject);
 	}
 
-	void OnHttpResponse(const csp::web::HttpResponse& Response) override
+	void OnHttpResponse(csp::web::HttpResponse& Response) override
 	{
 		ApiResp.SetResponse(&Response);
 

--- a/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
@@ -44,7 +44,7 @@ public:
 class ResponseReceiver : public csp::web::IHttpResponseHandler
 {
 public:
-	void OnHttpResponse(const csp::web::HttpResponse& InResponse) override
+	void OnHttpResponse(csp::web::HttpResponse& InResponse) override
 	{
 	}
 

--- a/Library/src/Systems/Assets/Asset.cpp
+++ b/Library/src/Systems/Assets/Asset.cpp
@@ -335,13 +335,12 @@ void UriResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
 {
 	ResultBase::OnResponse(ApiResponse);
 
-	const csp::web::HttpResponse* Response = ApiResponse->GetResponse();
+	const auto* Response = ApiResponse->GetResponse();
+	const auto& Headers	 = Response->GetPayload().GetHeaders();
 
-	auto Headers = Response->GetPayload().GetHeaders();
-
-	if (!Headers["x-errorcode"].empty())
+	if (Headers.count("x-errorcode") > 0 && !Headers.at("x-errorcode").empty())
 	{
-		XCodeError = Headers["x-errorcode"].c_str();
+		XCodeError = Headers.at("x-errorcode").c_str();
 	}
 
 	if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
@@ -356,71 +355,31 @@ void UriResult::SetResponseBody(const csp::common::String& Contents)
 }
 
 
-AssetDataResult::AssetDataResult(void*) : Data(nullptr), DataLength(0)
+AssetDataResult::AssetDataResult(void*)
 {
 }
 
-AssetDataResult::AssetDataResult(const AssetDataResult& Other) : Data(nullptr), DataLength(Other.DataLength), ResultBase(Other)
+AssetDataResult::AssetDataResult(const AssetDataResult& Other) : ResultBase(Other)
 {
-	if (DataLength > 0)
-	{
-		auto DataPtr = (char*) CSP_ALLOC(sizeof(char) * DataLength + 1);
-		memcpy(DataPtr, Other.Data, DataLength);
-		DataPtr[DataLength] = 0;
-
-		Data = DataPtr;
-	}
 }
 
 AssetDataResult::~AssetDataResult()
 {
-	if (Data)
-	{
-		CSP_FREE(Data);
-	}
-}
-
-void* AssetDataResult::GetData()
-{
-	return Data;
 }
 
 const void* AssetDataResult::GetData() const
 {
-	return Data;
+	return ResponseBody.c_str();
 }
 
-size_t AssetDataResult::GetDataLength()
+size_t AssetDataResult::GetDataLength() const
 {
-	return DataLength;
-}
-
-const size_t AssetDataResult::GetDataLength() const
-{
-	return DataLength;
+	return ResponseBody.Length();
 }
 
 void AssetDataResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
 {
 	ResultBase::OnResponse(ApiResponse);
-
-	auto* AssetResponse					   = static_cast<csp::services::AssetFileDto*>(ApiResponse->GetDto());
-	const csp::web::HttpResponse* Response = ApiResponse->GetResponse();
-
-	if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
-	{
-		// Build the Dto from the response Json
-		AssetResponse->FromJson(Response->GetPayload().GetContent());
-
-		const char* PayLoad = Response->GetPayload().GetContent().c_str();
-		DataLength			= Response->GetPayload().GetContent().Length();
-
-		auto DataPtr = (char*) CSP_ALLOC(sizeof(char) * DataLength + 1);
-		memcpy(DataPtr, PayLoad, DataLength);
-		DataPtr[DataLength] = 0;
-
-		Data = DataPtr;
-	}
 }
 
 const csp::common::String& Asset::GetThirdPartyPackagedAssetIdentifier() const

--- a/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
+++ b/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
@@ -64,8 +64,8 @@ void OnFetchSuccessOrError(emscripten_fetch_t* Fetch)
 	csp::common::Map<csp::common::String, csp::common::String> Headers;
 	GetResponseHeaders(Fetch, Headers);
 
-	auto& Response = Request->GetResponse();
-	auto& Payload  = ((csp::web::HttpResponse&) Response).GetMutablePayload();
+	auto& Response = Request->GetMutableResponse();
+	auto& Payload  = Response.GetMutablePayload();
 	auto Keys	   = Headers.Keys();
 
 	for (int i = 0; i < Keys->Size(); ++i)
@@ -79,7 +79,8 @@ void OnFetchSuccessOrError(emscripten_fetch_t* Fetch)
 	CSP_DELETE(Keys);
 
 	Request->GetCallback()->OnHttpResponse(Response);
-	CSP_DELETE_ARRAY(Fetch->__attributes.requestData);
+	// DO NOT DO THIS! This will delete Payload.Content twice
+	// CSP_DELETE_ARRAY(Fetch->__attributes.requestData);
 	CSP_DELETE(Request);
 	emscripten_fetch_close(Fetch);
 }

--- a/Library/src/Web/HttpRequest.cpp
+++ b/Library/src/Web/HttpRequest.cpp
@@ -75,9 +75,19 @@ const csp::web::Uri& HttpRequest::GetUri() const
 	return Uri;
 }
 
+HttpPayload& HttpRequest::GetMutablePayload()
+{
+	return Payload;
+}
+
 const HttpPayload& HttpRequest::GetPayload() const
 {
 	return Payload;
+}
+
+HttpResponse& HttpRequest::GetMutableResponse()
+{
+	return Response;
 }
 
 const HttpResponse& HttpRequest::GetResponse() const

--- a/Library/src/Web/HttpRequest.h
+++ b/Library/src/Web/HttpRequest.h
@@ -61,7 +61,9 @@ public:
 
 	const ERequestVerb GetVerb() const;
 	const csp::web::Uri& GetUri() const;
+	HttpPayload& GetMutablePayload();
 	const HttpPayload& GetPayload() const;
+	HttpResponse& GetMutableResponse();
 	const HttpResponse& GetResponse() const;
 
 	IHttpResponseHandler* GetCallback() const;

--- a/Library/src/Web/HttpResponse.h
+++ b/Library/src/Web/HttpResponse.h
@@ -27,8 +27,8 @@ class HttpResponse;
 
 struct IHttpResponseHandler
 {
-	virtual void OnHttpProgress(const HttpRequest& Request) {};
-	virtual void OnHttpResponse(const HttpResponse& Response) = 0;
+	virtual void OnHttpProgress(HttpRequest& Request) {};
+	virtual void OnHttpResponse(HttpResponse& Response) = 0;
 	virtual bool ShouldDelete() const
 	{
 		return false;

--- a/Library/src/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Web/POCOWebClient/POCOWebClient.cpp
@@ -301,7 +301,7 @@ void POCOWebClient::Delete(HttpRequest& Request)
 
 	AddCookie(PocoRequest);
 
-	const std::string Body(Request.GetPayload().GetContent());
+	const std::string Body(Request.GetPayload().GetContent().c_str());
 	PocoRequest.setContentLength(Body.length());
 	ClientSession.sendRequest(PocoRequest) << Body;
 

--- a/Library/src/Web/WebClient.cpp
+++ b/Library/src/Web/WebClient.cpp
@@ -394,24 +394,35 @@ void WebClient::PrintClientErrorResponseMessages(const HttpResponse& Response)
 	{
 		rapidjson::Document ResponseJson;
 		ResponseJson.Parse(ResponsePayload.c_str());
-		if (ResponseJson.HasMember("errors"))
-		{
-			const auto ResponseArray = ResponseJson["errors"].GetObject().FindMember("")->value.GetArray();
 
-			for (uint32_t i = 0; i < ResponseArray.Size(); i++)
+		if (ResponseJson.IsObject())
+		{
+			if (ResponseJson.HasMember("errors"))
+			{
+				const auto ResponseArray = ResponseJson["errors"].GetObject().FindMember("")->value.GetArray();
+
+				for (uint32_t i = 0; i < ResponseArray.Size(); i++)
+				{
+					FOUNDATION_LOG_ERROR_FORMAT("Services request %s has returned a failed response (%i) with error: %s",
+												Response.GetRequest()->GetUri().GetAsString(),
+												ResponseCode,
+												ResponseArray[i].GetString());
+				}
+			}
+			else if (ResponseJson.HasMember("error"))
 			{
 				FOUNDATION_LOG_ERROR_FORMAT("Services request %s has returned a failed response (%i) with error: %s",
 											Response.GetRequest()->GetUri().GetAsString(),
 											ResponseCode,
-											ResponseArray[i].GetString());
+											ResponseJson["error"].GetString());
 			}
 		}
-		else if (ResponseJson.HasMember("error"))
+		else
 		{
 			FOUNDATION_LOG_ERROR_FORMAT("Services request %s has returned a failed response (%i) with error: %s",
 										Response.GetRequest()->GetUri().GetAsString(),
 										ResponseCode,
-										ResponseJson["error"].GetString());
+										ResponsePayload.c_str());
 		}
 	}
 }

--- a/Library/src/Web/WebClient.cpp
+++ b/Library/src/Web/WebClient.cpp
@@ -263,7 +263,7 @@ void WebClient::ProcessResponses(const uint32_t MaxNumResponses)
 
 		if (!Request->Cancelled() && Callback)
 		{
-			const HttpResponse& Response = Request->GetResponse();
+			auto& Response = Request->GetMutableResponse();
 			Callback->OnHttpResponse(Response);
 		}
 
@@ -279,7 +279,7 @@ void WebClient::ProcessRequest(HttpRequest* Request)
 {
 	if (Request)
 	{
-		auto Payload = Request->GetPayload();
+		auto& Payload = Request->GetMutablePayload();
 		Payload.SetBearerToken();
 
 		const std::chrono::milliseconds SendDelay = Request->GetSendDelay();
@@ -317,7 +317,7 @@ void WebClient::ProcessRequest(HttpRequest* Request)
 			Request->SetResponseProgress(100.0f);
 		}
 
-		const HttpResponse& Response = Request->GetResponse();
+		auto& Response = Request->GetMutableResponse();
 
 		// Attempt Auto-retry if needed
 		bool RetryIssued = Request->CheckForAutoRetry();

--- a/Tests/Web/html/index.js
+++ b/Tests/Web/html/index.js
@@ -17,9 +17,9 @@ import { runTests } from './test_framework.js'
 
 async function runAllTests() {
     var options = new CspOptions();
-    options.wrapperUrl = "http://localhost:8080/node_modules/@magnopus/com.magnopus.olympus.foundation.web/Debug/OlympusFoundation_WASM.js";
-    options.wasmUrl = "http://localhost:8080/node_modules/@magnopus/com.magnopus.olympus.foundation.web/Debug/OlympusFoundation_WASM.wasm";
-    options.workerUrl = "http://localhost:8080/node_modules/@magnopus/com.magnopus.olympus.foundation.web/Debug/OlympusFoundation_WASM.worker.js";
+    options.wrapperUrl = "http://localhost:8080/node_modules/@magnopus-opensource/connected-spaces-platform.web/Debug/OlympusFoundation_WASM.js";
+    options.wasmUrl = "http://localhost:8080/node_modules/@magnopus-opensource/connected-spaces-platform.web/Debug/OlympusFoundation_WASM.wasm";
+    options.workerUrl = "http://localhost:8080/node_modules/@magnopus-opensource/connected-spaces-platform.web/Debug/OlympusFoundation_WASM.worker.js";
 
     var Module = await ready(options);
     console.log(`Foundation build Id: ${CSPFoundation.getBuildID()}`);

--- a/Tests/Web/html/olympus_foundation.js
+++ b/Tests/Web/html/olympus_foundation.js
@@ -1,1 +1,1 @@
-export * from './node_modules/@magnopus/com.magnopus.olympus.foundation.web/olympus.foundation.js'
+export * from './node_modules/@magnopus-opensource/connected-spaces-platform.web/olympus.foundation.js'

--- a/Tests/Web/html/package.json
+++ b/Tests/Web/html/package.json
@@ -6,6 +6,6 @@
   "author": "Michael Kelley",
   "license": "MIT",
   "dependencies": {
-    "@magnopus/com.magnopus.olympus.foundation.web": "^3.1.315"
+    "@magnopus-opensource/connected-spaces-platform.web": "4.5.1"
   }
 }

--- a/Tests/Web/html/tests/settingssystem_tests.js
+++ b/Tests/Web/html/tests/settingssystem_tests.js
@@ -5,7 +5,7 @@ import { createSpace } from './spacesystem_tests_helpers.js';
 
 import { freeBuffer, uint8ArrayToBuffer, Systems, Common } from '../olympus_foundation.js';
 import { createBufferAssetDataSource} from './assetsystem_tests_helpers.js'
-import { bufferToUint8Array } from '../node_modules/@magnopus/com.magnopus.olympus.foundation.web/olympus.foundation.js';
+import { bufferToUint8Array } from '../node_modules/@magnopus-opensource/connected-spaces-platform.web/olympus.foundation.js';
 
 
 test('SettingsSystemTests', 'BlockSpaceTest', async function() {

--- a/Tests/src/InternalTests/SpaceHelperTests.cpp
+++ b/Tests/src/InternalTests/SpaceHelperTests.cpp
@@ -13,15 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "CSP/Systems/Assets/AssetCollection.h"
 #include "signalrclient/signalr_value.h"
+
+
 #if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_SPACE_HELPER_TESTS)
 
 	#include "Services/ApiBase/ApiBase.h"
 	#include "Systems/Spaces/SpaceSystemHelpers.h"
 	#include "TestHelpers.h"
 
+
 using namespace csp::services;
+
 
 CSP_INTERNAL_TEST(CSPEngine, SpaceHelperTests, SpaceGetSpaceMetadataAssetCollectionNameTest)
 {
@@ -209,6 +214,5 @@ CSP_INTERNAL_TEST(CSPEngine, SpaceHelperTests, ConvertJsonMetadataToMapMetadataO
 
 	EXPECT_EQ(ObjectMetaDataMap[MetaDataSiteKey], MetaSiteData);
 }
-
 
 #endif

--- a/Tests/src/InternalTests/WebClientTests.cpp
+++ b/Tests/src/InternalTests/WebClientTests.cpp
@@ -39,7 +39,7 @@ public:
 	{
 	}
 
-	void OnHttpResponse(const csp::web::HttpResponse& InResponse) override
+	void OnHttpResponse(csp::web::HttpResponse& InResponse) override
 	{
 		// We expect the callback to have come from a seperate Thread
 		EXPECT_FALSE(std::this_thread::get_id() == ThreadId);
@@ -172,7 +172,7 @@ public:
 	{
 	}
 
-	void OnHttpResponse(const HttpResponse& InResponse) override
+	void OnHttpResponse(HttpResponse& InResponse) override
 	{
 		// Check that callbacks are called from the same thread as we poll from
 		EXPECT_TRUE(ThreadId == std::this_thread::get_id());
@@ -433,7 +433,7 @@ public:
 	{
 	}
 
-	void OnHttpResponse(const HttpResponse& InResponse) override
+	void OnHttpResponse(HttpResponse& InResponse) override
 	{
 		// We expect the callback to have come from a seperate Thread
 		EXPECT_FALSE(std::this_thread::get_id() == ThreadId);

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1907,7 +1907,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceThumbnailWithGuestUserTest)
 	}
 
 	{
-		// but it should be able to retrieve it
+		// But it should be able to retrieve it
 		auto [Result] = AWAIT_PRE(SpaceSystem, GetSpaceThumbnail, RequestPredicate, Space.Id);
 
 		EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);

--- a/Tools/WrapperGenerator/Templates/C/GeneratedWrapper.mustache
+++ b/Tools/WrapperGenerator/Templates/C/GeneratedWrapper.mustache
@@ -18,7 +18,7 @@
 extern "C"
 {
     typedef struct {
-        void* Pointer;
+        const void* Pointer;
         bool OwnsOwnData;
     } NativePointer;
 


### PR DESCRIPTION
* Add `String` move ctor/op, and fix copy ctor/op
* `AssetDataResult` now uses underlying `ResponseBody` property instead of making a copy of the data.
* `UriResult` no longer copies headers when trying to read a single header value.
* Updated Web tests to use CSP 4.5.1
* Fixed CSP for Web paths in Web tests

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
