### PR TITLE
[OF-1119] feat: add age verification flag

### DIFF
--- a/Library/include/CSP/Services/WebService.h
+++ b/Library/include/CSP/Services/WebService.h
@@ -96,9 +96,16 @@ public:
 	/// @return float
 	float GetResponseProgress() const;
 
+	/// @brief Get a code representing the failure reason, if relevant.
+	/// @return int
+	int GetFailureReason() const;
+
 protected:
 	ResultBase(csp::services::EResultCode ResCode, uint16_t HttpResCode);
+
 	void SetResult(csp::services::EResultCode ResCode, uint16_t HttpResCode);
+
+	virtual int ParseErrorCode(const csp::common::String& Value);
 
 	EResultCode Result		  = EResultCode::Init;
 	uint16_t HttpResponseCode = 0;
@@ -107,6 +114,7 @@ protected:
 	float ResponseProgress = 0.0f;
 
 	csp::common::String ResponseBody;
+	int FailureReason;
 };
 
 } // namespace csp::services

--- a/Library/include/CSP/Services/WebService.h
+++ b/Library/include/CSP/Services/WebService.h
@@ -59,6 +59,13 @@ enum class EResultCode : uint8_t
 };
 
 
+enum class EResultBaseFailureReason
+{
+	Unknown = -1,
+	None	= 0
+};
+
+
 /// @brief Base class for a HTTP request result.
 class CSP_API ResultBase
 {

--- a/Library/include/CSP/Systems/Users/Authentication.h
+++ b/Library/include/CSP/Systems/Users/Authentication.h
@@ -97,9 +97,10 @@ public:
 };
 
 
-enum ELoginStateResultFailureReason
+enum class ELoginStateResultFailureReason
 {
-	None,
+	Unknown = -1,
+	None	= 0,
 	AgeNotVerified
 };
 

--- a/Library/include/CSP/Systems/Users/Authentication.h
+++ b/Library/include/CSP/Systems/Users/Authentication.h
@@ -97,6 +97,13 @@ public:
 };
 
 
+enum ELoginStateResultFailureReason
+{
+	None,
+	AgeNotVerified
+};
+
+
 /// @brief Result structure for a login state request.
 class CSP_API LoginStateResult : public csp::services::ResultBase
 {
@@ -111,13 +118,15 @@ public:
 	LoginState& GetLoginState();
 	const LoginState& GetLoginState() const;
 
+protected:
+	int ParseErrorCode(const csp::common::String& Value) override;
+
 private:
 	LoginStateResult();
 	LoginStateResult(LoginState* InStatePtr);
 
 	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 
-private:
 	LoginState* State;
 };
 

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -62,10 +62,12 @@ public:
 	/// @param UserName csp::common::String
 	/// @param Email csp::common::String
 	/// @param Password csp::common::String
+	/// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are over 18
 	/// @param Callback LoginStateResultCallback : callback to call when a response is received
 	CSP_ASYNC_RESULT void Login(const csp::common::String& UserName,
 								const csp::common::String& Email,
 								const csp::common::String& Password,
+								const csp::common::Optional<bool>& UserHasVerifiedAge,
 								LoginStateResultCallback Callback);
 
 	/// @brief Log in to Magnopus Connected Services using a login token
@@ -77,8 +79,9 @@ public:
 	CSP_ASYNC_RESULT void LoginWithToken(const csp::common::String& UserId, const csp::common::String& LoginToken, LoginStateResultCallback Callback);
 
 	/// @brief Log in to Magnopus Connected Services as a guest.
+	/// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are over 18
 	/// @param Callback LoginStateResultCallback : callback to call when a response is received
-	CSP_ASYNC_RESULT void LoginAsGuest(LoginStateResultCallback Callback);
+	CSP_ASYNC_RESULT void LoginAsGuest(const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback);
 
 	/// @ingroup Third Party Authentication
 	/// @brief As a Connected Spaces Platform user the 3rd party authentication flow consists of two steps, first calling
