### PR TITLE
[OF-998] refac!: make Systems dtors private

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -26,18 +27,34 @@
 #include <mutex>
 #include <set>
 
+
 namespace signalr
 {
+
 class value;
-}
+
+} // namespace signalr
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
+
 
 namespace csp::multiplayer
 {
+
 class ClientElectionManager;
 
 class SignalRConnection;
 
 } // namespace csp::multiplayer
+
 
 
 /// @brief Namespace that encompasses everything in the multiplayer system
@@ -48,24 +65,26 @@ class MultiplayerConnection;
 class SpaceTransform;
 class SpaceEntity;
 
+
 /// @brief Class for creating and managing multiplayer objects known as space entities.
 ///
 /// This provides functions to create and manage multiple player avatars and other objects.
 /// It manages things like queueing updated entities and triggering tick events. Callbacks
 /// can be registered for certain events that occur within the entity system so clients can
 /// react appropriately.
-class CSP_API CSP_NO_DISPOSE SpaceEntitySystem
+class CSP_API SpaceEntitySystem
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class MultiplayerConnection;
 	friend class SpaceEntityEventHandler;
 	friend class ClientElectionManager;
 	friend class EntityScript;
+	friend void csp::memory::Delete<SpaceEntitySystem>(SpaceEntitySystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~SpaceEntitySystem();
-
 	// Callback used to provide a success/fail type of response.
 	typedef std::function<void(bool)> CallbackHandler;
 
@@ -132,15 +151,18 @@ public:
 
 	/// @brief Get the number of total entities in the system (both Avatars and Objects).
 	/// @return The total number of entities.
-	[[nodiscard]] size_t GetNumEntities() const;
+	[[nodiscard]]
+	size_t GetNumEntities() const;
 
 	/// @brief Get the number of total Avatars in the system.
 	/// @return The total number of Avatar entities.
-	[[nodiscard]] size_t GetNumAvatars() const;
+	[[nodiscard]]
+	size_t GetNumAvatars() const;
 
 	/// @brief Get the number of total Objects in the system.
 	/// @return The total number of object entities.
-	[[nodiscard]] size_t GetNumObjects() const;
+	[[nodiscard]]
+	size_t GetNumObjects() const;
 
 	/// @brief Get an Entity (Avatar or Object) by its index.
 	///
@@ -301,6 +323,7 @@ protected:
 
 private:
 	SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection);
+	~SpaceEntitySystem();
 
 	MultiplayerConnection* MultiplayerConnectionInst;
 	csp::multiplayer::SignalRConnection* Connection;

