### PR TITLE
[OB-3568] fix: VisionOS Unity Build Script Failing to Include CSP Binaries 

### DIFF
--- a/teamcity/templates/unity/NativePluginBuildProcessor.cs
+++ b/teamcity/templates/unity/NativePluginBuildProcessor.cs
@@ -31,7 +31,7 @@ public class NativePluginBuildProcessor : IPreprocessBuildWithReport
 
             // TODO: Remove this hack that always includes iOS and macOS binaries
             // This was put in place because we currently only include release binaries due to debug binary sizes
-            if (report.summary.platform == BuildTarget.iOS || report.summary.platform == BuildTarget.StandaloneOSX)
+            if (report.summary.platform == BuildTarget.iOS || report.summary.platform == BuildTarget.StandaloneOSX || report.summary.platform == BuildTarget.VisionOS)
                 importer.SetIncludeInBuildDelegate((_) => true);
             else if (report.summary.options.HasFlag(BuildOptions.Development) && !importer.assetPath.EndsWith($"_D{ext}"))
                 importer.SetIncludeInBuildDelegate((_) => false);


### PR DESCRIPTION
This change addresses an issue that was found to be preventing the `libConnectedSpacesPlatform.a` binary from being included in XCode projects generated by Unity.

The cause was an omission in a CSP-provided Unity build script, where the logic that determines whether or not to include the binary was not accounting for the VisionOS platform.

Full kudos to @MAG-MichaelK for finding the bug & fix!