### PR TITLE
[NT-0] fix: script logs use log verbosity level

### DIFF
--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -220,7 +220,7 @@ void EntityScriptLog(qjs::rest<std::string> Args)
 		Str << Arg << " ";
 	}
 
-	CSP_LOG_ERROR_FORMAT("%s", Str.str().c_str());
+	CSP_LOG_FORMAT(csp::systems::LogLevel::Log, "%s", Str.str().c_str());
 }
 
 


### PR DESCRIPTION
A client engineer observed that log messages emitted via script were being assigned the 'Error' verbosity level, which was unexpected.

It was agreed that the expected level is the regular 'Log' level.
