### PR TITLE
[NT-0] refac!: Refactor Authentication results

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,6 +18,9 @@ AllowShortLambdasOnASingleLine: None
 AllowShortLoopsOnASingleLine: 'false'
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakAfterAttributes: Always
 BreakBeforeBraces: Allman
 ColumnLimit: '150'
 CompactNamespaces: 'false'
@@ -54,7 +57,5 @@ SpacesInSquareBrackets: 'false'
 Standard: Auto
 TabWidth: '4'
 UseTab: Always
-BinPackArguments: 'false'
-BinPackParameters: 'false'
 
 ...

--- a/Library/include/CSP/Systems/SystemsResult.h
+++ b/Library/include/CSP/Systems/SystemsResult.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -23,8 +24,11 @@
 
 namespace csp::multiplayer
 {
+
 class ConversationSystem;
+
 }
+
 
 namespace csp::services
 {
@@ -39,6 +43,7 @@ CSP_END_IGNORE
 
 namespace csp::systems
 {
+
 /// @brief A result handler that is used to notify a user of an error.
 class CSP_API NullResult : public csp::systems::ResultBase
 {
@@ -62,6 +67,7 @@ protected:
 	NullResult(void*) {};
 };
 
+
 /// @brief A result handler that is used to notify a user of an error while passing a boolean value.
 class CSP_API BooleanResult : public csp::systems::ResultBase
 {
@@ -77,7 +83,8 @@ class CSP_API BooleanResult : public csp::systems::ResultBase
 
 public:
 	/// @brief A getter which returns the bool passed via the result.
-	[[nodiscard]] bool GetValue() const;
+	[[nodiscard]]
+	bool GetValue() const;
 
 private:
 	BooleanResult() = default;
@@ -88,6 +95,7 @@ private:
 
 	bool Value = false;
 };
+
 
 /// @brief A result handler that is used to notify a user of an error while passing a String value.
 class CSP_API StringResult : public csp::systems::ResultBase
@@ -104,18 +112,21 @@ class CSP_API StringResult : public csp::systems::ResultBase
 
 public:
 	/// @brief A getter which returns the String passed via the result.
-	[[nodiscard]] const csp::common::String& GetValue() const;
+	[[nodiscard]]
+	const csp::common::String& GetValue() const;
 
 	CSP_NO_EXPORT StringResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode) : csp::systems::ResultBase(ResCode, HttpResCode) {};
 
-private:
+protected:
 	StringResult() = default;
 	StringResult(void*) {};
 
 	void SetValue(const csp::common::String& InValue);
 
+private:
 	csp::common::String Value;
 };
+
 
 /// @brief A result handler that is used to notify a user of an error while passing a StringArray value.
 class CSP_API StringArrayResult : public csp::systems::ResultBase
@@ -131,7 +142,8 @@ class CSP_API StringArrayResult : public csp::systems::ResultBase
 
 public:
 	/// @brief A getter which returns the StringArray passed via the result.
-	[[nodiscard]] const csp::common::Array<csp::common::String>& GetValue() const;
+	[[nodiscard]]
+	const csp::common::Array<csp::common::String>& GetValue() const;
 
 private:
 	StringArrayResult() = default;
@@ -142,6 +154,7 @@ private:
 
 	csp::common::Array<csp::common::String> Value;
 };
+
 
 /// @brief A result handler that is used to notify a user of an error while passing a uint64_t value.
 class CSP_API UInt64Result : public csp::systems::ResultBase
@@ -157,7 +170,8 @@ class CSP_API UInt64Result : public csp::systems::ResultBase
 
 public:
 	/// @brief A getter which returns the uint64_t passed via the result.
-	[[nodiscard]] uint64_t GetValue() const;
+	[[nodiscard]]
+	uint64_t GetValue() const;
 
 private:
 	UInt64Result() = default;
@@ -168,6 +182,7 @@ private:
 
 	uint64_t Value = 0UL;
 };
+
 
 /// @brief A result handler that is used to notify a user of an error while providing an event for a callback response, in addition to
 /// passing a Map of Strings representing the HTTP Responses.
@@ -188,7 +203,8 @@ public:
 	CSP_NO_EXPORT void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 
 	/// @brief A getter which returns the map of strings representing HTTP responses passed via the result.
-	[[nodiscard]] const csp::common::Map<csp::common::String, csp::common::String>& GetValue() const;
+	[[nodiscard]]
+	const csp::common::Map<csp::common::String, csp::common::String>& GetValue() const;
 
 private:
 	HTTPHeadersResult() = default;

