### PR TITLE
[OF-1269] feat: Tint property for gaussian splats

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
@@ -43,6 +43,7 @@ enum class GaussianSplatPropertyKeys
 	IsVisible,
 	IsARVisible,
 	IsShadowCaster,
+    Tint,
 	Num
 };
 
@@ -124,6 +125,14 @@ public:
 	/// @copydoc IShadowCasterComponent::SetIsShadowCaster()
 	void SetIsShadowCaster(bool Value) override;
 	/// @}
+
+	/// @brief Gets the tint that should be globally applied to the Gaussian Splat associated with this component.
+	/// @return The global tint value, expected to be in RGB color space.
+	const csp::common::Vector3& GetTint() const;
+
+	/// @brief Sets the tint that should be globally applied to the Gaussian Splat.
+	/// @param Value The tint value, expected to be in RGB color space. Defaults to 1,1,1.
+	void SetTint(const csp::common::Vector3& TintValue);
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
@@ -127,11 +127,12 @@ public:
 	/// @}
 
 	/// @brief Gets the tint that should be globally applied to the Gaussian Splat associated with this component.
-	/// @return The global tint value, expected to be in RGB color space.
+	/// @return The global tint value, expected to be in RGB color space, with each value normalised between 0...1.
 	const csp::common::Vector3& GetTint() const;
 
 	/// @brief Sets the tint that should be globally applied to the Gaussian Splat.
-	/// @param Value The tint value, expected to be in RGB color space. Defaults to 1,1,1.
+	/// @param Value The tint value, expected to be in RGB color space, with each value normalised between 0...1.
+    /// Defaults to 1,1,1.
 	void SetTint(const csp::common::Vector3& TintValue);
 };
 

--- a/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
@@ -26,14 +26,15 @@ namespace csp::multiplayer
 
 GaussianSplatSpaceComponent::GaussianSplatSpaceComponent(SpaceEntity* Parent) : ComponentBase(ComponentType::GaussianSplat, Parent)
 {
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetId)]			  = "";
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetCollectionId)] = "";
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Position)]						  = csp::common::Vector3::Zero();
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Rotation)]						  = csp::common::Vector4::Identity();
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Scale)]							  = csp::common::Vector3::One();
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVisible)]						  = true;
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible)]						  = true;
-	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster)]					  = true;
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetId)]			    = "";
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetCollectionId)]     = "";
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Position)]						        = csp::common::Vector3::Zero();
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Rotation)]						        = csp::common::Vector4::Identity();
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Scale)]							        = csp::common::Vector3::One();
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVisible)]						        = true;
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible)]						    = true;
+	Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster)]					    = true;
+    Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint)]					                = csp::common::Vector3::One();
 
 	SetScriptInterface(CSP_NEW GaussianSplatSpaceComponentScriptInterface(this));
 }
@@ -219,6 +220,25 @@ bool GaussianSplatSpaceComponent::GetIsShadowCaster() const
 void GaussianSplatSpaceComponent::SetIsShadowCaster(bool Value)
 {
 	SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster), Value);
+}
+
+const csp::common::Vector3& GaussianSplatSpaceComponent::GetTint() const
+{
+	const auto& RepVal = GetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint));
+
+	if (RepVal.GetReplicatedValueType() == ReplicatedValueType::Vector3)
+	{
+		return RepVal.GetVector3();
+	}
+
+	CSP_LOG_ERROR_MSG("Underlying ReplicatedValue not valid");
+
+	return ReplicatedValue::GetDefaultVector3();
+}
+
+void GaussianSplatSpaceComponent::SetTint(const csp::common::Vector3& TintValue)
+{
+	SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint), TintValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
@@ -42,4 +42,6 @@ DEFINE_SCRIPT_PROPERTY_VEC4(GaussianSplatSpaceComponent, Rotation);
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsARVisible);
 
+DEFINE_SCRIPT_PROPERTY_VEC3(GaussianSplatSpaceComponent, Tint);
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
@@ -41,6 +41,8 @@ public:
 
 	DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+
+    DECLARE_SCRIPT_PROPERTY(Vector3, Tint);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -455,7 +455,8 @@ void BindComponents(qjs::Context::Module* Module)
 		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, Scale, "scale")
 		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, Rotation, "rotation")
 		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVisible, "isVisible")
