### PR TITLE
[OB-2864] fix: Expose parameter for reset password

### DIFF
--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -180,11 +180,11 @@ public:
 	/// @brief Allow a user to reset their password if forgotten by providing an email address.
 	/// @param Email csp::common::String : account to recover password for
 	/// @param RedirectUrl csp::common::Optional<csp::common::String> : the URL to redirect the user to after they have registered
-	/// @Param UseTokenChangePasswordUrl bool : Whether to have the link in the email direct to the Token Change URL
+	/// @Param UseTokenChangePasswordUrl bool : if true the link in the email will direct the user to the Token Change URL
 	/// @param Callback NullResultCallback : callback to call when a response is received
 	CSP_ASYNC_RESULT void ForgotPassword(const csp::common::String& Email,
 										 const csp::common::Optional<csp::common::String>& RedirectUrl,
-										 const bool UseTokenChangePasswordUrl,
+										 bool UseTokenChangePasswordUrl,
 										 NullResultCallback Callback);
 
 	/// @brief Get a user profile by user ID.

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -180,9 +180,12 @@ public:
 	/// @brief Allow a user to reset their password if forgotten by providing an email address.
 	/// @param Email csp::common::String : account to recover password for
 	/// @param RedirectUrl csp::common::Optional<csp::common::String> : the URL to redirect the user to after they have registered
+	/// @Param UseTokenChangePasswordUrl bool : Whether to have the link in the email direct to the Token Change URL
 	/// @param Callback NullResultCallback : callback to call when a response is received
-	CSP_ASYNC_RESULT void
-		ForgotPassword(const csp::common::String& Email, const csp::common::Optional<csp::common::String>& RedirectUrl, NullResultCallback Callback);
+	CSP_ASYNC_RESULT void ForgotPassword(const csp::common::String& Email,
+										 const csp::common::Optional<csp::common::String>& RedirectUrl,
+										 const bool UseTokenChangePasswordUrl,
+										 NullResultCallback Callback);
 
 	/// @brief Get a user profile by user ID.
 	/// @param InUserId csp::common::String : the ID of the user to get

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -502,6 +502,7 @@ bool UserSystem::EmailCheck(const std::string& Email) const
 
 void UserSystem::ForgotPassword(const csp::common::String& Email,
 								const csp::common::Optional<csp::common::String>& RedirectUrl,
+								const bool UseTokenChangePasswordUrl,
 								NullResultCallback Callback)
 {
 	if (EmailCheck(Email.c_str()))
@@ -522,7 +523,8 @@ void UserSystem::ForgotPassword(const csp::common::String& Email,
 																									  nullptr,
 																									  csp::web::EResponseCodes::ResponseNoContent);
 
-		static_cast<chs::ProfileApi*>(ProfileAPI)->apiV1UsersForgotPasswordPost(RedirectUrlValue, true, Request, ResponseHandler);
+		static_cast<chs::ProfileApi*>(ProfileAPI)
+			->apiV1UsersForgotPasswordPost(RedirectUrlValue, UseTokenChangePasswordUrl, Request, ResponseHandler);
 	}
 	else
 	{

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -502,7 +502,7 @@ bool UserSystem::EmailCheck(const std::string& Email) const
 
 void UserSystem::ForgotPassword(const csp::common::String& Email,
 								const csp::common::Optional<csp::common::String>& RedirectUrl,
-								const bool UseTokenChangePasswordUrl,
+								bool UseTokenChangePasswordUrl,
 								NullResultCallback Callback)
 {
 	if (EmailCheck(Email.c_str()))

--- a/Tests/CSharp/src/Tests/UserSystemTests.cs
+++ b/Tests/CSharp/src/Tests/UserSystemTests.cs
@@ -182,20 +182,40 @@ namespace CSPEngine
         {
             GetFoundationSystems(out var userSystem, out _, out _, out _, out _, out _, out _, out _, out _, out _);
 
+            // Tests passing false for UseTokenChangePasswordUrl
             {
-                using var result = userSystem.ForgotPassword("testnopus.pokemon@magnopus.com",null).Result;
+                using var result = userSystem.ForgotPassword("testnopus.pokemon@magnopus.com", null, false).Result;
 
                 Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Success);
             }
 
             {
-                using var result = userSystem.ForgotPassword("testnopus.pokemon+1@magnopus.com",null).Result;
+                using var result = userSystem.ForgotPassword("testnopus.pokemon+1@magnopus.com", null, false).Result;
 
                 Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Success);
             }
 
             {
-                using var result = userSystem.ForgotPassword("email",null).Result;
+                using var result = userSystem.ForgotPassword("email", null, false).Result;
+
+                Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Failed);
+            }
+
+            // Tests passing true for UseTokenChangePasswordUrl
+            {
+                using var result = userSystem.ForgotPassword("testnopus.pokemon@magnopus.com", null, true).Result;
+
+                Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Success);
+            }
+
+            {
+                using var result = userSystem.ForgotPassword("testnopus.pokemon+1@magnopus.com", null, true).Result;
+
+                Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Success);
+            }
+
+            {
+                using var result = userSystem.ForgotPassword("email", null, true).Result;
 
                 Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Failed);
             }
