### PR TITLE
[NT-0] refac: Refactor Org test accounts

### DIFF
--- a/Tests/src/PublicAPITests/UserSystemTestHelpers.h
+++ b/Tests/src/PublicAPITests/UserSystemTestHelpers.h
@@ -24,21 +24,6 @@ extern csp::common::String DefaultLoginEmail;
 extern csp::common::String DefaultLoginPassword;
 extern csp::common::String AlternativeLoginEmail;
 extern csp::common::String AlternativeLoginPassword;
-// Organizations non-member
-extern csp::common::String AltUser1NonMemberEmail;
-extern csp::common::String AltUser1NonMemberPassword;
-extern csp::common::String AltUser2NonMemberEmail;
-extern csp::common::String AltUser2NonMemberPassword;
-// Organizations member
-extern csp::common::String AltUser1MemberEmail;
-extern csp::common::String AltUser1MemberPassword;
-extern csp::common::String AltUser2MemberEmail;
-extern csp::common::String AltUser2MemberPassword;
-// Organizations admin
-extern csp::common::String AltUser1AdminEmail;
-extern csp::common::String AltUser1AdminPassword;
-extern csp::common::String AltUser2AdminEmail;
-extern csp::common::String AltUser2AdminPassword;
 
 const char GeneratedTestAccountEmailFormat[] = "testnopus.pokemon+%s@magnopus.com";
 const char GeneratedTestAccountPassword[]	 = "3R{d2}3C<x[J7=jU";

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -46,21 +46,6 @@ csp::common::String DefaultLoginEmail;
 csp::common::String DefaultLoginPassword;
 csp::common::String AlternativeLoginEmail;
 csp::common::String AlternativeLoginPassword;
-// Organizations non-member
-csp::common::String AltUser1NonMemberEmail;
-csp::common::String AltUser1NonMemberPassword;
-csp::common::String AltUser2NonMemberEmail;
-csp::common::String AltUser2NonMemberPassword;
-// Organizations member
-csp::common::String AltUser1MemberEmail;
-csp::common::String AltUser1MemberPassword;
-csp::common::String AltUser2MemberEmail;
-csp::common::String AltUser2MemberPassword;
-// Organizations admin
-csp::common::String AltUser1AdminEmail;
-csp::common::String AltUser1AdminPassword;
-csp::common::String AltUser2AdminEmail;
-csp::common::String AltUser2AdminPassword;
 
 
 void LoadTestAccountCredentials()
@@ -68,10 +53,7 @@ void LoadTestAccountCredentials()
 	if (!std::filesystem::exists("test_account_creds.txt"))
 	{
 		LogFatal("test_account_creds.txt not found! This file must exist and must contain the following information:\n<DefaultLoginEmail> "
-				 "<DefaultLoginPassword>\n<AlternativeLoginEmail> <AlternativeLoginPassword>\n<AlternativeNonMember1LoginEmail> <AlternativeNonMember1LoginPassword>\n<AlternativeNonMember2LoginEmail> "
-				 "<AlternativeNonMember2LoginPassword>\n<AlternativeMember1LoginEmail> <AlternativeMember1LoginPassword>\n<AlternativeMember2LoginEmail> "
-				 "<AlternativeMember2LoginPassword>\n<AlternativeAdmin1LoginEmail> <AlternativeAdmin1LoginPassword>\n<AlternativeAdmin2LoginEmail> "
-				 "<AlternativeAdmin2LoginPassword>");
+				 "<DefaultLoginPassword>\n<AlternativeLoginEmail> <AlternativeLoginPassword>");
 	}
 
 	std::ifstream CredsFile;
@@ -79,50 +61,19 @@ void LoadTestAccountCredentials()
 
 	std::string _DefaultLoginEmail, _DefaultLoginPassword, _AlternativeLoginEmail, _AlternativeLoginPassword;
 
-	// Organization non-member test accounts
-	std::string _AltUser1NonMemberEmail, _AltUser1NonMemberPassword, _AltUser2NonMemberEmail, _AltUser2NonMemberPassword;
-	// Organization member test accounts
-	std::string _AltUser1MemberEmail, _AltUser1MemberPassword, _AltUser2MemberEmail, _AltUser2MemberPassword;
-	// Organization admin test accounts
-	std::string _AltUser1AdminEmail, _AltUser1AdminPassword, _AltUser2AdminEmail, _AltUser2AdminPassword;
-
 	CredsFile >> _DefaultLoginEmail >> _DefaultLoginPassword;
 	CredsFile >> _AlternativeLoginEmail >> _AlternativeLoginPassword;
