### PR TITLE
[NT-0] fix: fix .clangformat for latest clang ver

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,7 +54,6 @@ SpacesInSquareBrackets: 'false'
 Standard: Auto
 TabWidth: '4'
 UseTab: Always
-AllowAllParametersOfDeclarationOnNextLine : 'false'
 BinPackArguments: 'false'
 BinPackParameters: 'false'
 


### PR DESCRIPTION
Our .clangformat file had a duplicate entry, causing newer versions of clangformat to throw an error.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
