### PR TITLE
[OB-3269] fix: Iterate over components correctly

### DIFF
--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -1158,7 +1158,7 @@ ComponentBase* SpaceEntity::FindFirstComponentOfType(ComponentType Type, bool Se
 		{
 			const DirtyComponent& Component = DirtyComponents[DirtyComponentKeys->operator[](i)];
 
-			if (Component.Component->GetComponentType() == Type)
+			if (Component.UpdateType != ComponentUpdateType::Delete && Component.Component->GetComponentType() == Type)
 			{
 				LocatedComponent = Component.Component;
 				break;

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -1133,11 +1133,9 @@ ComponentBase* SpaceEntity::FindFirstComponentOfType(ComponentType Type, bool Se
 {
 	auto& CheckComponents							  = *GetComponents();
 	const csp::common::Array<uint16_t>* ComponentKeys = Components.Keys();
+	ComponentBase* LocatedComponent					  = nullptr;
 
-	int i							= 0;
-	ComponentBase* LocatedComponent = nullptr;
-
-	for (i = 0; i < ComponentKeys->Size(); ++i)
+	for (int i = 0; i < ComponentKeys->Size(); ++i)
 	{
 		ComponentBase* Component = Components[ComponentKeys->operator[](i)];
 
@@ -1154,7 +1152,7 @@ ComponentBase* SpaceEntity::FindFirstComponentOfType(ComponentType Type, bool Se
 	{
 		const csp::common::Array<uint16_t>* DirtyComponentKeys = DirtyComponents.Keys();
 
-		for (i = 0; i < DirtyComponentKeys->Size(); ++i)
+		for (int i = 0; i < DirtyComponentKeys->Size(); ++i)
 		{
 			const DirtyComponent& Component = DirtyComponents[DirtyComponentKeys->operator[](i)];
 


### PR DESCRIPTION
[OB-3269] fix: Iterate over components correctly

- Fix issue in `SpaceEntity::FindFirstComponentOfType` which would only work correctly if a component had not been deleted from the entity
- The code was updated to iterate over the maps in question in a way consistent with other similar use cases in this class
- STL style iterators were added to the Map class as part of the TravelZoo work in this [PR](https://github.com/magnopus/connected-spaces-platform-internal/pull/4)
- These would probably be the best way to iterate over maps going forward

[OB-3269]: https://magnopus.atlassian.net/browse/OB-3269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