### PR TITLE
[NT-0] fix: Local entities are destroyed upon exiting a space

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -264,6 +264,11 @@ public:
 	/// It is highly advised not to call this function unless you know what you are doing.
 	void RetrieveAllEntities();
 
+	/// @brief Destroys the client's local view of all currently known entities.
+	///
+	/// They still reside on the server, however they will not be accessible in the client application.
+	void LocalDestroyAllEntities();
+
 	/// @brief Sets the selected state of an entity, if the operation is acceptable.
 	///
 	/// Criteria:

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -325,6 +325,10 @@ protected:
 	using SpaceEntityList = csp::common::List<SpaceEntity*>;
 
 	SpaceEntityList Entities;
+	SpaceEntityList Avatars;
+	SpaceEntityList Objects;
+	SpaceEntityList SelectedEntities;
+
 	std::recursive_mutex* EntitiesLock;
 
 private:
@@ -338,9 +342,6 @@ private:
 	using PatchMessageQueue = std::deque<signalr::value*>;
 	using SpaceEntitySet	= std::set<SpaceEntity*>;
 
-	SpaceEntityList Avatars;
-	SpaceEntityList Objects;
-	SpaceEntityList SelectedEntities;
 
 	EntityCreatedCallback SpaceEntityCreatedCallback;
 	CallbackHandler InitialEntitiesRetrievedCallback;

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -734,7 +734,11 @@ void SpaceEntitySystem::LocalDestroyAllEntities()
 		}
 	}
 
-    // Clear adds/removes, we don't want to add or remove if we're shutting down.
+    Entities.Clear();
+    Objects.Clear();
+    Avatars.Clear();
+
+    // Clear adds/removes, we don't want to mutate if we're cleaning everything else.
     PendingAdds->clear();
     PendingRemoves->clear();
 	PendingIncomingUpdates->clear();

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -207,36 +207,7 @@ SpaceEntitySystem::SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnect
 
 SpaceEntitySystem::~SpaceEntitySystem()
 {
-	LockEntityUpdate();
-
-	const auto NumEntities = GetNumEntities();
-
-	for (size_t i = 0; i < NumEntities; ++i)
-	{
-		SpaceEntity* Entity = GetEntityByIndex(i);
-
-		// We automatically invoke SignalR deletion for all transient entities that were owned by this local client
-		// as these are only ever valid for a single connected session
-		if (Entity->GetIsTransient() && Entity->GetOwnerId() == csp::systems::SystemsManager::Get().GetMultiplayerConnection()->GetClientId())
-		{
-			DestroyEntity(Entity,
-												[](auto Ok)
-												{
-												});
-		}
-		// Otherwise we clear up all all locally represented entities
-		else
-		{
-			LocalDestroyEntity(Entity);
-		}
-	}
-
-    // Clear adds/removes, we don't want to add or remove if we're shutting down.
-    PendingAdds->clear();
-    PendingRemoves->clear();
-	PendingIncomingUpdates->clear();
-
-	UnlockEntityUpdate();
+	LocalDestroyAllEntities();
 
 	EntityScriptBinding::RemoveBinding(ScriptBinding);
 
@@ -735,6 +706,40 @@ void SpaceEntitySystem::RetrieveAllEntities()
 	}
 
 	GetEntitiesPaged(0, ENTITY_PAGE_LIMIT, CreateRetrieveAllEntitiesCallback(0)); // Get at most ENTITY_PAGE_LIMIT entities at a time
+}
+
+void SpaceEntitySystem::LocalDestroyAllEntities()
+{
+	LockEntityUpdate();
+
+	const auto NumEntities = GetNumEntities();
+
+	for (size_t i = 0; i < NumEntities; ++i)
+	{
+		SpaceEntity* Entity = GetEntityByIndex(i);
+
+		// We automatically invoke SignalR deletion for all transient entities that were owned by this local client
+		// as these are only ever valid for a single connected session
+		if (Entity->GetIsTransient() && Entity->GetOwnerId() == csp::systems::SystemsManager::Get().GetMultiplayerConnection()->GetClientId())
+		{
+			DestroyEntity(Entity,
+			[](auto Ok)
+			{
+			});
+		}
+		// Otherwise we clear up all all locally represented entities
+		else
+		{
+			LocalDestroyEntity(Entity);
+		}
+	}
+
+    // Clear adds/removes, we don't want to add or remove if we're shutting down.
+    PendingAdds->clear();
+    PendingRemoves->clear();
+	PendingIncomingUpdates->clear();
+
+	UnlockEntityUpdate();
 }
 
 void SpaceEntitySystem::QueueEntityUpdate(SpaceEntity* EntityToUpdate)

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -274,6 +274,7 @@ void SpaceSystem::ExitSpace(NullResultCallback Callback)
 				{
 					MultiplayerConnection->ResetScopes([Callback](csp::multiplayer::ErrorCode Error)
 					{
+						csp::systems::SystemsManager::Get().GetSpaceEntitySystem()->LocalDestroyAllEntities();
 						if (Error != csp::multiplayer::ErrorCode::None)
 						{
 						    CSP_LOG_ERROR_FORMAT("Error on exiting spaces whilst clearing scopes, ErrorCode: %s", Error);


### PR DESCRIPTION
As part of a recent broad refactor to the multiplayer connection's application lifetime, the connection now persists for the duration of the application's lifetime. Entering a space now narrows the connections focus to listen to entities within the space, and exiting stops the connection from listening to entities within the space.

A bug has arisen however where whilst leaving a space stops the application receiving updates regarding entities, it does not clear CSP's local view of currently known entities.

This change introduces a new function to SpaceEntitySystem, `LocalDestroyAllEntities` which is invoked by the SpaceSystem after it has finished listening for entities within the space. It clear's CSP's local view of all currently known entities.

Tests have been updated to validate this behaviour.