--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "AnalyticsProvider.h"
@@ -25,22 +26,38 @@
 #include <thread>
 #include <vector>
 
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
+
+
 namespace csp::systems
 {
 
 class AnalyticsSystemImpl;
+
 
 /// @ingroup Analytics System
 /// @brief Public facing system that allows interfacing with an analytics provider.
 /// Offers methods for sending events to the provider
 /// Events are added to a queue to be processewd on a different thread
 /// If events are unable to be send to the provider, then they will be held in the queue
-class CSP_API CSP_NO_DISPOSE AnalyticsSystem
+class CSP_API AnalyticsSystem
 {
-public:
-	AnalyticsSystem();
-	~AnalyticsSystem();
+	CSP_START_IGNORE
+	/** @cond DO_NOT_DOCUMENT */
+	friend class SystemsManager;
+	friend void csp::memory::Delete<AnalyticsSystem>(AnalyticsSystem* Ptr);
+	/** @endcond */
+	CSP_END_IGNORE
 
+public:
 	CSP_START_IGNORE
 	AnalyticsSystem(const AnalyticsSystem&) = delete;
 	AnalyticsSystem(AnalyticsSystem&&)		= delete;
@@ -63,6 +80,9 @@ public:
 	CSP_END_IGNORE
 
 private:
+	AnalyticsSystem();
+	~AnalyticsSystem();
+
 	AnalyticsSystemImpl* Impl;
 };
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -24,6 +25,7 @@
 #include "CSP/Systems/Assets/LOD.h"
 #include "CSP/Systems/Spaces/Space.h"
 #include "CSP/Systems/SystemBase.h"
+
 
 namespace csp::services
 {
@@ -38,7 +40,17 @@ namespace csp::web
 
 class RemoteFileManager;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -46,15 +58,16 @@ namespace csp::systems
 
 /// @ingroup Asset System
 /// @brief Public facing system that allows uploading/downloading and creation of assets.
-class CSP_API CSP_NO_DISPOSE AssetSystem : public SystemBase
+class CSP_API AssetSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<AssetSystem>(AssetSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~AssetSystem();
-
 	/// @brief Creates an asset collection.
 	/// @param Space Space : optional space to associate the asset collection with
 	/// @param ParentAssetCollectionId csp::common::String : optional parent asset collection Id
@@ -238,10 +251,10 @@ public:
 	CSP_ASYNC_RESULT_WITH_PROGRESS void
 		RegisterAssetToLODChain(const AssetCollection& AssetCollection, const Asset& Asset, int LODLevel, AssetResultCallback Callback);
 
-
 private:
 	AssetSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	CSP_NO_EXPORT AssetSystem(csp::web::WebClient* InWebClient);
+	~AssetSystem();
 
 	csp::services::ApiBase* PrototypeAPI;
 	csp::services::ApiBase* AssetDetailAPI;

--- a/Library/include/CSP/Systems/ECommerce/ECommerceSystem.h
+++ b/Library/include/CSP/Systems/ECommerce/ECommerceSystem.h
@@ -13,18 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
+
 #include "CSP/Systems/ECommerce/ECommerce.h"
 #include "CSP/Systems/SystemBase.h"
 
 #include <CSP/Systems/SystemsResult.h>
+
 
 namespace csp::services
 {
 
 class ApiBase;
 
-}
+} // namespace csp::services
 
 
 namespace csp::web
@@ -32,7 +35,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -40,16 +53,16 @@ namespace csp::systems
 /// @ingroup ECommerce System
 /// @brief Public facing system that allows interfacing with CSP's concept of a ECommerce platform.
 /// Offers methods for utilising Ecommerce through CSP
-class CSP_API CSP_NO_DISPOSE ECommerceSystem : public SystemBase
+class CSP_API ECommerceSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<ECommerceSystem>(ECommerceSystem* Ptr);
 	/** @endcond */
-public:
-	ECommerceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
-	CSP_NO_EXPORT ECommerceSystem(csp::web::WebClient* InWebClient);
-	~ECommerceSystem();
+	CSP_END_IGNORE
 
+public:
 	/// @brief Get product information from a shopify store within a space
 	/// @param SpaceId csp::common::String : space id of product
 	/// @param ProductId csp::common::String : Product id of product
@@ -100,8 +113,11 @@ public:
 	CSP_ASYNC_RESULT void UpdateCartInformation(const CartInfo& CartInformation, CartInfoResultCallback Callback);
 
 private:
+	ECommerceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
+	CSP_NO_EXPORT ECommerceSystem(csp::web::WebClient* InWebClient);
+	~ECommerceSystem();
+
 	csp::services::ApiBase* ShopifyAPI;
 };
 
-void RemoveUrl(csp::common::String& Url);
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
+++ b/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
@@ -13,26 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/Common/Optional.h"
 #include "CSP/Systems/EventTicketing/EventTicketing.h"
 #include "CSP/Systems/SystemBase.h"
 
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
+
+
 namespace csp::systems
 {
 
 /// @ingroup Event Ticketing System
 /// @brief System that allows creation and management of ticketed events for spaces.
-class CSP_API CSP_NO_DISPOSE EventTicketingSystem : public SystemBase
+class CSP_API EventTicketingSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<EventTicketingSystem>(EventTicketingSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~EventTicketingSystem();
-
 	/// @brief Creates a ticketed event for the given space.
 	/// @param SpaceId csp::common::String : ID of the space to create the event for.
 	/// @param Vendor csp::systems::EventTicketingVendor : Enum representing the vendor that the event is created with.
@@ -109,6 +122,7 @@ public:
 private:
 	EventTicketingSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	CSP_NO_EXPORT EventTicketingSystem(csp::web::WebClient* InWebClient);
+	~EventTicketingSystem();
 
 	csp::services::ApiBase* EventTicketingAPI;
 };

--- a/Library/include/CSP/Systems/GraphQL/GraphQLSystem.h
+++ b/Library/include/CSP/Systems/GraphQL/GraphQLSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/Systems/GraphQL/GraphQL.h"
@@ -25,7 +26,7 @@ namespace csp::services
 
 class ApiBase;
 
-}
+} // namespace csp::services
 
 
 namespace csp::web
