### PR TITLE
[NT-0] fix: change required PyYAML version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ chevron==0.14.0
 gitdb==4.0.9
 GitPython==3.1.32
 smmap==5.0.0
-PyYAML==5.4.1
+PyYAML==5.3.1
 jinja2==3.1.2
 jinja2-workarounds==0.1.0


### PR DESCRIPTION
Python 3.10 and above currently has issues with PyYAML versions 5.4 and above. More info [here](https://github.com/galaxyproject/iwc/pull/226). Adopting the recommended workaround and targeting PyYAML 5.3.1 instead.
