### PR TITLE
[NT-0] fix: fix readme gen for GH commits

### DIFF
--- a/teamcity/GenerateReadMe.py
+++ b/teamcity/GenerateReadMe.py
@@ -68,8 +68,11 @@ def main():
     misc_changes = []
 
     for commit in commits:
-        index = commit.message.index('\n')
-        full_title = commit.message[:index]
+        index = commit.message.find('\n')
+
+        if index > -1:
+            full_title = commit.message[:index]
+
         description = commit.message[index + 1:]
         match = re.match(r'\[(?P<jira_id>[a-zA-Z]+\-[0-9]+)\] (?P<tag>[a-zA-Z]+)(?P<breaking_change>[\!]*)\: (?P<title>.*)', full_title)
 
@@ -77,6 +80,7 @@ def main():
             match = re.match(r'(?P<jira_id>[a-zA-Z]+\-[0-9]+) (?P<title>.*)', full_title)
             if match is None:
                 print("Invalid commit title format. Skipping...", file=sys.stderr)
+                print(">>", full_title)
                 continue
             
             jira_id = match.group("jira_id")

--- a/teamcity/templates/readme/readme.md.jinja2
+++ b/teamcity/templates/readme/readme.md.jinja2
@@ -2,7 +2,7 @@
 {%- if changes | length > 0 %}
 ### {{ list_title }}
 {% for change in changes %}
-- {{ change.title | capitalize }} *({{ change.commit_hash | truncate(7, true, '') }})* [**{{ change.jira_id }}**]
+- {{ change.title[0] | upper }}{{ change.title[1:] }} *({{ change.commit_hash | truncate(7, true, '') }})* [**{{ change.jira_id }}**]
 {%- endfor %}
 {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
This change fixes an issue where commit message parsing fails for commits authored from the GitHub UI, as no newline character exists. It also fixes an issue with summary lists breaking the string case of commit descriptions.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