--- a/Library/include/CSP/Systems/Users/Authentication.h
+++ b/Library/include/CSP/Systems/Users/Authentication.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/Common/Array.h"
@@ -71,6 +72,7 @@ public:
 
 	/// @brief Check if the access token for the login is expired.
 	/// @return Is the token expired.
+	[[nodiscard]]
 	bool RefreshNeeded() const;
 
 	ELoginState State;
@@ -96,8 +98,9 @@ public:
 	csp::common::String RefreshExpiryTime;
 };
 
+
 /// @brief Result structure for a login state request.
-class CSP_API LoginStateResult : public csp::systems::ResultBase
+class CSP_API LoginStateResult : public ResultBase
 {
 	/** @cond DO_NOT_DOCUMENT */
 	CSP_START_IGNORE
@@ -107,7 +110,7 @@ class CSP_API LoginStateResult : public csp::systems::ResultBase
 	/** @endcond */
 
 public:
-	LoginState& GetLoginState();
+	[[nodiscard]]
 	const LoginState& GetLoginState() const;
 
 private:
@@ -120,66 +123,28 @@ private:
 };
 
 
-/// @brief Result structure for a logout state request.
-class CSP_API LogoutResult : public NullResult
-{
-	/** @cond DO_NOT_DOCUMENT */
-	CSP_START_IGNORE
-	template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
-	friend class UserSystem;
-	CSP_END_IGNORE
-	/** @endcond */
-
-private:
-	LogoutResult();
-	LogoutResult(LoginState* InStatePtr);
-
-	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
-
-	LoginState* State;
-};
-
-
 /// @ingroup User System
 /// @brief @brief Data class used to contain information when the login token has changed
-class CSP_API LoginTokenReceived : public csp::systems::ResultBase
+class CSP_API LoginTokenInfoResult : public ResultBase
 {
 	/** @cond DO_NOT_DOCUMENT */
 	friend class UserSystem;
 	/** @endcond */
 
 public:
-	LoginTokenInfo& GetLoginTokenInfo();
+	[[nodiscard]]
 	const LoginTokenInfo& GetLoginTokenInfo() const;
 
 private:
-	LoginTokenReceived(void*) {};
-	LoginTokenReceived() {};
+	LoginTokenInfoResult() = default;
+	LoginTokenInfoResult(void*) {};
 
 	void FillLoginTokenInfo(const csp::common::String& AccessToken,
 							const csp::common::String& AuthTokenExpiry,
 							const csp::common::String& RefreshToken,
 							const csp::common::String& RefreshTokenExpiry);
 
-	LoginTokenInfo LoginTokenInfo;
-};
-
-
-/// @ingroup User System
-/// @brief @brief Data class used to contain information when a ping response is received
-class CSP_API PingResponseReceived : public csp::systems::ResultBase
-{
-	/** @cond DO_NOT_DOCUMENT */
-	CSP_START_IGNORE
-	template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
-	friend class UserSystem;
-	CSP_END_IGNORE
-	/** @endcond */
-
-public:
-private:
-	PingResponseReceived(void*) {};
-	PingResponseReceived() {};
+	LoginTokenInfo TokenInfo;
 };
 
 
@@ -188,8 +153,8 @@ class CSP_API AgoraUserTokenParams
 {
 public:
 	csp::common::String AgoraUserId;
-	int Lifespan;
 	csp::common::String ChannelName;
+	int Lifespan;
 	bool ReadOnly;
 	bool ShareAudio;
 	bool ShareVideo;
@@ -197,86 +162,7 @@ public:
 };
 
 
