### PR TITLE
[NT-0] fix: Fix unity package meta templates

### DIFF
--- a/teamcity/templates/unity/minimal.meta.jinja2
+++ b/teamcity/templates/unity/minimal.meta.jinja2
@@ -2,6 +2,6 @@ fileFormatVersion: 2
 guid: {{ guid }}
 {{ importer_type }}Importer:
   externalObjects: {}
-  userData: null
-  assetBundleName: null
-  assetBundleVariant: null
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/teamcity/templates/unity/plugin.meta.jinja2
+++ b/teamcity/templates/unity/plugin.meta.jinja2
@@ -109,16 +109,16 @@ PluginImporter:
       settings:
         AddToEmbeddedBinaries: false
         CPU: ARM64
-        CompileFlags: null
-        FrameworkDependencies: null
+        CompileFlags: 
+        FrameworkDependencies: 
     {%- else %}
       enabled: 0
       settings:
         AddToEmbeddedBinaries: false
         CPU: None
-        CompileFlags: null
-        FrameworkDependencies: null
+        CompileFlags: 
+        FrameworkDependencies: 
     {%- endif %}
-  userData: null
-  assetBundleName: null
-  assetBundleVariant: null
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/teamcity/templates/unity/source.cs.meta.jinja2
+++ b/teamcity/templates/unity/source.cs.meta.jinja2
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: null
-  assetBundleName: null
-  assetBundleVariant: null
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This fixes an issue with CSP for Unity iOS referencing null.framework

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
