### PR TITLE
[OF-793] feat: add Avatar info settings

### DIFF
--- a/Library/include/CSP/Systems/Settings/SettingsCollection.h
+++ b/Library/include/CSP/Systems/Settings/SettingsCollection.h
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/Array.h"
 #include "CSP/Common/Map.h"
 #include "CSP/Common/String.h"
+#include "CSP/Common/Variant.h"
 #include "CSP/Systems/WebService.h"
 #include "CSP/Web/HTTPResponseCodes.h"
 
@@ -37,7 +39,6 @@ CSP_END_IGNORE
 } // namespace csp::services
 
 
-
 namespace csp::systems
 {
 
@@ -52,7 +53,6 @@ public:
 	csp::common::String Context;
 	csp::common::Map<csp::common::String, csp::common::String> Settings;
 };
-
 
 
 /// @ingroup Settings System
@@ -79,8 +79,49 @@ private:
 };
 
 
+/// @brief Used to specify the type of the user's avatar
+enum class AvatarType
+{
+	None,
+	Premade,
+	ReadyPlayerMe,
+	Custom,
+};
+
+
+/// @brief A result handler that is used to notify a user of an error while passing a String value.
+class CSP_API AvatarInfoResult : public csp::systems::ResultBase
+{
+	/** @cond DO_NOT_DOCUMENT */
+	friend class SettingsSystem;
+	/** @endcond */
+
+public:
+	/// @brief A getter which returns the String passed via the result.
+	[[nodiscard]] AvatarType GetAvatarType() const;
+	[[nodiscard]] const csp::common::Variant& GetAvatarIdentifier() const;
+
+	CSP_NO_EXPORT AvatarInfoResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
+		: Type(AvatarType::None), csp::systems::ResultBase(ResCode, HttpResCode) {};
+
+private:
+	AvatarInfoResult() : Type(AvatarType::None) {};
+	AvatarInfoResult(void*) : Type(AvatarType::None) {};
+
+	void SetAvatarType(AvatarType InValue);
+	void SetAvatarIdentifier(const csp::common::Variant& InValue);
+
+	AvatarType Type;
+	csp::common::Variant Identifier;
+};
+
+
 /// @brief Callback containing Settings collection.
 /// @param Result SettingsCollectionResult : result class
 typedef std::function<void(const SettingsCollectionResult& Result)> SettingsResultCallback;
+
+/// @brief Callback containing Avatar info.
+/// @param Result AvatarInfoResult : result class
+typedef std::function<void(const AvatarInfoResult& Result)> AvatarInfoResultCallback;
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Settings/SettingsSystem.h
+++ b/Library/include/CSP/Systems/Settings/SettingsSystem.h
@@ -135,9 +135,17 @@ public:
 														 const csp::systems::BufferAssetDataSource& NewAvatarPortrait,
 														 NullResultCallback Callback);
 
+	/// @brief Sets the avatar type and identifier for a user.
+	/// @param InUserId csp::common::String : The ID of the user to set avatar info for.
+	/// @param InType csp::systems::AvatarType : The type of avatar (predefined, Ready Player Me, or custom).
+	/// @param InIdentifier csp::common::Variant : A value used to identify or locate the avatar. Differs depending on the value of InType.
+	/// @param Callback NullResultCallback : Callback to call when task finishes.
 	CSP_ASYNC_RESULT void
 		SetAvatarInfo(const csp::common::String& InUserId, AvatarType InType, const csp::common::Variant& InIdentifier, NullResultCallback Callback);
 
+	/// @brief Retrieves the avatar type and identifier for a user.
+	/// @param InUserId csp::common::String : The ID of the user to get avatar info for.
+	/// @param Callback NullResultCallback : Callback to call when task finishes.
 	CSP_ASYNC_RESULT void GetAvatarInfo(const csp::common::String& InUserId, AvatarInfoResultCallback Callback);
 
 private:

--- a/Library/include/CSP/Systems/Settings/SettingsSystem.h
+++ b/Library/include/CSP/Systems/Settings/SettingsSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/Systems/Assets/Asset.h"
@@ -20,6 +21,7 @@
 #include "CSP/Systems/Settings/SettingsCollection.h"
 #include "CSP/Systems/SystemBase.h"
 #include "CSP/Systems/SystemsResult.h"
