### PR TITLE
[NT-0] fix: Update module dependencies

### DIFF
--- a/teamcity/requirements.txt
+++ b/teamcity/requirements.txt
@@ -3,5 +3,6 @@ gitdb==4.0.9
 GitPython==3.1.32
 smmap==5.0.0
 PyYAML==5.3.1
+distutils==3.10.4
 jinja2==3.1.2
 jinja2-workarounds==0.1.0


### PR DESCRIPTION
We have a python dependency on the distutils module. This module is missing on the uk-hw-win-01 agent, and so I am adding it to our requirements.txt file.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
