### PR TITLE
[OF-1165] fix: disable import.meta in TS wrapper

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -265,7 +265,8 @@ if not Project then
                     "'locateFile'," ..
                     "'mainScriptUrlOrBlob'," ..
                     "'wasmMemory'" ..
-                "]"
+                "]",
+                "-sUSE_ES6_IMPORT_META=0"                                       -- disable use of import.meta as it is not yet supported everywhere
             }
 
             links {


### PR DESCRIPTION
`import.meta` is not yet supported everywhere, so disable it for now

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
