### PR TITLE
[OB-2804] fix: Handle non-JSON error responses

### DIFF
--- a/Library/src/Web/HttpPayload.cpp
+++ b/Library/src/Web/HttpPayload.cpp
@@ -207,4 +207,18 @@ void HttpPayload::SetBoundary(const csp::common::String& InBoundary)
 	Boundary = InBoundary;
 }
 
+const bool HttpPayload::IsJsonPayload() const
+{
+	const auto ContentTypeHeader = Headers.find("content-type");
+	if (ContentTypeHeader == Headers.end())
+	{
+		return false;
+	}
+	else
+	{
+		csp::common::String ContentType = ContentTypeHeader->second.c_str();
+		return ContentType.Split(';')[0] == "application/json";
+	}
+}
+
 } // namespace csp::web

--- a/Library/src/Web/HttpPayload.cpp
+++ b/Library/src/Web/HttpPayload.cpp
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+#include <regex>
 #include <sstream>
 
 namespace csp::web
@@ -207,17 +208,18 @@ void HttpPayload::SetBoundary(const csp::common::String& InBoundary)
 	Boundary = InBoundary;
 }
 
+// This checks not only for "application/json" but also covers cases like "application/graphql+json" and "application/problem+json"
 const bool HttpPayload::IsJsonPayload() const
 {
-	const auto ContentTypeHeader = Headers.find("content-type");
+	const auto& ContentTypeHeader = Headers.find("content-type");
 	if (ContentTypeHeader == Headers.end())
 	{
 		return false;
 	}
 	else
 	{
-		csp::common::String ContentType = ContentTypeHeader->second.c_str();
-		return ContentType.Split(';')[0] == "application/json";
+		std::regex Regex("^application\\/([a-z]+\\+)?json");
+		return std::regex_search(ContentTypeHeader->second.c_str(), Regex);
 	}
 }
 

--- a/Library/src/Web/HttpPayload.cpp
+++ b/Library/src/Web/HttpPayload.cpp
@@ -209,7 +209,7 @@ void HttpPayload::SetBoundary(const csp::common::String& InBoundary)
 }
 
 // This checks not only for "application/json" but also covers cases like "application/graphql+json" and "application/problem+json"
-const bool HttpPayload::IsJsonPayload() const
+bool HttpPayload::IsJsonPayload() const
 {
 	const auto& ContentTypeHeader = Headers.find("content-type");
 	if (ContentTypeHeader == Headers.end())

--- a/Library/src/Web/HttpPayload.h
+++ b/Library/src/Web/HttpPayload.h
@@ -71,7 +71,7 @@ public:
 
 	void SetBoundary(const csp::common::String& InBoundary);
 
-	const bool IsJsonPayload() const;
+	bool IsJsonPayload() const;
 
 private:
 	HeadersMap Headers;

--- a/Library/src/Web/HttpPayload.h
+++ b/Library/src/Web/HttpPayload.h
@@ -71,6 +71,8 @@ public:
 
 	void SetBoundary(const csp::common::String& InBoundary);
 
+	const bool IsJsonPayload() const;
+
 private:
 	HeadersMap Headers;
 	csp::common::String Content;

--- a/Library/src/Web/WebClient.cpp
+++ b/Library/src/Web/WebClient.cpp
@@ -390,7 +390,7 @@ void WebClient::PrintClientErrorResponseMessages(const HttpResponse& Response)
 									Response.GetRequest()->GetUri().GetAsString(),
 									ResponseCode);
 	}
-	else
+	else if (Response.GetPayload().IsJsonPayload())
 	{
 		rapidjson::Document ResponseJson;
 		ResponseJson.Parse(ResponsePayload.c_str());
@@ -413,6 +413,13 @@ void WebClient::PrintClientErrorResponseMessages(const HttpResponse& Response)
 										ResponseCode,
 										ResponseJson["error"].GetString());
 		}
+	}
+	else
+	{
+		FOUNDATION_LOG_ERROR_FORMAT("Services request %s has returned a failed response (%i) with payload/error message: %s",
+									Response.GetRequest()->GetUri().GetAsString(),
+									ResponseCode,
+									ResponsePayload.c_str());
 	}
 }
 } // namespace csp::web

