### PR TITLE
[OB-2980] fix: only delete StringImpl if not null

### DIFF
--- a/Library/src/Common/String.cpp
+++ b/Library/src/Common/String.cpp
@@ -217,14 +217,22 @@ String& String::swap(String& Other)
 
 String& String::operator=(const String& Rhs)
 {
-	CSP_DELETE(ImplPtr);
+	if (ImplPtr != nullptr)
+	{
+		CSP_DELETE(ImplPtr);
+	}
+
 	ImplPtr = Rhs.ImplPtr->Clone();
 	return *this;
 }
 
 String& String::operator=(String&& Rhs)
 {
-	CSP_DELETE(ImplPtr);
+	if (ImplPtr != nullptr)
+	{
+		CSP_DELETE(ImplPtr);
+	}
+
 	ImplPtr		= Rhs.ImplPtr;
 	Rhs.ImplPtr = nullptr;
 	return *this;
@@ -232,7 +240,11 @@ String& String::operator=(String&& Rhs)
 
 String& String::operator=(char const* const Text)
 {
-	CSP_DELETE(ImplPtr);
+	if (ImplPtr != nullptr)
+	{
+		CSP_DELETE(ImplPtr);
+	}
+
 	ImplPtr = CSP_NEW Impl(Text);
 	return *this;
 }


### PR DESCRIPTION
This addresses an issue that occurs when trying to reassign a string value that hasn't been initialised where the underlying StringImpl is deleted, even though it is null. This happens with ReplicatedValue and Variant.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
