### PR TITLE
[OF-1151] feat!: Add email link for user invite

### DIFF
--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -174,8 +174,8 @@ public:
 	/// @param Space Space : space to invite to
 	/// @param Email csp::common::String : email to invite to space
 	/// @param IsModeratorRole csp::common::Optional<bool> : if present and true sets the user's role in the space to "Moderator", pass false or
-	/// @param EmailLinkUrl csp::common::Optional<csp::common::String> : link that will be provided in the invite email
 	/// nullptr to leave role as default
+	/// @param EmailLinkUrl csp::common::Optional<csp::common::String> : link that will be provided in the invite email
 	/// @param Callback NullResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void InviteToSpace(const csp::common::String& SpaceId,
 										const csp::common::String& Email,

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -89,14 +89,15 @@ public:
 	/// @param Name csp::common::String : name for the new space
 	/// @param Description csp::common::String : description for the new space
 	/// @param Type csp::systems::SpaceType : type of the new space
-	/// @param InviteUsers csp::common::Array<csp::systems::InviteUserRoleInfo> : optional array of users to be invited into the space
+	/// @param InviteUsers csp::common::Optional<InviteUserRoleInfoCollection> : Collection containing the email link URL and the users to invite with
+	/// their emails and roles
 	/// @param Metadata csp::common::String : metadata information for the new space
 	/// @param FileThumbnail csp::systems::FileAssetDataSource : optional thumbnail image for the new space
 	/// @param Callback csp::systems::SpaceResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void CreateSpace(const csp::common::String& Name,
 									  const csp::common::String& Description,
 									  SpaceAttributes Attributes,
-									  const csp::common::Optional<csp::common::Array<csp::systems::InviteUserRoleInfo>>& InviteUsers,
+									  const csp::common::Optional<InviteUserRoleInfoCollection>& InviteUsers,
 									  const csp::common::Map<csp::common::String, csp::common::String>& Metadata,
 									  const csp::common::Optional<csp::systems::FileAssetDataSource>& FileThumbnail,
 									  SpaceResultCallback Callback);
@@ -105,14 +106,15 @@ public:
 	/// @param Name csp::common::String : name for the new space
 	/// @param Description csp::common::String : description for the new space
 	/// @param Type csp::systems::SpaceType : type of the new space
-	/// @param InviteUsers csp::common::Array<csp::systems::InviteUserRoleInfo> : optional array of users to be invited into the space
+	/// @param InviteUsers csp::common::Optional<InviteUserRoleInfoCollection> : Collection containing the email link URL and the users to invite with
+	/// their emails and roles
 	/// @param Metadata csp::common::String : metadata information for the new space
 	/// @param Thumbnail csp::systems::BufferAssetDataSource : thumbnail image buffer for the new space
 	/// @param Callback csp::systems::SpaceResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void CreateSpaceWithBuffer(const csp::common::String& Name,
 												const csp::common::String& Description,
 												SpaceAttributes Attributes,
-												const csp::common::Optional<csp::common::Array<csp::systems::InviteUserRoleInfo>>& InviteUsers,
+												const csp::common::Optional<InviteUserRoleInfoCollection>& InviteUsers,
 												const csp::common::Map<csp::common::String, csp::common::String>& Metadata,
 												const csp::systems::BufferAssetDataSource& Thumbnail,
 												SpaceResultCallback Callback);
@@ -172,19 +174,21 @@ public:
 	/// @param Space Space : space to invite to
 	/// @param Email csp::common::String : email to invite to space
 	/// @param IsModeratorRole csp::common::Optional<bool> : if present and true sets the user's role in the space to "Moderator", pass false or
+	/// @param EmailLinkUrl csp::common::Optional<csp::common::String> : link that will be provided in the invite email
 	/// nullptr to leave role as default
 	/// @param Callback NullResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void InviteToSpace(const csp::common::String& SpaceId,
 										const csp::common::String& Email,
 										const csp::common::Optional<bool>& IsModeratorRole,
+										const csp::common::Optional<csp::common::String>& EmailLinkUrl,
 										NullResultCallback Callback);
 
 	/// @brief Invites all the given emails to a specific space.
 	/// @param Space Space : space to invite to
