### PR TITLE
4.23.1

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -264,6 +264,11 @@ public:
 	/// It is highly advised not to call this function unless you know what you are doing.
 	void RetrieveAllEntities();
 
+	/// @brief Destroys the client's local view of all currently known entities.
+	///
+	/// They still reside on the server, however they will not be accessible in the client application.
+	void LocalDestroyAllEntities();
+
 	/// @brief Sets the selected state of an entity, if the operation is acceptable.
 	///
 	/// Criteria:
@@ -320,6 +325,10 @@ protected:
 	using SpaceEntityList = csp::common::List<SpaceEntity*>;
 
 	SpaceEntityList Entities;
+	SpaceEntityList Avatars;
+	SpaceEntityList Objects;
+	SpaceEntityList SelectedEntities;
+
 	std::recursive_mutex* EntitiesLock;
 
 private:
@@ -333,9 +342,6 @@ private:
 	using PatchMessageQueue = std::deque<signalr::value*>;
 	using SpaceEntitySet	= std::set<SpaceEntity*>;
 
-	SpaceEntityList Avatars;
-	SpaceEntityList Objects;
-	SpaceEntityList SelectedEntities;
 
 	EntityCreatedCallback SpaceEntityCreatedCallback;
 	CallbackHandler InitialEntitiesRetrievedCallback;

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -280,6 +280,7 @@ void AssetSystem::CopyAssetCollectionsToSpace(csp::common::Array<AssetCollection
 			std::nullopt,							// PrototypeOwnerIds
 			std::nullopt,							// ReadAccessFilters
 			std::nullopt,							// WriteAccessFilters
+            std::nullopt,							// OrganizationIds
 			SourceSpaceId,							// originalGroupId
 			DestSpaceId,							// newGroupId
 			std::nullopt,							// shallowCopy
@@ -402,25 +403,26 @@ void AssetSystem::FindAssetCollections(const Optional<Array<String>>& Ids,
 																																		   nullptr);
 
 	static_cast<chs::PrototypeApi*>(PrototypeAPI)
-		->apiV1PrototypesGet(PrototypeTags,
-							 std::nullopt,
-							 PrototypeIds,
-							 PrototypeNames,
-							 std::nullopt,
-							 std::nullopt,
-							 std::nullopt,
-							 ParentPrototypeId,
-							 GroupIds,
-							 PrototypeTypes,
-							 std::nullopt,
-							 std::nullopt,
-							 std::nullopt,
-							 std::nullopt,
-							 std::nullopt,
-							 Skip,
-							 Limit,
-							 std::nullopt,
-							 std::nullopt,
+		->apiV1PrototypesGet(PrototypeTags,         // Tags
+							 std::nullopt,          // TagsAll
+							 PrototypeIds,          // Ids
+							 PrototypeNames,        // Names
+							 std::nullopt,          // PartialNames
+							 std::nullopt,          // ExcludedIds
+							 std::nullopt,          // PointOfInterestIds
+							 ParentPrototypeId,     // ParentId
+							 GroupIds,              // GroupIds
+							 PrototypeTypes,        // Types
+							 std::nullopt,          // HasGroup
+							 std::nullopt,          // CreatedBy
+							 std::nullopt,          // PrototypeOwnerIds
+							 std::nullopt,          // ReadAccessFilters
+							 std::nullopt,          // WriteAccessFilters
+                             std::nullopt,          // OrganizationIds
+							 Skip,                  // Skip
+							 Limit,                 // Limit
+							 std::nullopt,          // SortBy
+							 std::nullopt,          // SortDirection
 							 ResponseHandler);
 }
 
@@ -446,7 +448,6 @@ void AssetSystem::CreateAsset(const AssetCollection& AssetCollection,
 {
 	auto AssetInfo = std::make_shared<chs::AssetDetailDto>();
 	AssetInfo->SetName(Name);
-	AssetInfo->SetPrototypeId(AssetCollection.Id);
 	String InAddressableId;
 
 	if (ThirdPartyPackagedAssetIdentifier.HasValue() || ThirdPartyPlatform.HasValue())
@@ -494,10 +495,7 @@ void AssetSystem::UpdateAsset(const Asset& Asset, AssetResultCallback Callback)
 {
 	auto AssetInfo = std::make_shared<chs::AssetDetailDto>();
 	AssetInfo->SetName(Asset.Name);
-	AssetInfo->SetId(Asset.Id);
-	AssetInfo->SetFileName(Asset.FileName);
 	AssetInfo->SetLanguageCode(Asset.LanguageCode);
-	AssetInfo->SetPrototypeId(Asset.AssetCollectionId);
 	AssetInfo->SetStyle(Convert(Asset.Styles));
 
 	// TODO: Move this to a separate function when we have some different values than DEFAULT

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -176,9 +176,6 @@ void ECommerceSystem::UpdateCartInformation(const CartInfo& CartInformation, Car
 
 	auto CartUpdateInfo = std::make_shared<chs::ShopifyCartUpdateDto>();
 
-	CartUpdateInfo->SetSpaceId(CartInformation.SpaceId);
-	CartUpdateInfo->SetShopifyCartId(CartInformation.CartId);
-
 	if (!CartInformation.CartLines.IsEmpty())
 	{
 		auto CartLinesRemoval	= std::vector<std::shared_ptr<chs::ShopifyCartLineDto>>();

--- a/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
+++ b/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
@@ -56,7 +56,6 @@ void EventTicketingSystem::CreateTicketedEvent(const csp::common::String& SpaceI
 {
 	auto Request = std::make_shared<chs::SpaceEventDto>();
 
-	Request->SetSpaceId(SpaceId);
 	Request->SetVendorName(GetVendorNameString(Vendor));
 	Request->SetVendorEventId(VendorEventId);
 	Request->SetVendorEventUri(VendorEventUri);

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -72,8 +72,6 @@ void SettingsSystem::SetSettingValue(const String& InContext, const String& InKe
 	NewSettings.clear();
 	NewSettings.insert(std::make_pair(InKey, InValue));
 	InSettings->SetSettings(NewSettings);
-	InSettings->SetContext(InContext);
-	InSettings->SetUserId(UserId);
 
 	SettingsResultCallback InternalCallback = [InKey, Callback](const SettingsCollectionResult& Result)
 	{

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -60,6 +60,7 @@ void CreateSpace(chs::GroupApi* GroupAPI,
 	GroupInfo->SetDescription(Description);
 	GroupInfo->SetDiscoverable(HasFlag(Attributes, csp::systems::SpaceAttributes::IsDiscoverable));
 	GroupInfo->SetRequiresInvite(HasFlag(Attributes, csp::systems::SpaceAttributes::RequiresInvite));
+    GroupInfo->SetGroupType("space");
 
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= GroupAPI->CreateHandler<csp::systems::SpaceResultCallback, csp::systems::SpaceResult, void, chs::GroupDto>(Callback, nullptr);
@@ -274,6 +275,7 @@ void SpaceSystem::ExitSpace(NullResultCallback Callback)
 				{
 					MultiplayerConnection->ResetScopes([Callback](csp::multiplayer::ErrorCode Error)
 					{
+						csp::systems::SystemsManager::Get().GetSpaceEntitySystem()->LocalDestroyAllEntities();
 						if (Error != csp::multiplayer::ErrorCode::None)
 						{
 						    CSP_LOG_ERROR_FORMAT("Error on exiting spaces whilst clearing scopes, ErrorCode: %s", Error);
@@ -563,13 +565,20 @@ void SpaceSystem::UpdateSpace(const String& SpaceId,
 		LiteGroupInfo->SetDescription(*Description);
 	}
 
+    
+    bool IsDiscoverable = false;
+    bool RequiresInvite = true;
+
 	if (Attributes.HasValue())
 	{
-		LiteGroupInfo->SetDiscoverable(HasFlag(*Attributes, SpaceAttributes::IsDiscoverable));
-		LiteGroupInfo->SetRequiresInvite(HasFlag(*Attributes, SpaceAttributes::RequiresInvite));
-
-		LiteGroupInfo->SetAutoModerator(false);
+		IsDiscoverable = HasFlag(*Attributes, SpaceAttributes::IsDiscoverable);
+		RequiresInvite = HasFlag(*Attributes, SpaceAttributes::RequiresInvite);
 	}
+
+	// Note that these are required fields from a services point of view.
+	LiteGroupInfo->SetDiscoverable(IsDiscoverable);
+	LiteGroupInfo->SetRequiresInvite(RequiresInvite);
+	LiteGroupInfo->SetAutoModerator(false);
 
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= GroupAPI->CreateHandler<BasicSpaceResultCallback, BasicSpaceResult, void, chs::GroupLiteDto>(Callback, nullptr);
@@ -658,19 +667,20 @@ void SpaceSystem::GetSpacesByAttributes(const Optional<bool>& InIsDiscoverable,
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= GroupAPI->CreateHandler<BasicSpacesResultCallback, BasicSpacesResult, void, csp::services::DtoArray<chs::GroupLiteDto>>(Callback, nullptr);
 
-	static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsLiteGet(std::nullopt, // Ids
-															  std::nullopt, // GroupTypes
-															  std::nullopt, // Names
-															  std::nullopt, // PartialName
-															  std::nullopt, // GroupOwnerIds
-															  std::nullopt, // ExcludeGroupOwnerIds
-															  std::nullopt, // Users
-															  IsDiscoverable,
-															  std::nullopt, // AutoModerator
-															  RequiresInvite,
-															  IsArchived,
-															  ResultsSkip,
-															  ResultsMax,
+	static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsLiteGet(std::nullopt,     // Ids
+															  std::nullopt,     // GroupTypes
+															  std::nullopt,     // Names
+															  std::nullopt,     // PartialName
+															  std::nullopt,     // GroupOwnerIds
+															  std::nullopt,     // ExcludeGroupOwnerIds
+															  std::nullopt,     // Users
+															  IsDiscoverable,   // Discoverable
+															  std::nullopt,     // AutoModerator
+															  RequiresInvite,   // RequiresInvite
+															  IsArchived,       // Archived
+                                                              std::nullopt,     // OrganizationIds
+															  ResultsSkip,      // Skip
+															  ResultsMax,       // Limit
 															  ResponseHandler);
 }
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -1773,11 +1773,13 @@ struct InternalSpaceEntitySystem : public csp::multiplayer::SpaceEntitySystem
 		std::scoped_lock<std::recursive_mutex> EntitiesLocker(*EntitiesLock);
 
 		Entities.Clear();
+		Objects.Clear();
+		Avatars.Clear();
 	}
 };
 
 // Disabled by default as it can be slow
-#if RUN_MULTIPLAYER_MANYENTITIES_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_MANYENTITIES_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 {
 	SetRandSeed();
@@ -1814,6 +1816,9 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 		{
 		});
 
+	EXPECT_EQ(EntitySystem->GetNumEntities(), 0);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), 0);
+
 	// Create a bunch of entities
 	constexpr size_t NUM_ENTITIES_TO_CREATE = 15;
 	constexpr char ENTITY_NAME_PREFIX[]		= "Object_";
@@ -1830,11 +1835,17 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 		EXPECT_NE(Object, nullptr);
 	}
 
+	EXPECT_EQ(EntitySystem->GetNumEntities(), NUM_ENTITIES_TO_CREATE);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), NUM_ENTITIES_TO_CREATE);
+
 	EntitySystem->ProcessPendingEntityOperations();
 
 	// Clear all entities locally
 	auto InternalEntitySystem = static_cast<InternalSpaceEntitySystem*>(EntitySystem);
 	InternalEntitySystem->ClearEntities();
+
+	EXPECT_EQ(EntitySystem->GetNumEntities(), 0);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), 0);
 
 	// Retrieve all entities and verify count
 	auto GotAllEntities = false;
@@ -1853,8 +1864,16 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 	}
 
 	EXPECT_EQ(EntitySystem->GetNumEntities(), NUM_ENTITIES_TO_CREATE);
+	// We created objects exclusively, so this should also be true.
+	EXPECT_EQ(EntitySystem->GetNumEntities(), EntitySystem->GetNumObjects());
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	auto [ExitResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+	EXPECT_EQ(ExitResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	// Validate that leaving a space flushes CSP's view of all currently known entities.
+	EXPECT_EQ(EntitySystem->GetNumEntities(), 0);
+	EXPECT_EQ(EntitySystem->GetNumObjects(), 0);
+	EXPECT_EQ(EntitySystem->GetNumAvatars(), 0);
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -591,14 +591,14 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTypeTest)
 	UpdateSpace(SpaceSystem, Space.Id, nullptr, nullptr, UpdatedAttributes, UpdatedBasicSpace);
 
 	EXPECT_EQ(UpdatedBasicSpace.Name, Space.Name);
-	EXPECT_EQ(UpdatedBasicSpace.Description, Space.Description);
+	EXPECT_EQ(UpdatedBasicSpace.Description, ""); // This should be empty because we elected to not give one when we invoked `UpdateSpace`.
 	EXPECT_EQ(UpdatedBasicSpace.Attributes, UpdatedAttributes);
 
 	::Space UpdatedSpace;
 	GetSpace(SpaceSystem, Space.Id, UpdatedSpace);
 
 	EXPECT_EQ(UpdatedSpace.Name, Space.Name);
-	EXPECT_EQ(UpdatedSpace.Description, Space.Description);
+	EXPECT_EQ(UpdatedSpace.Description, ""); // This should remain cleared since not specifying a description in `UpdateSpace` is equivalent to clearing it.
 	EXPECT_EQ(UpdatedSpace.Attributes, UpdatedAttributes);
 
 	// Delete space


### PR DESCRIPTION
* [NT-0] fix: Local entities are destroyed upon exiting a space
* [NT-0] fix: entity cleanup on space exit

As part of a recent broad refactor to the multiplayer connection's application lifetime, the connection now persists for the duration of the application's lifetime. Entering a space now narrows the connections focus to listen to entities within the space, and exiting stops the connection from listening to entities within the space.

A bug has arisen however where whilst leaving a space stops the application receiving updates regarding entities, it does not clear CSP's local view of currently known entities.

This change introduces a new function to SpaceEntitySystem, LocalDestroyAllEntities which is invoked by the SpaceSystem after it has finished listening for entities within the space. It clear's CSP's local view of all currently known entities.

Tests have been updated to validate this behaviour.
