### PR TITLE
[NT-0] fix: logging arg fix

### DIFF
--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -83,7 +83,7 @@ void ComponentBase::SetProperty(uint32_t Key, const ReplicatedValue& Value)
 	if (!GetParent()->IsModifiable())
 	{
 		CSP_LOG_ERROR_FORMAT("Error: Update attempted on a non-owned entity that is marked as non-transferable. Skipping update. Entity name: %s",
-							 GetParent()->GetName());
+							 GetParent()->GetName().c_str());
 		return;
 	}
 


### PR DESCRIPTION
Fixes an issue where we were passing a String instead of a C-String to CSP_LOG_*.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
