### PR TITLE
[OF-1166] refac: optimise header transform

### DIFF
--- a/Library/include/CSP/Common/String.h
+++ b/Library/include/CSP/Common/String.h
@@ -168,7 +168,11 @@ public:
 
 	/// @brief Returns a copy of this string with all leading and trailing whitespace removed.
 	/// @return String : A copy of this string with leading and trailing whitespace removed.
-	String Trim();
+	String Trim() const;
+
+	/// @brief Returns a copy of this string with all characters converted to lower-case.
+	/// @return String : A copy of this string with characters converted to lower-case.
+	String ToLower() const;
 
 	/// @brief Concatenates all elements in the list with a separator after each element and returns as a string.
 	/// @param Parts const csp::common::List<String>& : List to concatenate

--- a/Library/src/Common/String.cpp
+++ b/Library/src/Common/String.cpp
@@ -19,6 +19,7 @@
 #include "Memory/Memory.h"
 
 #include <algorithm>
+#include <cctype>
 
 
 namespace csp::common
@@ -348,7 +349,7 @@ String& String::operator+=(const char* Other)
 	return *this;
 }
 
-String String::Trim()
+String String::Trim() const
 {
 	static char Whitespace[] = {' ', '\r', '\n', '\t'};
 
@@ -379,6 +380,20 @@ String String::Trim()
 	}
 
 	return String(Text, Length);
+}
+
+String String::ToLower() const
+{
+	String Copy = *this;
+	auto Length = Copy.ImplPtr->Length;
+	auto Text	= Copy.ImplPtr->Text;
+
+	for (int i = 0; i < Length; ++i)
+	{
+		Text[i] = std::tolower(Text[i]);
+	}
+
+	return Copy;
 }
 
 String String::Join(const List<String>& Parts, Optional<char> Separator)

--- a/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
+++ b/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
@@ -66,30 +66,14 @@ void OnFetchSuccessOrError(emscripten_fetch_t* Fetch)
 
 	auto& Response = Request->GetMutableResponse();
 	auto& Payload  = Response.GetMutablePayload();
-	auto Keys	   = Headers.Keys();
+	auto* Keys	   = Headers.Keys();
 
 	for (int i = 0; i < Keys->Size(); ++i)
 	{
-		auto Key	  = Keys->operator[](i);
-		auto Val	  = std::string(Headers[Key].c_str());
-		auto KeyValue = std::string(Key.c_str());
-		// Make Key and Val lower-case
-		std::transform(KeyValue.begin(),
-					   KeyValue.end(),
-					   KeyValue.begin(),
-					   [](unsigned char c)
-					   {
-						   return std::tolower(c);
-					   });
-		std::transform(Val.begin(),
-					   Val.end(),
-					   Val.begin(),
-					   [](unsigned char c)
-					   {
-						   return std::tolower(c);
-					   });
+		auto Key   = Keys->operator[](i).ToLower();
+		auto Value = Headers[Key].ToLower();
 
-		Payload.AddHeader(KeyValue.c_str(), Val.c_str());
+		Payload.AddHeader(Key, Value);
 	}
 
 	CSP_DELETE(Keys);

--- a/Tests/src/InternalTests/CommonTypeTests/String.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/String.cpp
@@ -596,6 +596,23 @@ CSP_INTERNAL_TEST(CSPEngine, CommonStringTests, StringTrimAllWhitespaceTest)
 	}
 }
 
+CSP_INTERNAL_TEST(CSPEngine, CommonStringTests, StringToLowerTest)
+{
+	try
+	{
+		String Instance	   = "\nAbC! _76-WHAT-lol";
+		String Transformed = Instance.ToLower();
+
+		// The original String instance should not be modified
+		EXPECT_EQ(Instance, "\nAbC! _76-WHAT-lol");
+		EXPECT_EQ(Transformed, "\nabc! _76-what-lol");
+	}
+	catch (...)
+	{
+		FAIL();
+	}
+}
+
 CSP_INTERNAL_TEST(CSPEngine, CommonStringTests, StringJoinListTest)
 {
 	try


### PR DESCRIPTION
This change removes an extra allocation in the code that transforms header keys and values to lower-case in `EmscriptenWebClient`. To support this, a new `String::ToLower` function was added which returns a copy of the string converted to lower-case.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