-	/// @param InviteUsers csp::common::Array<InviteUserRoleInfo> : Array of users to invite with their email and role
+	/// @param InviteUsers InviteUserRoleInfoCollection : Collection containing the email link URL and the users to invite with their emails and roles
 	/// @param Callback NullResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void
-		BulkInviteToSpace(const csp::common::String& SpaceId, const csp::common::Array<InviteUserRoleInfo>& InviteUsers, NullResultCallback Callback);
+		BulkInviteToSpace(const csp::common::String& SpaceId, const InviteUserRoleInfoCollection& InviteUsers, NullResultCallback Callback);
 
 	/// @brief Returns an array of obfuscated email addresses, addresses of users that have not yet accepted the space invite
 	/// @param Space Space : Space for which the invites where sent

--- a/Library/include/CSP/Systems/Spaces/UserRoles.h
+++ b/Library/include/CSP/Systems/Spaces/UserRoles.h
@@ -56,7 +56,7 @@ public:
 };
 
 /// @ingroup Space System
-/// @brief Data representation of User Roles inside a space
+/// @brief Data representation of roles for an invited user inside a space
 class CSP_API InviteUserRoleInfo
 {
 public:
@@ -65,6 +65,18 @@ public:
 
 	csp::common::String UserEmail;
 	SpaceUserRole UserRole;
+};
+
+/// @ingroup Space System
+/// @brief Data representation of roles for a group of invited users and the email link to be included in the invite emails
+class CSP_API InviteUserRoleInfoCollection
+{
+public:
+	InviteUserRoleInfoCollection()											= default;
+	InviteUserRoleInfoCollection(const InviteUserRoleInfoCollection& Other) = default;
+
+	csp::common::String EmailLinkUrl;
+	csp::common::Array<InviteUserRoleInfo> InviteUserRoleInfos;
 };
 
 

--- a/Tests/CSharp/src/Tests/ConversationSystemTests.cs
+++ b/Tests/CSharp/src/Tests/ConversationSystemTests.cs
@@ -40,7 +40,7 @@ namespace CSPEngine
 
             // Add the second test user to the space
             {
-                using var result = spaceSystem.InviteToSpace(space.Id, UserSystemTests.AlternativeLoginEmail, true).Result;
+                using var result = spaceSystem.InviteToSpace(space.Id, UserSystemTests.AlternativeLoginEmail, true, "").Result;
 
                 Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Success);
             }
@@ -343,7 +343,7 @@ namespace CSPEngine
 
             // Add the second test user to the space
             {
-                using var result = spaceSystem.InviteToSpace(space.Id, UserSystemTests.AlternativeLoginEmail, true).Result;
+                using var result = spaceSystem.InviteToSpace(space.Id, UserSystemTests.AlternativeLoginEmail, true, "").Result;
 
                 Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Success);
             }

--- a/Tests/CSharp/src/Tests/MultiplayerTests.cs
+++ b/Tests/CSharp/src/Tests/MultiplayerTests.cs
@@ -325,11 +325,13 @@ namespace CSPEngine
             // Log in
             _ = userSystem.TestLogIn(UserSystemTests.AlternativeLoginEmail, UserSystemTests.AlternativeLoginPassword, Services.EResultCode.Success, false);
 
-            // Create space
-            var InviteUser1 = new Systems.InviteUserRoleInfo { UserEmail = UserSystemTests.DefaultLoginEmail, UserRole = Systems.SpaceUserRole.User };
-            Systems.InviteUserRoleInfo[] InviteUsers = { InviteUser1 };
+            var InviteUsers = new Systems.InviteUserRoleInfoCollection();
+            InviteUsers.EmailLinkUrl = "https://dev.magnoverse.space";
+            InviteUsers.InviteUserRoleInfos = new Csp.Common.Array<Systems.InviteUserRoleInfo>(1);
+            InviteUsers.InviteUserRoleInfos[0] = new Systems.InviteUserRoleInfo { UserEmail = UserSystemTests.DefaultLoginEmail, UserRole = Systems.SpaceUserRole.User };
 
-            var space = SpaceSystemTests.CreateSpace(spaceSystem, spaceName, spaceDescription, Systems.SpaceAttributes.Private, null, InviteUsers.ToFoundationArray(), null, pushCleanupFunction: false);
+            // Create space
+            var space = SpaceSystemTests.CreateSpace(spaceSystem, spaceName, spaceDescription, Systems.SpaceAttributes.Private, null, InviteUsers, null, pushCleanupFunction: false);
 
             var connection = CreateMultiplayerConnection(space.Id, false);
             var entitySystem = connection.GetSpaceEntitySystem();