@@ -33,7 +34,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -42,15 +53,16 @@ namespace csp::systems
 /// @ingroup GraphQL System
 /// @brief Public facing system that allows interfacing with Magnopus Connect Services' GraphQL Server.
 /// Offers methods for sending and receiving GraphQL Queries.
-class CSP_API CSP_NO_DISPOSE GraphQLSystem : public SystemBase
+class CSP_API GraphQLSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<GraphQLSystem>(GraphQLSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~GraphQLSystem();
-
 	/// @brief Make a request to the Magnopus Connect Services' GraphQL Server, can contain a query, variables and operationName.
 	/// @param RequestBody csp::common::String : graphql request body, JSON encoded string of full graphql request,
 	/// can include a query, variables and operationName.
@@ -67,6 +79,7 @@ public:
 private:
 	GraphQLSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	CSP_NO_EXPORT GraphQLSystem(csp::web::WebClient* InWebClient);
+	~GraphQLSystem();
 
 	csp::services::ApiBase* GraphQLAPI;
 };

--- a/Library/include/CSP/Systems/Log/LogSystem.h
+++ b/Library/include/CSP/Systems/Log/LogSystem.h
@@ -22,6 +22,16 @@
 #include <functional>
 
 
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
+
+
 namespace csp::systems
 {
 
@@ -41,15 +51,16 @@ enum class LogLevel
 
 /// @brief A Connected Spaces Platform level Logger for debugging or printing to console, also handles logging to a file.
 /// Contains a callback system that allows clients to react to specific logs or events.
-class CSP_API CSP_NO_DISPOSE LogSystem
+class CSP_API LogSystem
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<LogSystem>(LogSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~LogSystem();
-
 	typedef std::function<void(const csp::common::String&)> LogCallbackHandler;
 	typedef std::function<void(const csp::common::String&)> EventCallbackHandler;
 	typedef std::function<void(const csp::common::String&)> BeginMarkerCallbackHandler;
@@ -102,12 +113,12 @@ public:
 
 private:
 	LogSystem();
+	~LogSystem();
 
 	csp::systems::LogLevel SystemLevel = LogLevel::All;
 
 	void LogToFile(const csp::common::String& InMessage);
 
-private:
 	// Allocate internally to avoid warning C4251 'needs to have dll-interface to be used by clients'
 	struct LogCallbacks* Callbacks;
 };

--- a/Library/include/CSP/Systems/Maintenance/MaintenanceSystem.h
+++ b/Library/include/CSP/Systems/Maintenance/MaintenanceSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/Systems/Maintenance/Maintenance.h"
@@ -26,7 +27,7 @@ namespace csp::services
 
 class ApiBase;
 
-}
+} // namespace csp::services
 
 
 namespace csp::web
@@ -34,7 +35,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -44,15 +55,16 @@ namespace csp::systems
 /// @brief Public facing system that allows interfacing with the Maintenance Window Server.
 /// This system can be used to query if there is currently a planned outage
 /// and can also be used to check for up coming maintenances outages