@@ -104,16 +107,12 @@ public:
 	/// Note: The Authentication Provider and the Redirect URL you've passed in the first step will be used now
 	/// @param ThirdPartyToken csp::common::String : The authentication token returned by the Provider
 	/// @param ThirdPartyStateId csp::common::String : The state Id returned by the Provider
+	/// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are over 18
 	/// @param Callback LoginStateResultCallback : callback that contains the result of the Magnopus Connected Services Authentication operation
 	CSP_ASYNC_RESULT void LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken,
 																  const csp::common::String& ThirdPartyStateId,
+																  const csp::common::Optional<bool>& UserHasVerifiedAge,
 																  LoginStateResultCallback Callback);
-
-	/// @brief Log in to Magnopus Connected Services services as a guest.
-	/// @param DeviceId csp::common::String : The device Id to use when logging in
-	/// @param Callback LoginStateResultCallback : callback to call when a response is received
-	[[deprecated("This is no longer needed as we now have proper device ID generation! Please use LoginAsGuest() instead.")]] CSP_ASYNC_RESULT void
-		LoginAsGuestWithId(const csp::common::String& DeviceId, LoginStateResultCallback Callback);
 
 	/// @brief Log in to Magnopus Connected Services using the given one-time password/key.
 	/// @param UserId csp::common::String : the user Id
@@ -141,6 +140,7 @@ public:
 									 const csp::common::String& Email,
 									 const csp::common::String& Password,
 									 bool ReceiveNewsletter,
+									 bool HasVerifiedAge,
 									 const csp::common::Optional<csp::common::String>& RedirectUrl,
 									 const csp::common::Optional<csp::common::String>& InviteToken,
 									 ProfileResultCallback Callback);

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -132,6 +132,7 @@ public:
 	/// @param Email csp::common::String : email address associated with the new profile
 	/// @param Password csp::common::String : password associated with the new profile
 	/// @param ReceiveNewsletter bool : `true` if the user wants to receive the Magnopus Connected Services newsletter
+	/// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are over 18
 	/// @param RedirectUrl csp::common::Optional<csp::common::String> : the URL to redirect the user to after they have registered
 	/// @param InviteToken csp::common::Optional<csp::common::String> : A token provided to the user that can be used to auto-confirm their account
 	/// @param Callback ProfileResultCallback : callback when asynchronous task finishes
@@ -140,7 +141,7 @@ public:
 									 const csp::common::String& Email,
 									 const csp::common::String& Password,
 									 bool ReceiveNewsletter,
-									 bool HasVerifiedAge,
+									 bool UserHasVerifiedAge,
 									 const csp::common::Optional<csp::common::String>& RedirectUrl,
 									 const csp::common::Optional<csp::common::String>& InviteToken,
 									 ProfileResultCallback Callback);

--- a/Library/src/Services/WebService.cpp
+++ b/Library/src/Services/WebService.cpp
@@ -106,7 +106,7 @@ void ResultBase::SetResult(csp::services::EResultCode ResCode, uint16_t HttpResC
 
 int ResultBase::ParseErrorCode(const csp::common::String& Value)
 {
-	return 0;
+	return (int) EResultBaseFailureReason::Unknown;
 }
 
 } // namespace csp::services

