### PR TITLE
[OB-3197] fix: fix SetCustomProperty not sending changes to clients

### DIFF
--- a/Library/src/Multiplayer/Script/ComponentBinding/CustomSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/CustomSpaceComponentScriptInterface.cpp
@@ -140,6 +140,7 @@ void CustomSpaceComponentScriptInterface::SetCustomProperty(const std::string& K
 	}
 
 	static_cast<CustomSpaceComponent*>(Component)->SetCustomProperty(Key.c_str(), SetValue);
+	SendPropertyUpdate();
 }
 
 


### PR DESCRIPTION
This change fixes an issue where setting a new value on a property of a custom component in a script did not propagate that change to the clients.

- The function `CustomSpaceComponentScriptInterface::SetCustomProperty` was missing a call to `SendPropertyUpdate();` at the end. This was added.

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