+
 
 namespace csp::services
 {
@@ -132,6 +134,11 @@ public:
 	CSP_ASYNC_RESULT void UpdateAvatarPortraitWithBuffer(const csp::common::String& UserId,
 														 const csp::systems::BufferAssetDataSource& NewAvatarPortrait,
 														 NullResultCallback Callback);
+
+	CSP_ASYNC_RESULT void
+		SetAvatarInfo(const csp::common::String& InUserId, AvatarType InType, const csp::common::Variant& InIdentifier, NullResultCallback Callback);
+
+	CSP_ASYNC_RESULT void GetAvatarInfo(const csp::common::String& InUserId, AvatarInfoResultCallback Callback);
 
 private:
 	SettingsSystem(); // This constructor is only provided to appease the wrapper generator and should not be used

--- a/Library/src/Systems/Settings/SettingsCollection.cpp
+++ b/Library/src/Systems/Settings/SettingsCollection.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "CSP/Systems/Settings/SettingsCollection.h"
 
 #include "Services/ApiBase/ApiBase.h"
@@ -53,6 +54,27 @@ void SettingsDtoToSettingsCollection(const chs::SettingsDto& Dto, csp::systems::
 
 namespace csp::systems
 {
+
+AvatarType AvatarInfoResult::GetAvatarType() const
+{
+	return Type;
+}
+
+const csp::common::Variant& AvatarInfoResult::GetAvatarIdentifier() const
+{
+	return Identifier;
+}
+
+void AvatarInfoResult::SetAvatarType(AvatarType InValue)
+{
+	Type = InValue;
+}
+
+void AvatarInfoResult::SetAvatarIdentifier(const csp::common::Variant& InValue)
+{
+	Identifier = InValue;
+}
+
 
 const SettingsCollection& SettingsCollectionResult::GetSettingsCollection() const
 {

--- a/Library/src/Systems/Spaces/Space.cpp
+++ b/Library/src/Systems/Spaces/Space.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "CSP/Systems/Spaces/Space.h"
 
 #include "CSP/Systems/Assets/AssetCollection.h"
@@ -27,6 +28,7 @@
 
 
 using namespace csp;
+using namespace csp::common;
 
 namespace chs_users	  = csp::services::generated::userservice;
 namespace chs_spatial = csp::services::generated::spatialdataservice;

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "CSP/Systems/Spaces/SpaceSystem.h"
 
 #include "CSP/CSPFoundation.h"
@@ -37,6 +38,7 @@
 
 
 using namespace csp;
+using namespace csp::common;
 
 namespace chs			 = csp::services::generated::userservice;
 namespace chsaggregation = csp::services::generated::aggregationservice;

--- a/Library/src/Systems/Spaces/SpaceSystemHelpers.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystemHelpers.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "Systems/Spaces/SpaceSystemHelpers.h"
 
 #include "CSP/Systems/Assets/AssetSystem.h"
@@ -20,7 +21,11 @@
 #include "CSP/Systems/Users/UserSystem.h"
 #include "Debug/Logging.h"
 
+
+using namespace csp::common;
+
 namespace chs = csp::services::generated::userservice;
+
 
 namespace csp::systems
 {
@@ -55,12 +60,12 @@ String GetSpaceThumbnailAssetCollectionName(const String& SpaceId)
 
 String GetUniqueSpaceThumbnailAssetName(const String& SpaceId)
 {
-	return csp::common::String(SPACE_THUMBNAIL_ASSET_NAME_PREFIX) + SpaceId;
+	return String(SPACE_THUMBNAIL_ASSET_NAME_PREFIX) + SpaceId;
 }
 
 String GetUniqueAvatarThumbnailAssetName(const String& Extension)
 {
-	return csp::common::String(AVATAR_THUMBNAIL_ASSET_NAME_PREFIX) + Extension;
+	return String(AVATAR_THUMBNAIL_ASSET_NAME_PREFIX) + Extension;
 }
 
 String GetAssetFileExtension(const String& MimeType)
@@ -93,7 +98,7 @@ void ConvertJsonMetadataToMapMetadata(const String& JsonMetadata, Map<String, St
 
 	if (!Json.IsObject())
 	{
-		CSP_LOG_MSG(csp::systems::LogLevel::Verbose, "Space JSON metadata is not an object! Returning default metadata values...");
+		CSP_LOG_MSG(LogLevel::Verbose, "Space JSON metadata is not an object! Returning default metadata values...");
 
 		OutMapMetadata["site"]				 = "Void";
 		OutMapMetadata["multiplayerVersion"] = "3"; // 2 represents double-msg-packed serialiser spaces, 3 represents the change to dictionary packing
@@ -117,7 +122,7 @@ void ConvertJsonMetadataToMapMetadata(const String& JsonMetadata, Map<String, St
 		}
 		else
 		{
-			CSP_LOG_FORMAT(csp::systems::LogLevel::Error,
+			CSP_LOG_FORMAT(LogLevel::Error,
 						   "Unsupported JSON type in space metadata! (Key = %s, Value Type = %d)",
 						   Member.name.GetString(),
 						   Member.value.GetType());
@@ -131,7 +136,7 @@ std::shared_ptr<chs::GroupDto> DefaultGroupInfo()
 
 	DefaultGroupInfo->SetGroupType("Space");
 	DefaultGroupInfo->SetAutoModerator(false);
-	const auto* UserSystem = csp::systems::SystemsManager::Get().GetUserSystem();
+	const auto* UserSystem = SystemsManager::Get().GetUserSystem();
 	DefaultGroupInfo->SetGroupOwnerId(UserSystem->GetLoginState().UserId);
 
 	return DefaultGroupInfo;

--- a/Library/src/Systems/Spaces/SpaceSystemHelpers.h
+++ b/Library/src/Systems/Spaces/SpaceSystemHelpers.h
@@ -21,16 +21,16 @@
 #include "CSP/Common/String.h"
 #include "Services/UserService/Dto.h"
 
-using namespace csp::common;
-
 
 namespace csp::systems
 {
+
 class InviteUserRoleInfo;
 class AssetCollection;
 
 constexpr const char* PUBLIC_SPACE_TYPE	 = "public";
 constexpr const char* PRIVATE_SPACE_TYPE = "private";
+
 
 namespace SpaceSystemHelpers
 {
@@ -43,26 +43,27 @@ constexpr const char* SPACE_THUMBNAIL_ASSET_NAME_PREFIX			   = "SPACE_THUMBNAIL_
 
 constexpr const char* AVATAR_THUMBNAIL_ASSET_NAME_PREFIX = "AVATAR_THUMBNAIL";
 
-String GetSpaceMetadataAssetCollectionName(const String& SpaceId);
-Map<String, String> ConvertSpaceMetadataToAssetCollectionMetadata(const String& Metadata);
-String GetSpaceIdFromMetadataAssetCollectionName(const String& MetadataAssetCollectionName);
+csp::common::String GetSpaceMetadataAssetCollectionName(const csp::common::String& SpaceId);
+csp::common::Map<csp::common::String, csp::common::String> ConvertSpaceMetadataToAssetCollectionMetadata(const csp::common::String& Metadata);
+csp::common::String GetSpaceIdFromMetadataAssetCollectionName(const csp::common::String& MetadataAssetCollectionName);
 
-String GetSpaceThumbnailAssetCollectionName(const String& SpaceId);
-String GetUniqueSpaceThumbnailAssetName(const String& SpaceId);
-String GetUniqueAvatarThumbnailAssetName(const String& Extension);
+csp::common::String GetSpaceThumbnailAssetCollectionName(const csp::common::String& SpaceId);
+csp::common::String GetUniqueSpaceThumbnailAssetName(const csp::common::String& SpaceId);
+csp::common::String GetUniqueAvatarThumbnailAssetName(const csp::common::String& Extension);
 
-String GetAssetFileExtension(const String& MimeType);
+csp::common::String GetAssetFileExtension(const csp::common::String& MimeType);
 
 bool IdCheck(const common::String& UserId, const common::Array<common::String>& Ids);
 
 std::shared_ptr<csp::services::generated::userservice::GroupDto> DefaultGroupInfo();
 
-Map<String, String> LegacyAssetConversion(const systems::AssetCollection& AssetCollection);
+csp::common::Map<csp::common::String, csp::common::String> LegacyAssetConversion(const systems::AssetCollection& AssetCollection);
 
 std::vector<std::shared_ptr<csp::services::generated::userservice::GroupInviteDto>>
 	GenerateGroupInvites(const common::Array<systems::InviteUserRoleInfo> InviteUsers);
 
-void ConvertJsonMetadataToMapMetadata(const String& JsonMetadata, Map<String, String>& OutMapMetadata);
+void ConvertJsonMetadataToMapMetadata(const csp::common::String& JsonMetadata,
+									  csp::common::Map<csp::common::String, csp::common::String>& OutMapMetadata);
 
 } // namespace SpaceSystemHelpers
 

--- a/Tests/src/InternalTests/SpaceHelperTests.cpp
+++ b/Tests/src/InternalTests/SpaceHelperTests.cpp
@@ -25,6 +25,7 @@
 	#include "TestHelpers.h"
 
 
+using namespace csp::common;
 using namespace csp::services;
 
 


### PR DESCRIPTION
This change adds `SettingsSystem::SetAvatarInfo()` and `SettingsSystem::GetAvatarInfo()` to allow clients to set persistent Avatar values that can be retrieved outside of the Multiplayer system.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
