### PR TITLE
[NT-0] test: fixed LogInAsGuest in tests

### DIFF
--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -98,7 +98,7 @@ void LogIn(csp::systems::UserSystem* UserSystem,
 
 void LogInAsGuest(csp::systems::UserSystem* UserSystem, csp::common::String& OutUserId, csp::systems::EResultCode ExpectedResult)
 {
-	auto [Result] = Awaitable(&csp::systems::UserSystem::LoginAsGuest, UserSystem, nullptr).Await(RequestPredicate);
+	auto [Result] = Awaitable(&csp::systems::UserSystem::LoginAsGuest, UserSystem, true).Await(RequestPredicate);
 
 	EXPECT_EQ(Result.GetResultCode(), ExpectedResult);
 


### PR DESCRIPTION
* Unsure why this behavior changed but tests require LogInAsGuest to pass true for UserHasVerifiedAge now. Tests updated.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