-/// @ingroup User System
-/// @brief @brief Data class used to contain information requesting a user token
-class CSP_API AgoraUserTokenResult : public csp::systems::ResultBase
-{
-	/** @cond DO_NOT_DOCUMENT */
-	CSP_START_IGNORE
-	template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
-	friend class UserSystem;
-	CSP_END_IGNORE
-	/** @endcond */
-
-public:
-	const csp::common::String& GetUserToken() const;
-	const csp::common::String& GetUserToken();
-
-private:
-	AgoraUserTokenResult(void*) {};
-	AgoraUserTokenResult() = default;
-
-	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
-
-	csp::common::String UserToken;
-};
-
-/// @brief Result url for a tier checkout session request
-class CSP_API CheckoutSessionUrlResult : public csp::systems::ResultBase
-{
-	/** @cond DO_NOT_DOCUMENT */
-	CSP_START_IGNORE
-	friend class UserSystem;
-	CSP_END_IGNORE
-	/** @endcond */
-
-public:
-	CheckoutSessionUrlResult() = default;
-	CheckoutSessionUrlResult(void*) {};
-
-	const csp::common::String& GetUrl();
-	const csp::common::String& GetUrl() const;
-
-private:
-	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
-
-	csp::common::String CheckoutSessionUrl;
-};
-
-/// @brief Result url for a user customer portal request
-class CSP_API CustomerPortalUrlResult : public csp::systems::ResultBase
-{
-	/** @cond DO_NOT_DOCUMENT */
-	CSP_START_IGNORE
-	friend class UserSystem;
-	CSP_END_IGNORE
-	/** @endcond */
-
-public:
-	CustomerPortalUrlResult() = default;
-	CustomerPortalUrlResult(void*) {};
-
-	const csp::common::String& GetUrl();
-	const csp::common::String& GetUrl() const;
-
-private:
-	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
-
-	csp::common::String CustomerPortalUrl;
-};
-
-
 typedef std::function<void(LoginStateResult& Result)> LoginStateResultCallback;
-typedef std::function<void(LogoutResult& Result)> LogoutResultCallback;
-
-typedef std::function<void(LoginTokenReceived& Result)> NewLoginTokenReceivedCallback;
-
-typedef std::function<void(PingResponseReceived& Result)> PingResponseReceivedCallback;
-
-typedef std::function<void(AgoraUserTokenResult& Result)> UserTokenResultCallback;
-
-typedef std::function<void(CheckoutSessionUrlResult& Result)> CheckoutSessionUrlResultCallback;
-
-typedef std::function<void(CustomerPortalUrlResult& Result)> CustomerPortalUrlResultCallback;
+typedef std::function<void(LoginTokenInfoResult& Result)> LoginTokenInfoResultCallback;
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -62,8 +62,8 @@ public:
 	/// In the callback result the token and it's expiration time will be provided.
 	/// The expiration time is in OSI format {Year}-{Month}-{Date}T{Hour}:{Min}:{Sec}
 	/// For C#: register a callback to the OnNewLoginTokenReceived event
-	/// @param Callback NewLoginTokenReceivedCallback : callback that gets called as described above
-	CSP_EVENT void SetNewLoginTokenReceivedCallback(NewLoginTokenReceivedCallback Callback);
+	/// @param Callback LoginTokenInfoResultCallback : callback that gets called as described above
+	CSP_EVENT void SetNewLoginTokenReceivedCallback(LoginTokenInfoResultCallback Callback);
 
 	/// @brief Log in to Magnopus Connected Services services using a username-password or email-password combination.
 	/// @param UserName csp::common::String
@@ -82,7 +82,8 @@ public:
 	/// @param UserId csp::common::String : User ID for the previous session
 	/// @param RefreshToken csp::common::String : Refresh token to be used for refreshing the authentication token
 	/// @param Callback LoginStateResultCallback : Callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void RefreshSession(const csp::common::String& UserId, const csp::common::String& RefreshToken, LoginStateResultCallback Callback);
+	CSP_ASYNC_RESULT void
+		RefreshSession(const csp::common::String& UserId, const csp::common::String& RefreshToken, LoginStateResultCallback Callback);
 
 	/// @brief Log in to Magnopus Connected Services as a guest.
 	/// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are over 18
@@ -96,7 +97,8 @@ public:
 
 	/// @brief API to retrieve the Connected Spaces Platform supported 3rd party authentication providers
 	/// @return Array of Connected Spaces Platform supported 3rd party authentication providers
-	[[nodiscard]] csp::common::Array<EThirdPartyAuthenticationProviders> GetSupportedThirdPartyAuthenticationProviders() const;
+	[[nodiscard]]
+	csp::common::Array<EThirdPartyAuthenticationProviders> GetSupportedThirdPartyAuthenticationProviders() const;
 
 	/// @brief First step of the 3rd party authentication flow
 	/// If you call this API but for some reason you'd like to call this again, this is supported, the params you pass second time will replace the
@@ -127,8 +129,8 @@ public:
 	CSP_ASYNC_RESULT void ExchangeKey(const csp::common::String& UserId, const csp::common::String& Key, LoginStateResultCallback Callback);
 
 	/// @brief Logout from Magnopus Connected Services.