--- a/Library/src/Services/WebService.cpp
+++ b/Library/src/Services/WebService.cpp
@@ -20,11 +20,11 @@
 namespace csp::services
 {
 
-ResultBase::ResultBase()
+ResultBase::ResultBase() : FailureReason(0)
 {
 }
 
-ResultBase::ResultBase(csp::services::EResultCode ResCode, uint16_t HttpResCode) : Result(ResCode), HttpResponseCode(HttpResCode)
+ResultBase::ResultBase(csp::services::EResultCode ResCode, uint16_t HttpResCode) : Result(ResCode), HttpResponseCode(HttpResCode), FailureReason(0)
 {
 }
 
@@ -56,8 +56,16 @@ void ResultBase::OnResponse(const ApiResponseBase* ApiResponse)
 
 	HttpResponseCode = (uint16_t) ApiResponse->GetResponse()->GetResponseCode();
 
-	const csp::web::HttpResponse* HttpResponse = ApiResponse->GetResponse();
-	ResponseBody							   = HttpResponse->GetPayload().GetContent();
+	const auto* HttpResponse	= ApiResponse->GetResponse();
+	const auto& ResponsePayload = HttpResponse->GetPayload();
+	ResponseBody				= ResponsePayload.GetContent();
+
+	const auto& Headers = ResponsePayload.GetHeaders();
+
+	if (Result == EResultCode::Failed && Headers.count("x-errorcode") > 0 && !Headers.at("x-errorcode").empty())
+	{
+		FailureReason = ParseErrorCode(Headers.at("x-errorcode").c_str());
+	}
 }
 
 const EResultCode ResultBase::GetResultCode() const
@@ -85,10 +93,20 @@ float ResultBase::GetResponseProgress() const
 	return ResponseProgress;
 }
 
+int ResultBase::GetFailureReason() const
+{
+	return FailureReason;
+}
+
 void ResultBase::SetResult(csp::services::EResultCode ResCode, uint16_t HttpResCode)
 {
 	Result			 = ResCode;
 	HttpResponseCode = HttpResCode;
+}
+
+int ResultBase::ParseErrorCode(const csp::common::String& Value)
+{
+	return 0;
 }
 
 } // namespace csp::services

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -102,9 +102,9 @@ const LoginState& LoginStateResult::GetLoginState() const
 int LoginStateResult::ParseErrorCode(const csp::common::String& Value)
 {
 	if (Value == "User_AgeNotVerified")
-		return ELoginStateResultFailureReason::AgeNotVerified;
+		return (int) ELoginStateResultFailureReason::AgeNotVerified;
 
-	return ELoginStateResultFailureReason::None;
+	return ResultBase::ParseErrorCode(Value);
 }
 
 void LoginStateResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -99,6 +99,14 @@ const LoginState& LoginStateResult::GetLoginState() const
 	return *State;
 }
 
+int LoginStateResult::ParseErrorCode(const csp::common::String& Value)
+{
+	if (Value == "User_AgeNotVerified")
+		return ELoginStateResultFailureReason::AgeNotVerified;
+
+	return ELoginStateResultFailureReason::None;
+}
+
 void LoginStateResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
 {
 	ResultBase::OnResponse(ApiResponse);

--- a/Tests/CSharp/src/ExtensionMethods.cs
+++ b/Tests/CSharp/src/ExtensionMethods.cs
@@ -24,13 +24,10 @@ namespace CSharpTests
 
         public static string TestLogIn(this Systems.UserSystem userSystem, string email = null, string password = null, Services.EResultCode expectedResult = Services.EResultCode.Success, bool pushCleanupFunction = true)
         {
-            if (email == null)
-                email = UserSystemTests.DefaultLoginEmail;
+            email ??= UserSystemTests.DefaultLoginEmail;
+            password ??= UserSystemTests.DefaultLoginPassword;
 
-            if (password == null)
-                password = UserSystemTests.DefaultLoginPassword;
-
-            using var result = userSystem.Login("", email, password).Result;
+            using var result = userSystem.Login("", email, password, null).Result;
             var resCode = result.GetResultCode();
 
             Assert.AreEqual(resCode, expectedResult);
@@ -43,7 +40,7 @@ namespace CSharpTests
                 if (pushCleanupFunction)
                     PushCleanupFunction(() => userSystem.TestLogOut());
 
-                LogDebug($"Logged in (UserId: { userId })");
+                LogDebug($"Logged in (UserId: {userId})");
             }
 
             return userId;
@@ -51,7 +48,7 @@ namespace CSharpTests
 
         public static string TestGuestLogIn(this Systems.UserSystem userSystem, bool pushCleanupFunction = true)
         {
-            using var result = userSystem.LoginAsGuest().Result;
+            using var result = userSystem.LoginAsGuest(null).Result;
             var resCode = result.GetResultCode();
 
             Assert.AreEqual(resCode, Services.EResultCode.Success);
@@ -64,7 +61,7 @@ namespace CSharpTests
                 if (pushCleanupFunction)
                     PushCleanupFunction(() => userSystem.TestLogOut());
 
-                LogDebug($"Logged in as guest (UserId: { userId })");
+                LogDebug($"Logged in as guest (UserId: {userId})");
             }
 
             return userId;

--- a/Tests/Multiplayer/src/MultiplayerTestClient.cs
+++ b/Tests/Multiplayer/src/MultiplayerTestClient.cs
@@ -60,7 +60,7 @@ namespace MultiplayerTestClient
                 {
                     WriteLogEventToFile(logEvent);
                 }
-                else 
+                else
                 {
                     Thread.Sleep(1);
                 }
@@ -75,11 +75,11 @@ namespace MultiplayerTestClient
             {
                 Directory.CreateDirectory(sessionDirectory);
             }
-            
+
             using (StreamWriter outputFile = new StreamWriter(fileName, append: true))
             {
                 double ns = 1000000000.0 * (double)logEvent.ticks / Stopwatch.Frequency;
-                string eventText = String.Format("[{0:D12}|{1}|{2}] {3}", (long)ns/100, logEvent.clientId, logEvent.timeStamp.ToString("hh:mm:ss.fffffff"), logEvent.message);
+                string eventText = String.Format("[{0:D12}|{1}|{2}] {3}", (long)ns / 100, logEvent.clientId, logEvent.timeStamp.ToString("hh:mm:ss.fffffff"), logEvent.message);
                 outputFile.WriteLine(eventText);
             }
         }
