### PR TITLE
Staging 4.23.1

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -264,6 +264,11 @@ public:
 	/// It is highly advised not to call this function unless you know what you are doing.
 	void RetrieveAllEntities();
 
+	/// @brief Destroys the client's local view of all currently known entities.
+	///
+	/// They still reside on the server, however they will not be accessible in the client application.
+	void LocalDestroyAllEntities();
+
 	/// @brief Sets the selected state of an entity, if the operation is acceptable.
 	///
 	/// Criteria:
@@ -320,6 +325,10 @@ protected:
 	using SpaceEntityList = csp::common::List<SpaceEntity*>;
 
 	SpaceEntityList Entities;
+	SpaceEntityList Avatars;
+	SpaceEntityList Objects;
+	SpaceEntityList SelectedEntities;
+
 	std::recursive_mutex* EntitiesLock;
 
 private:
@@ -333,9 +342,6 @@ private:
 	using PatchMessageQueue = std::deque<signalr::value*>;
 	using SpaceEntitySet	= std::set<SpaceEntity*>;
 
-	SpaceEntityList Avatars;
-	SpaceEntityList Objects;
-	SpaceEntityList SelectedEntities;
 
 	EntityCreatedCallback SpaceEntityCreatedCallback;
 	CallbackHandler InitialEntitiesRetrievedCallback;

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -274,6 +274,7 @@ void SpaceSystem::ExitSpace(NullResultCallback Callback)
 				{
 					MultiplayerConnection->ResetScopes([Callback](csp::multiplayer::ErrorCode Error)
 					{
+						csp::systems::SystemsManager::Get().GetSpaceEntitySystem()->LocalDestroyAllEntities();
 						if (Error != csp::multiplayer::ErrorCode::None)
 						{
 						    CSP_LOG_ERROR_FORMAT("Error on exiting spaces whilst clearing scopes, ErrorCode: %s", Error);

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -1773,11 +1773,13 @@ struct InternalSpaceEntitySystem : public csp::multiplayer::SpaceEntitySystem
 		std::scoped_lock<std::recursive_mutex> EntitiesLocker(*EntitiesLock);
 
 		Entities.Clear();
+		Objects.Clear();
+		Avatars.Clear();
 	}
 };
 
 // Disabled by default as it can be slow
-#if RUN_MULTIPLAYER_MANYENTITIES_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_MANYENTITIES_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 {
 	SetRandSeed();
@@ -1814,6 +1816,9 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 		{
 		});
 
+	EXPECT_EQ(EntitySystem->GetNumEntities(), 0);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), 0);
+
 	// Create a bunch of entities
 	constexpr size_t NUM_ENTITIES_TO_CREATE = 15;
 	constexpr char ENTITY_NAME_PREFIX[]		= "Object_";
@@ -1830,11 +1835,17 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 		EXPECT_NE(Object, nullptr);
 	}
 
+	EXPECT_EQ(EntitySystem->GetNumEntities(), NUM_ENTITIES_TO_CREATE);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), NUM_ENTITIES_TO_CREATE);
+
 	EntitySystem->ProcessPendingEntityOperations();
 
 	// Clear all entities locally
 	auto InternalEntitySystem = static_cast<InternalSpaceEntitySystem*>(EntitySystem);
 	InternalEntitySystem->ClearEntities();
+
+	EXPECT_EQ(EntitySystem->GetNumEntities(), 0);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), 0);
 
 	// Retrieve all entities and verify count
 	auto GotAllEntities = false;
@@ -1853,8 +1864,16 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 	}
 
 	EXPECT_EQ(EntitySystem->GetNumEntities(), NUM_ENTITIES_TO_CREATE);
+	// We created objects exclusively, so this should also be true.
+	EXPECT_EQ(EntitySystem->GetNumEntities(), EntitySystem->GetNumObjects());
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	auto [ExitResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+	EXPECT_EQ(ExitResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	// Validate that leaving a space flushes CSP's view of all currently known entities.
+	EXPECT_EQ(EntitySystem->GetNumEntities(), 0);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), 0);
+	EXPECT_EQ(EntitySystem->GetNumAvatars(), 0);
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);


### PR DESCRIPTION
* [NT-0] fix: entity cleanup on space exit

As part of a recent broad refactor to the multiplayer connection's application lifetime, the connection now persists for the duration of the application's lifetime. Entering a space now narrows the connections focus to listen to entities within the space, and exiting stops the connection from listening to entities within the space.

A bug has arisen however where whilst leaving a space stops the application receiving updates regarding entities, it does not clear CSP's local view of currently known entities.

This change introduces a new function to SpaceEntitySystem, LocalDestroyAllEntities which is invoked by the SpaceSystem after it has finished listening for entities within the space. It clear's CSP's local view of all currently known entities.

Tests have been updated to validate this behaviour.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