-	/// @param Callback LogoutResultCallback : callback to call when a response is received
-	CSP_ASYNC_RESULT void Logout(LogoutResultCallback Callback);
+	/// @param Callback NullResultCallback : callback to call when a response is received
+	CSP_ASYNC_RESULT void Logout(NullResultCallback Callback);
 
 	// Profile
 
@@ -213,13 +215,13 @@ public:
 	CSP_ASYNC_RESULT void GetProfilesByUserId(const csp::common::Array<csp::common::String>& InUserIds, BasicProfilesResultCallback Callback);
 
 	/// @brief Ping Magnopus Connected Services
-	/// @param Callback PingResponseReceivedCallback : callback to call when a response is received
-	CSP_ASYNC_RESULT void Ping(PingResponseReceivedCallback Callback);
+	/// @param Callback NullResultCallback : callback to call when a response is received
+	CSP_ASYNC_RESULT void Ping(NullResultCallback Callback);
 
 	/// @brief Retrieve User token from Agora
 	/// @param Params AgoraUserTokenParams : Params to configure the User token
 	/// @param Callback UserTokenResultCallback : callback to call when a response is received
-	CSP_ASYNC_RESULT void GetAgoraUserToken(const AgoraUserTokenParams& Params, UserTokenResultCallback Callback);
+	CSP_ASYNC_RESULT void GetAgoraUserToken(const AgoraUserTokenParams& Params, StringResultCallback Callback);
 
 	/// @brief Re-send user verification email
 	/// @param InEmail csp::common::String : User's email address
@@ -232,18 +234,19 @@ public:
 	/// @brief Get the Customer Portal Url for a user from Stripe
 	/// @param UserId csp::common::String : the id of the user associated with the customer portal
 	/// @param Callback StringResultCallback : callback that contains the customer portal URL of the User
-	CSP_ASYNC_RESULT void GetCustomerPortalUrl(const csp::common::String& UserId, CustomerPortalUrlResultCallback Callback);
+	CSP_ASYNC_RESULT void GetCustomerPortalUrl(const csp::common::String& UserId, StringResultCallback Callback);
 
 	/// @brief Get the checkout session Url for a user from Stripe
 	/// @param Tier csp::systems::TierNames : the tier of the checkout session needed
-	/// @param Callback CheckoutSessionUrlResultCallback : callback that contains the checkout session URL of the tier
-	CSP_ASYNC_RESULT void GetCheckoutSessionUrl(TierNames Tier, CheckoutSessionUrlResultCallback Callback);
+	/// @param Callback StringResultCallback : callback that contains the checkout session URL of the tier
+	CSP_ASYNC_RESULT void GetCheckoutSessionUrl(TierNames Tier, StringResultCallback Callback);
 
 private:
 	UserSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	UserSystem(csp::web::WebClient* InWebClient);
 
-	[[nodiscard]] bool EmailCheck(const std::string& Email) const;
+	[[nodiscard]]
+	bool EmailCheck(const std::string& Email) const;
 
 	void NotifyRefreshTokenHasChanged();
 	void ResetAuthenticationState();
@@ -256,7 +259,7 @@ private:
 
 	LoginState CurrentLoginState;
 
-	NewLoginTokenReceivedCallback RefreshTokenChangedCallback;
+	LoginTokenInfoResultCallback RefreshTokenChangedCallback;
 
 	csp::common::String ThirdPartyAuthStateId;
 	csp::common::String ThirdPartyAuthRedirectURL;

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "CSP/Systems/Users/Authentication.h"
 
 #include "CSP/Systems/SystemsManager.h"
@@ -23,9 +24,13 @@
 #include "Services/AggregationService/Api.h"
 #include "Services/ApiBase/ApiBase.h"
 #include "Services/UserService/Dto.h"
+#include "Systems/Users/Authentication.h"
 
 
+using namespace csp;
+using namespace csp::common;
 using namespace std::chrono;
+
 namespace chs			  = csp::services::generated::userservice;
 namespace chs_aggregation = csp::services::generated::aggregationservice;
 
@@ -33,7 +38,7 @@ namespace chs_aggregation = csp::services::generated::aggregationservice;
 namespace csp::systems
 {
 
-LoginState::LoginState() : State(ELoginState::LoggedOut), AccessTokenRefreshTime(CSP_NEW csp::common::DateTime())
+LoginState::LoginState() : State(ELoginState::LoggedOut), AccessTokenRefreshTime(CSP_NEW DateTime())
 {
 }
 
@@ -59,9 +64,8 @@ void LoginState::CopyStateFrom(const LoginState& OtherState)
 
 	// Must reallocate the access token when copying otherwise destructor of
 	// copied state will delete the original memory pointer potentially causing corruption
-	AccessTokenRefreshTime = CSP_NEW csp::common::DateTime(OtherState.AccessTokenRefreshTime->GetTimePoint());
+	AccessTokenRefreshTime = CSP_NEW DateTime(OtherState.AccessTokenRefreshTime->GetTimePoint());
 }