@@ -144,18 +144,18 @@ namespace MultiplayerTestClient
                 // Create ServiceWire NamedPipe connection for inter process comms
                 nphost = new NpHost(pipeName, logger, stats);
                 nphost.AddService<IMultiplayerTestClient>(this);
-            
+
                 nphost.Open();
             }
-            catch 
+            catch
             {
-                isRunning = false;            
+                isRunning = false;
             }
 
             if (isRunning)
             {
                 InitialiseFoundationWithUserAgentInfo(CHSEndpointBaseUri);
-                
+
                 logSystem = Systems.SystemsManager.Get().GetLogSystem();
                 logSystem.OnLog += LogHandler;
             }
@@ -211,7 +211,7 @@ namespace MultiplayerTestClient
             var systemsManager = Csp.Systems.SystemsManager.Get();
             var userSystem = systemsManager.GetUserSystem();
 
-            using var result = userSystem.Login("", login, password).Result;
+            using var result = userSystem.Login("", login, password, null).Result;
             var resCode = result.GetResultCode();
 
             Log($"Login using username '{login}'");
@@ -262,7 +262,7 @@ namespace MultiplayerTestClient
         {
             var entitySystem = connection.GetSpaceEntitySystem();
             entitySystem.DestroyEntity(avatar);
-            avatar.Dispose();            
+            avatar.Dispose();
         }
 
         private void CreateObject(Multiplayer.SpaceEntitySystem entitySystem, string name, out Multiplayer.SpaceEntity entity)

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -82,7 +82,7 @@ void LogIn(csp::systems::UserSystem* UserSystem,
 		   const csp::common::String& Password,
 		   csp::services::EResultCode ExpectedResultCode)
 {
-	auto [Result] = Awaitable(&csp::systems::UserSystem::Login, UserSystem, "", Email, Password).Await(RequestPredicate);
+	auto [Result] = Awaitable(&csp::systems::UserSystem::Login, UserSystem, "", Email, Password, nullptr).Await(RequestPredicate);
 
 	EXPECT_EQ(Result.GetResultCode(), ExpectedResultCode);
 
@@ -94,7 +94,7 @@ void LogIn(csp::systems::UserSystem* UserSystem,
 
 void LogInAsGuest(csp::systems::UserSystem* UserSystem, csp::common::String& OutUserId, csp::services::EResultCode ExpectedResult)
 {
-	auto [Result] = Awaitable(&csp::systems::UserSystem::LoginAsGuest, UserSystem).Await(RequestPredicate);
+	auto [Result] = Awaitable(&csp::systems::UserSystem::LoginAsGuest, UserSystem, nullptr).Await(RequestPredicate);
 
 	EXPECT_EQ(Result.GetResultCode(), ExpectedResult);
 
@@ -408,7 +408,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameTest)
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
 	auto* UserSystem	 = SystemsManager.GetUserSystem();
 
-	csp::common::String UniqueTestDisplayName = csp::common::String("NAME ") + GetUniqueHexString().c_str();
+	csp::common::String UniqueTestDisplayName = csp::common::String("TEST") + GetUniqueHexString().c_str();
 
 	csp::common::String UserId;
 	LogIn(UserSystem, UserId);
@@ -440,7 +440,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameIncludingBlankSpace
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
 	auto* UserSystem	 = SystemsManager.GetUserSystem();
 
-	csp::common::String UniqueTestDisplayName = csp::common::String("Test ") + GetUniqueHexString().c_str();
+	csp::common::String UniqueTestDisplayName = csp::common::String("TEST ") + GetUniqueHexString().c_str();
 
 	csp::common::String UserId;
 	LogIn(UserSystem, UserId);
@@ -472,7 +472,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameIncludingSymbolsTes
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
 	auto* UserSystem	 = SystemsManager.GetUserSystem();
 
-	csp::common::String UniqueTestDisplayName = csp::common::String("Test ()= - ") + GetUniqueHexString(8).c_str();
+	csp::common::String UniqueTestDisplayName = csp::common::String("()= - ") + GetUniqueHexString(8).c_str();
 
 	csp::common::String UserId;
 	LogIn(UserSystem, UserId);
@@ -521,7 +521,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserTest)
 	const char* TestDisplayName = "CSP-TEST-DISPLAY";
 
 	char UniqueUserName[256];
-	SPRINTF(UniqueUserName, "%s-%s", TestUserName, GetUniqueHexString().c_str());
+	SPRINTF(UniqueUserName, "%s-%s-%s", TestUserName, GetUniqueHexString().c_str(), GetUniqueHexString().c_str());
 
 	char UniqueEmail[256];
 	SPRINTF(UniqueEmail, GeneratedTestAccountEmailFormat, GetUniqueHexString().c_str());
@@ -538,13 +538,14 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserTest)
 								  UniqueEmail,
 								  GeneratedTestAccountPassword,
 								  true,
