### PR TITLE
[NT-0] fix: revert import.meta change

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -266,7 +266,7 @@ if not Project then
                     "'mainScriptUrlOrBlob'," ..
                     "'wasmMemory'" ..
                 "]",
-                "-sUSE_ES6_IMPORT_META=0"                                       -- disable use of import.meta as it is not yet supported everywhere
+                --"-sUSE_ES6_IMPORT_META=0"                                       -- disable use of import.meta as it is not yet supported everywhere
             }
 
             links {


### PR DESCRIPTION
This change reverts a previous change we made to disable usage of import.meta in the WASM glue code in order to improve compatibility with build tools. Disabling import.meta actually ended up breaking webpack, so away it goes.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
