### PR TITLE
[OB-3042] fix: quota queries for non-basic tiers

### DIFF
--- a/Library/src/Systems/Quota/Quota.cpp
+++ b/Library/src/Systems/Quota/Quota.cpp
@@ -231,29 +231,16 @@ void FeaturesQuotaResult::OnResponse(const csp::services::ApiResponseBase* ApiRe
 }
 const csp::common::String TierNameEnumToString(const TierNames& Value)
 {
-	csp::common::String TierString;
 	switch (Value)
 	{
 		case TierNames::Basic:
-		{
-			TierString = "basic";
-			break;
-		}
+			return "basic";
 		case TierNames::Premium:
-		{
-			TierString = "premium";
-			break;
-		}
+			return "premium";
 		case TierNames::Pro:
-		{
-			TierString = "pro";
-			break;
-		}
+			return "pro";
 		case TierNames::Enterprise:
-		{
-			TierString = "enterprise";
-			break;
-		}
+			return "enterprise";
 		default:
 		{
 			CSP_LOG_ERROR_FORMAT("Unknown quota tier encountered whilst converting the enum to string. Value passed in was %i. To fix this, add a "
@@ -262,60 +249,34 @@ const csp::common::String TierNameEnumToString(const TierNames& Value)
 			break;
 		}
 	}
-	return TierString;
+
+	// return a default/invalid value if no matching tier was found
+	return "";
 }
 
 const csp::common::String TierFeatureEnumToString(const TierFeatures& Value)
 {
-	csp::common::String TierString;
-
 	switch (Value)
 	{
 		case TierFeatures::Agora:
-		{
-			TierString = "Agora";
+			return "Agora";
 			break;
-		}
 		case TierFeatures::Shopify:
-		{
-			TierString = "Shopify";
-			break;
-		}
+			return "Shopify";
 		case TierFeatures::TicketedSpace:
-		{
-			TierString = "TicketedSpace";
-			break;
-		}
+			return "TicketedSpace";
 		case TierFeatures::AudioVideoUpload:
-		{
-			TierString = "AudioVideoUpload";
-			break;
-		}
+			return "AudioVideoUpload";
 		case TierFeatures::ObjectCaptureUpload:
-		{
-			TierString = "ObjectCaptureUpload";
-			break;
-		}
+			return "ObjectCaptureUpload";
 		case TierFeatures::OpenAI:
-		{
-			TierString = "OpenAI";
-			break;
-		}
+			return "OpenAI";
 		case TierFeatures::ScopeConcurrentUsers:
-		{
-			TierString = "ScopeConcurrentUsers";
-			break;
-		}
+			return "ScopeConcurrentUsers";
 		case TierFeatures::TotalUploadSizeInKilobytes:
-		{
-			TierString = "TotalUploadSizeInKilobytes";
-			break;
-		}
+			return "TotalUploadSizeInKilobytes";
 		case TierFeatures::SpaceOwner:
-		{
-			TierString = "SpaceOwner";
-			break;
-		}
+			return "SpaceOwner";
 		default:
 		{
 			CSP_LOG_ERROR_FORMAT("Unknown quota feature encountered whilst converting the enum to string. Value passed in was %i. To fix this, add a "
@@ -325,83 +286,85 @@ const csp::common::String TierFeatureEnumToString(const TierFeatures& Value)
 		}
 	}
 
-	return TierString;
+	// return a default/invalid value if no matching feature was found
+	return "";
 }
 
 const TierNames StringToTierNameEnum(const csp::common::String& Value)
 {
-	TierNames TierName = TierNames::Basic;
-
 	if (Value == "basic")
 	{
-		TierName = TierNames::Basic;
-	}
-	else if (Value == "premium")
-	{
-		TierName = TierNames::Premium;
-	}
-	else if (Value == "pro")
-	{
-		TierName = TierNames::Pro;
-	}
-	else if (Value == "enterprise")
-	{
-		TierName = TierNames::Enterprise;
-	}
-	else
-	{
-		CSP_LOG_ERROR_FORMAT("QuotaSystem TierName not recognized: %s. Defaulting to basic tier.", Value.c_str());
+		return TierNames::Basic;
 	}
 
-	return TierName;
+	if (Value == "premium")
+	{
+		return TierNames::Premium;
+	}
+
+	if (Value == "pro")
+	{
+		return TierNames::Pro;
+	}
+
+	if (Value == "enterprise")
+	{
+		return TierNames::Enterprise;
+	}
+
+	CSP_LOG_ERROR_FORMAT("QuotaSystem TierName not recognized: %s. Defaulting to basic tier.", Value.c_str());
+	return TierNames::Basic;
 }
 
 const TierFeatures StringToTierFeatureEnum(const csp::common::String& Value)
 {
-	TierFeatures TierFeature = TierFeatures::SpaceOwner;
-
 	if (Value == "Agora")
 	{
-		TierFeature = TierFeatures::Agora;
-	}
-	else if (Value == "Shopify")
-	{
-		TierFeature = TierFeatures::Shopify;
-	}
-	else if (Value == "TicketedSpace")
-	{
-		TierFeature = TierFeatures::TicketedSpace;
-	}
-	else if (Value == "AudioVideoUpload")
-	{
-		TierFeature = TierFeatures::AudioVideoUpload;
-	}
-	else if (Value == "ObjectCaptureUpload")
-	{
-		TierFeature = TierFeatures::ObjectCaptureUpload;
-	}
-	else if (Value == "OpenAI")
-	{
-		TierFeature = TierFeatures::OpenAI;
-	}
-	else if (Value == "ScopeConcurrentUsers")
-	{
-		TierFeature = TierFeatures::ScopeConcurrentUsers;
-	}
-	else if (Value == "TotalUploadSizeInKilobytes")
-	{
-		TierFeature = TierFeatures::TotalUploadSizeInKilobytes;
-	}
-	else if (Value == "SpaceOwner")
-	{
-		TierFeature = TierFeatures::SpaceOwner;
-	}
-	else
-	{
-		CSP_LOG_ERROR_FORMAT("QuotaSystem TierFeature not recognized: %s. Defaulting to SpaceOwner", Value.c_str());
+		return TierFeatures::Agora;
 	}
 
-	return TierFeature;
+	if (Value == "Shopify")
+	{
+		return TierFeatures::Shopify;
+	}
+
+	if (Value == "TicketedSpace")
+	{
+		return TierFeatures::TicketedSpace;
+	}
+
+	if (Value == "AudioVideoUpload")
+	{
+		return TierFeatures::AudioVideoUpload;
+	}
+
+	if (Value == "ObjectCaptureUpload")
+	{
+		return TierFeatures::ObjectCaptureUpload;
+	}
+
+	if (Value == "OpenAI")
+	{
+		return TierFeatures::OpenAI;
+	}
+
+	if (Value == "ScopeConcurrentUsers")
+	{
+		return TierFeatures::ScopeConcurrentUsers;
+	}
+
+	if (Value == "TotalUploadSizeInKilobytes")
+	{
+		return TierFeatures::TotalUploadSizeInKilobytes;
+	}
+
+	if (Value == "SpaceOwner")
+	{
+		return TierFeatures::SpaceOwner;
+	}
+
+	CSP_LOG_ERROR_FORMAT("QuotaSystem TierFeature not recognized: %s. Defaulting to SpaceOwner", Value.c_str());
+	return TierFeatures::SpaceOwner;
 }
 
 } // namespace csp::systems

--- a/Library/src/Systems/Quota/Quota.cpp
+++ b/Library/src/Systems/Quota/Quota.cpp
@@ -15,10 +15,10 @@
  */
 #include "CSP/Systems/Quota/Quota.h"
 
+#include "Debug/Logging.h"
 #include "Services/ApiBase/ApiBase.h"
 #include "Services/TrackingService/Api.h"
 #include "Services/UserService/Dto.h"
-
 
 namespace chs = csp::services::generated::trackingservice;
 
@@ -231,118 +231,177 @@ void FeaturesQuotaResult::OnResponse(const csp::services::ApiResponseBase* ApiRe
 }
 const csp::common::String TierNameEnumToString(const TierNames& Value)
 {
+	csp::common::String TierString;
 	switch (Value)
 	{
 		case TierNames::Basic:
-			return "Basic";
+		{
+			TierString = "basic";
+			break;
+		}
 		case TierNames::Premium:
-			return "Premium";
+		{
+			TierString = "premium";
+			break;
+		}
 		case TierNames::Pro:
-			return "Pro";
+		{
+			TierString = "pro";
+			break;
+		}
 		case TierNames::Enterprise:
-			return "Enterprise";
+		{
+			TierString = "enterprise";
+			break;
+		}
+		default:
+		{
+			CSP_LOG_ERROR_FORMAT("Unknown quota tier encountered whilst converting the enum to string. Value passed in was %i. To fix this, add a "
+								 "case to the enum switch statement.",
+								 static_cast<int>(Value));
+			break;
+		}
 	}
+	return TierString;
 }
 
 const csp::common::String TierFeatureEnumToString(const TierFeatures& Value)
 {
+	csp::common::String TierString;
+
 	switch (Value)
 	{
 		case TierFeatures::Agora:
-			return "Agora";
+		{
+			TierString = "Agora";
+			break;
+		}
 		case TierFeatures::Shopify:
-			return "Shopify";
+		{
+			TierString = "Shopify";
+			break;
+		}
 		case TierFeatures::TicketedSpace:
-			return "TicketedSpace";
+		{
+			TierString = "TicketedSpace";
+			break;
+		}
 		case TierFeatures::AudioVideoUpload:
-			return "AudioVideoUpload";
+		{
+			TierString = "AudioVideoUpload";
+			break;
+		}
 		case TierFeatures::ObjectCaptureUpload:
-			return "ObjectCaptureUpload";
+		{
+			TierString = "ObjectCaptureUpload";
+			break;
+		}
 		case TierFeatures::OpenAI:
-			return "OpenAI";
+		{
+			TierString = "OpenAI";
+			break;
+		}
 		case TierFeatures::ScopeConcurrentUsers:
-			return "ScopeConcurrentUsers";
+		{
+			TierString = "ScopeConcurrentUsers";
+			break;
+		}
 		case TierFeatures::TotalUploadSizeInKilobytes:
-			return "TotalUploadSizeInKilobytes";
+		{
+			TierString = "TotalUploadSizeInKilobytes";
+			break;
+		}
 		case TierFeatures::SpaceOwner:
-			return "SpaceOwner";
+		{
+			TierString = "SpaceOwner";
+			break;
+		}
+		default:
+		{
+			CSP_LOG_ERROR_FORMAT("Unknown quota feature encountered whilst converting the enum to string. Value passed in was %i. To fix this, add a "
+								 "case to the enum switch statement.",
+								 static_cast<int>(Value));
+			break;
+		}
 	}
+
+	return TierString;
 }
 
 const TierNames StringToTierNameEnum(const csp::common::String& Value)
 {
+	TierNames TierName = TierNames::Basic;
+
 	if (Value == "basic")
 	{
-		return TierNames::Basic;
+		TierName = TierNames::Basic;
 	}
-
-	if (Value == "premium")
+	else if (Value == "premium")
 	{
-		return TierNames::Premium;
+		TierName = TierNames::Premium;
 	}
-
-	if (Value == "pro")
+	else if (Value == "pro")
 	{
-		return TierNames::Pro;
+		TierName = TierNames::Pro;
 	}
-
-	if (Value == "enterprise")
+	else if (Value == "enterprise")
 	{
-		return TierNames::Enterprise;
+		TierName = TierNames::Enterprise;
+	}
+	else
+	{
+		CSP_LOG_ERROR_FORMAT("QuotaSystem TierName not recognized: %s. Defaulting to basic tier.", Value.c_str());
 	}
 
-	CSP_LOG_ERROR_FORMAT("QuotaSystem TierName not recognized: %s", Value.c_str());
+	return TierName;
 }
 
 const TierFeatures StringToTierFeatureEnum(const csp::common::String& Value)
 {
+	TierFeatures TierFeature = TierFeatures::SpaceOwner;
+
 	if (Value == "Agora")
 	{
-		return TierFeatures::Agora;
+		TierFeature = TierFeatures::Agora;
 	}
-
-	if (Value == "Shopify")
+	else if (Value == "Shopify")
 	{
-		return TierFeatures::Shopify;
+		TierFeature = TierFeatures::Shopify;
 	}
-
-	if (Value == "TicketedSpace")
+	else if (Value == "TicketedSpace")
 	{
-		return TierFeatures::TicketedSpace;
+		TierFeature = TierFeatures::TicketedSpace;
 	}
-
-	if (Value == "AudioVideoUpload")
+	else if (Value == "AudioVideoUpload")
 	{
-		return TierFeatures::AudioVideoUpload;
+		TierFeature = TierFeatures::AudioVideoUpload;
 	}
-
-	if (Value == "ObjectCaptureUpload")
+	else if (Value == "ObjectCaptureUpload")
 	{
-		return TierFeatures::ObjectCaptureUpload;
+		TierFeature = TierFeatures::ObjectCaptureUpload;
 	}
-
-	if (Value == "OpenAI")
+	else if (Value == "OpenAI")
 	{
-		return TierFeatures::OpenAI;
+		TierFeature = TierFeatures::OpenAI;
 	}
-
-	if (Value == "ScopeConcurrentUsers")
+	else if (Value == "ScopeConcurrentUsers")
 	{
-		return TierFeatures::ScopeConcurrentUsers;
+		TierFeature = TierFeatures::ScopeConcurrentUsers;
 	}
-
-	if (Value == "TotalUploadSizeInKilobytes")
+	else if (Value == "TotalUploadSizeInKilobytes")
 	{
-		return TierFeatures::TotalUploadSizeInKilobytes;
+		TierFeature = TierFeatures::TotalUploadSizeInKilobytes;
 	}
-
-	if (Value == "SpaceOwner")
+	else if (Value == "SpaceOwner")
 	{
-		return TierFeatures::SpaceOwner;
+		TierFeature = TierFeatures::SpaceOwner;
+	}
+	else
+	{
+		CSP_LOG_ERROR_FORMAT("QuotaSystem TierFeature not recognized: %s. Defaulting to SpaceOwner", Value.c_str());
 	}
 
-	CSP_LOG_ERROR_FORMAT("QuotaSystem TierFeature not recognized: %s", Value.c_str());
-	return TierFeatures::SpaceOwner;
+	return TierFeature;
 }
 
 } // namespace csp::systems

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -202,7 +202,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForSpace)
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATUREQUOTA_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATUREQUOTA_TEST || 1
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureQuota)
 {
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -212,14 +212,19 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureQuota)
 	csp::common::String UserId;
 	LogIn(UserSystem, UserId);
 