-	CredsFile >> _AltUser1NonMemberEmail >> _AltUser1NonMemberPassword;
-	CredsFile >> _AltUser2NonMemberEmail >> _AltUser2NonMemberPassword;
-	CredsFile >> _AltUser1MemberEmail >> _AltUser1MemberPassword;
-	CredsFile >> _AltUser2MemberEmail >> _AltUser2MemberPassword;
-	CredsFile >> _AltUser1AdminEmail >> _AltUser1AdminPassword;
-	CredsFile >> _AltUser2AdminEmail >> _AltUser2AdminPassword;
 
-	if (_DefaultLoginEmail.empty() || _DefaultLoginPassword.empty() || _AlternativeLoginEmail.empty() || _AlternativeLoginPassword.empty()
-		|| _AltUser1NonMemberEmail.empty() || _AltUser1NonMemberPassword.empty() || _AltUser2NonMemberEmail.empty() || _AltUser2NonMemberPassword.empty()
-		|| _AltUser1MemberEmail.empty() || _AltUser1MemberPassword.empty() || _AltUser2MemberEmail.empty() || _AltUser2MemberPassword.empty()
-		|| _AltUser1AdminEmail.empty() || _AltUser1AdminPassword.empty() || _AltUser2AdminEmail.empty() || _AltUser2AdminPassword.empty())
+	if (_DefaultLoginEmail.empty() || _DefaultLoginPassword.empty() || _AlternativeLoginEmail.empty() || _AlternativeLoginPassword.empty())
 	{
 		LogFatal("test_account_creds.txt must be in the following format:\n<DefaultLoginEmail> <DefaultLoginPassword>\n<AlternativeLoginEmail> "
-				 "<AlternativeLoginPassword>\n<AlternativeNonMember1LoginEmail> <AlternativeNonMember1LoginPassword>\n<AlternativeNonMember2LoginEmail> "
-				 "<AlternativeNonMember2LoginPassword>\n<AlternativeMember1LoginEmail> <AlternativeMember1LoginPassword>\n<AlternativeMember2LoginEmail> "
-				 "<AlternativeMember2LoginPassword>\n<AlternativeAdmin1LoginEmail> <AlternativeAdmin1LoginPassword>\n<AlternativeAdmin2LoginEmail> "
-				 "<AlternativeAdmin2LoginPassword>");
+				 "<AlternativeLoginPassword>");
 	}
 
 	DefaultLoginEmail		 = _DefaultLoginEmail.c_str();
 	DefaultLoginPassword	 = _DefaultLoginPassword.c_str();
 	AlternativeLoginEmail	 = _AlternativeLoginEmail.c_str();
 	AlternativeLoginPassword = _AlternativeLoginPassword.c_str();
-	AltUser1NonMemberEmail = _AltUser1NonMemberEmail.c_str();
-	AltUser1NonMemberPassword = _AltUser1NonMemberPassword.c_str();
-	AltUser2NonMemberEmail = _AltUser2NonMemberEmail.c_str();
-	AltUser2NonMemberPassword = _AltUser2NonMemberPassword.c_str();
-	AltUser1MemberEmail = _AltUser1MemberEmail.c_str();
-	AltUser1MemberPassword = _AltUser1MemberPassword.c_str();
-	AltUser2MemberEmail = _AltUser2MemberEmail.c_str();
-	AltUser2MemberPassword = _AltUser2MemberPassword.c_str();
-	AltUser1AdminEmail = _AltUser1AdminEmail.c_str();
-	AltUser1AdminPassword = _AltUser1AdminPassword.c_str();
-	AltUser2AdminEmail = _AltUser2AdminEmail.c_str();
-	AltUser2AdminPassword = _AltUser2AdminPassword.c_str();
 }
 
 void LogIn(csp::systems::UserSystem* UserSystem,


### PR DESCRIPTION
I have made the following quality of life improvements to remove the requirement to create/add new org test accounts to the test_account_creds.txt file: 
- I have reverted the test_account_creds.txt so that it only requires the default and alt email address and password information.
- I have reduced the Organization test account requirements down to a single test account with the member and admin roles.
- I have introduced a new organization_test_account_creds.txt file which contains the credentials for this new test account.
- I have updated the Functional Test TeamCity deployment steps to account for this.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