-
 
 LoginState::~LoginState()
 {
@@ -75,7 +79,7 @@ bool LoginState::RefreshNeeded() const
 		return false;
 	}
 
-	const auto CurrentTime = csp::common::DateTime::UtcTimeNow();
+	const auto CurrentTime = DateTime::UtcTimeNow();
 
 	return CurrentTime >= (*AccessTokenRefreshTime);
 }
@@ -89,24 +93,19 @@ LoginStateResult::LoginStateResult(LoginState* InStatePtr) : State(InStatePtr)
 {
 }
 
-LoginState& LoginStateResult::GetLoginState()
-{
-	return *State;
-}
-
 const LoginState& LoginStateResult::GetLoginState() const
 {
 	return *State;
 }
 
-void LoginStateResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
+void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
 	ResultBase::OnResponse(ApiResponse);
 
-	auto AuthResponse					   = static_cast<chs::AuthDto*>(ApiResponse->GetDto());
-	const csp::web::HttpResponse* Response = ApiResponse->GetResponse();
+	auto AuthResponse				  = static_cast<chs::AuthDto*>(ApiResponse->GetDto());
+	const web::HttpResponse* Response = ApiResponse->GetResponse();
 
-	if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
+	if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
 	{
 		// Build the Dto from the response Json
 		AuthResponse->FromJson(Response->GetPayload().GetContent());
@@ -119,12 +118,12 @@ void LoginStateResult::OnResponse(const csp::services::ApiResponseBase* ApiRespo
 			State->UserId		= AuthResponse->GetUserId();
 			State->DeviceId		= AuthResponse->GetDeviceId();
 
-			const csp::common::DateTime Expiry(AuthResponse->GetAccessTokenExpiresAt());
-			const csp::common::DateTime CurrentTime(csp::common::DateTime::UtcTimeNow());
+			const DateTime Expiry(AuthResponse->GetAccessTokenExpiresAt());
+			const DateTime CurrentTime(DateTime::UtcTimeNow());
 
 			if (CurrentTime >= Expiry)
 			{
-				CSP_LOG_FORMAT(csp::systems::LogLevel::Error,
+				CSP_LOG_FORMAT(LogLevel::Error,
 							   "AccessToken Expired: %s %s",
 							   AuthResponse->GetAccessToken().c_str(),
 							   AuthResponse->GetAccessTokenExpiresAt().c_str());
@@ -132,18 +131,18 @@ void LoginStateResult::OnResponse(const csp::services::ApiResponseBase* ApiRespo
 				return;
 			}
 
-			csp::web::HttpAuth::SetAccessToken(AuthResponse->GetAccessToken(),
-											   AuthResponse->GetAccessTokenExpiresAt(),
-											   AuthResponse->GetRefreshToken(),
-											   AuthResponse->GetRefreshTokenExpiresAt());
+			web::HttpAuth::SetAccessToken(AuthResponse->GetAccessToken(),
+										  AuthResponse->GetAccessTokenExpiresAt(),
+										  AuthResponse->GetRefreshToken(),
+										  AuthResponse->GetRefreshTokenExpiresAt());
 
 			// Schedule a Refresh of the Token 5 minutes before it expires
 			system_clock::time_point RefreshTimepoint = Expiry.GetTimePoint() - system_clock::duration(5min);
-			csp::common::DateTime RefreshTime(RefreshTimepoint);
+			DateTime RefreshTime(RefreshTimepoint);
 
 			if (RefreshTime >= Expiry)
 			{
-				CSP_LOG_FORMAT(csp::systems::LogLevel::Error,
+				CSP_LOG_FORMAT(LogLevel::Error,
 							   "RefreshToken Expired: %s %s",
 							   AuthResponse->GetRefreshToken().c_str(),
 							   AuthResponse->GetRefreshTokenExpiresAt().c_str());
@@ -154,9 +153,9 @@ void LoginStateResult::OnResponse(const csp::services::ApiResponseBase* ApiRespo
 			*(State->AccessTokenRefreshTime) = RefreshTime;
 
 			// Signal login to anyone interested
-			csp::events::Event* LoginEvent = csp::events::EventSystem::Get().AllocateEvent(csp::events::USERSERVICE_LOGIN_EVENT_ID);
+			events::Event* LoginEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGIN_EVENT_ID);
 			LoginEvent->AddString("UserId", AuthResponse->GetUserId());
-			csp::events::EventSystem::Get().EnqueueEvent(LoginEvent);
+			events::EventSystem::Get().EnqueueEvent(LoginEvent);
 
 			SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
 		}
@@ -165,7 +164,7 @@ void LoginStateResult::OnResponse(const csp::services::ApiResponseBase* ApiRespo
 	{
 		if (State)
 		{
-			csp::web::HttpAuth::SetAccessToken("", "", "", "");
+			web::HttpAuth::SetAccessToken("", "", "", "");
 
 			State->State		= ELoginState::Error;
 			State->AccessToken	= "InvalidAccessToken";
@@ -185,11 +184,11 @@ LogoutResult::LogoutResult(LoginState* InStatePtr) : NullResult(InStatePtr), Sta
 {
 }
 
-void LogoutResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
+void LogoutResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
 	ResultBase::OnResponse(ApiResponse);
 
-	if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
+	if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
 	{
 		if (State)
 		{
@@ -199,11 +198,11 @@ void LogoutResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
 			State->UserId		= "InvalidUserId";
 			State->DeviceId		= "InvalidDeviceId";
 
-			csp::web::HttpAuth::SetAccessToken("", "", "", "");
+			web::HttpAuth::SetAccessToken("", "", "", "");
 
 			// Send logout event
-			csp::events::Event* LogoutEvent = csp::events::EventSystem::Get().AllocateEvent(csp::events::USERSERVICE_LOGOUT_EVENT_ID);
-			csp::events::EventSystem::Get().EnqueueEvent(LogoutEvent);
+			events::Event* LogoutEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGOUT_EVENT_ID);
+			events::EventSystem::Get().EnqueueEvent(LogoutEvent);
 		}
 	}
 	else
@@ -216,126 +215,94 @@ void LogoutResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
 			State->UserId		= "InvalidUserId";
 			State->DeviceId		= "InvalidDeviceId";
 
-			csp::web::HttpAuth::SetAccessToken("", "", "", "");
+			web::HttpAuth::SetAccessToken("", "", "", "");
 		}
 	}
 }
 
 
-LoginTokenInfo& LoginTokenReceived::GetLoginTokenInfo()
+const LoginTokenInfo& LoginTokenInfoResult::GetLoginTokenInfo() const
 {
-	return LoginTokenInfo;
+	return TokenInfo;
 }
 
-const LoginTokenInfo& LoginTokenReceived::GetLoginTokenInfo() const
+void LoginTokenInfoResult::FillLoginTokenInfo(const String& AccessToken,
+											  const String& AccessTokenExpiry,
+											  const String& RefreshToken,
+											  const String& RefreshTokenExpiry)
 {
-	return LoginTokenInfo;
+	SetResult(EResultCode::Success, static_cast<uint16_t>(web::EResponseCodes::ResponseOK));
+
+	TokenInfo.AccessToken		= AccessToken;
+	TokenInfo.AccessExpiryTime	= AccessTokenExpiry;
+	TokenInfo.RefreshToken		= RefreshToken;
+	TokenInfo.RefreshExpiryTime = RefreshTokenExpiry;
 }
 
-void LoginTokenReceived::FillLoginTokenInfo(const csp::common::String& AccessToken,
-											const csp::common::String& AccessTokenExpiry,
-											const csp::common::String& RefreshToken,
-											const csp::common::String& RefreshTokenExpiry)
+void AgoraUserTokenResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
-	SetResult(csp::systems::EResultCode::Success, static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
+	ResultBase::OnResponse(ApiResponse);
 
-	LoginTokenInfo.AccessToken		 = AccessToken;
-	LoginTokenInfo.AccessExpiryTime	 = AccessTokenExpiry;
-	LoginTokenInfo.RefreshToken		 = RefreshToken;
-	LoginTokenInfo.RefreshExpiryTime = RefreshTokenExpiry;
-}
+	auto AuthResponse				  = static_cast<chs_aggregation::ServiceResponse*>(ApiResponse->GetDto());
+	const web::HttpResponse* Response = ApiResponse->GetResponse();
 
-const csp::common::String& AgoraUserTokenResult::GetUserToken() const
-{
-	return UserToken;
-}
-
-const csp::common::String& AgoraUserTokenResult::GetUserToken()
-{
-	return UserToken;
-}
-
-void AgoraUserTokenResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
-{
-	csp::systems::ResultBase::OnResponse(ApiResponse);
-
-	auto AuthResponse					   = static_cast<chs_aggregation::ServiceResponse*>(ApiResponse->GetDto());
-	const csp::web::HttpResponse* Response = ApiResponse->GetResponse();
-
-	if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
+	if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
 	{
 		AuthResponse->FromJson(Response->GetPayload().GetContent());
-
 		std::shared_ptr<rapidjson::Document> Result = AuthResponse->GetOperationResult();
 
 		if (!Result)
 		{
-			CSP_LOG_MSG(csp::systems::LogLevel::Error, "AgoraUserTokenResult invalid");
+			CSP_LOG_MSG(LogLevel::Error, "AgoraUserTokenResult invalid");
+
 			return;
 		}
 
 		if (!Result->HasMember("token"))
 		{
-			CSP_LOG_MSG(csp::systems::LogLevel::Error, "AgoraUserTokenResult doesn't contain expected member: token");
+			CSP_LOG_MSG(LogLevel::Error, "AgoraUserTokenResult doesn't contain expected member: token");
+
 			return;
 		}
 
-		UserToken = Result->operator[]("token").GetString();
+		SetValue(Result->operator[]("token").GetString());
 	}
 }
 
-const csp::common::String& CheckoutSessionUrlResult::GetUrl() const
-{
-	return CheckoutSessionUrl;
-}
 
-const csp::common::String& CheckoutSessionUrlResult::GetUrl()
-{
-	return CheckoutSessionUrl;
-}
-
-void CheckoutSessionUrlResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
+void CheckoutSessionUrlResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
 	ResultBase::OnResponse(ApiResponse);
 
-	auto CheckoutSessionResponse		   = static_cast<chs::StripeCheckoutSessionDto*>(ApiResponse->GetDto());
-	const csp::web::HttpResponse* Response = ApiResponse->GetResponse();
+	auto CheckoutSessionResponse	  = static_cast<chs::StripeCheckoutSessionDto*>(ApiResponse->GetDto());
+	const web::HttpResponse* Response = ApiResponse->GetResponse();
 
-	if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
+	if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
 	{
 		CheckoutSessionResponse->FromJson(Response->GetPayload().GetContent());
 
 		if (CheckoutSessionResponse->HasCheckoutUrl())
 		{
-			CheckoutSessionUrl = CheckoutSessionResponse->GetCheckoutUrl();
+			SetValue(CheckoutSessionResponse->GetCheckoutUrl());
 		}
 	}
 }
 
-const csp::common::String& CustomerPortalUrlResult::GetUrl() const
-{
-	return CustomerPortalUrl;
-}
 
-const csp::common::String& CustomerPortalUrlResult::GetUrl()
-{
-	return CustomerPortalUrl;
-}
-
-void CustomerPortalUrlResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
+void CustomerPortalUrlResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
 	ResultBase::OnResponse(ApiResponse);
 
-	auto CustomerPortalResponse			   = static_cast<chs::StripeCustomerPortalDto*>(ApiResponse->GetDto());
-	const csp::web::HttpResponse* Response = ApiResponse->GetResponse();
+	auto CustomerPortalResponse		  = static_cast<chs::StripeCustomerPortalDto*>(ApiResponse->GetDto());
+	const web::HttpResponse* Response = ApiResponse->GetResponse();
 
-	if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
+	if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
 	{
 		CustomerPortalResponse->FromJson(Response->GetPayload().GetContent());
 
 		if (CustomerPortalResponse->HasCustomerPortalUrl())
 		{
-			CustomerPortalUrl = CustomerPortalResponse->GetCustomerPortalUrl();
+			SetValue(CustomerPortalResponse->GetCustomerPortalUrl());
 		}
 	}
 }

--- a/Library/src/Systems/Users/Authentication.h
+++ b/Library/src/Systems/Users/Authentication.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+
+#include "CSP/Systems/Users/Authentication.h"
+
+
+namespace csp::systems
+{
+
+/// @brief Result structure for a logout state request.
+class CSP_API LogoutResult : public NullResult
+{
+	/** @cond DO_NOT_DOCUMENT */
+	CSP_START_IGNORE
+	template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
+	friend class UserSystem;
+	CSP_END_IGNORE
+	/** @endcond */
+
+private:
+	LogoutResult();
+	LogoutResult(LoginState* InStatePtr);
+
+	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+
+	LoginState* State;
+};
+
+
+/// @brief @brief Data class used to contain information requesting a user token
+class CSP_API AgoraUserTokenResult : public StringResult
+{
+	/** @cond DO_NOT_DOCUMENT */
+	CSP_START_IGNORE
+	template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
+	friend class UserSystem;
+	CSP_END_IGNORE
+	/** @endcond */
+
+private:
+	AgoraUserTokenResult() = default;
+	AgoraUserTokenResult(void*) {};
+
+	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+};
+
+
+/// @brief Result url for a tier checkout session request
+class CSP_API CheckoutSessionUrlResult : public StringResult
+{
+	/** @cond DO_NOT_DOCUMENT */
+	CSP_START_IGNORE
+	friend class UserSystem;
+	CSP_END_IGNORE
+	/** @endcond */
+
+public:
+	CheckoutSessionUrlResult() = default;
+	CheckoutSessionUrlResult(void*) {};
+
+private:
+	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+};
+
+
+/// @brief Result url for a user customer portal request
+class CSP_API CustomerPortalUrlResult : public StringResult
+{
+	/** @cond DO_NOT_DOCUMENT */
+	CSP_START_IGNORE
+	friend class UserSystem;
+	CSP_END_IGNORE
+	/** @endcond */
+
+public:
+	CustomerPortalUrlResult() = default;
+	CustomerPortalUrlResult(void*) {};
+
+private:
+	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+};
+
+} // namespace csp::systems

--- a/Tests/CSharp/src/Tests/UserSystemTests.cs
+++ b/Tests/CSharp/src/Tests/UserSystemTests.cs
@@ -834,7 +834,7 @@ namespace CSPEngine
             var result = userSystem.GetAgoraUserToken(tokenParams).Result;
 
             Assert.AreEqual(result.GetResultCode(), Systems.EResultCode.Success);
-            Assert.AreNotEqual(result.GetUserToken(), "");
+            Assert.AreNotEqual(result.GetValue(), "");
         }
 #endif
 

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -346,7 +346,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInWithTokenTest)
 	csp::common::String LoginToken;
 	bool LoginTokenAvailable = false;
 
