### PR TITLE
[NT-0] refac: expand `Variant` float type

### DIFF
--- a/Library/include/CSP/Common/Variant.h
+++ b/Library/include/CSP/Common/Variant.h
@@ -52,9 +52,9 @@ public:
 	/// @param InBoolValue bool : In value
 	Variant(bool InBoolValue);
 
-	/// @brief Construct a Variant based on a float type.
-	/// @param InFloatValue float : In value
-	Variant(float InFloatValue);
+	/// @brief Construct a Variant based on a double-precision float type.
+	/// @param InFloatValue double : In value
+	Variant(double InFloatValue);
 
 	/// @brief Construct a Variant based on a Long (uint64_t) type.
 	/// @param InLongValue int64_t : In value
@@ -100,11 +100,11 @@ public:
 	/// @return bool
 	bool GetBool() const;
 
-	/// @brief Sets internal variant type as a float.
-	void SetFloat(float InValue);
-	/// @brief Gets internal variant type as a float.
-	/// @return float
-	float GetFloat() const;
+	/// @brief Sets internal variant type as a double-precision float.
+	void SetFloat(double InValue);
+	/// @brief Gets internal variant type as a double-precision float.
+	/// @return double
+	double GetFloat() const;
 
 	/// @brief Sets internal variant type as an int64_t.
 	void SetInt(int64_t InValue);
@@ -147,7 +147,7 @@ private:
 		~InternalValue();
 
 		bool Bool;
-		float Float;
+		double Float;
 		int64_t Int;
 		String String;
 		Vector3 Vector3;

--- a/Library/src/Common/Variant.cpp
+++ b/Library/src/Common/Variant.cpp
@@ -40,7 +40,7 @@ Variant::Variant(bool InValue) : ValueType(VariantType::Boolean)
 	Value.Bool = InValue;
 }
 
-Variant::Variant(float InValue) : ValueType(VariantType::Float)
+Variant::Variant(double InValue) : ValueType(VariantType::Float)
 {
 	Value.Float = InValue;
 }
@@ -190,13 +190,13 @@ bool Variant::GetBool() const
 	return Value.Bool;
 }
 
-void Variant::SetFloat(float InValue)
+void Variant::SetFloat(double InValue)
 {
 	ValueType	= VariantType::Float;
 	Value.Float = InValue;
 }
 
-float Variant::GetFloat() const
+double Variant::GetFloat() const
 {
 	assert(ValueType == VariantType::Float);
 	return Value.Float;


### PR DESCRIPTION
This change expands floats in `csp::common::Variant` from single to double precision.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
