### PR TITLE
[OF-1302] refac: Remove UserID parameter from GetShopifyStores

### DIFF
--- a/Library/include/CSP/Systems/ECommerce/ECommerceSystem.h
+++ b/Library/include/CSP/Systems/ECommerce/ECommerceSystem.h
@@ -95,12 +95,9 @@ public:
 	CSP_ASYNC_RESULT void GetCart(const common::String& SpaceId, const common::String& CartId, CartInfoResultCallback Callback);
 
 	/// @brief Gets all shopify stores for the given user.
-	/// @param UserId csp::common::String : ID of the user to get all stores for.
 	/// @param IsActive csp::common::Optional<bool> : optional bool for filtering returned stores by active status.
 	/// @param Callback GetShopifyStoresResultCallback : Callback when asynchronous task finishes
-	CSP_ASYNC_RESULT void GetShopifyStores(const common::String& UserId, 
-                                           const csp::common::Optional<bool>& IsActive, 
-                                           GetShopifyStoresResultCallback Callback);
+	CSP_ASYNC_RESULT void GetShopifyStores(const csp::common::Optional<bool>& IsActive, GetShopifyStoresResultCallback Callback);
 
 	/// @brief Adds a Shopify store to a space.
 	/// @param StoreName csp::common::String : The store name (URL) to the Shopify store. Do not include the '.shopify.com' part of the url.
@@ -120,9 +117,9 @@ public:
 	/// @param IsEcommerceActive bool : Bool to set the ecommerce system status to.
 	/// @param Callback SetECommerceActiveResultCallback : Callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void SetECommerceActiveInSpace(const common::String& StoreName,
-													 const common::String& SpaceId,
-													 const bool IsEcommerceActive,
-													 SetECommerceActiveResultCallback Callback);
+													const common::String& SpaceId,
+													const bool IsEcommerceActive,
+													SetECommerceActiveResultCallback Callback);
 
 	/// @brief Validates a shopify store given a store name and an access token.
 	/// @param StoreName csp::common::String : The store name (URL) to the Shopify store. Do not include the '.shopify.com' part of the url.

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -126,7 +126,7 @@ void ECommerceSystem::GetCart(const common::String& SpaceId, const common::Strin
 	static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyCartsCartIdGet(SpaceId, CartId, ResponseHandler);
 }
 
