### PR TITLE
[OB-2914] fix: Fixed incorrect ordering in EAssetChangeType enum values for AssetDetailBlobChanged event

### DIFF
--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -52,8 +52,8 @@ enum class EAssetChangeType
 {
 	Created,
 	Updated,
-	Deleted,
 	MusubiFailed,
+	Deleted,
 	Invalid,
 	Num
 };


### PR DESCRIPTION
There was a mismatch in the values for the `ChangeType` used in the `AssetDetailBlobChanged` event between CSP and and the Magnopus Cloud Services. 

CSP used the `EAssetChangeType` enum ordered as follows:
```
{
	Created,
	Updated,
	Deleted,
	MusubiFailed,
	Invalid
};
```

Whereas the equivalent returned by Magnopus Cloud Services is ordered:
```
{
	Created,
	Updated,
	MusubiFailed,
	Deleted,
	Invalid
};
```
(Notice that the `Deleted` and `MusubiFailed` values are inverted).

This meant that clients were receiving `AssetDetailBlobChanged` events with a change type of `MusubiFailed` when an asset had been deleted and vice-versa when Musubi processing failed.

This change updates the `EAssetChangeType` to match the Magnopus Cloud Services equivalent.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
