### PR TITLE
[OF-1094] test: Cancellation token tests

### DIFF
--- a/Library/include/CSP/Common/CancellationToken.h
+++ b/Library/include/CSP/Common/CancellationToken.h
@@ -55,7 +55,7 @@ public:
 
 	/// @brief Check if a request has been cancelled.
 	/// @return bool
-	bool Cancelled();
+	bool Cancelled() const;
 
 	/// @brief Constructs a blank token.
 	/// @return CancellationToken&

--- a/Library/src/Common/CancellationToken.cpp
+++ b/Library/src/Common/CancellationToken.cpp
@@ -38,7 +38,7 @@ public:
 		IsCancelled = true;
 	}
 
-	bool Cancelled()
+	bool Cancelled() const
 	{
 		return IsCancelled;
 	}
@@ -62,7 +62,7 @@ void CancellationToken::Cancel()
 	ImplPtr->Cancel();
 }
 
-bool CancellationToken::Cancelled()
+bool CancellationToken::Cancelled() const
 {
 	return ImplPtr->Cancelled();
 }

--- a/Tests/src/PublicAPITests/CancellationTokenTests.cpp
+++ b/Tests/src/PublicAPITests/CancellationTokenTests.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Awaitable.h"
+#include "CSP/CSPFoundation.h"
+#include "CSP/Common/CancellationToken.h"
+#include "TestHelpers.h"
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_CANCEL_TEST
+CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelStateTest)
+{
+	csp::common::CancellationToken CancellationToken;
+	CancellationToken.Cancel();
+	EXPECT_TRUE(CancellationToken.Cancelled());
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_ASYNCREF_TEST
+CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelAsyncRefTest)
+{
+	csp::common::CancellationToken CancellationToken;
+
+	std::thread Thread(
+		[&CancellationToken]()
+		{
+			while (CancellationToken.Cancelled() == false)
+			{
+			}
+		});
+
+	CancellationToken.Cancel();
+	Thread.join();
+}
+#endif
+
+} // namespace

--- a/Tests/src/PublicAPITests/CancellationTokenTests.cpp
+++ b/Tests/src/PublicAPITests/CancellationTokenTests.cpp
@@ -21,8 +21,6 @@
 
 #include "gtest/gtest.h"
 
-#define RUN_CANCELLATION_TOKEN_TESTS 1
-
 namespace
 {
 

--- a/Tests/src/PublicAPITests/CancellationTokenTests.cpp
+++ b/Tests/src/PublicAPITests/CancellationTokenTests.cpp
@@ -37,10 +37,10 @@ CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelStateTest)
 	csp::common::CancellationToken CancellationToken;
 	EXPECT_FALSE(CancellationToken.Cancelled());
 
-	EXPECT_NO_THROW(CancellationToken.Cancel());
+	CancellationToken.Cancel();
 	EXPECT_TRUE(CancellationToken.Cancelled());
 
-	CancellationToken.Cancel(); // Test that multiple cancellations don't affect the state
+	EXPECT_NO_THROW(CancellationToken.Cancel()); // Test that multiple cancellations don't affect the state
 	EXPECT_TRUE(CancellationToken.Cancelled());
 }
 #endif

--- a/Tests/src/PublicAPITests/CancellationTokenTests.cpp
+++ b/Tests/src/PublicAPITests/CancellationTokenTests.cpp
@@ -27,8 +27,7 @@ namespace
 #if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_CONSTRUCTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, ConstructionAndDestructionTest)
 {
-	csp::common::CancellationToken CancellationToken;
-	// No need to assert anything, just ensuring that construction and destruction don't crash
+	EXPECT_NO_THROW(csp::common::CancellationToken());
 }
 #endif
 
@@ -38,7 +37,7 @@ CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelStateTest)
 	csp::common::CancellationToken CancellationToken;
 	EXPECT_FALSE(CancellationToken.Cancelled());
 
-	CancellationToken.Cancel();
+	EXPECT_NO_THROW(CancellationToken.Cancel());
 	EXPECT_TRUE(CancellationToken.Cancelled());
 
 	CancellationToken.Cancel(); // Test that multiple cancellations don't affect the state
@@ -50,28 +49,10 @@ CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelStateTest)
 CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CopyMoveTest)
 {
 	// Ensure copy and move operations are deleted
-	ASSERT_FALSE(std::is_copy_constructible<csp::common::CancellationToken>::value);
-	ASSERT_FALSE(std::is_move_constructible<csp::common::CancellationToken>::value);
-	ASSERT_FALSE(std::is_copy_assignable<csp::common::CancellationToken>::value);
-	ASSERT_FALSE(std::is_move_assignable<csp::common::CancellationToken>::value);
-}
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_ASYNCREF_TEST
-CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, AsyncRefTest)
-{
-	csp::common::CancellationToken CancellationToken;
-
-	std::thread Thread(
-		[&CancellationToken]()
-		{
-			while (CancellationToken.Cancelled() == false)
-			{
-			}
-		});
-
-	CancellationToken.Cancel();
-	Thread.join();
+	ASSERT_FALSE(std::is_copy_constructible_v<csp::common::CancellationToken>);
+	ASSERT_FALSE(std::is_move_constructible_v<csp::common::CancellationToken>);
+	ASSERT_FALSE(std::is_copy_assignable_v<csp::common::CancellationToken>);
+	ASSERT_FALSE(std::is_move_assignable_v<csp::common::CancellationToken>);
 }
 #endif
 

--- a/Tests/src/PublicAPITests/CancellationTokenTests.cpp
+++ b/Tests/src/PublicAPITests/CancellationTokenTests.cpp
@@ -21,20 +21,46 @@
 
 #include "gtest/gtest.h"
 
+#define RUN_CANCELLATION_TOKEN_TESTS 1
+
 namespace
 {
+
+#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_CONSTRUCTION_TEST
+CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, ConstructionAndDestructionTest)
+{
+	csp::common::CancellationToken CancellationToken;
+	// No need to assert anything, just ensuring that construction and destruction don't crash
+}
+#endif
 
 #if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_CANCEL_TEST
 CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelStateTest)
 {
 	csp::common::CancellationToken CancellationToken;
+	EXPECT_FALSE(CancellationToken.Cancelled());
+
 	CancellationToken.Cancel();
+	EXPECT_TRUE(CancellationToken.Cancelled());
+
+	CancellationToken.Cancel(); // Test that multiple cancellations don't affect the state
 	EXPECT_TRUE(CancellationToken.Cancelled());
 }
 #endif
 
+#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_COPYMOVE_TEST
+CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CopyMoveTest)
+{
+	// Ensure copy and move operations are deleted
+	ASSERT_FALSE(std::is_copy_constructible<csp::common::CancellationToken>::value);
+	ASSERT_FALSE(std::is_move_constructible<csp::common::CancellationToken>::value);
+	ASSERT_FALSE(std::is_copy_assignable<csp::common::CancellationToken>::value);
+	ASSERT_FALSE(std::is_move_assignable<csp::common::CancellationToken>::value);
+}
+#endif
+
 #if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_ASYNCREF_TEST
-CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelAsyncRefTest)
+CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, AsyncRefTest)
 {
 	csp::common::CancellationToken CancellationToken;
 


### PR DESCRIPTION
Introducing test coverage for `csp::common::CancellationToken`.