### PR TITLE
[NT-0] refac: Enable macOS binaries for Unity Editor Apple Silicon

### DIFF
--- a/teamcity/templates/unity/plugin.meta.jinja2
+++ b/teamcity/templates/unity/plugin.meta.jinja2
@@ -40,7 +40,7 @@ PluginImporter:
     {%- elif platform == 'macosx' %}
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
         DefaultValueInitialized: true
         OS: OSX
     {%- else %}


### PR DESCRIPTION
This change should allow users of the Unity CSP package to run CSP within a Unity Editor Apple Silicon versions. Previously this was only possible for Unity Editor Intel versions.

This is what the change will look like on the macOS library's metadata.
Before:
<img width="442" alt="Screenshot 2024-04-12 at 14 48 08" src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/74913022/52e3881e-aa36-4ba0-8a40-11d8bbb9e624">
After:
<img width="442" alt="Screenshot 2024-04-12 at 14 48 36" src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/74913022/cceaf643-0ec1-4c49-a189-24e5c440218c">

Tested locally by modifying metadata settings in-editor.

Now CSP appears to work as expected when running on a Unity client in both scenarios:
- CSP running on Unity Editor Intel (via Rosetta) as before
- CSP running on Unity Editor Apple Silicon

If there is a way to test the TC build scripts locally as well, please let me know. Thank you.


connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
