### PR TITLE
[OB-3040] fix: Resolving a QuotaSystem C# crash

### DIFF
--- a/Library/include/CSP/Systems/Quota/QuotaSystem.h
+++ b/Library/include/CSP/Systems/Quota/QuotaSystem.h
@@ -36,7 +36,7 @@ class WebClient;
 
 namespace csp::systems
 {
-/// @ingroup QuotaSystem
+/// @ingroup Quota System
 /// @brief Public facing system that allows interfacing with Magnopus Connect Services' Quota Server.
 /// Offers methods for receiving Quota Queries.
 class CSP_API CSP_NO_DISPOSE QuotaSystem : public SystemBase

--- a/Library/include/CSP/Systems/Quota/QuotaSystem.h
+++ b/Library/include/CSP/Systems/Quota/QuotaSystem.h
@@ -83,12 +83,12 @@ public:
 	/// @param TierName TierNames : Name of the tier
 	/// @param FeatureName TierFeatures : Name of the feature
 	/// @param Callback FeatureQuotaCallback : callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetTierFeatureQuota(const TierNames TierName, const TierFeatures FeatureName, FeatureQuotaCallback Callback);
+	CSP_ASYNC_RESULT void GetTierFeatureQuota(TierNames TierName, TierFeatures FeatureName, FeatureQuotaCallback Callback);
 
 	/// @brief Get current array of current feature quota information inside a tier
 	/// @param TierName TierNames : Name of the tier
 	/// @param Callback FeaturesQuotaCallback : callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetTierFeaturesQuota(const TierNames TierName, FeaturesQuotaCallback Callback);
+	CSP_ASYNC_RESULT void GetTierFeaturesQuota(TierNames TierName, FeaturesQuotaCallback Callback);
 
 private:
 	QuotaSystem(); // This constructor is only provided to appease the wrapper generator and should not be used

--- a/Library/include/CSP/Systems/Quota/QuotaSystem.h
+++ b/Library/include/CSP/Systems/Quota/QuotaSystem.h
@@ -36,7 +36,7 @@ class WebClient;
 
 namespace csp::systems
 {
-/// @ingroup GraphQL System
+/// @ingroup QuotaSystem
 /// @brief Public facing system that allows interfacing with Magnopus Connect Services' Quota Server.
 /// Offers methods for receiving Quota Queries.
 class CSP_API CSP_NO_DISPOSE QuotaSystem : public SystemBase

--- a/Library/include/CSP/Systems/Quota/QuotaSystem.h
+++ b/Library/include/CSP/Systems/Quota/QuotaSystem.h
@@ -83,12 +83,12 @@ public:
 	/// @param TierName TierNames : Name of the tier
 	/// @param FeatureName TierFeatures : Name of the feature
 	/// @param Callback FeatureQuotaCallback : callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetTierFeatureQuota(const TierNames& TierName, const TierFeatures& FeatureName, FeatureQuotaCallback Callback);
+	CSP_ASYNC_RESULT void GetTierFeatureQuota(const TierNames TierName, const TierFeatures FeatureName, FeatureQuotaCallback Callback);
 
 	/// @brief Get current array of current feature quota information inside a tier
 	/// @param TierName TierNames : Name of the tier
 	/// @param Callback FeaturesQuotaCallback : callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetTierFeaturesQuota(const TierNames& TierName, FeaturesQuotaCallback Callback);
+	CSP_ASYNC_RESULT void GetTierFeaturesQuota(const TierNames TierName, FeaturesQuotaCallback Callback);
 
 private:
 	QuotaSystem(); // This constructor is only provided to appease the wrapper generator and should not be used

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -25,14 +25,14 @@ namespace chs = csp::services::generated::trackingservice;
 
 namespace csp::systems
 {
-QuotaSystem::QuotaSystem() : SystemBase(), QuotaTierAssignmentAPI(nullptr), QuotaManagementAPI(nullptr), QuotaActivityAPI(nullptr)
+QuotaSystem::QuotaSystem() : SystemBase(), QuotaManagementAPI(nullptr), QuotaTierAssignmentAPI(nullptr), QuotaActivityAPI(nullptr)
 {
 }
 
 QuotaSystem::QuotaSystem(csp::web::WebClient* InWebClient) : SystemBase(InWebClient)
 {
-	QuotaTierAssignmentAPI = CSP_NEW chs::QuotaTierAssignmentApi(InWebClient);
 	QuotaManagementAPI	   = CSP_NEW chs::QuotaManagementApi(InWebClient);
+	QuotaTierAssignmentAPI = CSP_NEW chs::QuotaTierAssignmentApi(InWebClient);
 	QuotaActivityAPI	   = CSP_NEW chs::QuotaActivityApi(InWebClient);
 }
 
@@ -132,7 +132,7 @@ void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
 		->apiV1UsersUserIdTierAssignmentGet(csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, ResponseHandler);
 }
 
-void QuotaSystem::GetTierFeatureQuota(const TierNames& TierName, const TierFeatures& FeatureName, FeatureQuotaCallback Callback)
+void QuotaSystem::GetTierFeatureQuota(const TierNames TierName, const TierFeatures FeatureName, FeatureQuotaCallback Callback)
 {
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= QuotaManagementAPI->CreateHandler<FeatureQuotaCallback, FeatureQuotaResult, void, chs::QuotaFeatureTierDto>(Callback, nullptr);
@@ -141,7 +141,7 @@ void QuotaSystem::GetTierFeatureQuota(const TierNames& TierName, const TierFeatu
 		->apiV1TiersTierNameFeaturesFeatureNameQuotaGet(TierNameEnumToString(TierName), TierFeatureEnumToString(FeatureName), ResponseHandler);
 }
 
-void QuotaSystem::GetTierFeaturesQuota(const TierNames& TierName, FeaturesQuotaCallback Callback)
+void QuotaSystem::GetTierFeaturesQuota(const TierNames TierName, FeaturesQuotaCallback Callback)
 {
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= QuotaManagementAPI->CreateHandler<FeaturesQuotaCallback, FeaturesQuotaResult, void, csp::services::DtoArray<chs::QuotaFeatureTierDto>>(

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -132,7 +132,7 @@ void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
 		->apiV1UsersUserIdTierAssignmentGet(csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, ResponseHandler);
 }
 
-void QuotaSystem::GetTierFeatureQuota(const TierNames TierName, const TierFeatures FeatureName, FeatureQuotaCallback Callback)
+void QuotaSystem::GetTierFeatureQuota(TierNames TierName, TierFeatures FeatureName, FeatureQuotaCallback Callback)
 {
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= QuotaManagementAPI->CreateHandler<FeatureQuotaCallback, FeatureQuotaResult, void, chs::QuotaFeatureTierDto>(Callback, nullptr);
@@ -141,7 +141,7 @@ void QuotaSystem::GetTierFeatureQuota(const TierNames TierName, const TierFeatur
 		->apiV1TiersTierNameFeaturesFeatureNameQuotaGet(TierNameEnumToString(TierName), TierFeatureEnumToString(FeatureName), ResponseHandler);
 }
 
-void QuotaSystem::GetTierFeaturesQuota(const TierNames TierName, FeaturesQuotaCallback Callback)
+void QuotaSystem::GetTierFeaturesQuota(TierNames TierName, FeaturesQuotaCallback Callback)
 {
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= QuotaManagementAPI->CreateHandler<FeaturesQuotaCallback, FeaturesQuotaResult, void, csp::services::DtoArray<chs::QuotaFeatureTierDto>>(


### PR DESCRIPTION
A bug in the CSP wrapper generator means that reference-to-enum parameters will be considered to be int pointers at the C# wrapper level.

These int pointers were then passed to the generated C wrapper, which attempted to dereference them before passing them to CSP's C++ API.

Those dereferences were the cause of the crash.

The fix here is to alter the signature of the QuotaSystem API such that it passes enum params by value rather than reference.

A separate issue for the wrapper generator bug will be raised and tracked.
