### PR TITLE
[OB-3490] fix: don't p/invoke private ctors/dtors

### DIFF
--- a/Tools/WrapperGenerator/Templates/CSharp/Class.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Class.mustache
@@ -86,6 +86,7 @@
 {{/ is_operator_overload }}
 {{^ is_operator_overload }}
 {{^ is_event }}
+{{^ is_private }}
         {{> DllImport }}
 {{# is_constructor }}
         static extern NativePointer
@@ -190,6 +191,7 @@
 {{/ is_task }}
 {{/ is_destructor }}
 {{/ is_constructor }}
+{{/ is_private }}
 {{/ is_event }}
 {{/ is_operator_overload }}
 


### PR DESCRIPTION
The C# wrapper generator was generating p/invoke imports for private constructors and destructors, resulting in VisionOS attempting to link against these non-existing exports.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