-class CSP_API CSP_NO_DISPOSE MaintenanceSystem : public SystemBase
+class CSP_API MaintenanceSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<MaintenanceSystem>(MaintenanceSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~MaintenanceSystem();
-
 	/// @brief Receives information on planned maintenances outages schedules for the future
 	/// @param Callback MaintenanceInfoCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void GetMaintenanceInfo(MaintenanceInfoCallback Callback);
@@ -60,6 +72,7 @@ public:
 private:
 	MaintenanceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	CSP_NO_EXPORT MaintenanceSystem(csp::web::WebClient* InWebClient);
+	~MaintenanceSystem();
 
 	csp::services::ApiBase* MaintenanceAPI;
 };

--- a/Library/include/CSP/Systems/Quota/QuotaSystem.h
+++ b/Library/include/CSP/Systems/Quota/QuotaSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/Systems/Quota/Quota.h"
@@ -24,7 +25,7 @@ namespace csp::services
 
 class ApiBase;
 
-}
+} // namespace csp::services
 
 
 namespace csp::web
@@ -32,7 +33,18 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
+
 
 namespace csp::systems
 {
@@ -41,13 +53,14 @@ namespace csp::systems
 /// Offers methods for receiving Quota Queries.
 class CSP_API CSP_NO_DISPOSE QuotaSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<QuotaSystem>(QuotaSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~QuotaSystem();
-
 	/// @brief Get the total number of Spaces owned by the current user and their tier space limit
 	/// @param Callback FeatureProgressCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback);
@@ -93,6 +106,7 @@ public:
 private:
 	QuotaSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	CSP_NO_EXPORT QuotaSystem(csp::web::WebClient* InWebClient);
+	~QuotaSystem();
 
 	csp::services::ApiBase* QuotaTierAssignmentAPI;
 	csp::services::ApiBase* QuotaManagementAPI;

--- a/Library/include/CSP/Systems/Script/ScriptSystem.h
+++ b/Library/include/CSP/Systems/Script/ScriptSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -22,6 +23,16 @@
 #include <functional>
 #include <string>
 #include <vector>
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -34,17 +45,19 @@ public:
 	virtual void Bind(int64_t ContextId, class ScriptSystem* InScriptSystem) = 0;
 };
 
+
 /// @brief A JavaScript based scripting system that can be used to create advanced behaviours and interactions between entities in spaces.
-class CSP_API CSP_NO_DISPOSE ScriptSystem
+class CSP_API ScriptSystem
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
 	friend class ScriptContext;
+	friend void csp::memory::Delete<ScriptSystem>(ScriptSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~ScriptSystem();
-
 	/// @brief Starts up the JavaScript runtime context.
 	void Initialise();
 	/// @brief Shuts down and deletes the JavaScript runtime context.
@@ -83,6 +96,7 @@ public:
 
 private:
 	ScriptSystem();
+	~ScriptSystem();
 
 	class ScriptRuntime* TheScriptRuntime;
 };

--- a/Library/include/CSP/Systems/Settings/SettingsSystem.h
+++ b/Library/include/CSP/Systems/Settings/SettingsSystem.h
@@ -28,7 +28,7 @@ namespace csp::services
 
 class ApiBase;
 
-}
+} // namespace csp::services
 
 
 namespace csp::web
@@ -36,7 +36,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -45,15 +55,16 @@ namespace csp::systems
 /// @ingroup Settings System
 /// @brief Public facing system that allows interfacing with Magnopus Connected Services' settings service.
 /// Offers methods for storing and retrieving client settings.
