### PR TITLE
[NT-0] fix: portal script bindings

### DIFF
--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -381,7 +381,7 @@ void BindComponents(qjs::Context::Module* Module)
 		.PROPERTY_GET_SET(StaticModelSpaceComponent, Rotation, "rotation")
 		.PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible");
 
-	Module->class_<PortalSpaceComponentScriptInterface>("StaticModelSpaceComponent")
+	Module->class_<PortalSpaceComponentScriptInterface>("PortalSpaceComponent")
 		.constructor<>()
 		.base<ComponentScriptInterface>()
 		.PROPERTY_GET_SET(PortalSpaceComponent, SpaceId, "spaceId")


### PR DESCRIPTION
* Portal Component Script Bindings had the incorrect component name for the interface

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
