### PR TITLE
[OB-3363] fix: e-commerce structures default values

### DIFF
--- a/Library/include/CSP/Systems/ECommerce/ECommerce.h
+++ b/Library/include/CSP/Systems/ECommerce/ECommerce.h
@@ -37,7 +37,7 @@ namespace csp::systems
 class CSP_API CurrencyInfo
 {
 public:
-	CurrencyInfo() = default;
+	CurrencyInfo();
 
 	/// @brief Currency Amount.
 	double Amount;
@@ -50,7 +50,7 @@ public:
 class CSP_API ProductMediaInfo
 {
 public:
-	ProductMediaInfo() = default;
+	ProductMediaInfo();
 
 	/// @brief Type of media content used.
 	csp::common::String MediaContentType;
@@ -69,7 +69,7 @@ public:
 class CSP_API VariantOptionInfo
 {
 public:
-	VariantOptionInfo() = default;
+	VariantOptionInfo();
 
 	/// @brief Id of the variant option.
 	csp::common::String Name;
@@ -82,7 +82,8 @@ public:
 class CSP_API ProductVariantInfo
 {
 public:
-	ProductVariantInfo() = default;
+	ProductVariantInfo();
+
 	/// @brief Id of the variant.
 	csp::common::String Id;
 	/// @brief Title of the variant.
@@ -105,7 +106,7 @@ public:
 class CSP_API ProductInfo
 {
 public:
-	ProductInfo() = default;
+	ProductInfo();
 
 	/// @brief Id of the product.
 	csp::common::String Id;
@@ -128,7 +129,7 @@ public:
 class CSP_API CheckoutInfo
 {
 public:
-	CheckoutInfo() = default;
+	CheckoutInfo();
 	/// @brief Url of the Store.
 	csp::common::String StoreUrl;
 	/// @brief Url of Checkout.
@@ -140,7 +141,7 @@ public:
 class CSP_API CartLine
 {
 public:
-	CartLine() : Quantity(0) {};
+	CartLine();
 
 	/// @brief ID of the line in the cart.
 	csp::common::String CartLineId;
@@ -157,7 +158,7 @@ public:
 class CSP_API CartInfo
 {
 public:
-	CartInfo() : TotalQuantity(0) {};
+	CartInfo();
 
 	/// @brief Space that the cart is associated with.
 	csp::common::String SpaceId;
@@ -177,7 +178,7 @@ public:
 class CSP_API ShopifyStoreInfo
 {
 public:
-	ShopifyStoreInfo() = default;
+	ShopifyStoreInfo();
 
 	/// @brief ID of the store.
 	csp::common::String StoreId;

--- a/Library/include/CSP/Systems/ECommerce/ECommerce.h
+++ b/Library/include/CSP/Systems/ECommerce/ECommerce.h
@@ -28,8 +28,6 @@ CSP_END_IGNORE
 
 } // namespace csp::services
 
-
-
 namespace csp::systems
 {
 /// @ingroup ECommerce System
@@ -37,7 +35,9 @@ namespace csp::systems
 class CSP_API CurrencyInfo
 {
 public:
-	CurrencyInfo();
+	CurrencyInfo()
+    : Amount(0.0)
+	{}
 
 	/// @brief Currency Amount.
 	double Amount;
@@ -50,7 +50,10 @@ public:
 class CSP_API ProductMediaInfo
 {
 public:
-	ProductMediaInfo();
+	ProductMediaInfo()
+    : Width(0)
+	, Height(0)
+	{}
 
 	/// @brief Type of media content used.
 	csp::common::String MediaContentType;
@@ -69,7 +72,7 @@ public:
 class CSP_API VariantOptionInfo
 {
 public:
-	VariantOptionInfo();
+	VariantOptionInfo() = default;
 
 	/// @brief Id of the variant option.
 	csp::common::String Name;
@@ -82,7 +85,9 @@ public:
 class CSP_API ProductVariantInfo
 {
 public:
-	ProductVariantInfo();
+	ProductVariantInfo()
+    : AvailableForSale(false)
+	{}
 
 	/// @brief Id of the variant.
 	csp::common::String Id;
@@ -106,7 +111,7 @@ public:
 class CSP_API ProductInfo
 {
 public:
-	ProductInfo();
+	ProductInfo() = default;
 
 	/// @brief Id of the product.
 	csp::common::String Id;
@@ -129,7 +134,8 @@ public:
 class CSP_API CheckoutInfo
 {
 public:
-	CheckoutInfo();
+	CheckoutInfo() = default;
+
 	/// @brief Url of the Store.
 	csp::common::String StoreUrl;
 	/// @brief Url of Checkout.
@@ -141,7 +147,9 @@ public:
 class CSP_API CartLine
 {
 public:
-	CartLine();
+	CartLine()
+    : Quantity(0)
+	{}
 
 	/// @brief ID of the line in the cart.
 	csp::common::String CartLineId;
@@ -158,7 +166,9 @@ public:
 class CSP_API CartInfo
 {
 public:
-	CartInfo();
+	CartInfo()
+    : TotalQuantity(0)
+	{}
 
 	/// @brief Space that the cart is associated with.
 	csp::common::String SpaceId;
@@ -178,7 +188,9 @@ public:
 class CSP_API ShopifyStoreInfo
 {
 public:
-	ShopifyStoreInfo();
+	ShopifyStoreInfo()
+    : IsEcommerceActive(false)
+	{}
 
 	/// @brief ID of the store.
 	csp::common::String StoreId;

--- a/Library/src/Systems/ECommerce/ECommerce.cpp
+++ b/Library/src/Systems/ECommerce/ECommerce.cpp
@@ -37,6 +37,10 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 	{
 		ProductInfo.Description = Dto.GetDescription();
 	}
+    else
+    {
+	    CSP_LOG_ERROR_MSG("ShopifyProductDto missing Description");
+    }
 
 	if (Dto.HasVariants())
 	{
@@ -52,6 +56,10 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 			{
 				ProductInfo.Variants[i].AvailableForSale = VariantProductInformation[i]->GetAvailableForSale();
 			}
+            else
+            {
+	            CSP_LOG_ERROR_MSG("ShopifyProductDto missing HasAvailableForSale");
+            }
 
 			if (VariantProductInformation[i]->HasImage())
 			{
@@ -82,6 +90,10 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 					ProductInfo.Variants[i].Media.Height = VariantProductImage->GetHeight();
 				}
 			}
+            else
+            {
+	            CSP_LOG_ERROR_MSG("ShopifyProductDto missing Image");
+            }
 
 			if (Dto.GetVariants()[i]->HasSelectedOptions())
 			{
@@ -95,6 +107,10 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 					ProductInfo.Variants[i].Options[n].Value = VariantOptionInformation[n]->GetOptionValue();
 				}
 			}
+            else
+            {
+	            CSP_LOG_ERROR_MSG("ShopifyProductDto missing SelectedOptions");
+            }
 
 			if (VariantProductInformation[i]->HasUnitPrice())
 			{
@@ -108,7 +124,14 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 					ProductInfo.Variants[i].UnitPrice.CurrencyCode = VariantProductInformation[i]->GetUnitPrice()->GetCurrencyCode();
 				}
 			}
+            else
+            {
+	            CSP_LOG_ERROR_MSG("ShopifyProductDto missing UnitPrice");
+            }
 		}
+	}
+	{
+		CSP_LOG_ERROR_MSG("ShopifyProductDto missing Variants");
 	}
 
 	if (Dto.HasTags())
@@ -122,6 +145,10 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 			ProductInfo.Tags[i] = TagsProductInformation[i];
 		}
 	}
+    else
+    {
+	    CSP_LOG_ERROR_MSG("ShopifyProductDto missing Tags");
+    }
 
 	if (Dto.HasMedia())
 	{
@@ -156,6 +183,9 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 				ProductInfo.Media[i].Height = MediaProductInformation[i]->GetHeight();
 			}
 		}
+	}
+	{
+		CSP_LOG_ERROR_MSG("ShopifyProductDto missing Media");
 	}
 }
 
@@ -285,6 +315,36 @@ void ShopifyStoreDtoToShopifyStoreInfo(const chs_aggregation::ShopifyStorefrontD
 	}
 }
 
+CurrencyInfo::CurrencyInfo()
+	: Amount(0.0)
+{
+}
+
+ProductMediaInfo::ProductMediaInfo()
+	: Width(0)
+	, Height(0)
+{
+}
+
+ProductVariantInfo::ProductVariantInfo()
+	: AvailableForSale(false)
+{
+}
+
+CartLine::CartLine()
+	: Quantity(0)
+{
+}
+
+CartInfo::CartInfo()
+	: TotalQuantity(0)
+{
+}
+
+ShopifyStoreInfo::ShopifyStoreInfo()
+	: IsEcommerceActive(false)
+{
+}
 
 const ProductInfo& ProductInfoResult::GetProductInfo() const
 {

--- a/Library/src/Systems/ECommerce/ECommerce.cpp
+++ b/Library/src/Systems/ECommerce/ECommerce.cpp
@@ -315,37 +315,6 @@ void ShopifyStoreDtoToShopifyStoreInfo(const chs_aggregation::ShopifyStorefrontD
 	}
 }
 
-CurrencyInfo::CurrencyInfo()
-	: Amount(0.0)
-{
-}
-
-ProductMediaInfo::ProductMediaInfo()
-	: Width(0)
-	, Height(0)
-{
-}
-
-ProductVariantInfo::ProductVariantInfo()
-	: AvailableForSale(false)
-{
-}
-
-CartLine::CartLine()
-	: Quantity(0)
-{
-}
-
-CartInfo::CartInfo()
-	: TotalQuantity(0)
-{
-}
-
-ShopifyStoreInfo::ShopifyStoreInfo()
-	: IsEcommerceActive(false)
-{
-}
-
 const ProductInfo& ProductInfoResult::GetProductInfo() const
 {
 	return ProductInformation;


### PR DESCRIPTION
CSP now default initializes all e-commerce structures' member variables to sensible values. It also reports additional errors to the log if expected values in DTOs returned by services are not present.

For more information, check out this [Slack thread](https://magnopus.slack.com/archives/C037VC209QT/p1712217718004689?thread_ts=1712161667.802179&cid=C037VC209QT).
