### PR TITLE
[OF-1322] refac: Update generate shell scripts

### DIFF
--- a/generate_solution_ios.sh
+++ b/generate_solution_ios.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 # *** Command Line Arguments *** 
 # DLLOnly - Generates a solution with only DLL-related build configurations
+
+python_prefix="Python "
+python_version=$(python3 -V 2>&1)
+
+if [[ -z "$python_version" ]]
+then
+    echo "No Python installation found, please install Python 3.12.+ before proceeding."
+    exit
+else
+    # Remove the 'Python ' prefix from the version.
+    version_number=${python_version#"$python_prefix"}
+    echo "Python version: $version_number installed."
+fi
+
+# Check if the installed Python version is >= 3.12
+if ! { echo "$version_number"; echo "3.12.0"; } | sort --version-sort --check
+then
+    # Check to see if venv exists by searching for config file.
+    venv_file="./venv/pyvenv.cfg"
+    
+    # If no venv config file found create a venv.
+    if [ ! -f "$venv_file" ]
+    then
+        echo "Virtual evironment does not exist, creating now..."
+        mkdir ./venv
+        python3 -m venv ./venvx
+    fi
+    
+    echo "Activating virtual evironment."
+    source ./venv/bin/activate
+fi
+
 python3 -m pip install -r teamcity/requirements.txt
 
 git config core.hooksPath .githooks

--- a/generate_solution_mac.sh
+++ b/generate_solution_mac.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 # *** Command Line Arguments *** 
 # DLLOnly - Generates a solution with only DLL-related build configurations
+
+python_prefix="Python "
+python_version=$(python3 -V 2>&1)
+
+if [[ -z "$python_version" ]]
+then
+    echo "No Python installation found, please install Python 3.12.+ before proceeding."
+    exit
+else
+    # Remove the 'Python ' prefix from the version.
+    version_number=${python_version#"$python_prefix"}
+    echo "Python version: $version_number installed."
+fi
+
+# Check if the installed Python version is >= 3.12
+if ! { echo "$version_number"; echo "3.12.0"; } | sort --version-sort --check
+then
+    # Check to see if venv exists by searching for config file.
+    venv_file="./venv/pyvenv.cfg"
+    
+    # If no venv config file found create a venv.
+    if [ ! -f "$venv_file" ]
+    then
+        echo "Virtual evironment does not exist, creating now..."
+        mkdir ./venv
+        python3 -m venv ./venvx
+    fi
+    
+    echo "Activating virtual evironment."
+    source ./venv/bin/activate
+fi
+
 python3 -m pip install -r teamcity/requirements.txt
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/generate_solution_visionos.sh
+++ b/generate_solution_visionos.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 # *** Command Line Arguments *** 
 # DLLOnly - Generates a solution with only DLL-related build configurations
+
+python_prefix="Python "
+python_version=$(python3 -V 2>&1)
+
+if [[ -z "$python_version" ]]
+then
+    echo "No Python installation found, please install Python 3.12.+ before proceeding."
+    exit
+else
+    # Remove the 'Python ' prefix from the version.
+    version_number=${python_version#"$python_prefix"}
+    echo "Python version: $version_number installed."
+fi
+
+# Check if the installed Python version is >= 3.12
+if ! { echo "$version_number"; echo "3.12.0"; } | sort --version-sort --check
+then
+    # Check to see if venv exists by searching for config file.
+    venv_file="./venv/pyvenv.cfg"
+    
+    # If no venv config file found create a venv.
+    if [ ! -f "$venv_file" ]
+    then
+        echo "Virtual evironment does not exist, creating now..."
+        mkdir ./venv
+        python3 -m venv ./venvx
+    fi
+    
+    echo "Activating virtual evironment."
+    source ./venv/bin/activate
+fi
+
 python3 -m pip install -r teamcity/requirements.txt
 
 git config core.hooksPath .githooks


### PR DESCRIPTION
As of Python 3.12+ it is a requirement that we use a venv to install modules. The generate_solution_X.sh scripts for mac, ios and visionos have all been updated to check for the version of Python installed, and if >= 3.12, to create and activate a venv before proceeding with module installation.

connected-spaces-platform Pull Request

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