-	csp::systems::NewLoginTokenReceivedCallback LoginTokenReceivedCallback = [&](csp::systems::LoginTokenReceived& Result)
+	csp::systems::LoginTokenInfoResultCallback LoginTokenReceivedCallback = [&](csp::systems::LoginTokenInfoResult& Result)
 	{
 		EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -1122,7 +1122,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
 	auto [Result] = AWAIT_PRE(UserSystem, GetAgoraUserToken, RequestPredicate, Params);
 
 	EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
-	EXPECT_FALSE(Result.GetUserToken().IsEmpty());
+	EXPECT_FALSE(Result.GetValue().IsEmpty());
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1247,6 +1247,6 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetCheckoutSessionUrlTest)
 
 	EXPECT_EQ(Result.GetFailureReason(), csp::systems::ERequestFailureReason::None);
 
-	EXPECT_NE(Result.GetUrl(), "");
+	EXPECT_NE(Result.GetValue(), "");
 }
 #endif


### PR DESCRIPTION
Some result types have been refactored to reduce the number of public result types, and to make the return value type more apparent.

BREAKING CHANGES:
* `UserSystem::LogOut` now takes `NullResultCallback` instead of `LogoutResultCallback`. `LogoutResultCallback` is now private.
* `UserSystem::GetAgoraUserToken` now takes `StringResultCallback` instead of `UserTokenResultCallback`. `UserTokenResultCallback` is now private.
* `UserSystem::GetCustomerPortalUrl` now takes `StringResultCallback` instead of `CustomerPortalUrlResultCallback`. `CustomerPortalUrlResultCallback` is now private.
* `UserSystem::GetCheckoutSessionUrl` now takes `StringResultCallback` instead of `CheckoutSessionUrlResultCallback`. `CheckoutSessionUrlResultCallback` is now private.
* `UserSystem::Ping` now takes a `NullResultCallback` instead of a `PingResponseReceivedCallback`. `PingResponseReceivedCallback` has been removed.
* `LoginTokenReceived` has been renamed `LoginTokenInfoResult`.
* `NewLoginTokenReceivedCallback` has been renamed `LoginTokenInfoResultCallback`,
* Non-const versions of result types' `GetX` members have been removed.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
