### PR TITLE
[OB-3426] fix: Fix crash accessing components from scripts after component removed

### DIFF
--- a/Library/src/Multiplayer/Script/EntityScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptInterface.cpp
@@ -153,16 +153,19 @@ std::vector<ComponentScriptInterface*> EntityScriptInterface::GetComponents()
 	if (Entity)
 	{
 		const csp::common::Map<uint16_t, ComponentBase*>& ComponentMap = *Entity->GetComponents();
+		const auto ComponentKeys									   = ComponentMap.Keys();
 
-		for (int i = 0; i < ComponentMap.Size(); ++i)
+		for (int i = 0; i < ComponentKeys->Size(); ++i)
 		{
-			ComponentBase* Component = ComponentMap[i];
+			ComponentBase* Component = ComponentMap[ComponentKeys->operator[](i)];
 
 			if (Component->GetScriptInterface() != nullptr)
 			{
 				Components.push_back(Component->GetScriptInterface());
 			}
 		}
+
+		CSP_DELETE(ComponentKeys);
 	}
 
 	return Components;

--- a/Library/src/Multiplayer/Script/EntityScriptInterface.h
+++ b/Library/src/Multiplayer/Script/EntityScriptInterface.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "CSP/Multiplayer/SpaceEntity.h"
+#include "Memory/Memory.h"
 
 #include <string>
 #include <vector>
@@ -73,16 +74,19 @@ template <typename ScriptInterface, ComponentType Type> std::vector<ScriptInterf
 		const ComponentType ThisType = Type;
 
 		const auto& ComponentMap = *Entity->GetComponents();
+		const auto KeySet		 = ComponentMap.Keys();
 
-		for (int i = 0; i < ComponentMap.Size(); ++i)
+		for (int i = 0; i < KeySet->Size(); ++i)
 		{
-			ComponentBase* Component = ComponentMap[i];
+			ComponentBase* Component = ComponentMap[KeySet->operator[](i)];
 
 			if ((Component != nullptr) && (Component->GetComponentType() == ThisType) && (Component->GetScriptInterface() != nullptr))
 			{
 				Components.push_back((ScriptInterface*) Component->GetScriptInterface());
 			}
 		}
+
+		CSP_DELETE(KeySet);
 	}
 
 	return Components;

--- a/Library/src/Multiplayer/Script/EntityScriptInterface.h
+++ b/Library/src/Multiplayer/Script/EntityScriptInterface.h
@@ -74,11 +74,11 @@ template <typename ScriptInterface, ComponentType Type> std::vector<ScriptInterf
 		const ComponentType ThisType = Type;
 
 		const auto& ComponentMap = *Entity->GetComponents();
-		const auto KeySet		 = ComponentMap.Keys();
+		const auto ComponentKeys = ComponentMap.Keys();
 
-		for (int i = 0; i < KeySet->Size(); ++i)
+		for (int i = 0; i < ComponentKeys->Size(); ++i)
 		{
-			ComponentBase* Component = ComponentMap[KeySet->operator[](i)];
+			ComponentBase* Component = ComponentMap[ComponentKeys->operator[](i)];
 
 			if ((Component != nullptr) && (Component->GetComponentType() == ThisType) && (Component->GetScriptInterface() != nullptr))
 			{
@@ -86,7 +86,7 @@ template <typename ScriptInterface, ComponentType Type> std::vector<ScriptInterf
 			}
 		}
 
-		CSP_DELETE(KeySet);
+		CSP_DELETE(ComponentKeys);
 	}
 
 	return Components;


### PR DESCRIPTION
[OB-3426] fix: Fix crash accessing components from scripts after component removed

- Fix the way the component list is iterated over in 
  - `EntityScriptInterface::GetComponents()` 
  - `EntityScriptInterface::GetComponentsOfType()`


[OB-3426]: https://magnopus.atlassian.net/browse/OB-3426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