### PR TITLE
[OB-3438] fix: ensure context clear on ExitSpace

### DIFF
--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -28,12 +28,15 @@
 #include <map>
 #include <vector>
 
+
 namespace csp::systems
 {
+
 class SpaceSystem;
 class SystemsManager;
 class UserSystem;
-}
+
+} // namespace csp::systems
 
 namespace csp::memory
 {
@@ -43,6 +46,7 @@ template <typename T> void Delete(T* Ptr);
 CSP_END_IGNORE
 
 } // namespace csp::memory
+
 
 /// @brief Namespace that encompasses everything in the multiplayer system
 namespace csp::multiplayer
@@ -116,7 +120,6 @@ public:
 
 	// Callback to receive access permission changes Data when a message is sent.
 	typedef std::function<void(const UserPermissionsParams&)> UserPermissionsChangedCallbackHandler;
-
 
 
 	/// @brief Sends a network event by EventName to all currently connected clients.
@@ -203,13 +206,13 @@ private:
 	typedef std::function<void(std::exception_ptr)> ExceptionCallbackHandler;
 
 	/// @brief Start the connection and register to start receiving updates from the server.
-    /// Connect should be called after LogIn and before EnterSpace.
+	/// Connect should be called after LogIn and before EnterSpace.
 	/// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-	CSP_ASYNC_RESULT void Connect(ErrorCodeCallbackHandler Callback);
+	void Connect(ErrorCodeCallbackHandler Callback);
 
 	/// @brief End the multiplayer connection.
 	/// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-	CSP_ASYNC_RESULT void Disconnect(ErrorCodeCallbackHandler Callback);
+	void Disconnect(ErrorCodeCallbackHandler Callback);
 
 	void Start(ExceptionCallbackHandler Callback) const;
 	void Stop(ExceptionCallbackHandler Callback) const;
@@ -226,7 +229,7 @@ private:
 
 	/// @brief Clears the connected user's subscription to their current set of scopes.
 	/// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-    void ResetScopes(ErrorCodeCallbackHandler Callback);
+	void ResetScopes(ErrorCodeCallbackHandler Callback);
 
 	void RequestClientId(ErrorCodeCallbackHandler Callback);
 

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -46,28 +46,24 @@ CSP_END_IGNORE
 } // namespace csp::memory
 
 
-namespace csp::multiplayer
-{
-
-class ClientElectionManager;
-
-class SignalRConnection;
-
-} // namespace csp::multiplayer
-
 namespace csp::systems
 {
+
+class SpaceSystem;
 class SystemsManager;
-}
+
+} // namespace csp::systems
 
 
 /// @brief Namespace that encompasses everything in the multiplayer system
 namespace csp::multiplayer
 {
 
+class ClientElectionManager;
 class MultiplayerConnection;
-class SpaceTransform;
+class SignalRConnection;
 class SpaceEntity;
+class SpaceTransform;
 
 
 /// @brief Class for creating and managing multiplayer objects known as space entities.
@@ -81,6 +77,7 @@ class CSP_API SpaceEntitySystem
 	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class csp::systems::SystemsManager;
+	friend class csp::systems::SpaceSystem;
 	friend class MultiplayerConnection;
 	friend class SpaceEntityEventHandler;
 	friend class ClientElectionManager;
@@ -347,6 +344,9 @@ private:
 	CallbackHandler InitialEntitiesRetrievedCallback;
 	CallbackHandler ScriptSystemReadyCallback;
 
+	void Initialise();
+	void Shutdown();
+
 	void BindOnObjectMessage();
 	void BindOnObjectPatch();
 	void BindOnRequestToSendObject();
@@ -393,6 +393,8 @@ private:
 	std::chrono::milliseconds EntityPatchRate;
 
 	bool EntityPatchRateLimitEnabled = true;
+
+	bool IsInitialised = false;
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Election/ClientElectionManager.cpp
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.cpp
@@ -103,15 +103,18 @@ void ClientElectionManager::OnConnect(const SpaceEntitySystem::SpaceEntityList& 
 		ClientProxy* Client				= FindClientUsingAvatar(ClientAvatar);
 		SetLeader(Client);
 	}
-	else
-	{
-	}
 
 	CSP_LOG_FORMAT(csp::systems::LogLevel::VeryVerbose, "Number of clients=%d", Avatars.Size());
 }
 
 void ClientElectionManager::OnDisconnect()
 {
+	for (const auto& Client : Clients)
+	{
+		ClientProxy* Proxy = Client.second;
+		CSP_DELETE(Proxy);
+	}
+
 	UnBindNetworkEvents();
 }
 

--- a/Library/src/Multiplayer/Election/ClientElectionManager.h
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.h
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/SpaceEntitySystem.h"
 #include "ClientProxy.h"