-	auto [Result] = AWAIT_PRE(QuotaSystem, GetTierFeatureQuota, RequestPredicate, TierNames::Basic, TierFeatures::OpenAI);
+	// test quota queries for basic tier
+	auto [BasicResult] = AWAIT_PRE(QuotaSystem, GetTierFeatureQuota, RequestPredicate, TierNames::Basic, TierFeatures::OpenAI);
 
-	EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);
-	EXPECT_EQ(Result.GetFeatureQuotaInfo().FeatureName, TierFeatures::OpenAI);
-	EXPECT_EQ(Result.GetFeatureQuotaInfo().TierName, TierNames::Basic);
-	EXPECT_EQ(Result.GetFeatureQuotaInfo().Limit, 0);
-	EXPECT_EQ(Result.GetFeatureQuotaInfo().Period, PeriodEnum::Total);
-	EXPECT_EQ(Result.GetFeatureQuotaInfo().AllowReductions, false);
+	EXPECT_EQ(BasicResult.GetResultCode(), csp::services::EResultCode::Success);
+	EXPECT_EQ(BasicResult.GetFeatureQuotaInfo().FeatureName, TierFeatures::OpenAI);
+	EXPECT_EQ(BasicResult.GetFeatureQuotaInfo().TierName, TierNames::Basic);
+
+	// test quota queries for pro tier
+	auto [ProResult] = AWAIT_PRE(QuotaSystem, GetTierFeatureQuota, RequestPredicate, TierNames::Pro, TierFeatures::SpaceOwner);
+
+	EXPECT_EQ(ProResult.GetResultCode(), csp::services::EResultCode::Success);
+	EXPECT_EQ(ProResult.GetFeatureQuotaInfo().FeatureName, TierFeatures::SpaceOwner);
+	EXPECT_EQ(ProResult.GetFeatureQuotaInfo().TierName, TierNames::Pro);
 }
 #endif
 

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -28,7 +28,6 @@
 #include <filesystem>
 using namespace csp::systems;
 
