### PR TITLE
[OF-498] refac!: merge asset collection get functions

### DIFF
--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -98,12 +98,6 @@ public:
 	/// @param Callback AssetCollectionResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void GetAssetCollectionByName(const csp::common::String& AssetCollectionName, AssetCollectionResultCallback Callback);
 
-	/// @brief Finds a collection of asset collections by their Ids.
-	/// @param AssetCollectionIds csp::common::Array<csp::common::String> : an array of Ids to search for
-	/// @param Callback AssetCollectionResultCallback : callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetAssetCollectionsByIds(const csp::common::Array<csp::common::String>& AssetCollectionIds,
-												   AssetCollectionsResultCallback Callback);
-
 	/// @brief Retrieves asset collections based on the specified search criteria.
 	/// Results pagination is supported through the use of ResultsSkipNumber and ResultsMaxNumber.
 	/// @param Space Space : optional space to get asset collections associated with it
@@ -117,14 +111,15 @@ public:
 	/// @param ResultsMaxNumber int : optional param representing the maximum number of result entries to be retrieved. For all available result
 	/// entries pass nullptr.
 	/// @param Callback AssetCollectionsResultCallback : callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetAssetCollectionsByCriteria(const csp::common::Optional<csp::common::String>& SpaceId,
-														const csp::common::Optional<csp::common::String>& AssetCollectionParentId,
-														const csp::common::Optional<EAssetCollectionType>& AssetCollectionType,
-														const csp::common::Optional<csp::common::Array<csp::common::String>>& AssetCollectionTags,
-														const csp::common::Optional<csp::common::Array<csp::common::String>>& AssetCollectionNames,
-														const csp::common::Optional<int>& ResultsSkipNumber,
-														const csp::common::Optional<int>& ResultsMaxNumber,
-														AssetCollectionsResultCallback Callback);
+	CSP_ASYNC_RESULT void FindAssetCollections(const csp::common::Optional<csp::common::Array<csp::common::String>>& Ids,
+											   const csp::common::Optional<csp::common::String>& ParentId,
+											   const csp::common::Optional<csp::common::Array<csp::common::String>>& Names,
+											   const csp::common::Optional<csp::common::Array<EAssetCollectionType>>& Types,
+											   const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags,
+											   const csp::common::Optional<csp::common::Array<csp::common::String>>& SpaceIds,
+											   const csp::common::Optional<int>& ResultsSkipNumber,
+											   const csp::common::Optional<int>& ResultsMaxNumber,
+											   AssetCollectionsResultCallback Callback);
 
 	/// @brief Updates the Metadata field of an Asset Collection
 	/// @param AssetCollection AssetCollection : asset collection to be updated

--- a/Library/src/Multiplayer/Conversation/ConversationSystem.cpp
+++ b/Library/src/Multiplayer/Conversation/ConversationSystem.cpp
@@ -326,15 +326,18 @@ void ConversationSystem::GetMessagesFromConversation(const csp::common::String& 
 		INVOKE_IF_NOT_NULL(Callback, InternalResult);
 	};
 
+	Array<csp::systems::EAssetCollectionType> PrototypeTypes = {csp::systems::EAssetCollectionType::COMMENT};
+
 	auto* AssetSystem = csp::systems::SystemsManager::Get().GetAssetSystem();
-	AssetSystem->GetAssetCollectionsByCriteria(nullptr,
-											   ConversationId,
-											   csp::systems::EAssetCollectionType::COMMENT,
-											   nullptr,
-											   nullptr,
-											   ResultsSkipNumber,
-											   ResultsMaxNumber,
-											   GetMessagesCallback);
+	AssetSystem->FindAssetCollections(nullptr,
+									  ConversationId,
+									  nullptr,
+									  PrototypeTypes,
+									  nullptr,
+									  nullptr,
+									  ResultsSkipNumber,
+									  ResultsMaxNumber,
+									  GetMessagesCallback);
 }
 
 void ConversationSystem::GetMessage(const csp::common::String& MessageId, MessageResultCallback Callback)
@@ -578,15 +581,10 @@ void ConversationSystem::DeleteConversation(const csp::common::String& Conversat
 
 	auto* AssetSystem = csp::systems::SystemsManager::Get().GetAssetSystem();
 
+	Array<csp::systems::EAssetCollectionType> PrototypeTypes = {csp::systems::EAssetCollectionType::COMMENT};
+
 	// Retrieve first the messages from this conversation
-	AssetSystem->GetAssetCollectionsByCriteria(nullptr,
-											   ConversationId,
-											   csp::systems::EAssetCollectionType::COMMENT,
-											   nullptr,
-											   nullptr,
-											   nullptr,
-											   nullptr,
-											   GetMessagesCallback);
+	AssetSystem->FindAssetCollections(nullptr, ConversationId, nullptr, PrototypeTypes, nullptr, nullptr, nullptr, nullptr, GetMessagesCallback);
 }
 
 void ConversationSystem::DeleteMessage(const csp::common::String& MessageId, csp::systems::NullResultCallback Callback)

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "CSP/Systems/Assets/AssetSystem.h"
 
 #include "CallHelpers.h"
@@ -26,7 +27,10 @@
 #include "CSP/Common/StringFormat.h"
 
 
-namespace chs = csp::services::generated::prototypeservice;
+using namespace csp;
+using namespace csp::common;
+
+namespace chs = services::generated::prototypeservice;
 
 constexpr int DEFAULT_SKIP_NUMBER		= 0;
 constexpr int DEFAULT_RESULT_MAX_NUMBER = 100;