-class CSP_API CSP_NO_DISPOSE SettingsSystem : public SystemBase
+class CSP_API SettingsSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<SettingsSystem>(SettingsSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~SettingsSystem();
-
 	/// @brief Set a boolean indicating whether the current user has completed a non-disclosure agreement.
 	/// NullResultCallback. Returns status of the update task, no payload expected.
 	/// @param InValue bool : boolean reflecting desired state to store in Magnopus Connected Services.
@@ -151,6 +162,7 @@ public:
 private:
 	SettingsSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	CSP_NO_EXPORT SettingsSystem(csp::web::WebClient* InWebClient);
+	~SettingsSystem();
 
 	void SetSettingValue(const csp::common::String& InUserId,
 						 const csp::common::String& InContext,

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -26,12 +27,13 @@
 #include "CSP/Systems/Spaces/UserRoles.h"
 #include "CSP/Systems/SystemBase.h"
 
+
 namespace csp::services
 {
 
 class ApiBase;
 
-}
+} // namespace csp::services
 
 
 namespace csp::web
@@ -39,7 +41,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -50,13 +62,14 @@ namespace csp::systems
 /// Offers methods for creating, deleting and joining spaces.
 class CSP_API CSP_NO_DISPOSE SpaceSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<SpaceSystem>(SpaceSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~SpaceSystem();
-
 	/** @name Helper Functions
 	 *
 	 *   @{ */
@@ -322,6 +335,7 @@ public:
 private:
 	SpaceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	SpaceSystem(csp::web::WebClient* InWebClient);
+	~SpaceSystem();
 
 	// Space Metadata
 	void GetMetadataAssetCollection(const csp::common::String& SpaceId, AssetCollectionResultCallback Callback);

--- a/Library/include/CSP/Systems/Spatial/AnchorSystem.h
+++ b/Library/include/CSP/Systems/Spatial/AnchorSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -31,7 +32,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -40,15 +51,16 @@ namespace csp::systems
 /// @ingroup Anchor System
 /// @brief Public facing system that allows interfacing with Magnopus Connected Services' concept of an Anchor.
 /// Offers methods for creating and deleting Anchors.
-class CSP_API CSP_NO_DISPOSE AnchorSystem : public SystemBase
+class CSP_API AnchorSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<AnchorSystem>(AnchorSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~AnchorSystem();
-
 	/** @name Asynchronous Calls
 	 *   These are methods that perform WebClient calls and therefore operate asynchronously and require a callback to be passed for a completion
 	 * result
@@ -165,6 +177,7 @@ public:
 private:
 	AnchorSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	CSP_NO_EXPORT AnchorSystem(csp::web::WebClient* InWebClient);
+	~AnchorSystem();
 
 	csp::services::ApiBase* AnchorsAPI;
 };

--- a/Library/include/CSP/Systems/Spatial/PointOfInterestSystem.h
+++ b/Library/include/CSP/Systems/Spatial/PointOfInterestSystem.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -30,7 +31,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -38,17 +49,22 @@ namespace csp::systems
 
 class Space;
 class AssetCollection;
+class PointOfInterestInternalSystem;
 
 
 /// @ingroup Point of Interest System
 /// @brief Public facing system that allows interfacing with Magnopus Connected Services' concept of a Point of Interest.
 /// Offers methods for creating and deleting POIs.
-class CSP_API CSP_NO_DISPOSE PointOfInterestSystem : public SystemBase
+class CSP_API PointOfInterestSystem : public SystemBase
 {
+	CSP_START_IGNORE
+	/** @cond DO_NOT_DOCUMENT */
+	friend class PointOfInterestInternalSystem;
+	friend void csp::memory::Delete<PointOfInterestSystem>(PointOfInterestSystem* Ptr);
+	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~PointOfInterestSystem();
-
 	/** @name Asynchronous Calls
 	 *   These are methods that perform WebClient calls and therefore operate asynchronously and require a callback to be passed for a completion
 	 * result
@@ -128,6 +144,8 @@ protected:
 
 
 private:
+	~PointOfInterestSystem();
+
 	void DeletePOIInternal(const csp::common::String POIId, NullResultCallback Callback);
 
 	csp::services::ApiBase* POIApiPtr;

--- a/Library/include/CSP/Systems/SystemsManager.h
+++ b/Library/include/CSP/Systems/SystemsManager.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/CSPCommon.h"
@@ -50,14 +51,25 @@ namespace csp
 
 class CSPFoundation;
 
-}
+} // namespace csp
+
 
 namespace csp::web
 {
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -65,15 +77,16 @@ namespace csp::systems
 
 /// @ingroup Systems
 /// @brief Interface used to access each of the systems.
-class CSP_API CSP_NO_DISPOSE SystemsManager
+class CSP_API SystemsManager
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class csp::CSPFoundation;
+	friend void csp::memory::Delete<SystemsManager>(SystemsManager* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~SystemsManager();
-
 	static SystemsManager& Get();
 
 	/// @brief Retrieves user system.
@@ -138,6 +151,7 @@ public:
 
 private:
 	SystemsManager();
+	~SystemsManager();
 
 	static void Instantiate();
 	static void Destroy();

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -32,7 +32,17 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
@@ -41,16 +51,17 @@ namespace csp::systems
 /// @ingroup User System
 /// @brief Public facing system that allows interfacing with Magnopus Connected Services' user service.
 /// Offers methods for creating accounts, authenticating, and retrieving user profiles.
-class CSP_API CSP_NO_DISPOSE UserSystem : public SystemBase
+class CSP_API UserSystem : public SystemBase
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
 	friend class LoginStateResult;
+	friend void csp::memory::Delete<UserSystem>(UserSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~UserSystem();
-
 	// Authentication
 
 	/// @brief Get the current login state.
@@ -244,6 +255,7 @@ public:
 private:
 	UserSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	UserSystem(csp::web::WebClient* InWebClient);
+	~UserSystem();
 
 	[[nodiscard]]
 	bool EmailCheck(const std::string& Email) const;

--- a/Library/include/CSP/Systems/Voip/VoipSystem.h
+++ b/Library/include/CSP/Systems/Voip/VoipSystem.h
@@ -23,22 +23,33 @@ namespace csp::web
 
 class WebClient;
 
-}
+} // namespace csp::web
+
+
+namespace csp::memory
+{
+
+CSP_START_IGNORE
+template <typename T> void Delete(T* Ptr);
+CSP_END_IGNORE
+
+} // namespace csp::memory
 
 
 namespace csp::systems
 {
 
 /// @brief System class for handling VOIP. Provides Connected Spaces Platform specific overidden functionality.
-class CSP_API CSP_NO_DISPOSE VoipSystem
+class CSP_API VoipSystem
 {
+	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SystemsManager;
+	friend void csp::memory::Delete<VoipSystem>(VoipSystem* Ptr);
 	/** @endcond */
+	CSP_END_IGNORE
 
 public:
-	~VoipSystem();
-
 	/// @brief Mutes a local user. Not implemented.
 	/// @param IsMuted
 	void MuteLocalUser(bool IsMuted);
@@ -48,6 +59,7 @@ public:
 
 private:
 	VoipSystem();
+	~VoipSystem();
 };
 
 } // namespace csp::systems

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -16,9 +16,9 @@
 
 #include "CSP/Systems/ECommerce/ECommerceSystem.h"
 
+#include "CallHelpers.h"
 #include "ECommerceSystemHelpers.h"
 #include "Services/aggregationservice/Api.h"
-#include "CallHelpers.h"
 #include "Systems/ResultHelpers.h"
 
 
@@ -27,8 +27,31 @@ using namespace csp;
 namespace chs = csp::services::generated::aggregationservice;
 
 
+namespace
+{
+
+void RemoveUrl(csp::common::String& Url)
+{
+	if (std::string(Url.c_str()).find("gid://shopify/Cart/") != std::string::npos)
+	{
+		Url = Url.Split('/')[Url.Split('/').Size() - 1];
+	}
+	else if (std::string(Url.c_str()).find("?cart=") != std::string::npos)
+	{
+		Url = Url.Split('/')[Url.Split('/').Size() - 1].c_str();
+	}
+	else if (std::string(Url.c_str()).find("gid://shopify/ProductVariant/") != std::string::npos)
+	{
+		Url = Url.Split('/')[Url.Split('/').Size() - 1];
+	}
+}
+
+} // namespace
+
+
 namespace csp::systems
 {
+
 ECommerceSystem::ECommerceSystem() : SystemBase(), ShopifyAPI(nullptr)
 {
 }
@@ -196,19 +219,4 @@ void ECommerceSystem::UpdateCartInformation(const CartInfo& CartInformation, Car
 		->apiV1SpacesSpaceIdVendorsShopifyCartsCartIdPut(CartInformation.SpaceId, CartInformation.CartId, CartUpdateInfo, ResponseHandler);
 }
 
-void RemoveUrl(csp::common::String& Url)
-{
-	if (std::string(Url.c_str()).find("gid://shopify/Cart/") != std::string::npos)
-	{
-		Url = Url.Split('/')[Url.Split('/').Size() - 1];
-	}
-	else if (std::string(Url.c_str()).find("?cart=") != std::string::npos)
-	{
-		Url = Url.Split('/')[Url.Split('/').Size() - 1].c_str();
-	}
-	else if (std::string(Url.c_str()).find("gid://shopify/ProductVariant/") != std::string::npos)
-	{
-		Url = Url.Split('/')[Url.Split('/').Size() - 1];
-	}
-}
 } // namespace csp::systems

--- a/Tests/src/PublicAPITests/Analytics/AnalyticsSystemUnitTests.cpp
+++ b/Tests/src/PublicAPITests/Analytics/AnalyticsSystemUnitTests.cpp
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "AnalyticsSystemTestHelpers.h"
 #include "CSP/Systems/Analytics/AnalyticsProvider.h"
 #include "CSP/Systems/Analytics/AnalyticsProviderGoogleUA.h"
 #include "CSP/Systems/Analytics/AnalyticsSystem.h"
 #include "CSP/Systems/Analytics/AnalyticsSystemUtils.h"
+#include "CSP/Systems/SystemsManager.h"
 #include "TestHelpers.h"
 
 #include "gtest/gtest.h"
@@ -26,12 +28,12 @@
 #if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_LOG_METRIC_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMetricTest)
 {
-	csp::systems::AnalyticsSystem System;
+	auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
 
 	// Create our test provider
 	TestAnalyticsProvider Provider;
 
-	System.RegisterProvider(&Provider);
+	AnalyticsSystem->RegisterProvider(&Provider);
 
 	// Create metric value
 	const csp::common::String TestMetricTag = "TestTag";
@@ -41,7 +43,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMetricTest)
 	Event->AddInt("Value", TestMetricValue);
 
 	// Send metric
-	System.Log(Event);
+	AnalyticsSystem->Log(Event);
 
 	// Call tick to process analytics events
 	csp::CSPFoundation::Tick();
@@ -52,7 +54,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMetricTest)
 	EXPECT_EQ(Metrics[0].GetTag(), TestMetricTag);
 	EXPECT_EQ(Metrics[0].GetInt("Value"), TestMetricValue);
 
