### PR TITLE
[NT-0] feat: Dependencies auto-install on OSX

### DIFF
--- a/generate_solution_ios.sh
+++ b/generate_solution_ios.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # *** Command Line Arguments *** 
 # DLLOnly - Generates a solution with only DLL-related build configurations
+python3 -m pip install -r teamcity/requirements.txt
+
 git config core.hooksPath .githooks
 git config commit.template .githooks/commit-template.txt
 

--- a/generate_solution_mac.sh
+++ b/generate_solution_mac.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # *** Command Line Arguments *** 
 # DLLOnly - Generates a solution with only DLL-related build configurations
+python3 -m pip install -r teamcity/requirements.txt
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 XCODE_VERSION=$(softwareupdate --history | awk '/Command Line Tools for Xcode/ {print $6}' | tail -1)


### PR DESCRIPTION
In the same way we automatically install python dependencies at the start of the project generation process on Windows, we now also invoke the equivalent pip command at the start of OSX project generation.
