### PR TITLE
[OF-1324] fix: path validation for CartId

### DIFF
--- a/Library/include/CSP/Systems/ECommerce/ECommerce.h
+++ b/Library/include/CSP/Systems/ECommerce/ECommerce.h
@@ -282,6 +282,8 @@ public:
 	/// @return ProductInfo : reference to the CheckoutInfo
 	CheckoutInfo& GetCheckoutInfo();
 
+    CSP_NO_EXPORT CheckoutInfoResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode) : csp::systems::ResultBase(ResCode, HttpResCode) {};
+
 private:
 	CheckoutInfoResult(void*) {};
 

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -99,7 +99,7 @@ void ECommerceSystem::GetProductInfoCollectionByVariantIds(const common::String&
 void ECommerceSystem::GetCheckoutInformation(const common::String& SpaceId, const common::String& CartId, CheckoutInfoResultCallback Callback)
 {
 	std::string CharacterCheck = CartId.c_str();
-    if (CharacterCheck.find("/") != std::string::npos && CharacterCheck.find(R"(\)") != std::string::npos)
+    if (CharacterCheck.find("/") != std::string::npos || CharacterCheck.find(R"(\)") != std::string::npos)
     {
 		CSP_LOG_ERROR_MSG("Call to GetCheckoutInformation failed. CartId must NOT include path characters forward or back slash.");
 

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -98,6 +98,16 @@ void ECommerceSystem::GetProductInfoCollectionByVariantIds(const common::String&
 
 void ECommerceSystem::GetCheckoutInformation(const common::String& SpaceId, const common::String& CartId, CheckoutInfoResultCallback Callback)
 {
+	std::string CharacterCheck = CartId.c_str();
+    if (CharacterCheck.find("/") != std::string::npos && CharacterCheck.find(R"(\)") != std::string::npos)
+    {
+		CSP_LOG_ERROR_MSG("Call to GetCheckoutInformation failed. CartId must NOT include path characters forward or back slash.");
+
+		INVOKE_IF_NOT_NULL(Callback, MakeInvalid<CheckoutInfoResult>());
+
+        return;
+    }
+
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= ShopifyAPI->CreateHandler<CheckoutInfoResultCallback, CheckoutInfoResult, void, chs::ShopifyCheckoutDto>(
 			Callback,


### PR DESCRIPTION
* GetCheckoutInformation checks CartId for forward and backward slashes, early outs if found


Unsure if this is the best approach, but wrapper gen changes for API level coverage were too complex to achieve in a reasonable time-frame. It's questionable if this is better than no change at all, so I expect discussion either here in PR or externally.