-	System.DeregisterProvider(&Provider);
+	AnalyticsSystem->DeregisterProvider(&Provider);
 }
 #endif
 
@@ -60,12 +62,12 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMetricTest)
 #if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_LOG_MULTIPLE_METRIC_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMultipleMetricTest)
 {
-	csp::systems::AnalyticsSystem System;
+	auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
 
 	// Create our test provider
 	TestAnalyticsProvider Provider;
 
-	System.RegisterProvider(&Provider);
+	AnalyticsSystem->RegisterProvider(&Provider);
 
 	// Create metric values
 	const csp::common::String TestMetricTag1 = "TestTag";
@@ -87,9 +89,9 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMultipleMetricTest)
 	Event3->AddInt("Value", TestMetricValue3);
 
 	// Send metrics
-	System.Log(Event);
-	System.Log(Event2);
-	System.Log(Event3);
+	AnalyticsSystem->Log(Event);
+	AnalyticsSystem->Log(Event2);
+	AnalyticsSystem->Log(Event3);
 
 	// Call tick to process analytics events
 	csp::CSPFoundation::Tick();
@@ -107,7 +109,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMultipleMetricTest)
 	EXPECT_EQ(Metrics[2].GetTag(), TestMetricTag3);
 	EXPECT_EQ(Metrics[2].GetInt("Value"), TestMetricValue3);
 