-
 namespace
 {
 
@@ -213,18 +212,22 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureQuota)
 	LogIn(UserSystem, UserId);
 
 	// test quota queries for basic tier
-	auto [BasicResult] = AWAIT_PRE(QuotaSystem, GetTierFeatureQuota, RequestPredicate, TierNames::Basic, TierFeatures::OpenAI);
+	{
+		auto [Result] = AWAIT_PRE(QuotaSystem, GetTierFeatureQuota, RequestPredicate, TierNames::Basic, TierFeatures::OpenAI);
 
-	EXPECT_EQ(BasicResult.GetResultCode(), csp::services::EResultCode::Success);
-	EXPECT_EQ(BasicResult.GetFeatureQuotaInfo().FeatureName, TierFeatures::OpenAI);
-	EXPECT_EQ(BasicResult.GetFeatureQuotaInfo().TierName, TierNames::Basic);
+		EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);
+		EXPECT_EQ(Result.GetFeatureQuotaInfo().FeatureName, TierFeatures::OpenAI);
+		EXPECT_EQ(Result.GetFeatureQuotaInfo().TierName, TierNames::Basic);
+	}
 
 	// test quota queries for pro tier
-	auto [ProResult] = AWAIT_PRE(QuotaSystem, GetTierFeatureQuota, RequestPredicate, TierNames::Pro, TierFeatures::SpaceOwner);
+	{
+		auto [Result] = AWAIT_PRE(QuotaSystem, GetTierFeatureQuota, RequestPredicate, TierNames::Pro, TierFeatures::SpaceOwner);
 
-	EXPECT_EQ(ProResult.GetResultCode(), csp::services::EResultCode::Success);
-	EXPECT_EQ(ProResult.GetFeatureQuotaInfo().FeatureName, TierFeatures::SpaceOwner);
-	EXPECT_EQ(ProResult.GetFeatureQuotaInfo().TierName, TierNames::Pro);
+		EXPECT_EQ(Result.GetResultCode(), csp::services::EResultCode::Success);
+		EXPECT_EQ(Result.GetFeatureQuotaInfo().FeatureName, TierFeatures::SpaceOwner);
+		EXPECT_EQ(Result.GetFeatureQuotaInfo().TierName, TierNames::Pro);
+	}
 }
 #endif
 

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -42,10 +42,10 @@ bool RequestPredicate(const csp::services::ResultBase& Result)
 #if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_QUERY_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, TierNameEnumTesttoStringTest)
 {
-	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Basic), "Basic");
-	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Premium), "Premium");
-	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Pro), "Pro");
-	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Enterprise), "Enterprise");
+	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Basic), "basic");
+	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Premium), "premium");
+	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Pro), "pro");
+	EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Enterprise), "enterprise");
 }
 #endif
 

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -202,7 +202,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForSpace)
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATUREQUOTA_TEST || 1
+#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATUREQUOTA_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureQuota)
 {
 	auto& SystemsManager = csp::systems::SystemsManager::Get();


### PR DESCRIPTION
We had a typo in the strings we created to form URL GET requests, where we were creating tier strings that began with an uppercase.

The convention here is for tier strings to be all lowercase.

The impact was that services could return 200 responses to the incorrectly formatted GET requests but with the wrong information.

And the fix is to ensure tier string parsing is consistently treating the tier names as all lower-case.