+
 
 namespace csp::multiplayer
 {
@@ -26,12 +28,14 @@ class IClientSelectionCriteria;
 class SpaceEntitySystem;
 class SpaceEntity;
 
+
 enum class ElectionState
 {
 	Idle,
 	Requested,
 	Electing,
 };
+
 
 class ClientElectionManager
 {

--- a/Library/src/Multiplayer/Script/EntityScript.cpp
+++ b/Library/src/Multiplayer/Script/EntityScript.cpp
@@ -41,8 +41,7 @@ EntityScript::EntityScript(SpaceEntity* InEntity, SpaceEntitySystem* InSpaceEnti
 
 EntityScript::~EntityScript()
 {
-	ScriptSystem->ClearModuleSource(Entity->GetName());
-	ScriptSystem->DestroyContext(Entity->GetId());
+	Shutdown();
 }
 
 bool EntityScript::Invoke()

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -301,6 +301,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
 	csp::systems::Space Space;
 	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
 
+	auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
 	csp::common::String ObjectName = "Object 1";
 	SpaceTransform ObjectTransform
 		= {csp::common::Vector3 {1.452322f, 2.34f, 3.45f}, csp::common::Vector4 {4.1f, 5.1f, 6.1f, 7.1f}, csp::common::Vector3 {1, 1, 1}};
@@ -316,6 +318,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
 	EXPECT_EQ(CreatedObject->GetPosition(), ObjectTransform.Position);
 	EXPECT_EQ(CreatedObject->GetRotation(), ObjectTransform.Rotation);
 	EXPECT_EQ(CreatedObject->GetScale(), ObjectTransform.Scale);
+
+	auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -368,7 +372,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
 		{
 		});
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -428,7 +435,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
 		WaitForTestTimeoutCountMs += 20;
 	}
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -512,7 +522,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
 
 	EXPECT_TRUE(IsTestComplete);
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -613,7 +626,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
 		EXPECT_EQ(CreatedObject->GetScale().Z, 3.0f);
 	}
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -691,7 +707,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
 	EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), UserAvatarPlayMode);
 	EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -770,7 +789,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
 	EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), AvatarPlayMode::Creator);
 	EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -843,7 +865,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
 
 	EXPECT_EQ(AvatarComponent->GetMovementDirection(), csp::common::Vector3::One());
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -910,7 +935,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
 	EXPECT_EQ(CreatedObject->GetThirdPartyRef(), "");
 	EXPECT_EQ(CreatedObject->GetThirdPartyPlatformType(), csp::systems::EThirdPartyPlatform::NONE);
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1019,7 +1047,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
 
 	EXPECT_EQ(RealImageComponent->GetImageAssetId(), ImageAssetId);
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1125,7 +1156,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
 	EXPECT_FALSE(RealComponents.HasKey(StaticModelComponentKey));
 	EXPECT_FALSE(RealComponents.HasKey(ImageComponentKey));
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1223,7 +1257,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, NetworkEventEmptyTest)
 		WaitForTestTimeoutCountMs += 50;
 	}
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1333,7 +1370,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, NetworkEventMultiTypeTest)
 		WaitForTestTimeoutCountMs += 50;
 	}
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1685,7 +1725,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
 
 	csp::CSPFoundation::Tick();
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1755,7 +1798,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
 
 	EXPECT_FALSE(CreatedObject->IsSelected());
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -1938,7 +1984,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
 	Object->QueueUpdate();
 	EntitySystem->ProcessPendingEntityOperations();
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Log out
 	LogOut(UserSystem);
@@ -1953,8 +2002,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, FindComponentByIdTest)
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
 	auto* UserSystem	 = SystemsManager.GetUserSystem();
 	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
-	auto* Connection				 = SystemsManager.GetMultiplayerConnection();
-	auto* EntitySystem				 = SystemsManager.GetSpaceEntitySystem();
+	auto* Connection	 = SystemsManager.GetMultiplayerConnection();
+	auto* EntitySystem	 = SystemsManager.GetSpaceEntitySystem();
 
 	const char* TestSpaceName		 = "OLY-UNITTEST-SPACE-REWIND";
 	const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
@@ -2007,7 +2056,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, FindComponentByIdTest)
 	EXPECT_TRUE(FoundComponent != nullptr);
 	EXPECT_EQ(Component2->GetId(), FoundComponent->GetId());
 
-	SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result){});
+	SpaceSystem->ExitSpace(
+		[](const csp::systems::NullResult& Result)
+		{
+		});
 
 	// Log out
 	LogOut(UserSystem);

--- a/Tools/WrapperGenerator/Parser.py
+++ b/Tools/WrapperGenerator/Parser.py
@@ -962,10 +962,11 @@ class Parser:
                         word = reader.next_word()
 
                         if word == '(': # Deprecated attribute has a string description
-                            # Read until closing parens
-                            deprecation_message = reader.next_word(delimiters=[')'])
-                            # Trim leading and trailing double quotes
-                            deprecation_message = deprecation_message[1:-1]
+                            if reader.peek_char() == '"':
+                                reader.skip_char()
+                                deprecation_message = reader.next_word(delimiters=['"'])
+                                reader.skip_char()
+                                
                             # Skip closing parens and brackets
                             reader.skip(3)  # ')]]'
                         elif word == ']':


### PR DESCRIPTION
This change ensures that entities are deleted and leader election is reset when exiting a space.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