-	System.DeregisterProvider(&Provider);
+	AnalyticsSystem->DeregisterProvider(&Provider);
 }
 #endif
 
@@ -115,12 +117,12 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, LogMultipleMetricTest)
 #if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_DEREGISTER_PROVIDER_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, DeregisterProviderTest)
 {
-	csp::systems::AnalyticsSystem System;
+	auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
 
 	// Create our test provider
 	TestAnalyticsProvider Provider;
 
-	System.RegisterProvider(&Provider);
+	AnalyticsSystem->RegisterProvider(&Provider);
 
 	// Create metric value
 	const csp::common::String TestMetricTag = "TestTag";
@@ -129,10 +131,10 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, DeregisterProviderTest)
 	csp::systems::AnalyticsEvent* Event = INIT_EVENT(TestMetricTag);
 	Event->AddInt("Value", TestMetricValue);
 
-	System.DeregisterProvider(&Provider);
+	AnalyticsSystem->DeregisterProvider(&Provider);
 
 	// Send metric
-	System.Log(Event);
+	AnalyticsSystem->Log(Event);
 
 	// Call tick to process analytics events
 	csp::CSPFoundation::Tick();
@@ -147,12 +149,12 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, DeregisterProviderTest)
 #if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_MULTIPLE_THREADS_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, MultipleThreadsTest)
 {
-	csp::systems::AnalyticsSystem System;
+	auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
 
 	// Create our test provider
 	TestAnalyticsProvider Provider;
 
-	System.RegisterProvider(&Provider);
+	AnalyticsSystem->RegisterProvider(&Provider);
 
 	const int ThreadCount = 5;
 	bool Start			  = false;
@@ -161,7 +163,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, MultipleThreadsTest)
 
 	for (int i = 0; i < ThreadCount; i++)
 	{
-		Threads.push_back(std::thread {[&Start, &System]()
+		Threads.push_back(std::thread {[&Start, AnalyticsSystem]()
 									   {
 										   while (!Start)
 										   {
@@ -175,7 +177,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, MultipleThreadsTest)
 										   Event->AddInt("Value", TestMetricValue);
 
 										   // Send metric
-										   System.Log(Event);
+										   AnalyticsSystem->Log(Event);
 									   }});
 	}
 
@@ -195,7 +197,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, MultipleThreadsTest)
 
 	EXPECT_EQ(Metrics.size(), ThreadCount);
 
-	System.DeregisterProvider(&Provider);
+	AnalyticsSystem->DeregisterProvider(&Provider);
 }
 #endif
 

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Method/Destructor.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Method/Destructor.mustache
@@ -1,3 +1,4 @@
+{{# should_dispose }}
 {{^ is_private }}
 ~{{ parent_class.name }}()
 {
@@ -19,3 +20,4 @@ void RealDispose() {
     GC.SuppressFinalize(this);
 }
 {{/ is_private }}
+{{/ should_dispose }}


### PR DESCRIPTION
BREAKING CHANGE: Systems classes no longer expose their destructors. If you were calling `delete` (C++), `.Dispose()` (C#), or `.delete()` (JS) you will need to remove these calls.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