--- a/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
+++ b/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
@@ -35,8 +35,6 @@ bool RequestPredicate(const csp::services::ResultBase& Result)
 
 } // namespace
 
-
-
 #if RUN_ALL_UNIT_TESTS || RUN_GRAPHQLSYSTEM_TESTS || RUN_GRAPHQLSYSTEM_QUERY_TEST
 CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, QueryTest)
 {
@@ -81,6 +79,56 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, QueryTest)
 
 	// Delete Space
 	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log Out
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_GRAPHQLSYSTEM_TESTS || RUN_GRAPHQLSYSTEM_QUERY_BADINPUT_TEST
+CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunQueryBadInputTest)
+{
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto GraphQLSystem	 = SystemsManager.GetGraphQLSystem();
+	auto UserSystem		 = SystemsManager.GetUserSystem();
+	auto SpaceSystem	 = SystemsManager.GetSpaceSystem();
+
+	csp::common::String UserId;
+
+	// Log in
+	LogIn(UserSystem, UserId);
+
+	csp::common::String testQuery = "badQuery";
+
+	auto [Result] = AWAIT_PRE(GraphQLSystem, RunQuery, RequestPredicate, testQuery);
+
+	// Search Space Name
+	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Failed);
+
+	// Log Out
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_GRAPHQLSYSTEM_TESTS || RUN_GRAPHQLSYSTEM_REQUEST_BADINPUT_TEST
+CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunRequestBadInputTest)
+{
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto GraphQLSystem	 = SystemsManager.GetGraphQLSystem();
+	auto UserSystem		 = SystemsManager.GetUserSystem();
+	auto SpaceSystem	 = SystemsManager.GetSpaceSystem();
+
+	csp::common::String UserId;
+
+	// Log in
+	LogIn(UserSystem, UserId);
+
+	csp::common::String testQuery = "badRequest";
+
+	auto [Result] = AWAIT_PRE(GraphQLSystem, RunRequest, RequestPredicate, testQuery);
+
+	// Search Space Name
+	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Failed);
 
 	// Log Out
 	LogOut(UserSystem);

--- a/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
+++ b/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
@@ -94,18 +94,12 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunQueryBadInputTest)
 	auto SpaceSystem	 = SystemsManager.GetSpaceSystem();
 
 	csp::common::String UserId;
-
-	// Log in
 	LogIn(UserSystem, UserId);
 
 	csp::common::String testQuery = "badQuery";
-
-	auto [Result] = AWAIT_PRE(GraphQLSystem, RunQuery, RequestPredicate, testQuery);
-
-	// Search Space Name
+	auto [Result]				  = AWAIT_PRE(GraphQLSystem, RunQuery, RequestPredicate, testQuery);
 	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Failed);
 
-	// Log Out
 	LogOut(UserSystem);
 }
 #endif
@@ -119,18 +113,12 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunRequestBadInputTest)
 	auto SpaceSystem	 = SystemsManager.GetSpaceSystem();
 
 	csp::common::String UserId;
-
-	// Log in
 	LogIn(UserSystem, UserId);
 
 	csp::common::String testQuery = "badRequest";
-
-	auto [Result] = AWAIT_PRE(GraphQLSystem, RunRequest, RequestPredicate, testQuery);
-
-	// Search Space Name
+	auto [Result]				  = AWAIT_PRE(GraphQLSystem, RunRequest, RequestPredicate, testQuery);
 	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Failed);
 
-	// Log Out
 	LogOut(UserSystem);
 }
 #endif

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -181,6 +181,19 @@ void ValidateThirdPartyAuthoriseURL(const csp::common::String& AuthoriseURL, con
 	EXPECT_EQ(RetrievedRedirectURL, RedirectURL.c_str());
 }
 
+#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_EXCHANGEKEY_BADINPUT_TEST
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ExchangeKeyBadInputTest)
+{
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+
+	auto [Result] = AWAIT_PRE(UserSystem, UserSystem::ExchangeKey, RequestPredicate, "userId", "key");
+
+	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Failed);
+}
+#endif
+
+
 #if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_FORGOTPASSWORD_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)
 {


### PR DESCRIPTION
This adds a function to HttpPayload to check if the payload has a JSON mime-type. This is then used when printing error messages to check if an error response is JSON formatted before trying to parse it as JSON. If it is not JSON then it is simply printed as is.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