-		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsARVisible, "isARVisible");
+		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsARVisible, "isARVisible")
+		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, Tint, "tint");
 }
 
 void EntityScriptBinding::Bind(int64_t ContextId, csp::systems::ScriptSystem* ScriptSystem)

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../AssetSystemTestHelpers.h"
+#include "../SpaceSystemTestHelpers.h"
+#include "../UserSystemTestHelpers.h"
+#include "Awaitable.h"
+#include "CSP/CSPFoundation.h"
+#include "CSP/Common/Optional.h"
+#include "CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h"
+#include "CSP/Multiplayer/Components/ScriptSpaceComponent.h"
+#include "CSP/Multiplayer/MultiPlayerConnection.h"
+#include "CSP/Multiplayer/Script/EntityScript.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
+#include "TestHelpers.h"
+
+#include "gtest/gtest.h"
+#include <chrono>
+#include <filesystem>
+#include <thread>
+
+
+using namespace csp::multiplayer;
+using namespace std::chrono_literals;
+
+
+namespace
+{
+
+bool RequestPredicate(const csp::systems::ResultBase& Result)
+{
+	return Result.GetResultCode() != csp::systems::EResultCode::InProgress;
+}
+
+#define RUN_GAUSSIAN_SPLAT_TESTS 0 // LOCAL TEST CODE
+
+#if RUN_ALL_UNIT_TESTS || RUN_GAUSSIAN_SPLAT_TESTS || RUN_GAUSSIAN_SPLAT_TEST
+CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* AssetSystem	 = SystemsManager.GetAssetSystem();
+	auto* Connection					= SystemsManager.GetMultiplayerConnection();
+	auto* EntitySystem					= SystemsManager.GetSpaceEntitySystem();
+
+	const char* TestSpaceName			= "OLY-UNITTEST-SPACE-REWIND";
+	const char* TestSpaceDescription	= "OLY-UNITTEST-SPACEDESC-REWIND";
+	const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
+	const char* TestAssetName			= "OLY-UNITTEST-ASSET-REWIND";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	csp::common::String UserId;
+
+	// Log in
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+	EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	EntitySystem->SetEntityCreatedCallback(
+		[](csp::multiplayer::SpaceEntity* Entity)
+		{
+		});
+
+	bool AssetDetailBlobChangedCallbackCalled = false;
+	csp::common::String CallbackAssetId;
+
+	const csp::common::String ObjectName = "Object 1";
+	SpaceTransform ObjectTransform		 = {csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One()};
+
+	auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+
+	const csp::common::String ModelAssetId = "NotARealId";
+
+	auto* GaussianSplatComponent = (GaussianSplatSpaceComponent*) Object->AddComponent(ComponentType::GaussianSplat);
+
+	// Process component creation
+	Object->QueueUpdate();
+	EntitySystem->ProcessPendingEntityOperations();
+
+	// Check component was created
+	auto& Components = *Object->GetComponents();
+	EXPECT_EQ(Components.Size(), 1);
+
+	char UniqueAssetCollectionName[256];
+	SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
+
+	char UniqueAssetName[256];
+	SPRINTF(UniqueAssetName, "%s-%s", TestAssetName, GetUniqueString().c_str());
+
+	EXPECT_EQ(GaussianSplatComponent->GetPosition(), csp::common::Vector3::Zero());
+	EXPECT_EQ(GaussianSplatComponent->GetRotation(), csp::common::Vector4::Identity());
+	EXPECT_EQ(GaussianSplatComponent->GetScale(), csp::common::Vector3::One());
+	EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), true);
+	EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), true);
+	EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), true);
+	EXPECT_EQ(GaussianSplatComponent->GetTint(), csp::common::Vector3::One());
+
+	GaussianSplatComponent->SetPosition(csp::common::Vector3(1.0f, 2.0f, 3.0f));
+	EXPECT_EQ(GaussianSplatComponent->GetPosition(), csp::common::Vector3(1.0f, 2.0f, 3.0f));
+
+	GaussianSplatComponent->SetRotation(csp::common::Vector4(0.3f, 0.2f, 0.7f, 0.4f));
+	EXPECT_EQ(GaussianSplatComponent->GetRotation(), csp::common::Vector4(0.3f, 0.2f, 0.7f, 0.4f));
+
+	GaussianSplatComponent->SetScale(csp::common::Vector3(2.0f, 4.0f, 6.0f));
+	EXPECT_EQ(GaussianSplatComponent->GetScale(), csp::common::Vector3(2.0f, 4.0f, 6.0f));
+
+	GaussianSplatComponent->SetIsVisible(false);
+	EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), false);
+
+	GaussianSplatComponent->SetIsARVisible(false);
+	EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), false);
+
+	GaussianSplatComponent->SetIsShadowCaster(false);
+	EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), false);
+
+	GaussianSplatComponent->SetTint(csp::common::Vector3(1.0f, 0.4f, 0.0f));
+	EXPECT_EQ(GaussianSplatComponent->GetTint(), csp::common::Vector3(1.0f, 0.4f, 0.0f));
+
+	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_GAUSSIAN_SPLAT_TESTS || RUN_GAUSSIAN_SPLAT_SCRIPT_INTERFACE_TEST
+CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* Connection				 = SystemsManager.GetMultiplayerConnection();
+	auto* EntitySystem				 = SystemsManager.GetSpaceEntitySystem();
+
+	const char* TestSpaceName		 = "OLY-UNITTEST-SPACE-REWIND";
+	const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	// Log in
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+	EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	EntitySystem->SetEntityCreatedCallback(
+		[](csp::multiplayer::SpaceEntity* Entity)
+		{
+		});
+
+	// Create object to represent the image
+	csp::common::String ObjectName = "Object 1";
+	SpaceTransform ObjectTransform = {csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One()};
+	auto [CreatedObject]		   = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+
+	auto* GaussianSplatComponent = (GaussianSplatSpaceComponent*) CreatedObject->AddComponent(ComponentType::GaussianSplat);
+	auto* ScriptComponent = (ScriptSpaceComponent*) CreatedObject->AddComponent(ComponentType::ScriptData);
+
+	CreatedObject->QueueUpdate();
+	EntitySystem->ProcessPendingEntityOperations();
+
+	EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), true);
+
+	// Setup script
+	const std::string ScriptSource = R"xx(
+	
+		var splat = ThisEntity.getGaussianSplatComponents()[0];
+		splat.tint = [0.0, 0.1, 0.2];
+    )xx";
+
+	ScriptComponent->SetScriptSource(ScriptSource.c_str());
+	CreatedObject->GetScript()->Invoke();
+
+	EntitySystem->ProcessPendingEntityOperations();
+
+	const bool ScriptHasErrors = CreatedObject->GetScript()->HasError();
+	EXPECT_FALSE(ScriptHasErrors);
+
+	EXPECT_EQ(GaussianSplatComponent->GetTint(), csp::common::Vector3(0.0f, 0.1f, 0.2f));
+
+	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif
+
+} // namespace


### PR DESCRIPTION
The Gaussian Splat component now also describes a 'tint' property, which is intended to represent an RGB tuple that is globally applied to the Gaussian Splat asset associated with the component, when rendered in a client viewport.