--- a/Tests/CSharp/src/Tests/SpaceSystemTests.cs
+++ b/Tests/CSharp/src/Tests/SpaceSystemTests.cs
@@ -35,7 +35,7 @@ namespace CSPEngine
         /// <remarks>Automatically deletes and disposes the created space after each test unless otherwise specified.</remarks>
         public static Systems.Space CreateSpace(Systems.SpaceSystem spaceSystem, string name, string description,
             Systems.SpaceAttributes spaceAttributes, Common.Map<string, string>? spaceMetadata, 
-            Common.Array<Systems.InviteUserRoleInfo>? inviteUsers, Systems.FileAssetDataSource? thumbnail,
+            Systems.InviteUserRoleInfoCollection? inviteUsers, Systems.FileAssetDataSource? thumbnail,
             bool pushCleanupFunction = true, bool disposeFoundationResources = true)
         {
             var testMetadata = spaceMetadata;
@@ -65,7 +65,7 @@ namespace CSPEngine
         /// <remarks>Automatically deletes and disposes the created space after each test unless otherwise specified.</remarks>
         public static Systems.Space CreateSpaceWithBuffer(Systems.SpaceSystem spaceSystem, string name, string description,
             Systems.SpaceAttributes spaceAttributes, Common.Map<string, string>? spaceMetadata,
-            Common.Array<Systems.InviteUserRoleInfo>? inviteUsers, Systems.BufferAssetDataSource thumbnail,
+            Systems.InviteUserRoleInfoCollection? inviteUsers, Systems.BufferAssetDataSource thumbnail,
             bool pushCleanupFunction = true, bool disposeFoundationResources = true)
         {
             var testMetadata = spaceMetadata;
@@ -290,7 +290,7 @@ namespace CSPEngine
             return (fileName == uriFileName);
         }
 
-        static Common.Array<Systems.InviteUserRoleInfo> CreateInviteUsers()
+        static Systems.InviteUserRoleInfoCollection CreateInviteUsers()
         {
             // Create normal users
             var InviteUser1 = new Systems.InviteUserRoleInfo { UserEmail = "testnopus.pokemon+1@magnopus.com", UserRole = Systems.SpaceUserRole.User };
@@ -300,8 +300,15 @@ namespace CSPEngine
             var ModInviteUser1 = new Systems.InviteUserRoleInfo { UserEmail = "testnopus.pokemon+mod1@magnopus.com", UserRole = Systems.SpaceUserRole.Moderator };
             var ModInviteUser2 = new Systems.InviteUserRoleInfo { UserEmail = "testnopus.pokemon+mod2@magnopus.com", UserRole = Systems.SpaceUserRole.Moderator };
 
-            Systems.InviteUserRoleInfo[] InviteUsers = { InviteUser1, InviteUser2, ModInviteUser1, ModInviteUser2 };
-            return InviteUsers.ToFoundationArray<Systems.InviteUserRoleInfo>();
+            var InviteUsers = new Systems.InviteUserRoleInfoCollection();
+            InviteUsers.EmailLinkUrl = "https://dev.magnoverse.space";
+            InviteUsers.InviteUserRoleInfos = new Csp.Common.Array<Systems.InviteUserRoleInfo>(4);
+            InviteUsers.InviteUserRoleInfos[0] = InviteUser1;
+            InviteUsers.InviteUserRoleInfos[1] = InviteUser2;
+            InviteUsers.InviteUserRoleInfos[2] = ModInviteUser1;
+            InviteUsers.InviteUserRoleInfos[3] = ModInviteUser2;
+
+            return InviteUsers;
         }
 
 
@@ -1017,6 +1024,7 @@ namespace CSPEngine
 
             string testSpaceName = GenerateUniqueString("OLY-UNITTEST-SPACE-REWIND");
             string testSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+            string testEmailLinkUrl = "https://dev.magnoverse.space";
 
             // Log in with alt account first to get its ID
             var altUserId = userSystem.TestLogIn(email: UserSystemTests.AlternativeLoginEmail, password: UserSystemTests.AlternativeLoginPassword, pushCleanupFunction: false);
@@ -1027,7 +1035,7 @@ namespace CSPEngine
 
             using var space = CreateSpace(spaceSystem, testSpaceName, testSpaceDescription, Systems.SpaceAttributes.Public, null, null, null, pushCleanupFunction: false);
 
-            using var result = spaceSystem.InviteToSpace(space.Id, UserSystemTests.AlternativeLoginEmail, true).Result;
+            using var result = spaceSystem.InviteToSpace(space.Id, UserSystemTests.AlternativeLoginEmail, true, testEmailLinkUrl).Result;
             Assert.AreEqual(result.GetResultCode(), Services.EResultCode.Success);
 
             GetRoleForSpecificUser(spaceSystem, space, altUserId, out var userRoleInfo);
@@ -1261,12 +1269,13 @@ namespace CSPEngine
 
             string testSpaceName = GenerateUniqueString("OLY-UNITTEST-SPACE-REWIND");
             string testSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+            string testEmailLinkUrl = "https://dev.magnoverse.space";
 
             _ = UserSystemTests.LogIn(userSystem);
 
             var space = CreateSpace(spaceSystem, testSpaceName, testSpaceDescription, Systems.SpaceAttributes.Private, null, null, null);
 
-            using var result = spaceSystem.InviteToSpace(space.Id, "testnopus.pokemon@magnopus.com", null).Result;
+            using var result = spaceSystem.InviteToSpace(space.Id, "testnopus.pokemon@magnopus.com", null, testEmailLinkUrl).Result;
             var resCode = result.GetResultCode();
 
             Assert.AreEqual(resCode, Services.EResultCode.Success);

--- a/Tests/Web/html/tests/spacesystem_tests.js
+++ b/Tests/Web/html/tests/spacesystem_tests.js
@@ -45,7 +45,7 @@ test('SpaceSystemTests', 'CreateSpaceWithBulkInviteTest', async function() {
     assert.succeeded(pendingUserInvitesResult);
 
     const pendingUserInviteEmails = pendingUserInvitesResult.getPendingInvitesEmails();
-    assert.areEqual(pendingUserInviteEmails.size(), inviteUsers.size());
+    assert.areEqual(pendingUserInviteEmails.size(), inviteUsers.inviteUserRoleInfos.size());
 
     pendingUserInvitesResult.delete();
     inviteUsers.delete();
@@ -520,7 +520,7 @@ test('SpaceSystemTests', 'BulkInviteToSpaceTest', async function() {
     assert.succeeded(pendingUserInvitesResult);
 
     const pendingUserInviteEmails = pendingUserInvitesResult.getPendingInvitesEmails();
-    assert.areEqual(pendingUserInviteEmails.size(), inviteUsers.size());
+    assert.areEqual(pendingUserInviteEmails.size(), inviteUsers.inviteUserRoleInfos.size());
 
     pendingUserInvitesResult.delete();
     inviteUsers.delete();

--- a/Tests/Web/html/tests/spacesystem_tests_helpers.js
+++ b/Tests/Web/html/tests/spacesystem_tests_helpers.js
@@ -33,7 +33,7 @@ export async function deleteSpace(spaceSystem, space, deleteFoundationResources 
  * @param {!string} description 
  * @param {!Systems.SpaceAttributes} type 
  * @param {?Common.Map<string, string>} [metadata] 
- * @param {?Common.Array<Systems.InviteUserRoleInfo>} [inviteUsers]
+ * @param {?Systems.InviteUserRoleInfoCollection} [inviteUsers]
  * @param {?Systems.FileAssetDataSource} [thumbnail] 
  * @param {!boolean} [pushCleanup] 
  * @param {!boolean} [deleteFoundationResources] 
@@ -127,30 +127,32 @@ export async function updateSpace(spaceSystem, space, newName = null, newDescrip
 }
 
 export function createInviteUsers() {
-    const inviteUsers = Common.Array.ofcsp_systems_InviteUserRoleInfo_number(4);
+    const inviteUsers = Systems.InviteUserRoleInfoCollection.create();
+    inviteUsers.emailLinkUrl = "https://dev.magnoverse.space";
+    inviteUsers.inviteUserRoleInfos = Common.Array.ofcsp_systems_InviteUserRoleInfo_number(4);
 
     const inviteUser1 = Systems.InviteUserRoleInfo.create();
     inviteUser1.userEmail = "testnopus.pokemon+1@magnopus.com";
     inviteUser1.userRole = Systems.SpaceUserRole.User;
-    inviteUsers.set(0, inviteUser1);
+    inviteUsers.inviteUserRoleInfos.set(0, inviteUser1);
     inviteUser1.delete();
 
     const inviteUser2 = Systems.InviteUserRoleInfo.create();
     inviteUser2.userEmail = "testnopus.pokemon+2@magnopus.com";
     inviteUser2.userRole = Systems.SpaceUserRole.User;
-    inviteUsers.set(1, inviteUser2);
+    inviteUsers.inviteUserRoleInfos.set(1, inviteUser2);
     inviteUser2.delete();
 
     const modUser1 = Systems.InviteUserRoleInfo.create();
     modUser1.userEmail = "testnopus.pokemon+mod1@magnopus.com";
     modUser1.userRole = Systems.SpaceUserRole.Moderator;
-    inviteUsers.set(2, modUser1);
+    inviteUsers.inviteUserRoleInfos.set(2, modUser1);
     modUser1.delete();
 
     const modUser2 = Systems.InviteUserRoleInfo.create();
     modUser2.userEmail = "testnopus.pokemon+mod2@magnopus.com";
     modUser2.userRole = Systems.SpaceUserRole.Moderator;
-    inviteUsers.set(3, modUser2);
+    inviteUsers.inviteUserRoleInfos.set(3, modUser2);
     modUser2.delete();
 
     return inviteUsers;

--- a/Tests/src/PublicAPITests/ConversationSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ConversationSystemTests.cpp
@@ -230,7 +230,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, GetMessagesTest)
 	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
 
 	// add the second test user to the space
-	auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, AlternativeLoginEmail, true);
+	auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, AlternativeLoginEmail, true, "");
 	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);
 
 	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -446,7 +446,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, TwoConversationsTest)
 	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
 
 	// add the second test user to the space
-	auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, AlternativeLoginEmail, true);
+	auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, AlternativeLoginEmail, true, "");
 	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);
 
 	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);

