### PR TITLE
[OB-953] fix: FileAssetDataSource bad path

### DIFF
--- a/Library/src/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Web/POCOWebClient/POCOWebClient.cpp
@@ -488,7 +488,7 @@ void POCOWebClient::SetFileUploadContentFromFile(HttpPayload* Payload,
 	}
 	else
 	{
-		CSP_LOG_WARN_MSG("File not found.");
+		CSP_LOG_WARN_FORMAT("File not found. Path given: %s", FilePath);
 	}
 }
 

--- a/Library/src/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Web/POCOWebClient/POCOWebClient.cpp
@@ -17,6 +17,7 @@
 
 #include "Debug/Logging.h"
 
+#include <Poco/File.h>
 #include <Poco/MD5Engine.h>
 #include <Poco/Net/AcceptCertificateHandler.h>
 #include <Poco/Net/Context.h>
@@ -478,9 +479,17 @@ void POCOWebClient::SetFileUploadContentFromFile(HttpPayload* Payload,
 												 const char* Version,
 												 const csp::common::String& MediaType)
 {
-	/// @note this must be newed as it is deleted by the HTMLForm
-	Poco::Net::FilePartSource* Source = new Poco::Net::FilePartSource(FilePath, MediaType.c_str());
-	SetFileUploadContent(Payload, Source, Version);
+	Poco::File* File = new Poco::File(FilePath);
+	if (File->exists())
+	{
+		/// @note this must be newed as it is deleted by the HTMLForm
+		Poco::Net::FilePartSource* Source = new Poco::Net::FilePartSource(FilePath, MediaType.c_str());
+		SetFileUploadContent(Payload, Source, Version);
+	}
+	else
+	{
+		CSP_LOG_WARN_MSG("File not found.");
+	}
 }
 
 void POCOWebClient::SetFileUploadContentFromString(HttpPayload* Payload,

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1485,6 +1485,19 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceThumbnailTest)
 		EXPECT_TRUE(Result.GetUri().IsEmpty());
 	}
 
+
+	{ /// Bad file path test
+		FileAssetDataSource SpaceThumbnail;
+		const std::string LocalFileName = "OKO.png";
+		const auto FilePath				= std::filesystem::absolute("assets/badpath/" + LocalFileName);
+		SpaceThumbnail.FilePath			= FilePath.u8string().c_str();
+		SpaceThumbnail.SetMimeType("image/png");
+
+		auto [Result] = AWAIT_PRE(SpaceSystem, UpdateSpaceThumbnail, RequestPredicate, Space.Id, SpaceThumbnail);
+
+		EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+	}
+
 	{
 		FileAssetDataSource SpaceThumbnail;
 		const std::string LocalFileName = "OKO.png";


### PR DESCRIPTION
* Fixed a crash when a bad path was supplied for a file upload
* Added a test for bad paths in uploads

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
