### PR TITLE
[OB-2323] fix: CSP crashing on M1 macs

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -185,7 +185,8 @@ if not Project then
             }
         filter "platforms:macosx"
             defines { 
-                "CSP_MACOSX", 				
+                "CSP_MACOSX",
+                "USE_STD_MALLOC=1",
                 "JS_STRICT_NAN_BOXING"
             }
 

--- a/ThirdParty/mimalloc/premake5.lua
+++ b/ThirdParty/mimalloc/premake5.lua
@@ -24,5 +24,7 @@ function MiMalloc.AddProject()
 
     filter "platforms:Android"
         flags { "ExcludeFromBuild" }
+    filter "platforms:macosx"
+        flags { "ExcludeFromBuild" }
     filter {}
 end


### PR DESCRIPTION
Similar to recent crashes that have been fixed for Quest & Android, mimalloc crashes when CSP is initialized within an application running on an M1 Mac.

The short-term fix for this is the same as was applied for Quest. We fall back to STL allocator behaviour and avoid the usage of mimalloc entirely when we're running on macosx.
