### PR TITLE
[NT-0] doc: changing tenant language from key to ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ Build instructions for each supported language are below.
 
 ****
 
-## 🔑 Tenant Keys
+## 🔑 Tenant IDs
 
-If you choose to use the Connected Spaces Platform in conjunction with Magnopus Cloud Services, you'll need a Tenant Key.
+If you choose to use the Connected Spaces Platform in conjunction with Magnopus Cloud Services, you'll need a Tenant ID.
 
 For information on how to obtain one, head over here.
 
- - [Obtaining a Tenant Key](https://www.magnopus.com/csp/for-developers#tenant-key)
+ - [Obtaining a Tenant ID](https://www.magnopus.com/csp/for-developers#tenant-id)
 ****
 
 ## 🖥️ Usage


### PR DESCRIPTION
Updating language used to describe tenant keys to be tenant IDs on the readme, at the request of our services team. We're also making the same change on the website.