+								  true,
 								  nullptr,
 								  nullptr);
 
 		EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);
 
-		auto CreatedProfile = Result.GetProfile();
-		CreatedUserId		= CreatedProfile.UserId;
+		const auto& CreatedProfile = Result.GetProfile();
+		CreatedUserId			   = CreatedProfile.UserId;
 
 		EXPECT_EQ(CreatedProfile.UserName, UniqueUserName);
 		EXPECT_EQ(CreatedProfile.DisplayName, TestDisplayName);
@@ -578,7 +579,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserTest)
 		EXPECT_EQ(LiteProfile.DisplayName, TestDisplayName);
 	}
 
-	// Whilst logged in as one user with normal roles, we cannot deleted another
+	// Whilst logged in as one user with normal roles, we cannot delete another
 	{
 		auto [Result] = AWAIT_PRE(UserSystem, DeleteUser, RequestPredicate, CreatedUserId);
 
@@ -614,6 +615,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserEmptyUsernameDisplaynameTe
 								  UniqueEmail,
 								  GeneratedTestAccountPassword,
 								  false,
+								  true,
 								  nullptr,
 								  nullptr);
 


### PR DESCRIPTION
This change adds `HasVerifiedAge` to `CreateUser` and `Login` functions. It also adds a way of getting back errors returned by CHS via the `X-ErrorCode` response header.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
