### PR TITLE
[NT-0] fix: python preq installation

### DIFF
--- a/generate_solution.bat
+++ b/generate_solution.bat
@@ -1,6 +1,6 @@
 REM *** Command Line Arguments *** 
 REM DLLOnly - Generates a solution with only DLL-related build configurations
-pip install -r teamcity/requirements.txt
+py -m pip install -r teamcity/requirements.txt
 
 if "%~1"=="-ci" (goto :NoGitConfig) else goto :GitConfig
 


### PR DESCRIPTION
On windows, the python prerequisites installed during at the start of solution generation now invokes the same python commands as on OSX.