@@ -35,17 +39,17 @@ constexpr int DEFAULT_RESULT_MAX_NUMBER = 100;
 namespace
 {
 
-csp::common::String ConvertAssetCollectionTypeToString(csp::systems::EAssetCollectionType AssetCollectionType)
+String ConvertAssetCollectionTypeToString(systems::EAssetCollectionType AssetCollectionType)
 {
-	if (AssetCollectionType == csp::systems::EAssetCollectionType::DEFAULT)
+	if (AssetCollectionType == systems::EAssetCollectionType::DEFAULT)
 		return "Default";
-	else if (AssetCollectionType == csp::systems::EAssetCollectionType::FOUNDATION_INTERNAL)
+	else if (AssetCollectionType == systems::EAssetCollectionType::FOUNDATION_INTERNAL)
 		return "FoundationInternal";
-	else if (AssetCollectionType == csp::systems::EAssetCollectionType::COMMENT_CONTAINER)
+	else if (AssetCollectionType == systems::EAssetCollectionType::COMMENT_CONTAINER)
 		return "CommentContainer";
-	else if (AssetCollectionType == csp::systems::EAssetCollectionType::COMMENT)
+	else if (AssetCollectionType == systems::EAssetCollectionType::COMMENT)
 		return "Comment";
-	else if (AssetCollectionType == csp::systems::EAssetCollectionType::SPACE_THUMBNAIL)
+	else if (AssetCollectionType == systems::EAssetCollectionType::SPACE_THUMBNAIL)
 		return "SpaceThumbnail";
 	else
 	{
@@ -54,25 +58,25 @@ csp::common::String ConvertAssetCollectionTypeToString(csp::systems::EAssetColle
 	}
 }
 
-csp::common::String ConvertAssetTypeToString(csp::systems::EAssetType AssetType)
+String ConvertAssetTypeToString(systems::EAssetType AssetType)
 {
-	if (AssetType == csp::systems::EAssetType::IMAGE)
+	if (AssetType == systems::EAssetType::IMAGE)
 		return "Image";
-	else if (AssetType == csp::systems::EAssetType::THUMBNAIL)
+	else if (AssetType == systems::EAssetType::THUMBNAIL)
 		return "Thumbnail";
-	else if (AssetType == csp::systems::EAssetType::SIMULATION)
+	else if (AssetType == systems::EAssetType::SIMULATION)
 		return "Simulation";
-	else if (AssetType == csp::systems::EAssetType::MODEL)
+	else if (AssetType == systems::EAssetType::MODEL)
 		return "Model";
-	else if (AssetType == csp::systems::EAssetType::VIDEO)
+	else if (AssetType == systems::EAssetType::VIDEO)
 		return "Video";
-	else if (AssetType == csp::systems::EAssetType::SCRIPT_LIBRARY)
+	else if (AssetType == systems::EAssetType::SCRIPT_LIBRARY)
 		return "ScriptLibrary";
-	else if (AssetType == csp::systems::EAssetType::HOLOCAP_VIDEO)
+	else if (AssetType == systems::EAssetType::HOLOCAP_VIDEO)
 		return "HolocapVideo";
-	else if (AssetType == csp::systems::EAssetType::HOLOCAP_AUDIO)
+	else if (AssetType == systems::EAssetType::HOLOCAP_AUDIO)
 		return "HolocapAudio";
-	else if (AssetType == csp::systems::EAssetType::AUDIO)
+	else if (AssetType == systems::EAssetType::AUDIO)
 		return "Audio";
 	else
 	{
@@ -81,13 +85,12 @@ csp::common::String ConvertAssetTypeToString(csp::systems::EAssetType AssetType)
 	}
 }
 
-std::shared_ptr<chs::PrototypeDto>
-	CreatePrototypeDto(const csp::common::Optional<csp::common::String>& SpaceId,
-					   const csp::common::Optional<csp::common::String>& ParentAssetCollectionId,
-					   const csp::common::String& AssetCollectionName,
-					   const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata,
-					   csp::systems::EAssetCollectionType Type,
-					   const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags)
+std::shared_ptr<chs::PrototypeDto> CreatePrototypeDto(const Optional<String>& SpaceId,
+													  const Optional<String>& ParentAssetCollectionId,
+													  const String& AssetCollectionName,
+													  const Optional<Map<String, String>>& Metadata,
+													  systems::EAssetCollectionType Type,
+													  const Optional<Array<String>>& Tags)
 {
 	auto PrototypeInfo = std::make_shared<chs::PrototypeDto>();
 	PrototypeInfo->SetName(AssetCollectionName);
@@ -96,7 +99,7 @@ std::shared_ptr<chs::PrototypeDto>
 
 	if (SpaceId.HasValue())
 	{
-		const std::vector<csp::common::String> GroupIds = {*SpaceId};
+		const std::vector<String> GroupIds = {*SpaceId};
 		PrototypeInfo->SetGroupIds(GroupIds);
 	}
 
@@ -107,7 +110,7 @@ std::shared_ptr<chs::PrototypeDto>
 
 	if (Metadata.HasValue())
 	{
-		std::map<csp::common::String, csp::common::String> DTOMetadata;
+		std::map<String, String> DTOMetadata;
 
 		auto* Keys = Metadata->Keys();
 
@@ -115,7 +118,7 @@ std::shared_ptr<chs::PrototypeDto>
 		{
 			auto Key   = Keys->operator[](idx);
 			auto Value = Metadata->operator[](Key);
-			DTOMetadata.insert(std::pair<csp::common::String, csp::common::String>(Key, Value));
+			DTOMetadata.insert(std::pair<String, String>(Key, Value));
 		}
 
 		PrototypeInfo->SetMetadata(DTOMetadata);
@@ -123,7 +126,7 @@ std::shared_ptr<chs::PrototypeDto>
 
 	if (Tags.HasValue())
 	{
-		std::vector<csp::common::String> TagsVector;
+		std::vector<String> TagsVector;
 		TagsVector.reserve(Tags->Size());
 
 		for (size_t idx = 0; idx < Tags->Size(); ++idx)
@@ -147,12 +150,12 @@ AssetSystem::AssetSystem() : SystemBase(), PrototypeAPI(nullptr), AssetDetailAPI
 {
 }
 
-AssetSystem::AssetSystem(csp::web::WebClient* InWebClient) : SystemBase(InWebClient)
+AssetSystem::AssetSystem(web::WebClient* InWebClient) : SystemBase(InWebClient)
 {
 	PrototypeAPI   = CSP_NEW chs::PrototypeApi(InWebClient);
 	AssetDetailAPI = CSP_NEW chs::AssetDetailApi(InWebClient);
 
-	FileManager = CSP_NEW csp::web::RemoteFileManager(InWebClient);
+	FileManager = CSP_NEW web::RemoteFileManager(InWebClient);
 }
 
 AssetSystem::~AssetSystem()
@@ -163,15 +166,15 @@ AssetSystem::~AssetSystem()
 	CSP_DELETE(PrototypeAPI);
 }
 
-void AssetSystem::CreateAssetCollection(const csp::common::Optional<csp::common::String>& InSpaceId,
-										const csp::common::Optional<csp::common::String>& ParentAssetCollectionId,
-										const csp::common::String& AssetCollectionName,
-										const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata,
+void AssetSystem::CreateAssetCollection(const Optional<String>& InSpaceId,
+										const Optional<String>& ParentAssetCollectionId,
+										const String& AssetCollectionName,
+										const Optional<Map<String, String>>& Metadata,
 										EAssetCollectionType Type,
-										const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags,
+										const Optional<Array<String>>& Tags,
 										AssetCollectionResultCallback Callback)
 {
-	csp::common::Optional<csp::common::String> SpaceId;
+	Optional<String> SpaceId;
 
 	if (InSpaceId.HasValue())
 	{
@@ -180,18 +183,18 @@ void AssetSystem::CreateAssetCollection(const csp::common::Optional<csp::common:
 
 	const auto PrototypeInfo = CreatePrototypeDto(SpaceId, ParentAssetCollectionId, AssetCollectionName, Metadata, Type, Tags);
 
-	const csp::services::ResponseHandlerPtr ResponseHandler
+	const services::ResponseHandlerPtr ResponseHandler
 		= PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(
 			Callback,
 			nullptr,
-			csp::web::EResponseCodes::ResponseCreated);
+			web::EResponseCodes::ResponseCreated);
 
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesPost(PrototypeInfo, ResponseHandler);
 }
 
 void AssetSystem::DeleteAssetCollection(const AssetCollection& AssetCollection, NullResultCallback Callback)
 {
-	const csp::common::String PrototypeId = AssetCollection.Id;
+	const String PrototypeId = AssetCollection.Id;
 
 	if (PrototypeId.IsEmpty())
 	{
@@ -202,10 +205,10 @@ void AssetSystem::DeleteAssetCollection(const AssetCollection& AssetCollection, 
 		return;
 	}
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= PrototypeAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback,
-																									nullptr,
-																									csp::web::EResponseCodes::ResponseNoContent);
+	services::ResponseHandlerPtr ResponseHandler
+		= PrototypeAPI->CreateHandler<NullResultCallback, NullResult, void, services::NullDto>(Callback,
+																							   nullptr,
+																							   web::EResponseCodes::ResponseNoContent);
 
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdDelete(PrototypeId, ResponseHandler);
 }
@@ -285,23 +288,23 @@ void AssetSystem::CopyAssetCollectionsToSpace(csp::common::Array<AssetCollection
 		);
 }
 
-void AssetSystem::GetAssetCollectionById(const csp::common::String& AssetCollectionId, AssetCollectionResultCallback Callback)
+void AssetSystem::GetAssetCollectionById(const String& AssetCollectionId, AssetCollectionResultCallback Callback)
 {
-	csp::services::ResponseHandlerPtr ResponseHandler
+	services::ResponseHandlerPtr ResponseHandler
 		= PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
 
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdGet(AssetCollectionId, ResponseHandler);
 }
 
-void AssetSystem::GetAssetCollectionByName(const csp::common::String& AssetCollectionName, AssetCollectionResultCallback Callback)
+void AssetSystem::GetAssetCollectionByName(const String& AssetCollectionName, AssetCollectionResultCallback Callback)
 {
-	csp::services::ResponseHandlerPtr ResponseHandler
+	services::ResponseHandlerPtr ResponseHandler
 		= PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
 
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesNameNameGet(AssetCollectionName, ResponseHandler);
 }
 
-void AssetSystem::GetAssetCollectionsByIds(const csp::common::Array<csp::common::String>& AssetCollectionIds, AssetCollectionsResultCallback Callback)
+void AssetSystem::GetAssetCollectionsByIds(const Array<String>& AssetCollectionIds, AssetCollectionsResultCallback Callback)
 {
 	if (AssetCollectionIds.IsEmpty())
 	{
@@ -312,7 +315,7 @@ void AssetSystem::GetAssetCollectionsByIds(const csp::common::Array<csp::common:
 		return;
 	}
 
-	std::vector<csp::common::String> Ids;
+	std::vector<String> Ids;
 	Ids.reserve(AssetCollectionIds.Size());
 
 	for (int i = 0; i < AssetCollectionIds.Size(); ++i)
@@ -320,10 +323,9 @@ void AssetSystem::GetAssetCollectionsByIds(const csp::common::Array<csp::common:
 		Ids.push_back(AssetCollectionIds[i]);
 	}
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= PrototypeAPI->CreateHandler<AssetCollectionsResultCallback, AssetCollectionsResult, void, csp::services::DtoArray<chs::PrototypeDto>>(
-			Callback,
-			nullptr);
+	services::ResponseHandlerPtr ResponseHandler
+		= PrototypeAPI->CreateHandler<AssetCollectionsResultCallback, AssetCollectionsResult, void, services::DtoArray<chs::PrototypeDto>>(Callback,
+																																		   nullptr);
 
 	// Use `GET /api/v1/prototypes` and only pass asset collection IDs
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)
@@ -349,34 +351,34 @@ void AssetSystem::GetAssetCollectionsByIds(const csp::common::Array<csp::common:
 							 ResponseHandler);
 }
 
-void AssetSystem::GetAssetCollectionsByCriteria(const csp::common::Optional<csp::common::String>& SpaceId,
-												const csp::common::Optional<csp::common::String>& AssetCollectionParentId,
-												const csp::common::Optional<EAssetCollectionType>& AssetCollectionType,
-												const csp::common::Optional<csp::common::Array<csp::common::String>>& AssetCollectionTags,
-												const csp::common::Optional<csp::common::Array<csp::common::String>>& AssetCollectionNames,
-												const csp::common::Optional<int>& ResultsSkipNumber,
-												const csp::common::Optional<int>& ResultsMaxNumber,
+void AssetSystem::GetAssetCollectionsByCriteria(const Optional<String>& SpaceId,
+												const Optional<String>& AssetCollectionParentId,
+												const Optional<EAssetCollectionType>& AssetCollectionType,
+												const Optional<Array<String>>& AssetCollectionTags,
+												const Optional<Array<String>>& AssetCollectionNames,
+												const Optional<int>& ResultsSkipNumber,
+												const Optional<int>& ResultsMaxNumber,
 												AssetCollectionsResultCallback Callback)
 {
-	std::optional<std::vector<csp::common::String>> GroupIds;
+	std::optional<std::vector<String>> GroupIds;
 
 	if (SpaceId.HasValue())
 	{
 		GroupIds.emplace({*SpaceId});
 	}
 
-	std::optional<csp::common::String> ParentId;
+	std::optional<String> ParentId;
 
 	if (AssetCollectionParentId.HasValue())
 	{
 		ParentId = *AssetCollectionParentId;
 	}
 
-	std::optional<std::vector<csp::common::String>> Tags;
+	std::optional<std::vector<String>> Tags;
 
 	if (AssetCollectionTags.HasValue())
 	{
-		Tags.emplace(std::vector<csp::common::String>());
+		Tags.emplace(std::vector<String>());
 		Tags->reserve(AssetCollectionTags->Size());
 
 		for (size_t idx = 0; idx < AssetCollectionTags->Size(); ++idx)
@@ -385,11 +387,11 @@ void AssetSystem::GetAssetCollectionsByCriteria(const csp::common::Optional<csp:
 		}
 	}
 
-	std::optional<std::vector<csp::common::String>> Names;
+	std::optional<std::vector<String>> Names;
 
 	if (AssetCollectionNames.HasValue())
 	{
-		Names.emplace(std::vector<csp::common::String>());
+		Names.emplace(std::vector<String>());
 		Names->reserve(AssetCollectionNames->Size());
 
 		for (size_t idx = 0; idx < AssetCollectionNames->Size(); ++idx)
@@ -420,18 +422,17 @@ void AssetSystem::GetAssetCollectionsByCriteria(const csp::common::Optional<csp:
 		Limit = DEFAULT_RESULT_MAX_NUMBER;
 	}
 
-	std::optional<std::vector<csp::common::String>> AssetsType;
+	std::optional<std::vector<String>> AssetsType;
 
 	if (AssetCollectionType.HasValue())
 	{
-		AssetsType.emplace(std::vector<csp::common::String>());
+		AssetsType.emplace(std::vector<String>());
 		AssetsType->push_back({ConvertAssetCollectionTypeToString(*AssetCollectionType)});
 	};
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= PrototypeAPI->CreateHandler<AssetCollectionsResultCallback, AssetCollectionsResult, void, csp::services::DtoArray<chs::PrototypeDto>>(
-			Callback,
-			nullptr);
+	services::ResponseHandlerPtr ResponseHandler
+		= PrototypeAPI->CreateHandler<AssetCollectionsResultCallback, AssetCollectionsResult, void, services::DtoArray<chs::PrototypeDto>>(Callback,
+																																		   nullptr);
 
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)
 		->apiV1PrototypesGet(Tags,
@@ -457,44 +458,43 @@ void AssetSystem::GetAssetCollectionsByCriteria(const csp::common::Optional<csp:
 }
 
 void AssetSystem::UpdateAssetCollectionMetadata(const AssetCollection& AssetCollection,
-												const csp::common::Map<csp::common::String, csp::common::String>& NewMetadata,
+												const Map<String, String>& NewMetadata,
 												AssetCollectionResultCallback Callback)
 {
 	auto PrototypeInfo
 		= CreatePrototypeDto(AssetCollection.SpaceId, AssetCollection.ParentId, AssetCollection.Name, NewMetadata, AssetCollection.Type, nullptr);
 
-	csp::services::ResponseHandlerPtr ResponseHandler
+	services::ResponseHandlerPtr ResponseHandler
 		= PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
 
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdPut(AssetCollection.Id, PrototypeInfo, ResponseHandler);
 }
 
 void AssetSystem::CreateAsset(const AssetCollection& AssetCollection,
-							  const csp::common::String& Name,
-							  const csp::common::Optional<csp::common::String>& ThirdPartyPackagedAssetIdentifier,
-							  const csp::common::Optional<csp::systems::EThirdPartyPlatform>& ThirdPartyPlatform,
+							  const String& Name,
+							  const Optional<String>& ThirdPartyPackagedAssetIdentifier,
+							  const Optional<EThirdPartyPlatform>& ThirdPartyPlatform,
 							  EAssetType Type,
 							  AssetResultCallback Callback)
 {
 	auto AssetInfo = std::make_shared<chs::AssetDetailDto>();
 	AssetInfo->SetName(Name);
 	AssetInfo->SetPrototypeId(AssetCollection.Id);
-	csp::common::String InAddressableId;
+	String InAddressableId;
 
 	if (ThirdPartyPackagedAssetIdentifier.HasValue() || ThirdPartyPlatform.HasValue())
 	{
 		if (ThirdPartyPackagedAssetIdentifier.HasValue() && ThirdPartyPlatform.HasValue())
 		{
-			InAddressableId = csp::common::StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(*ThirdPartyPlatform));
+			InAddressableId = StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(*ThirdPartyPlatform));
 		}
 		else if (ThirdPartyPackagedAssetIdentifier.HasValue())
 		{
-			InAddressableId
-				= csp::common::StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(EThirdPartyPlatform::NONE));
+			InAddressableId = StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(EThirdPartyPlatform::NONE));
 		}
 		else if (ThirdPartyPlatform.HasValue())
 		{
-			InAddressableId = csp::common::StringFormat("%s|%d", "", static_cast<int>(*ThirdPartyPlatform));
+			InAddressableId = StringFormat("%s|%d", "", static_cast<int>(*ThirdPartyPlatform));
 		}
 
 		// TODO: CHS naming refactor planned for AssetDetailDto.m_AddressableId, becoming AssetDetailDto.m_ThirdPartyReferenceId
@@ -504,21 +504,21 @@ void AssetSystem::CreateAsset(const AssetCollection& AssetCollection,
 	AssetInfo->SetAssetType(ConvertAssetTypeToString(Type));
 
 	// TODO: Move this to a separate function when we have some different values than DEFAULT
-	std::vector<csp::common::String> Styles;
+	std::vector<String> Styles;
 	const auto DefaultStyle = "Default";
 	Styles.push_back(DefaultStyle);
 	AssetInfo->SetStyle(Styles);
 
 	// TODO: Move this to a separate function when we have some different values than DEFAULT
-	std::vector<csp::common::String> Platform;
+	std::vector<String> Platform;
 	const auto DefaultPlatform = "Default";
 	Platform.push_back(DefaultPlatform);
 	AssetInfo->SetSupportedPlatforms(Platform);
 
-	csp::services::ResponseHandlerPtr ResponseHandler
+	services::ResponseHandlerPtr ResponseHandler
 		= AssetDetailAPI->CreateHandler<AssetResultCallback, AssetResult, void, chs::AssetDetailDto>(Callback,
 																									 nullptr,
-																									 csp::web::EResponseCodes::ResponseCreated);
+																									 web::EResponseCodes::ResponseCreated);
 
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)->apiV1PrototypesPrototypeIdAssetDetailsPost(AssetCollection.Id, AssetInfo, ResponseHandler);
 }
@@ -531,10 +531,10 @@ void AssetSystem::UpdateAsset(const Asset& Asset, AssetResultCallback Callback)
 	AssetInfo->SetFileName(Asset.FileName);
 	AssetInfo->SetLanguageCode(Asset.LanguageCode);
 	AssetInfo->SetPrototypeId(Asset.AssetCollectionId);
-	AssetInfo->SetStyle(csp::common::Convert(Asset.Styles));
+	AssetInfo->SetStyle(Convert(Asset.Styles));
 
 	// TODO: Move this to a separate function when we have some different values than DEFAULT
-	std::vector<csp::common::String> Platform;
+	std::vector<String> Platform;
 	const auto DefaultPlatform = "Default";
 	Platform.push_back(DefaultPlatform);
 	AssetInfo->SetSupportedPlatforms(Platform);
@@ -545,25 +545,24 @@ void AssetSystem::UpdateAsset(const Asset& Asset, AssetResultCallback Callback)
 		AssetInfo->SetExternalMimeType(Asset.ExternalMimeType);
 	}
 
-	AssetInfo->SetAddressableId(csp::common::StringFormat("%s|%d",
-														  Asset.GetThirdPartyPackagedAssetIdentifier().c_str(),
-														  static_cast<int>(Asset.GetThirdPartyPlatformType())));
+	AssetInfo->SetAddressableId(
+		StringFormat("%s|%d", Asset.GetThirdPartyPackagedAssetIdentifier().c_str(), static_cast<int>(Asset.GetThirdPartyPlatformType())));
 
 	AssetInfo->SetAssetType(ConvertAssetTypeToString(Asset.Type));
-	csp::services::ResponseHandlerPtr ResponseHandler
+	services::ResponseHandlerPtr ResponseHandler
 		= AssetDetailAPI->CreateHandler<AssetResultCallback, AssetResult, void, chs::AssetDetailDto>(Callback,
 																									 nullptr,
-																									 csp::web::EResponseCodes::ResponseCreated);
+																									 web::EResponseCodes::ResponseCreated);
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
 		->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdPut(Asset.AssetCollectionId, Asset.Id, AssetInfo, ResponseHandler);
 }
 
 void AssetSystem::DeleteAsset(const AssetCollection& AssetCollection, const Asset& Asset, NullResultCallback Callback)
 {
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= AssetDetailAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback,
-																									  nullptr,
-																									  csp::web::EResponseCodes::ResponseNoContent);
+	services::ResponseHandlerPtr ResponseHandler
+		= AssetDetailAPI->CreateHandler<NullResultCallback, NullResult, void, services::NullDto>(Callback,
+																								 nullptr,
+																								 web::EResponseCodes::ResponseNoContent);
 
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
 		->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdDelete(AssetCollection.Id, Asset.Id, ResponseHandler);
@@ -571,10 +570,10 @@ void AssetSystem::DeleteAsset(const AssetCollection& AssetCollection, const Asse
 
 void AssetSystem::GetAssetsInCollection(const AssetCollection& AssetCollection, AssetsResultCallback Callback)
 {
-	std::vector<csp::common::String> PrototypeIds = {AssetCollection.Id};
+	std::vector<String> PrototypeIds = {AssetCollection.Id};
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, csp::services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
+	services::ResponseHandlerPtr ResponseHandler
+		= AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
 
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
 		->apiV1PrototypesAssetDetailsGet(std::nullopt,
@@ -590,19 +589,19 @@ void AssetSystem::GetAssetsInCollection(const AssetCollection& AssetCollection, 
 										 ResponseHandler);
 }
 
-void AssetSystem::GetAssetById(const csp::common::String& AssetCollectionId, const csp::common::String& AssetId, AssetResultCallback Callback)
+void AssetSystem::GetAssetById(const String& AssetCollectionId, const String& AssetId, AssetResultCallback Callback)
 {
-	csp::services::ResponseHandlerPtr ResponseHandler
+	services::ResponseHandlerPtr ResponseHandler
 		= AssetDetailAPI->CreateHandler<AssetResultCallback, AssetResult, void, chs::AssetDetailDto>(Callback, nullptr);
 
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
 		->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdGet(AssetCollectionId, AssetId, ResponseHandler);
 }
 
-void AssetSystem::GetAssetsByCriteria(const csp::common::Array<csp::common::String>& AssetCollectionIds,
-									  const csp::common::Optional<csp::common::Array<csp::common::String>>& AssetIds,
-									  const csp::common::Optional<csp::common::Array<csp::common::String>>& AssetNames,
-									  const csp::common::Optional<csp::common::Array<EAssetType>>& AssetTypes,
+void AssetSystem::GetAssetsByCriteria(const Array<String>& AssetCollectionIds,
+									  const Optional<Array<String>>& AssetIds,
+									  const Optional<Array<String>>& AssetNames,
+									  const Optional<Array<EAssetType>>& AssetTypes,
 									  AssetsResultCallback Callback)
 {
 	if (AssetCollectionIds.IsEmpty())
@@ -614,7 +613,7 @@ void AssetSystem::GetAssetsByCriteria(const csp::common::Array<csp::common::Stri
 		return;
 	}
 
-	std::vector<csp::common::String> PrototypeIds;
+	std::vector<String> PrototypeIds;
 	PrototypeIds.reserve(AssetCollectionIds.Size());
 
 	for (size_t idx = 0; idx < AssetCollectionIds.Size(); ++idx)
@@ -622,11 +621,11 @@ void AssetSystem::GetAssetsByCriteria(const csp::common::Array<csp::common::Stri
 		PrototypeIds.push_back(AssetCollectionIds[idx]);
 	}
 
-	std::optional<std::vector<csp::common::String>> AssetDetailIds;
+	std::optional<std::vector<String>> AssetDetailIds;
 
 	if (AssetIds.HasValue())
 	{
-		AssetDetailIds.emplace(std::vector<csp::common::String>());
+		AssetDetailIds.emplace(std::vector<String>());
 		AssetDetailIds->reserve(AssetIds->Size());
 
 		for (size_t idx = 0; idx < AssetIds->Size(); ++idx)
@@ -635,11 +634,11 @@ void AssetSystem::GetAssetsByCriteria(const csp::common::Array<csp::common::Stri
 		}
 	}
 
-	std::optional<std::vector<csp::common::String>> AssetDetailNames;
+	std::optional<std::vector<String>> AssetDetailNames;
 
 	if (AssetNames.HasValue())
 	{
-		AssetDetailNames.emplace(std::vector<csp::common::String>());
+		AssetDetailNames.emplace(std::vector<String>());
 		AssetDetailNames->reserve(AssetNames->Size());
 
 		for (size_t idx = 0; idx < AssetNames->Size(); ++idx)
@@ -648,11 +647,11 @@ void AssetSystem::GetAssetsByCriteria(const csp::common::Array<csp::common::Stri
 		}
 	}
 
-	std::optional<std::vector<csp::common::String>> AssetDetailTypes;
+	std::optional<std::vector<String>> AssetDetailTypes;
 
 	if (AssetTypes.HasValue())
 	{
-		AssetDetailTypes.emplace(std::vector<csp::common::String>());
+		AssetDetailTypes.emplace(std::vector<String>());
 		AssetDetailTypes->reserve(AssetTypes->Size());
 
 		for (size_t idx = 0; idx < AssetTypes->Size(); ++idx)
@@ -661,8 +660,8 @@ void AssetSystem::GetAssetsByCriteria(const csp::common::Array<csp::common::Stri
 		}
 	}
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, csp::services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
+	services::ResponseHandlerPtr ResponseHandler
+		= AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
 
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
 		->apiV1PrototypesAssetDetailsGet(AssetDetailIds,
@@ -678,7 +677,7 @@ void AssetSystem::GetAssetsByCriteria(const csp::common::Array<csp::common::Stri
 										 ResponseHandler);
 }
 
-void AssetSystem::GetAssetsByCollectionIds(const csp::common::Array<csp::common::String>& AssetCollectionIds, AssetsResultCallback Callback)
+void AssetSystem::GetAssetsByCollectionIds(const Array<String>& AssetCollectionIds, AssetsResultCallback Callback)
 {
 	if (AssetCollectionIds.IsEmpty())
 	{
@@ -689,15 +688,15 @@ void AssetSystem::GetAssetsByCollectionIds(const csp::common::Array<csp::common:
 		return;
 	}
 
-	std::vector<csp::common::String> Ids;
+	std::vector<String> Ids;
 
 	for (int i = 0; i < AssetCollectionIds.Size(); ++i)
 	{
 		Ids.push_back(AssetCollectionIds[i]);
 	}
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, csp::services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
+	services::ResponseHandlerPtr ResponseHandler
+		= AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
 
 	// Use `GET /api/v1/prototypes/asset-details` and only pass asset collection IDs
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
@@ -719,13 +718,13 @@ void AssetSystem::UploadAssetData(const AssetCollection& AssetCollection,
 								  const AssetDataSource& AssetDataSource,
 								  UriResultCallback Callback)
 {
-	UploadAssetDataEx(AssetCollection, Asset, AssetDataSource, csp::common::CancellationToken::Dummy(), Callback);
+	UploadAssetDataEx(AssetCollection, Asset, AssetDataSource, CancellationToken::Dummy(), Callback);
 }
 
 void AssetSystem::UploadAssetDataEx(const AssetCollection& AssetCollection,
 									const Asset& Asset,
 									const AssetDataSource& AssetDataSource,
-									csp::common::CancellationToken& CancellationToken,
+									CancellationToken& CancellationToken,
 									UriResultCallback Callback)
 {
 	if (Asset.Name.IsEmpty())
@@ -735,23 +734,23 @@ void AssetSystem::UploadAssetDataEx(const AssetCollection& AssetCollection,
 		return;
 	}
 
-	auto FormFile = std::make_shared<csp::web::HttpPayload>();
+	auto FormFile = std::make_shared<web::HttpPayload>();
 	AssetDataSource.SetUploadContent(WebClient, FormFile.get(), Asset);
 
 	UriResultCallback InternalCallback = [Callback, Asset](const UriResult& Result)
 	{
-		if (Result.GetFailureReason() != systems::ERequestFailureReason::None)
+		if (Result.GetFailureReason() != ERequestFailureReason::None)
 		{
-			CSP_LOG_ERROR_MSG(csp::common::String("Asset with Id %s has failed to upload").c_str());
+			CSP_LOG_ERROR_MSG(String("Asset with Id %s has failed to upload").c_str());
 		}
 
 		INVOKE_IF_NOT_NULL(Callback, Result);
 	};
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= AssetDetailAPI->CreateHandler<UriResultCallback, UriResult, void, csp::services::NullDto>(InternalCallback,
-																									nullptr,
-																									csp::web::EResponseCodes::ResponseOK);
+	services::ResponseHandlerPtr ResponseHandler
+		= AssetDetailAPI->CreateHandler<UriResultCallback, UriResult, void, services::NullDto>(InternalCallback,
+																							   nullptr,
+																							   web::EResponseCodes::ResponseOK);
 
 	static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
 		->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdBlobPost(AssetCollection.Id,
@@ -764,13 +763,13 @@ void AssetSystem::UploadAssetDataEx(const AssetCollection& AssetCollection,
 
 void AssetSystem::DownloadAssetData(const Asset& Asset, AssetDataResultCallback Callback)
 {
-	DownloadAssetDataEx(Asset, csp::common::CancellationToken::Dummy(), Callback);
+	DownloadAssetDataEx(Asset, CancellationToken::Dummy(), Callback);
 }
 
-void AssetSystem::DownloadAssetDataEx(const Asset& Asset, csp::common::CancellationToken& CancellationToken, AssetDataResultCallback Callback)
+void AssetSystem::DownloadAssetDataEx(const Asset& Asset, CancellationToken& CancellationToken, AssetDataResultCallback Callback)
 {
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= AssetDetailAPI->CreateHandler<AssetDataResultCallback, AssetDataResult, void, csp::services::AssetFileDto>(Callback, nullptr);
+	services::ResponseHandlerPtr ResponseHandler
+		= AssetDetailAPI->CreateHandler<AssetDataResultCallback, AssetDataResult, void, services::AssetFileDto>(Callback, nullptr);
 
 	FileManager->GetFile(Asset.Uri, ResponseHandler, CancellationToken);
 }
@@ -781,7 +780,7 @@ void AssetSystem::GetAssetDataSize(const Asset& Asset, UInt64ResultCallback Call
 	{
 		UInt64Result InternalResult(Result.GetResultCode(), Result.GetHttpResultCode());
 
-		if (Result.GetResultCode() == csp::systems::EResultCode::Success)
+		if (Result.GetResultCode() == EResultCode::Success)
 		{
 			auto& Headers		= Result.GetValue();
 			auto& ContentLength = Headers["content-length"];
@@ -792,69 +791,69 @@ void AssetSystem::GetAssetDataSize(const Asset& Asset, UInt64ResultCallback Call
 		INVOKE_IF_NOT_NULL(Callback, InternalResult);
 	};
 
-	csp::services::ResponseHandlerPtr ResponseHandler
-		= AssetDetailAPI->CreateHandler<HTTPHeadersResultCallback, HTTPHeadersResult, void, csp::services::NullDto>(InternalCallback, nullptr);
+	services::ResponseHandlerPtr ResponseHandler
+		= AssetDetailAPI->CreateHandler<HTTPHeadersResultCallback, HTTPHeadersResult, void, services::NullDto>(InternalCallback, nullptr);
 
 	FileManager->GetResponseHeaders(Asset.Uri, ResponseHandler);
 }
 
 CSP_ASYNC_RESULT void AssetSystem::GetLODChain(const AssetCollection& AssetCollection, LODChainResultCallback Callback)
 {
-	auto GetAssetsCallback = [AssetCollection, Callback](const csp::systems::AssetsResult& AssetsResult)
+	auto GetAssetsCallback = [AssetCollection, Callback](const AssetsResult& Result)
 	{
-		LODChainResult LODResult(AssetsResult.GetResultCode(), AssetsResult.GetHttpResultCode());
+		LODChainResult LODResult(Result.GetResultCode(), Result.GetHttpResultCode());
 
-		if (AssetsResult.GetResultCode() == csp::systems::EResultCode::Success)
+		if (Result.GetResultCode() == EResultCode::Success)
 		{
-			LODChain Chain = CreateLODChainFromAssets(AssetsResult.GetAssets(), AssetCollection.Id);
+			LODChain Chain = CreateLODChainFromAssets(Result.GetAssets(), AssetCollection.Id);
 			LODResult.SetLODChain(std::move(Chain));
 		}
 
 		INVOKE_IF_NOT_NULL(Callback, LODResult);
 	};
 
-	GetAssetsByCriteria({AssetCollection.Id}, nullptr, nullptr, csp::common::Array<EAssetType> {EAssetType::MODEL}, GetAssetsCallback);
+	GetAssetsByCriteria({AssetCollection.Id}, nullptr, nullptr, Array<EAssetType> {EAssetType::MODEL}, GetAssetsCallback);
 }
 
 CSP_ASYNC_RESULT_WITH_PROGRESS void
-	AssetSystem::RegisterAssetToLODChain(const AssetCollection& AssetCollection, const Asset& Asset, int LODLevel, AssetResultCallback Callback)
+	AssetSystem::RegisterAssetToLODChain(const AssetCollection& AssetCollection, const Asset& InAsset, int LODLevel, AssetResultCallback Callback)
 {
 	// GetAssetsByCriteria
-	auto GetAssetsCallback = [this, AssetCollection, Asset, LODLevel, Callback](const AssetsResult& AssetsResult)
+	auto GetAssetsCallback = [this, AssetCollection, InAsset, LODLevel, Callback](const AssetsResult& Result)
 	{
-		if (AssetsResult.GetResultCode() == csp::systems::EResultCode::InProgress)
+		if (Result.GetResultCode() == EResultCode::InProgress)
 		{
 			return;
 		}
 
-		if (AssetsResult.GetResultCode() == csp::systems::EResultCode::Failed)
+		if (Result.GetResultCode() == EResultCode::Failed)
 		{
-			INVOKE_IF_NOT_NULL(Callback, AssetsResult);
+			INVOKE_IF_NOT_NULL(Callback, Result);
 
 			return;
 		}
 
-		const csp::common::Array<csp::systems::Asset>& Assets = AssetsResult.GetAssets();
-		LODChain Chain										  = CreateLODChainFromAssets(Assets, AssetCollection.Id);
+		const Array<Asset>& Assets = Result.GetAssets();
+		LODChain Chain			   = CreateLODChainFromAssets(Assets, AssetCollection.Id);
 
 		if (!ValidateNewLODLevelForChain(Chain, LODLevel))
 		{
 			CSP_LOG_MSG(LogLevel::Error, "LOD level already exists in chain");
 
-			INVOKE_IF_NOT_NULL(Callback, AssetsResult);
+			INVOKE_IF_NOT_NULL(Callback, Result);
 
 			return;
 		}
 
 		// UpdateAsset
-		auto UpdateAssetCallback = [this, AssetCollection, Callback, Assets](const AssetResult& AssetResult)
+		auto UpdateAssetCallback = [this, AssetCollection, Callback, Assets](const AssetResult& Result)
 		{
-			INVOKE_IF_NOT_NULL(Callback, AssetResult);
+			INVOKE_IF_NOT_NULL(Callback, Result);
 		};
 
 		// Add new LOD style
-		csp::systems::Asset NewAsset = Asset;
-		csp::common::Array<csp::common::String> NewStyles(NewAsset.Styles.Size() + 1);
+		Asset NewAsset = InAsset;
+		Array<String> NewStyles(NewAsset.Styles.Size() + 1);
 
 		for (int i = 0; i < NewAsset.Styles.Size(); ++i)
 		{
@@ -867,7 +866,7 @@ CSP_ASYNC_RESULT_WITH_PROGRESS void
 		UpdateAsset(NewAsset, UpdateAssetCallback);
 	};
 
-	GetAssetsByCriteria({Asset.AssetCollectionId}, nullptr, nullptr, csp::common::Array<EAssetType> {EAssetType::MODEL}, GetAssetsCallback);
+	GetAssetsByCriteria({InAsset.AssetCollectionId}, nullptr, nullptr, Array<EAssetType> {EAssetType::MODEL}, GetAssetsCallback);
 }
 
 } // namespace csp::systems

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -752,14 +752,10 @@ void SettingsSystem::GetAvatarPortraitAssetCollection(const csp::common::String&
 	auto AssetSystem														  = SystemsManager::Get().GetAssetSystem();
 	csp::common::Array<csp::common::String> AvatarPortraitAssetCollectionName = {AVATAR_PORTRAIT_ASSET_COLLECTION_NAME + UserId};
 
-	AssetSystem->GetAssetCollectionsByCriteria(nullptr,
-											   nullptr,
-											   EAssetCollectionType::DEFAULT,
-											   nullptr,
-											   AvatarPortraitAssetCollectionName,
-											   nullptr,
-											   nullptr,
-											   GetAssetCollCallback);
+	Array<String> PrototypeNames							 = {AvatarPortraitAssetCollectionName};
+	Array<csp::systems::EAssetCollectionType> PrototypeTypes = {EAssetCollectionType::DEFAULT};
+
+	AssetSystem->FindAssetCollections(nullptr, nullptr, PrototypeNames, PrototypeTypes, nullptr, nullptr, nullptr, nullptr, GetAssetCollCallback);
 }
 
 void SettingsSystem::GetAvatarPortraitAsset(const AssetCollection& AvatarPortraitAssetCollection, AssetsResultCallback Callback)

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -39,6 +39,8 @@ constexpr const char* AVATAR_PORTRAIT_ASSET_NAME			= "AVATAR_PORTRAIT_ASSET_";
 constexpr const char* AVATAR_PORTRAIT_ASSET_COLLECTION_NAME = "AVATAR_PORTRAIT_ASSET_COLLECTION_";
 
 
+using namespace csp::common;
+
 namespace chs = csp::services::generated::userservice;
 
 

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -1099,14 +1099,14 @@ void SpaceSystem::GetMetadataAssetCollection(const String& SpaceId, AssetCollect
 void SpaceSystem::GetMetadataAssetCollections(const Array<csp::common::String>& SpaceIds, AssetCollectionsResultCallback Callback)
 {
 	auto* AssetSystem = SystemsManager::Get().GetAssetSystem();
-	Array<String> AssetCollectionNames(SpaceIds.Size());
+	Array<String> PrototypeNames(SpaceIds.Size());
 
 	for (auto item = 0; item < SpaceIds.Size(); ++item)
 	{
-		AssetCollectionNames[item] = SpaceSystemHelpers::GetSpaceMetadataAssetCollectionName(SpaceIds[item]);
+		PrototypeNames[item] = SpaceSystemHelpers::GetSpaceMetadataAssetCollectionName(SpaceIds[item]);
 	}
 
-	AssetSystem->GetAssetCollectionsByCriteria(nullptr, nullptr, nullptr, nullptr, AssetCollectionNames, nullptr, nullptr, Callback);
+	AssetSystem->FindAssetCollections(nullptr, nullptr, PrototypeNames, nullptr, nullptr, nullptr, nullptr, nullptr, Callback);
 }
 
 void SpaceSystem::AddMetadata(const csp::common::String& SpaceId, const Map<String, String>& Metadata, NullResultCallback Callback)
@@ -1353,16 +1353,11 @@ void SpaceSystem::GetSpaceThumbnailAssetCollection(const csp::common::String& Sp
 	auto* AssetSystem				 = SystemsManager::Get().GetAssetSystem();
 	auto MetadataAssetCollectionName = SpaceSystemHelpers::GetSpaceMetadataAssetCollectionName(SpaceId);
 
-	const Array<String> Tag({SpaceId});
+	Array<csp::systems::EAssetCollectionType> PrototypeTypes = {EAssetCollectionType::SPACE_THUMBNAIL};
+	Array<String> PrototypeTags								 = {SpaceId};
+	Array<String> GroupIds									 = {SpaceId};
 
-	AssetSystem->GetAssetCollectionsByCriteria(SpaceId,
-											   nullptr,
-											   EAssetCollectionType::SPACE_THUMBNAIL,
-											   Tag,
-											   nullptr,
-											   nullptr,
-											   nullptr,
-											   GetAssetCollCallback);
+	AssetSystem->FindAssetCollections(nullptr, nullptr, nullptr, PrototypeTypes, PrototypeTags, GroupIds, nullptr, nullptr, GetAssetCollCallback);
 }
 
 void SpaceSystem::GetSpaceThumbnailAsset(const AssetCollection& ThumbnailAssetCollection, AssetsResultCallback Callback)

--- a/Tests/CSharp/src/Tests/AssetSystemTests.cs
+++ b/Tests/CSharp/src/Tests/AssetSystemTests.cs
@@ -25,13 +25,22 @@ namespace CSPEngine
 
             Assert.AreEqual(resCode, Systems.EResultCode.Success);
 
-            LogDebug($"AssetCollection deleted (Id: { assetCollection.Id })");
+            LogDebug($"AssetCollection deleted (Id: {assetCollection.Id})");
 
             if (disposeFoundationResources)
                 assetCollection.Dispose();
         }
 
-        public static void CreateAssetCollection(Systems.AssetSystem assetSystem, Systems.Space? space, string parentId, string name, Systems.EAssetCollectionType? type, Common.Array<string>? tags, out Systems.AssetCollection assetCollection, bool disposeFoundationResources = true)
+        public static void CreateAssetCollection(
+            Systems.AssetSystem assetSystem,
+            Systems.Space? space,
+            string parentId,
+            string name,
+            Systems.EAssetCollectionType?
+            type, Common.Array<string>? tags,
+            out Systems.AssetCollection assetCollection,
+            bool disposeFoundationResources = true
+        )
         {
             var AssetCollectionType = type ?? Systems.EAssetCollectionType.DEFAULT;
 
@@ -42,7 +51,7 @@ namespace CSPEngine
 
             assetCollection = result.GetAssetCollection();
 
-            LogDebug($"AssetCollection created (Id: { assetCollection.Id }, Name: { assetCollection.Name })");
+            LogDebug($"AssetCollection created (Id: {assetCollection.Id}, Name: {assetCollection.Name})");
 
             var outAssetCollection = assetCollection;
 
@@ -51,7 +60,13 @@ namespace CSPEngine
 
         static void GetAssetCollections(Systems.AssetSystem assetSystem, Systems.Space space, out Common.Array<Systems.AssetCollection> assetCollections)
         {
-            using var result = assetSystem.GetAssetCollectionsByCriteria(space.Id, null, Systems.EAssetCollectionType.DEFAULT, null, null, null, null).Result;
+            using var types = new Common.Array<Systems.EAssetCollectionType>(1);
+            types[0] = Systems.EAssetCollectionType.DEFAULT;
+
+            using var spaceIds = new Common.Array<string>(1);
+            spaceIds[0] = space.Id;
+
+            using var result = assetSystem.FindAssetCollections(null, null, null, types, null, spaceIds, null, null).Result;
             var resCode = result.GetResultCode();
 
             Assert.AreEqual(resCode, Systems.EResultCode.Success);
@@ -59,14 +74,51 @@ namespace CSPEngine
             assetCollections = result.GetAssetCollections();
         }
 
-        static void GetAssetCollectionsByCriteria(Systems.AssetSystem assetSystem, Systems.Space space, string parentId, Systems.EAssetCollectionType? type, Common.Array<string>? tags, Common.Array<string>? names, int? ResultsSkipNumber, int? ResultsMaxNumber, out Common.Array<Systems.AssetCollection> assetCollections)
+        static Common.Array<Systems.AssetCollection> FindAssetCollections(
+            Systems.AssetSystem assetSystem,
+            string[]? ids = null,
+            string? parentId = null,
+            string[]? names = null,
+            Systems.EAssetCollectionType[]? types = null,
+            string[]? tags = null,
+            string[]? spaceIds = null,
+            int? resultsSkipNumber = null,
+            int? resultsMaxNumber = null
+        )
         {
-            using var result = assetSystem.GetAssetCollectionsByCriteria(space?.Id, parentId, type, tags, names, ResultsSkipNumber, ResultsMaxNumber).Result;
+            Common.Array<string> _ids = null;
+
+            if (ids != null)
+                _ids = ids.ToFoundationArray();
+
+            Common.Array<string> _names = null;
+
+            if (names != null)
+                _names = names.ToFoundationArray();
+
+            Common.Array<Systems.EAssetCollectionType> _types = null;
+
+            if (types != null)
+                _types = types.ToFoundationArray();
+
+            Common.Array<string> _tags = null;
+
+            if (tags != null)
+                _tags = tags.ToFoundationArray();
+
+            Common.Array<string> _spaceIds = null;
+
+            if (spaceIds != null)
+                _spaceIds = spaceIds.ToFoundationArray();
+
+            using var result = assetSystem.FindAssetCollections(_ids, parentId, _names, _types, _tags, _spaceIds, resultsSkipNumber, resultsMaxNumber).Result;
             var resCode = result.GetResultCode();
+
+            _ids?.Dispose();
 
             Assert.AreEqual(resCode, Systems.EResultCode.Success);
 
-            assetCollections = result.GetAssetCollections();
+            return result.GetAssetCollections();
         }
 
         static void GetAssetCollectionByName(Systems.AssetSystem assetSystem, String assetCollectionName, out Systems.AssetCollection assetCollection)
@@ -79,18 +131,11 @@ namespace CSPEngine
             assetCollection = result.GetAssetCollection();
         }
 
-        static void GetAssetCollectionsByIds(Systems.AssetSystem assetSystem, string[] ids, out Common.Array<Systems.AssetCollection> assetCollections)
+        static Common.Array<Systems.AssetCollection> GetAssetCollectionsByIds(Systems.AssetSystem assetSystem, string[] ids)
         {
             Assert.IsGreaterThan(ids.Length, 0);
 
-            var _ids = ids.ToFoundationArray();
-
-            using var result = assetSystem.GetAssetCollectionsByIds(_ids).Result;
-            var resCode = result.GetResultCode();
-
-            Assert.AreEqual(resCode, Systems.EResultCode.Success);
-
-            assetCollections = result.GetAssetCollections();
+            return FindAssetCollections(assetSystem, ids: ids);
         }
 
         static void DeleteAsset(Systems.AssetSystem assetSystem, Systems.AssetCollection assetCollection, Systems.Asset asset, bool disposeFoundationResources = true)
@@ -100,22 +145,29 @@ namespace CSPEngine
 
             Assert.AreEqual(resCode, Systems.EResultCode.Success);
 
-            LogDebug($"Asset deleted (Id: { asset.Id }, AssetCollection Id: { assetCollection.Id })");
+            LogDebug($"Asset deleted (Id: {asset.Id}, AssetCollection Id: {assetCollection.Id})");
 
             if (disposeFoundationResources)
                 asset.Dispose();
         }
 
-        public static void CreateAsset(Systems.AssetSystem assetSystem, Systems.AssetCollection assetCollection, string name, string? thirdPartyPackagedAssetIdentifier,Systems.EThirdPartyPlatform? thirdPartyPlatform, out Systems.Asset asset, bool disposeFoundationResources = true)
+        public static void CreateAsset(
+            Systems.AssetSystem assetSystem,
+            Systems.AssetCollection assetCollection,
+            string name,
+            string? thirdPartyPackagedAssetIdentifier,
+            Systems.EThirdPartyPlatform? thirdPartyPlatform,
+            out Systems.Asset asset,
+            bool disposeFoundationResources = true)
         {
-            using var result = assetSystem.CreateAsset(assetCollection, name, thirdPartyPackagedAssetIdentifier,thirdPartyPlatform, Systems.EAssetType.MODEL).Result;
+            using var result = assetSystem.CreateAsset(assetCollection, name, thirdPartyPackagedAssetIdentifier, thirdPartyPlatform, Systems.EAssetType.MODEL).Result;
             var resCode = result.GetResultCode();
 
             Assert.AreEqual(resCode, Systems.EResultCode.Success);
 
             asset = result.GetAsset();
 
-            LogDebug($"Asset created (Id: { asset.Id }, Name: { asset.Name })");
+            LogDebug($"Asset created (Id: {asset.Id}, Name: {asset.Name})");
 
             var outAsset = asset;
 
@@ -261,7 +313,7 @@ namespace CSPEngine
             CreateAssetCollection(assetSystem, space, null, testAssetCollectionName2, null, null, out var assetCollection2);
 
             // Get asset collections
-            GetAssetCollectionsByIds(assetSystem, new[] { assetCollection1.Id, assetCollection2.Id }, out var assetCollections);
+            var assetCollections = GetAssetCollectionsByIds(assetSystem, new[] { assetCollection1.Id, assetCollection2.Id });
 
             Assert.AreEqual(assetCollections.Size(), 2UL);
 
@@ -320,7 +372,7 @@ namespace CSPEngine
             Assert.AreEqual(assets.Size(), 1UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
             Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), thirdPartyPackagedAssetIdentifier);
-            
+
             var inboundAsset = assets[0];
             inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
             Assert.AreEqual(inboundAsset.GetThirdPartyPackagedAssetIdentifier(), "Test");
@@ -334,7 +386,7 @@ namespace CSPEngine
             Assert.AreEqual(updatedAsset.GetAsset().GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
             updatedAsset.Dispose();
             inboundAsset.Dispose();
-            
+
             // Clean up
             assets.Dispose();
         }
@@ -365,7 +417,7 @@ namespace CSPEngine
             Assert.AreEqual(assets.Size(), 1UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
             Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), thirdPartyPackagedAssetIdentifier);
-            
+
             var inboundAsset = assets[0];
             inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
             Assert.AreEqual(inboundAsset.GetThirdPartyPackagedAssetIdentifier(), "Test");
@@ -379,7 +431,7 @@ namespace CSPEngine
             Assert.AreEqual(updatedAsset.GetAsset().GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
             updatedAsset.Dispose();
             inboundAsset.Dispose();
-            
+
             // Clean up
             assets.Dispose();
         }
@@ -461,16 +513,16 @@ namespace CSPEngine
 
             var space = SpaceSystemTests.CreateSpace(spaceSystem, testSpaceName, testSpaceDescription, Systems.SpaceAttributes.Private, null, null, null);
 
-            var Tags = new Common.Array<string>(1);
-            Tags[0] = space.Id;
+            var tags = new Common.Array<string>(1);
+            tags[0] = space.Id;
 
             CreateAssetCollection(assetSystem, space, null, testAssetCollectionName1, Systems.EAssetCollectionType.SPACE_THUMBNAIL, null, out var assetCollection1);
-            CreateAssetCollection(assetSystem, space, null, testAssetCollectionName2, Systems.EAssetCollectionType.SPACE_THUMBNAIL, Tags, out var assetCollection2);
+            CreateAssetCollection(assetSystem, space, null, testAssetCollectionName2, Systems.EAssetCollectionType.SPACE_THUMBNAIL, tags, out var assetCollection2);
             CreateAssetCollection(assetSystem, space, assetCollection1.Id, testAssetCollectionName3, null, null, out var assetCollection3);
 
             // Search by space
             {
-                GetAssetCollectionsByCriteria(assetSystem, space, null, null, null, null, null, null, out var assetCollections);
+                var assetCollections = FindAssetCollections(assetSystem, spaceIds: new[] { space.Id });
 
                 Assert.AreEqual(assetCollections.Size(), 4UL);
 
@@ -479,7 +531,7 @@ namespace CSPEngine
 
             // Search by parentId
             {
-                GetAssetCollectionsByCriteria(assetSystem, null, assetCollection1.Id, null, null, null, null, null, out var assetCollections);
+                var assetCollections = FindAssetCollections(assetSystem, ids: new[] { assetCollection1.Id });
 
                 Assert.AreEqual(assetCollections.Size(), 1UL);
                 Assert.AreEqual(assetCollections[0].Id, assetCollection3.Id);
@@ -490,7 +542,7 @@ namespace CSPEngine
 
             // Search by tag
             {
-                GetAssetCollectionsByCriteria(assetSystem, null, null, null, Tags, null, null, null, out var assetCollections);
+                var assetCollections = FindAssetCollections(assetSystem, tags: new[] { space.Id });
 
                 Assert.AreEqual(assetCollections.Size(), 1UL);
                 Assert.AreEqual(assetCollections[0].Id, assetCollection2.Id);
@@ -501,17 +553,13 @@ namespace CSPEngine
 
             // Search by names and types
             {
-                var names = new Common.Array<string>(2);
-                names[0] = testAssetCollectionName1;
-                names[1] = testAssetCollectionName2;
-
                 // Search for Default types with these names
-                GetAssetCollectionsByCriteria(assetSystem, null, null, Systems.EAssetCollectionType.DEFAULT, null, names, null, null, out var assetCollections1);
+                var assetCollections1 = FindAssetCollections(assetSystem, names: new[] { testAssetCollectionName1, testAssetCollectionName2 }, types: new[] { Systems.EAssetCollectionType.DEFAULT });
 
                 Assert.AreEqual(assetCollections1.Size(), 0UL);
 
                 // Search same names with Space thumbnail type 
-                GetAssetCollectionsByCriteria(assetSystem, null, null, Systems.EAssetCollectionType.SPACE_THUMBNAIL, null, names, null, null, out var assetCollections2);
+                var assetCollections2 = FindAssetCollections(assetSystem, names: new[] { testAssetCollectionName1, testAssetCollectionName2 }, types: new[] { Systems.EAssetCollectionType.SPACE_THUMBNAIL });
 
                 Assert.AreEqual(assetCollections2.Size(), 2UL);
 
@@ -540,7 +588,7 @@ namespace CSPEngine
 
             // Test pagination
             {
-                GetAssetCollectionsByCriteria(assetSystem, space, null, null, null, null, 1, 1, out var assetCollections);
+                var assetCollections = FindAssetCollections(assetSystem, spaceIds: new[] { space.Id }, resultsSkipNumber: 1, resultsMaxNumber: 1);
 
                 Assert.AreEqual(assetCollections.Size(), 1UL);
 
@@ -572,7 +620,7 @@ namespace CSPEngine
 
             // Search by asset id
             {
-                GetAssetsByCriteria(assetSystem, new[] {assetCollection.Id}, new[] { asset1.Id }, null, null, out var assets);
+                GetAssetsByCriteria(assetSystem, new[] { assetCollection.Id }, new[] { asset1.Id }, null, null, out var assets);
 
                 Assert.AreEqual(assets.Size(), 1UL);
                 Assert.AreEqual(assets[0].Id, asset1.Id);
@@ -583,7 +631,7 @@ namespace CSPEngine
 
             // Search by asset name
             {
-                GetAssetsByCriteria(assetSystem, new[] {assetCollection.Id}, null, new[] { asset1.Name }, null, out var assets);
+                GetAssetsByCriteria(assetSystem, new[] { assetCollection.Id }, null, new[] { asset1.Name }, null, out var assets);
 
                 Assert.AreEqual(assets.Size(), 1UL);
                 Assert.AreEqual(assets[0].Id, asset1.Id);
@@ -597,7 +645,7 @@ namespace CSPEngine
                 using var assetTypes1 = new Common.Array<Systems.EAssetType>(1);
                 assetTypes1[0] = Systems.EAssetType.VIDEO;
 
-                GetAssetsByCriteria(assetSystem, new[] {assetCollection.Id}, null, new[] { asset1.Name, asset2.Name }, assetTypes1, out var assets1);
+                GetAssetsByCriteria(assetSystem, new[] { assetCollection.Id }, null, new[] { asset1.Name, asset2.Name }, assetTypes1, out var assets1);
 
                 Assert.AreEqual(assets1.Size(), 0UL);
 
@@ -606,7 +654,7 @@ namespace CSPEngine
                 assetTypes2[0] = Systems.EAssetType.MODEL;
                 assetTypes2[1] = Systems.EAssetType.VIDEO;
 
-                GetAssetsByCriteria(assetSystem, new[] {assetCollection.Id}, null, new[] { asset1.Name, asset2.Name }, assetTypes2, out var assets2);
+                GetAssetsByCriteria(assetSystem, new[] { assetCollection.Id }, null, new[] { asset1.Name, asset2.Name }, assetTypes2, out var assets2);
 
                 Assert.AreEqual(assets2.Size(), 2UL);
 
@@ -823,7 +871,7 @@ namespace CSPEngine
             // Upload data
             {
                 assetSystem.UploadAssetDataOnProgress += (s, e) => LogDebug($"Uploading asset... ({e.Progress}%)");
-                
+
                 using var result = assetSystem.UploadAssetData(assetCollection, asset, source).Result;
                 var resCode = result.GetResultCode();
 
@@ -908,7 +956,7 @@ namespace CSPEngine
             // Upload data
             {
                 assetSystem.UploadAssetDataOnProgress += (s, e) => LogDebug($"Uploading asset... ({e.Progress}%)");
-                
+
                 using var result = assetSystem.UploadAssetData(assetCollection, asset, source).Result;
                 var resCode = result.GetResultCode();
 
@@ -985,7 +1033,7 @@ namespace CSPEngine
             // Upload data
             {
                 assetSystem.UploadAssetDataOnProgress += (s, e) => LogDebug($"Uploading asset... ({e.Progress}%)");
-                
+
                 using var result = assetSystem.UploadAssetData(assetCollection, asset, source).Result;
                 var resCode = result.GetResultCode();
 
@@ -1114,7 +1162,7 @@ namespace CSPEngine
             // Upload data
             {
                 assetSystem.UploadAssetDataOnProgress += (s, e) => LogDebug($"Uploading asset... ({e.Progress}%)");
-                
+
                 using var result = assetSystem.UploadAssetData(assetCollection, asset, source).Result;
                 var resCode = result.GetResultCode();
 
@@ -1186,7 +1234,7 @@ namespace CSPEngine
             // Upload data
             {
                 assetSystem.UploadAssetDataOnProgress += (s, e) => LogDebug($"Uploading asset... ({e.Progress}%)");
-                
+
                 using var result = assetSystem.UploadAssetData(assetCollection, asset, source).Result;
                 var resCode = result.GetResultCode();
 
@@ -1360,7 +1408,7 @@ namespace CSPEngine
             Assert.AreEqual(assets[0].Name, testAssetName);
             Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), "");
             Assert.AreEqual(assets[0].GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.NONE);
-            
+
             var inboundAsset = assets[0];
             inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
             Assert.AreEqual(inboundAsset.GetThirdPartyPackagedAssetIdentifier(), "Test");
@@ -1373,7 +1421,7 @@ namespace CSPEngine
 
             // Get assets
             GetAssetsInCollection(assetSystem, assetCollection, out assets);
-            
+
             Assert.AreEqual(assets.Size(), 2UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
             Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), thirdPartyPackagedAssetIdentifierAlphanumeric);

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -820,7 +820,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, FindAssetCollectionsTest)
 		csp::common::Array<csp::common::String> SpaceIds = {Space.Id};
 
 		auto [Result]
-			= AWAIT_PRE(AssetSystem, FindAssetCollections, RequestPredicate, SpaceIds, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+			= AWAIT_PRE(AssetSystem, FindAssetCollections, RequestPredicate, nullptr, nullptr, nullptr, nullptr, nullptr, SpaceIds, nullptr, nullptr);
 
 		EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 		EXPECT_EQ(Result.GetAssetCollections().Size(), 4);
@@ -922,7 +922,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, FindAssetCollectionsTest)
 	{
 		csp::common::Array<csp::common::String> SpaceIds = {Space.Id};
 
-		auto [Result] = AWAIT_PRE(AssetSystem, FindAssetCollections, RequestPredicate, SpaceIds, nullptr, nullptr, nullptr, nullptr, nullptr, 1, 1);
+		auto [Result] = AWAIT_PRE(AssetSystem, FindAssetCollections, RequestPredicate, nullptr, nullptr, nullptr, nullptr, nullptr, SpaceIds, 1, 1);
 
 		EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 		EXPECT_EQ(Result.GetAssetCollections().Size(), 1);

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -95,16 +95,20 @@ void GetAssetCollections(csp::systems::AssetSystem* AssetSystem,
 						 csp::systems::Space& Space,
 						 csp::common::Array<csp::systems::AssetCollection>& OutAssetCollections)
 {
-	auto [Result] = Awaitable(&csp::systems::AssetSystem::GetAssetCollectionsByCriteria,
-							  AssetSystem,
-							  Space.Id,
+	csp::common::Array<csp::systems::EAssetCollectionType> PrototypeTypes = {csp::systems::EAssetCollectionType::DEFAULT};
+	csp::common::Array<csp::common::String> GroupIds					  = {Space.Id};
+
+	auto [Result] = AWAIT_PRE(AssetSystem,
+							  FindAssetCollections,
+							  RequestPredicate,
 							  nullptr,
-							  csp::systems::EAssetCollectionType::DEFAULT,
 							  nullptr,
 							  nullptr,
+							  PrototypeTypes,
 							  nullptr,
-							  nullptr)
-						.Await(RequestPredicate);
+							  GroupIds,
+							  nullptr,
+							  nullptr);
 
 	EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -135,7 +139,8 @@ void GetAssetCollectionsByIds(csp::systems::AssetSystem* AssetSystem,
 {
 	EXPECT_FALSE(Ids.IsEmpty());
 
-	auto [Result] = Awaitable(&csp::systems::AssetSystem::GetAssetCollectionsByIds, AssetSystem, Ids).Await(RequestPredicate);
+	auto [Result]
+		= AWAIT_PRE(AssetSystem, FindAssetCollections, RequestPredicate, Ids, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 
 	EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 


### PR DESCRIPTION
This change merges `GetAssetCollectionsById` and
`GetAssetCollectionsByCriteria` into the function
`FindAssetCollections`

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