@@ -418,7 +438,7 @@ namespace CSPEngine
 
             // Create new user
             {
-                using var result = userSystem.CreateUser(uniqueUserName, testDisplayName, uniqueTestEmail, GeneratedTestAccountPassword, true, null,null).Result;
+                using var result = userSystem.CreateUser(uniqueUserName, testDisplayName, uniqueTestEmail, GeneratedTestAccountPassword, true, null, null).Result;
                 var resCode = result.GetResultCode();
 
                 Assert.AreEqual(resCode, Services.EResultCode.Success);
@@ -561,8 +581,8 @@ namespace CSPEngine
 #if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GET_SUPPORTED_PROVIDERS_TEST
         [Test]
         public static void GetThirdPartySupportedProvidersTest()
-{
-	GetFoundationSystems(out var userSystem, out _, out _, out _, out _, out _, out _, out _, out _, out _);
+        {
+            GetFoundationSystems(out var userSystem, out _, out _, out _, out _, out _, out _, out _, out _, out _);
 
             // Check the FDN supported providers
             using var supportedProviders = userSystem.GetSupportedThirdPartyAuthenticationProviders();
@@ -571,7 +591,7 @@ namespace CSPEngine
             bool foundGoogle = false;
             bool foundDiscord = false;
             bool foundApple = false;
-            
+
             for (uint idx = 0; idx < supportedProviders.Size(); ++idx)
             {
                 if (supportedProviders[idx] == Systems.EThirdPartyAuthenticationProviders.Google)

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -200,17 +200,31 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
 	auto* UserSystem	 = SystemsManager.GetUserSystem();
 
-	auto [Result] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "testnopus.pokemon@magnopus.com", nullptr);
+	// Tests passing false for UseTokenChangePasswordUrl
+	auto [Result] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "testnopus.pokemon@magnopus.com", nullptr, false);
 
 	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);
 
-	auto [Result2] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "testnopus.pokemon+1@magnopus.com", nullptr);
+	auto [Result2] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "testnopus.pokemon+1@magnopus.com", nullptr, false);
 
 	EXPECT_EQ(Result2.GetResultCode(), csp::services::EResultCode::Success);
 
-	auto [FailResult] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "email", nullptr);
+	auto [FailResult] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "email", nullptr, false);
 
 	EXPECT_EQ(FailResult.GetResultCode(), csp::services::EResultCode::Failed);
+
+	// Tests passing true for UseTokenChangePasswordUrl
+	auto [Result3] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "testnopus.pokemon@magnopus.com", nullptr, true);
+
+	EXPECT_EQ(Result3.GetResultCode(), csp::services::EResultCode::Success);
+
+	auto [Result4] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "testnopus.pokemon+1@magnopus.com", nullptr, true);
+
+	EXPECT_EQ(Result4.GetResultCode(), csp::services::EResultCode::Success);
+
+	auto [FailResult2] = AWAIT_PRE(UserSystem, UserSystem::ForgotPassword, RequestPredicate, "email", nullptr, true);
+
+	EXPECT_EQ(FailResult2.GetResultCode(), csp::services::EResultCode::Failed);
 }
 #endif
 


### PR DESCRIPTION
Expose parameter for reset password to define whether link in Email should direct to token change URL.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
