### PR TITLE
[OF-1176] refac: Make params in UpdateEvent opt

### DIFF
--- a/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
+++ b/Library/include/CSP/Systems/EventTicketing/EventTicketingSystem.h
@@ -67,17 +67,17 @@ public:
 	///
 	/// @param SpaceId csp::common::String : ID of the space the event belongs to.
 	/// @param EventId csp::common::String : ID of the Event to update.
-	/// @param Vendor csp::systems::EventTicketingVendor : Enum representing the vendor that the event is created with.
-	/// @param VendorEventId csp::common::String : Specifies the event ID in the vendors system.
-	/// @param VendorEventUri csp::common::String : Specifies the URI for the event in the vendors system.
-	/// @param IsTicketingActive bool : Specifies whether ticketing is currently active for this event.
+	/// @param Vendor csp::systems::EventTicketingVendor : Optional enum representing the vendor that the event should be updated with.
+	/// @param VendorEventId csp::common::String : Optional value to update the event ID in the vendors system with.
+	/// @param VendorEventUri csp::common::String : Optional value to update the URI for the event in the vendors system with.
+	/// @param IsTicketingActive bool : Optional value to update whether ticketing is currently active for this event.
 	/// @param Callback TicketedEventResultCallback : Callback providing the TicketedEvent once created.
 	CSP_ASYNC_RESULT void UpdateTicketedEvent(const csp::common::String& SpaceId,
 											  const csp::common::String& EventId,
-											  EventTicketingVendor Vendor,
-											  const csp::common::String& VendorEventId,
-											  const csp::common::String& VendorEventUri,
-											  bool IsTicketingActive,
+											  const csp::common::Optional<EventTicketingVendor>& Vendor,
+											  const csp::common::Optional<csp::common::String>& VendorEventId,
+											  const csp::common::Optional<csp::common::String>& VendorEventUri,
+											  const csp::common::Optional<bool>& IsTicketingActive,
 											  TicketedEventResultCallback Callback);
 
 	/// @brief Creates a ticketed event for the given space.

--- a/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
+++ b/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
@@ -72,18 +72,33 @@ void EventTicketingSystem::CreateTicketedEvent(const csp::common::String& SpaceI
 
 void EventTicketingSystem::UpdateTicketedEvent(const csp::common::String& SpaceId,
 											   const csp::common::String& EventId,
-											   EventTicketingVendor Vendor,
-											   const csp::common::String& VendorEventId,
-											   const csp::common::String& VendorEventUri,
-											   bool IsTicketingActive,
+											   const csp::common::Optional<EventTicketingVendor>& Vendor,
+											   const csp::common::Optional<csp::common::String>& VendorEventId,
+											   const csp::common::Optional<csp::common::String>& VendorEventUri,
+											   const csp::common::Optional<bool>& IsTicketingActive,
 											   TicketedEventResultCallback Callback)
 {
 	auto Request = std::make_shared<chs::SpaceEventDto>();
 
-	Request->SetVendorName(GetVendorNameString(Vendor));
-	Request->SetVendorEventId(VendorEventId);
-	Request->SetVendorEventUri(VendorEventUri);
-	Request->SetIsTicketingActive(IsTicketingActive);
+	if (Vendor.HasValue())
+	{
+		Request->SetVendorName(GetVendorNameString(*Vendor));
+	}
+
+	if (VendorEventId.HasValue())
+	{
+		Request->SetVendorEventId(*VendorEventId);
+	}
+
+	if (VendorEventUri.HasValue())
+	{
+		Request->SetVendorEventUri(*VendorEventUri);
+	}
+
+	if (IsTicketingActive.HasValue())
+	{
+		Request->SetIsTicketingActive(*IsTicketingActive);
+	}
 
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= EventTicketingAPI->CreateHandler<TicketedEventResultCallback, TicketedEventResult, void, chs::SpaceEventDto>(
@@ -117,14 +132,14 @@ void EventTicketingSystem::GetTicketedEvents(const csp::common::Array<csp::commo
 	const auto RequestLimit = Limit.HasValue() ? *Limit : std::optional<int>(std::nullopt);
 
 	static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)
-		->apiV1SpacesEventsGet(std::nullopt,    //VendorEventIds
-                               std::nullopt,    //VendorName
-                               RequestSpaceIds, //SpaceIds
-							   std::nullopt,    //UserIds
-							   std::nullopt,	//IsTicketingActive
-                               RequestSkip,     //Skip
-                               RequestLimit,    //Limit
-                               ResponseHandler);
+		->apiV1SpacesEventsGet(std::nullopt,	// VendorEventIds
+							   std::nullopt,	// VendorName
+							   RequestSpaceIds, // SpaceIds
+							   std::nullopt,	// UserIds
+							   std::nullopt,	// IsTicketingActive
+							   RequestSkip,		// Skip
+							   RequestLimit,	// Limit
+							   ResponseHandler);
 }
 
 void EventTicketingSystem::SubmitEventTicket(const csp::common::String& SpaceId,


### PR DESCRIPTION
This change makes most of the parameters for UpdateTicketedEvent optional, allowing devs to disable an event without providing all event parameters.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
