### PR TITLE
[OB-3254] fix: Clients can retrieve the avatar portraits of any user

### DIFF
--- a/Library/include/CSP/Systems/Settings/SettingsSystem.h
+++ b/Library/include/CSP/Systems/Settings/SettingsSystem.h
@@ -130,8 +130,9 @@ public:
 	/// @brief Retrieves the Avatar Portrait information associated with the space
 	/// If the user of the Avatar portrait associated with it the result callback will be successful, the HTTP res code will be ResponseNotFound
 	/// and the Uri field inside the UriResult will be empty
+    /// @param InUserID const csp::common::String : The id of the user we are seelomg to retrieve the portrait for
 	/// @param Callback UriResultCallback : callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetAvatarPortrait(UriResultCallback Callback);
+	CSP_ASYNC_RESULT void GetAvatarPortrait(const csp::common::String InUserID, UriResultCallback Callback);
 
 	/// @brief Updates the Avatar Portrait image or adds one if it didn't have it previously using BufferAssetDataSource
 	/// @param NewAvatarPortrait csp::systems::BufferAssetDataSource : New Avatar Portrait information
@@ -163,7 +164,7 @@ private:
 
 	void AddAvatarPortrait(const csp::systems::FileAssetDataSource& ImageDataSource, NullResultCallback Callback);
 	void AddAvatarPortraitWithBuffer(const csp::systems::BufferAssetDataSource& ImageDataSource, NullResultCallback Callback);
-	void GetAvatarPortraitAssetCollection(AssetCollectionsResultCallback Callback);
+	void GetAvatarPortraitAssetCollection(const csp::common::String InUserID, AssetCollectionsResultCallback Callback);
 	void GetAvatarPortraitAsset(const AssetCollection& AvatarPortraitAssetCollection, AssetsResultCallback Callback);
 	void RemoveAvatarPortrait(NullResultCallback Callback);
 };

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -431,10 +431,12 @@ void SettingsSystem::UpdateAvatarPortrait(const FileAssetDataSource& NewAvatarPo
 		}
 	};
 
-	GetAvatarPortraitAssetCollection(AvatarPortraitAssetCollCallback);
+    auto* UserSystem     = SystemsManager::Get().GetUserSystem();
+    const auto& UserId = UserSystem->GetLoginState().UserId;
+	GetAvatarPortraitAssetCollection(UserId, AvatarPortraitAssetCollCallback);
 }
 
-void SettingsSystem::GetAvatarPortrait(UriResultCallback Callback)
+void SettingsSystem::GetAvatarPortrait(const csp::common::String InUserID, UriResultCallback Callback)
 {
 	AssetCollectionsResultCallback AvatarPortraitAssetCollCallback = [=](const AssetCollectionsResult& AssetCollResult)
 	{
@@ -490,7 +492,7 @@ void SettingsSystem::GetAvatarPortrait(UriResultCallback Callback)
 		}
 	};
 
-	GetAvatarPortraitAssetCollection(AvatarPortraitAssetCollCallback);
+	GetAvatarPortraitAssetCollection(InUserID, AvatarPortraitAssetCollCallback);
 }
 
 void SettingsSystem::UpdateAvatarPortraitWithBuffer(const BufferAssetDataSource& NewAvatarPortrait, NullResultCallback Callback)
@@ -552,7 +554,9 @@ void SettingsSystem::UpdateAvatarPortraitWithBuffer(const BufferAssetDataSource&
 		}
 	};
 
-	GetAvatarPortraitAssetCollection(ThumbnailAssetCollCallback);
+    auto* UserSystem     = SystemsManager::Get().GetUserSystem();
+    const auto& UserId = UserSystem->GetLoginState().UserId;
+	GetAvatarPortraitAssetCollection(UserId, ThumbnailAssetCollCallback);
 }
 
 void SettingsSystem::AddAvatarPortrait(const FileAssetDataSource& ImageDataSource, NullResultCallback Callback)
@@ -725,13 +729,10 @@ void SettingsSystem::AddAvatarPortraitWithBuffer(const BufferAssetDataSource& Im
 									   CreateAssetCollCallback);
 }
 