-void ECommerceSystem::GetShopifyStores(const common::String& UserId, const csp::common::Optional<bool>& IsActive, GetShopifyStoresResultCallback Callback)
+void ECommerceSystem::GetShopifyStores(const csp::common::Optional<bool>& IsActive, GetShopifyStoresResultCallback Callback)
 {
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= ShopifyAPI->CreateHandler<GetShopifyStoresResultCallback, GetShopifyStoresResult, void, csp::services::DtoArray<chs::ShopifyStorefrontDto>>(
@@ -136,16 +136,16 @@ void ECommerceSystem::GetShopifyStores(const common::String& UserId, const csp::
 
 	std::optional<bool> ActiveParam;
 
-    if (IsActive.HasValue())
+	if (IsActive.HasValue())
 	{
 		ActiveParam = *IsActive;
 	}
 
+	auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
+	const uint64_t ClientId		= MultiplayerConnection->GetClientId();
+
 	static_cast<chs::ShopifyApi*>(ShopifyAPI)
-		->apiV1VendorsShopifyUsersUserIdStorefrontsGet(UserId, ActiveParam,
-													   std::nullopt,
-													   std::nullopt,
-													   ResponseHandler);
+		->apiV1VendorsShopifyUsersUserIdStorefrontsGet(ClientId, ActiveParam, std::nullopt, std::nullopt, ResponseHandler);
 }
 
 void ECommerceSystem::AddShopifyStore(const common::String& StoreName,
@@ -169,9 +169,9 @@ void ECommerceSystem::AddShopifyStore(const common::String& StoreName,
 }
 
 void ECommerceSystem::SetECommerceActiveInSpace(const common::String& StoreName,
-												 const common::String& SpaceId,
-												 const bool IsEcommerceActive,
-												 SetECommerceActiveResultCallback Callback)
+												const common::String& SpaceId,
+												const bool IsEcommerceActive,
+												SetECommerceActiveResultCallback Callback)
 {
 	auto ShopifyStorefrontInfo = systems::ECommerceSystemHelpers::DefaultShopifyStorefrontInfo();
 	ShopifyStorefrontInfo->SetStoreName(StoreName);

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -16,6 +16,7 @@
 
 #include "CSP/Systems/ECommerce/ECommerceSystem.h"
 
+#include "CSP/Systems/Users/UserSystem.h"
 #include "CallHelpers.h"
 #include "Common/Convert.h"
 #include "ECommerceSystemHelpers.h"
@@ -141,11 +142,13 @@ void ECommerceSystem::GetShopifyStores(const csp::common::Optional<bool>& IsActi
 		ActiveParam = *IsActive;
 	}
 
-	auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-	const uint64_t ClientId		= MultiplayerConnection->GetClientId();
+	auto& SystemsManager   = SystemsManager::Get();
+	const auto* UserSystem = SystemsManager.GetUserSystem();
+
+	const auto& UserId = UserSystem->GetLoginState().UserId;
 
 	static_cast<chs::ShopifyApi*>(ShopifyAPI)
-		->apiV1VendorsShopifyUsersUserIdStorefrontsGet(ClientId, ActiveParam, std::nullopt, std::nullopt, ResponseHandler);
+		->apiV1VendorsShopifyUsersUserIdStorefrontsGet(UserId, ActiveParam, std::nullopt, std::nullopt, ResponseHandler);
 }
 
 void ECommerceSystem::AddShopifyStore(const common::String& StoreName,

--- a/Tests/src/PublicAPITests/ECommerceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ECommerceSystemTests.cpp
@@ -753,7 +753,8 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceSystemTests, AddShopifyStoreTest)
 	*
 		1. Create a space (Add to Shopify Creds)
 		2. Create a Shopify Store on the Shopify site (Ensure it has at least 1 product)
-		3. Add `StoreName MyStoreName` and `PrivateAccessToken MyPrivateAccessToken` to the ShopifyCreds.txt
+		3. Connect the Shopify Store to the Space you created
+		4. Add `SpaceId YourSpaceId`, `StoreName MyStoreName` and `PrivateAccessToken MyPrivateAccessToken` to the ShopifyCreds.txt
 		Now you can use this test!*/
 
 	auto& SystemsManager  = csp::systems::SystemsManager::Get();
@@ -817,7 +818,8 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceSystemTests, GetShopifyStoresTest)
 	*
 		1. Create a space (Add to Shopify Creds)
 		2. Create a Shopify Store on the Shopify site (Ensure it has at least 1 product)
-		3. Add `StoreName MyStoreName` and `PrivateAccessToken MyPrivateAccessToken` to the ShopifyCreds.txt
+		3. Connect the Shopify Store to the Space you created
+		3. Add `SpaceId YourSpaceId`, `StoreName MyStoreName` and `PrivateAccessToken MyPrivateAccessToken` to the ShopifyCreds.txt
 		Now you can use this test!*/
 
 	auto& SystemsManager  = csp::systems::SystemsManager::Get();
@@ -849,7 +851,7 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceSystemTests, GetShopifyStoresTest)
 	EXPECT_NE(ShopifyStore.StoreId, "");
 	EXPECT_EQ(ShopifyStore.StoreName, StoreName);
 
-	auto [GetShopifyStoresResult] = AWAIT_PRE(ECommerceSystem, GetShopifyStores, RequestPredicate, UserId, nullptr);
+	auto [GetShopifyStoresResult] = AWAIT_PRE(ECommerceSystem, GetShopifyStores, RequestPredicate, nullptr);
 
 	EXPECT_EQ(GetShopifyStoresResult.GetShopifyStores()[0].StoreId, ShopifyStore.StoreId);
 	EXPECT_EQ(GetShopifyStoresResult.GetShopifyStores()[0].SpaceId, ShopifyStore.SpaceId);


### PR DESCRIPTION
[OF-1302] refac: Remove UserID parameter from GetShopifyStores

- Update the GetShopifyStores to get the UserId from the internal UserSystem rather than as a parameter on the function, as we currently only want to get the current user's stores.

**For the reviewer**

* [x] If required, are the changes covered by appropriate tests?
* [x] Are any public-facing API changes well documented?
* [x] Is the code easily readable and extensible and/or follow existing conventions?


[OF-1302]: https://magnopus.atlassian.net/browse/OF-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