--- a/Tests/src/PublicAPITests/SpaceSystemTestHelpers.h
+++ b/Tests/src/PublicAPITests/SpaceSystemTestHelpers.h
@@ -25,7 +25,7 @@ void CreateSpace(csp::systems::SpaceSystem* SpaceSystem,
 				 const csp::common::String& Description,
 				 csp::systems::SpaceAttributes SpaceAttributes,
 				 const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& SpaceMetadata,
-				 const csp::common::Optional<csp::common::Array<csp::systems::InviteUserRoleInfo>>& InviteUsers,
+				 const csp::common::Optional<csp::systems::InviteUserRoleInfoCollection>& InviteUsers,
 				 const csp::common::Optional<csp::systems::FileAssetDataSource>& Thumbnail,
 				 csp::systems::Space& OutSpace);
 void CreateSpaceWithBuffer(csp::systems::SpaceSystem* SpaceSystem,
@@ -33,7 +33,7 @@ void CreateSpaceWithBuffer(csp::systems::SpaceSystem* SpaceSystem,
 						   const csp::common::String& Description,
 						   csp::systems::SpaceAttributes SpaceAttributes,
 						   const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& SpaceMetadata,
-						   const csp::common::Optional<csp::common::Array<csp::systems::InviteUserRoleInfo>>& InviteUsers,
+						   const csp::common::Optional<csp::systems::InviteUserRoleInfoCollection>& InviteUsers,
 						   csp::systems::BufferAssetDataSource& Thumbnail,
 						   csp::systems::Space& OutSpace);
 void DeleteSpace(csp::systems::SpaceSystem* SpaceSystem, const csp::common::String& SpaceId);


### PR DESCRIPTION
This changes when there is an array of InviteUserRoleInfo to use a new InviteUserRoleInfoCollection. This collection class now includes an EmailLinkUrl parameter that can be provided to specify where to redirect a user back to. It is OK to leave this blank. This applies to the CreateSpace, CreateSpaceWithBuffer and BulkInviteToSpace calls.

The same thing is also added as a new optional parameter to the InviteToSpace call.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