-void SettingsSystem::GetAvatarPortraitAssetCollection(AssetCollectionsResultCallback Callback)
+void SettingsSystem::GetAvatarPortraitAssetCollection(const csp::common::String InUserID, AssetCollectionsResultCallback Callback)
 {
 	auto& SystemsManager = SystemsManager::Get();
 	auto* AssetSystem	 = SystemsManager.GetAssetSystem();
-	auto* UserSystem	 = SystemsManager.GetUserSystem();
-
-	const auto& UserId = UserSystem->GetLoginState().UserId;
 
 	AssetCollectionsResultCallback GetAssetCollCallback = [=](const AssetCollectionsResult& AssetCollResult)
 	{
@@ -746,7 +747,7 @@ void SettingsSystem::GetAvatarPortraitAssetCollection(AssetCollectionsResultCall
 		INVOKE_IF_NOT_NULL(Callback, AssetCollResult);
 	};
 
-	Array<String> AvatarPortraitAssetCollectionName = {AVATAR_PORTRAIT_ASSET_COLLECTION_NAME + UserId};
+	Array<String> AvatarPortraitAssetCollectionName = {AVATAR_PORTRAIT_ASSET_COLLECTION_NAME + InUserID};
 
 	Array<String> PrototypeNames			   = {AvatarPortraitAssetCollectionName};
 	Array<EAssetCollectionType> PrototypeTypes = {EAssetCollectionType::DEFAULT};
@@ -864,7 +865,9 @@ void SettingsSystem::RemoveAvatarPortrait(NullResultCallback Callback)
 		}
 	};
 
-	GetAvatarPortraitAssetCollection(PortraitAvatarAssetCollCallback);
+    auto* UserSystem     = SystemsManager::Get().GetUserSystem();
+    const auto& UserId = UserSystem->GetLoginState().UserId;
+	GetAvatarPortraitAssetCollection(UserId, PortraitAvatarAssetCollCallback);
 }
 
 void SettingsSystem::SetAvatarInfo(AvatarType InType, const Variant& InIdentifier, NullResultCallback Callback)

--- a/Tests/src/PublicAPITests/SettingsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SettingsSystemTests.cpp
@@ -29,6 +29,7 @@
 
 using namespace std::chrono_literals;
 
+#define RUN_SETTINGSSYSTEM_TESTS 1
 
 namespace
 {
@@ -393,7 +394,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, UpdateAvatarPortraitTest)
 		auto [Result] = AWAIT_PRE(SettingsSystem, UpdateAvatarPortrait, RequestPredicate, AvatarPortrait);
 		EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
-		auto [GetAvatarPortraitResult] = AWAIT_PRE(SettingsSystem, GetAvatarPortrait, RequestPredicate);
+		auto [GetAvatarPortraitResult] = AWAIT_PRE(SettingsSystem, GetAvatarPortrait, RequestPredicate, UserId);
 		EXPECT_EQ(GetAvatarPortraitResult.GetResultCode(), csp::systems::EResultCode::Success);
 		EXPECT_TRUE(IsUriValid(GetAvatarPortraitResult.GetUri().c_str(), LocalFileName));
 	}
@@ -408,7 +409,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, UpdateAvatarPortraitTest)
 		auto [Result] = AWAIT_PRE(SettingsSystem, UpdateAvatarPortrait, RequestPredicate, AvatarPortrait);
 		EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
-		auto [GetAvatarPortraitResult] = AWAIT_PRE(SettingsSystem, GetAvatarPortrait, RequestPredicate);
+		auto [GetAvatarPortraitResult] = AWAIT_PRE(SettingsSystem, GetAvatarPortrait, RequestPredicate, UserId);
 		EXPECT_EQ(GetAvatarPortraitResult.GetResultCode(), csp::systems::EResultCode::Success);
 		EXPECT_TRUE(IsUriValid(GetAvatarPortraitResult.GetUri().c_str(), LocalFileName));
 	}
@@ -449,7 +450,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, UpdateAvatarPortraitWithBufferTe
 	auto [Result] = AWAIT_PRE(SettingsSystem, UpdateAvatarPortraitWithBuffer, RequestPredicate, AvatarPortraitThumbnail);
 	EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 	// get asset uri
-	auto [GetAvatarPortraitResult] = AWAIT_PRE(SettingsSystem, GetAvatarPortrait, RequestPredicate);
+	auto [GetAvatarPortraitResult] = AWAIT_PRE(SettingsSystem, GetAvatarPortrait, RequestPredicate, UserId);
 	csp::systems::Asset Asset;
 	Asset.FileName = "OKO.png";
 	Asset.Uri	   = GetAvatarPortraitResult.GetUri().c_str();


### PR DESCRIPTION
Via the settings system, client applications can query for and retrieve the avatar portrait for any other user, given a provided user ID argument.
