### PR TITLE
[NT-0] fix: Remove distutils dependency

### DIFF
--- a/teamcity/BuildNPMWebPackage.py
+++ b/teamcity/BuildNPMWebPackage.py
@@ -3,8 +3,6 @@ import argparse
 import shutil
 import subprocess
 
-from distutils.dir_util import copy_tree
-
 from Config import config
 
 class ConnectedSpacesPlatformPyError(Exception): pass
@@ -104,7 +102,7 @@ def copy_packages_in(input_args, output_path):
             file_path = os.path.join(path, file)
 
             if os.path.isdir(file_path):
-                copy_tree(file_path, output_path + "\\" + file)
+                shutil.copytree(file_path, output_path + "\\" + file, dirs_exist_ok=True)
             else:
                 shutil.copy2(file_path, output_path)
 

--- a/teamcity/PublishCSPForUnity.py
+++ b/teamcity/PublishCSPForUnity.py
@@ -8,7 +8,6 @@ import uuid
 
 import git
 
-from distutils import dir_util
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -163,7 +162,7 @@ def main():
         f.write(minimal_meta_template.render(guid=generate_guid(), importer_type="Default"))
 
     for path in args.csharp_artifact_paths:
-        dir_util.copy_tree(path, source_output_directory)
+        shutil.copytree(path, source_output_directory)
 
     for path, dirs, files in os.walk(source_output_directory):
         for dir in dirs:

--- a/teamcity/PublishCSPForUnity.py
+++ b/teamcity/PublishCSPForUnity.py
@@ -162,7 +162,7 @@ def main():
         f.write(minimal_meta_template.render(guid=generate_guid(), importer_type="Default"))
 
     for path in args.csharp_artifact_paths:
-        shutil.copytree(path, source_output_directory)
+        shutil.copytree(path, source_output_directory, dirs_exist_ok=True)
 
     for path, dirs, files in os.walk(source_output_directory):
         for dir in dirs:


### PR DESCRIPTION
The build agents have been updated to Python 3.12
and support distutils has been removed with that release. Updating the script to use shutil.copy_tree instead.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
