### PR TITLE
[OF-1213] feat: recent spaces storage increased to 50

### DIFF
--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -33,7 +33,7 @@
 #include <sstream>
 
 
-constexpr int MAX_RECENT_SPACES								= 10;
+constexpr int MAX_RECENT_SPACES								= 50;
 constexpr const char* AVATAR_PORTRAIT_ASSET_NAME			= "AVATAR_PORTRAIT_ASSET_";
 constexpr const char* AVATAR_PORTRAIT_ASSET_COLLECTION_NAME = "AVATAR_PORTRAIT_ASSET_COLLECTION_";
 


### PR DESCRIPTION
Users can now store up to the fifty most recent spaces that they have visited. Previously this value was ten.