### PR TITLE
[OF-1359] refac: Update the hotspot component type properties

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -30,19 +30,14 @@
 namespace csp::multiplayer
 {
 
-enum class HotspotType
-{
-	TeleportHotspot = 0,
-	SpawnHotspot
-};
-
 /// @brief Enumerates the list of properties that can be replicated for an Hotspot space component.
 enum class HotspotPropertyKeys
 {
 	Position,
 	Rotation,
 	Name,
-	HotspotType,
+	IsTeleportPoint,
+	IsSpawnPoint,
 	IsVisible,
 	IsARVisible,
 	Num
@@ -66,17 +61,24 @@ public:
 	/// @param Value The Name of this Hotspot.
 	void SetName(const csp::common::String& Value);
 
-    /// @brief Gets the HotspotType of this Hotspot.
-    HotspotType GetHotspotType() const;
+	/// @brief Gets the IsTeleportPoint of this Hotspot.
+	bool GetIsTeleportPoint() const;
 
-    /// @brief Sets the HotspotType of this Hotspot.
-    /// @param Value The Type of the Hotspot.
-    void SetHotspotType(HotspotType Value);
+	/// @brief Sets this Hotspot to be a teleport point.
+	/// @param InValue The teleport point state flag value.
+	void SetIsTeleportPoint(bool InValue);
 
-    /// @brief Gets a unique identifier for this component in the hierarchy.
-    /// @note This does not give a complete hierarchy path, only the entityId of the parent for the component.
-    /// @return A string composed of 'parentId:componentId'.
-    const csp::common::String& GetUniqueComponentId() const;
+	/// @brief Gets the IsSpawnPoint of this Hotspot.
+	bool GetIsSpawnPoint() const;
+
+	/// @brief Sets this Hotspot to be a spawn point.
+	/// @param InValue The spawn point state flag value.
+	void SetIsSpawnPoint(bool InValue);
+
+	/// @brief Gets a unique identifier for this component in the hierarchy.
+	/// @note This does not give a complete hierarchy path, only the entityId of the parent for the component.
+	/// @return A string composed of 'parentId:componentId'.
+	const csp::common::String& GetUniqueComponentId() const;
 
 	/// \addtogroup IPositionComponent
 	/// @{

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "CSP/Multiplayer/Components/HotspotSpaceComponent.h"
+
 #include "CSP/Multiplayer/SpaceEntity.h"
 #include "Debug/Logging.h"
 #include "Memory/Memory.h"
@@ -25,12 +26,13 @@ namespace csp::multiplayer
 
 HotspotSpaceComponent::HotspotSpaceComponent(SpaceEntity* Parent) : ComponentBase(ComponentType::Hotspot, Parent)
 {
-	Properties[static_cast<uint32_t>(HotspotPropertyKeys::Position)]			 = csp::common::Vector3::Zero();
-	Properties[static_cast<uint32_t>(HotspotPropertyKeys::Rotation)]			 = csp::common::Vector4 {0, 0, 0, 1};
-	Properties[static_cast<uint32_t>(HotspotPropertyKeys::Name)]				 = "";
-	Properties[static_cast<uint32_t>(HotspotPropertyKeys::HotspotType)]			 = static_cast<int64_t>(csp::multiplayer::HotspotType::TeleportHotspot);
-    Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVisible)]			 = true;
-	Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible)]		     = true;
+	Properties[static_cast<uint32_t>(HotspotPropertyKeys::Position)]		= csp::common::Vector3::Zero();
+	Properties[static_cast<uint32_t>(HotspotPropertyKeys::Rotation)]		= csp::common::Vector4 {0, 0, 0, 1};
+	Properties[static_cast<uint32_t>(HotspotPropertyKeys::Name)]			= "";
+	Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsTeleportPoint)] = true;
+	Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint)]	= false;
+	Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVisible)]		= true;
+	Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible)]		= true;
 
 	SetScriptInterface(CSP_NEW HotspotSpaceComponentScriptInterface(this));
 }
@@ -45,15 +47,26 @@ void HotspotSpaceComponent::SetName(const csp::common::String& Value)
 	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::Name), Value);
 }
 
-HotspotType HotspotSpaceComponent::GetHotspotType() const
+bool HotspotSpaceComponent::GetIsTeleportPoint() const
 {
-	return static_cast<HotspotType>(GetIntegerProperty(static_cast<uint32_t>(HotspotPropertyKeys::HotspotType)));
+	return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsTeleportPoint));
 }
 
-void HotspotSpaceComponent::SetHotspotType(HotspotType Value)
+void HotspotSpaceComponent::SetIsTeleportPoint(bool Value)
 {
-	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::HotspotType), static_cast<int64_t>(Value));
+	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsTeleportPoint), Value);
 }
+
+bool HotspotSpaceComponent::GetIsSpawnPoint() const
+{
+	return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint));
+}
+
+void HotspotSpaceComponent::SetIsSpawnPoint(bool Value)
+{
+	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint), Value);
+}
+
 
 const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
 {
@@ -61,7 +74,7 @@ const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
 	UniqueComponentId += ":";
 	UniqueComponentId += std::to_string(Id).c_str();
 
-    return UniqueComponentId;
+	return UniqueComponentId;
 }
 
 

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -67,7 +67,6 @@ void HotspotSpaceComponent::SetIsSpawnPoint(bool Value)
 	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint), Value);
 }
 
-
 const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
 {
 	static csp::common::String UniqueComponentId = std::to_string(Parent->GetId()).c_str();
@@ -76,7 +75,6 @@ const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
 
 	return UniqueComponentId;
 }
-
 
 /* IPositionComponent */
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
@@ -35,7 +35,9 @@ DEFINE_SCRIPT_PROPERTY_VEC3(HotspotSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(HotspotSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_STRING(HotspotSpaceComponent, Name);
-DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, csp::multiplayer::HotspotType, int64_t, HotspotType);
+
+DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsTeleportPoint);
+DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsSpawnPoint);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsARVisible);

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
@@ -30,12 +30,13 @@ class HotspotSpaceComponentScriptInterface : public ComponentScriptInterface
 public:
 	HotspotSpaceComponentScriptInterface(HotspotSpaceComponent* InComponent = nullptr);
 
-    std::string GetUniqueComponentId();
+	std::string GetUniqueComponentId();
 
 	DECLARE_SCRIPT_PROPERTY(Vector3, Position);
 	DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
 	DECLARE_SCRIPT_PROPERTY(std::string, Name);
-	DECLARE_SCRIPT_PROPERTY(int64_t, HotspotType);
+	DECLARE_SCRIPT_PROPERTY(bool, IsTeleportPoint);
+	DECLARE_SCRIPT_PROPERTY(bool, IsSpawnPoint);
 	DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
 	DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
 };

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -35,6 +35,7 @@
 #include "Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h"
+#include "Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/PortalSpaceComponentScriptInterface.h"
@@ -42,7 +43,6 @@
 #include "Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h"
-#include "Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentScriptInterface.h"
 #include "Multiplayer/Script/EntityScriptInterface.h"
 #include "ScriptHelpers.h"
@@ -476,7 +476,7 @@ void BindComponents(qjs::Context::Module* Module)
 		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsARVisible, "isARVisible")
 		.PROPERTY_GET_SET(GaussianSplatSpaceComponent, Tint, "tint");
 
-    Module->class_<HotspotSpaceComponentScriptInterface>("HotspotSpaceComponent")
+	Module->class_<HotspotSpaceComponentScriptInterface>("HotspotSpaceComponent")
 		.constructor<>()
 		.base<ComponentScriptInterface>()
 		.fun<&HotspotSpaceComponentScriptInterface::GetUniqueComponentId>("getUniqueComponentId")
@@ -485,7 +485,8 @@ void BindComponents(qjs::Context::Module* Module)
 		.PROPERTY_GET_SET(HotspotSpaceComponent, IsVisible, "isVisible")
 		.PROPERTY_GET_SET(HotspotSpaceComponent, IsARVisible, "isARVisible")
 		.PROPERTY_GET_SET(HotspotSpaceComponent, Name, "name")
-		.PROPERTY_GET_SET(HotspotSpaceComponent, HotspotType, "hotspotType");
+		.PROPERTY_GET_SET(HotspotSpaceComponent, IsTeleportPoint, "isTeleportPoint")
+		.PROPERTY_GET_SET(HotspotSpaceComponent, IsSpawnPoint, "isSpawnPoint");
 }
 
 void EntityScriptBinding::Bind(int64_t ContextId, csp::systems::ScriptSystem* ScriptSystem)

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -19,8 +19,8 @@
 #include "Awaitable.h"
 #include "CSP/CSPFoundation.h"
 #include "CSP/Common/Optional.h"
-#include "CSP/Multiplayer/Components/ScriptSpaceComponent.h"
 #include "CSP/Multiplayer/Components/HotspotSpaceComponent.h"
+#include "CSP/Multiplayer/Components/ScriptSpaceComponent.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
@@ -99,7 +99,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 	EXPECT_EQ(HotspotComponent->GetRotation().X, 0);
 	EXPECT_EQ(HotspotComponent->GetRotation().Y, 0);
 	EXPECT_EQ(HotspotComponent->GetRotation().Z, 0);
-	EXPECT_EQ(HotspotComponent->GetHotspotType(), HotspotType::TeleportHotspot);
+	EXPECT_EQ(HotspotComponent->GetIsTeleportPoint(), true);
+	EXPECT_EQ(HotspotComponent->GetIsSpawnPoint(), false);
 	EXPECT_EQ(HotspotComponent->GetName(), "");
 
 	csp::common::String UniqueComponentId = std::to_string(CreatedObject->GetId()).c_str();
@@ -117,7 +118,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 	HotspotComponent->SetIsVisible(false);
 	HotspotComponent->SetPosition(csp::common::Vector3::One());
 	HotspotComponent->SetRotation(csp::common::Vector4 {1, 1, 1, 1});
-	HotspotComponent->SetHotspotType(HotspotType::SpawnHotspot);
+	HotspotComponent->SetIsTeleportPoint(false);
+	HotspotComponent->SetIsSpawnPoint(true);
 	HotspotComponent->SetName("HotspotName");
 
 	// Ensure values are set correctly
@@ -130,7 +132,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 	EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().X, 1.0f);
 	EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Y, 1.0f);
 	EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Z, 1.0f);
-	EXPECT_EQ(HotspotComponent->GetHotspotType(), HotspotType::SpawnHotspot);
+	EXPECT_EQ(HotspotComponent->GetIsTeleportPoint(), false);
+	EXPECT_EQ(HotspotComponent->GetIsSpawnPoint(), true);
 	EXPECT_EQ(HotspotComponent->GetName(), "HotspotName");
 
 	SpaceSystem->ExitSpace(
@@ -204,7 +207,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
 		hotspot.isVisible = false;
 		hotspot.rotation = [1.0, 1.0, 1.0, 1.0];
 		hotspot.name = "HotspotName";
-		hotspot.hotspotType = 1;
+		hotspot.isSpawnPoint = true;
+		hotspot.isTeleportPoint = false;
 
 		var id = hotspot.getUniqueComponentId();
 		if (!id)
@@ -229,7 +233,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
 	EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().X, 1.0f);
 	EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Y, 1.0f);
 	EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Z, 1.0f);
-	EXPECT_EQ(HotspotComponent->GetHotspotType(), HotspotType::SpawnHotspot);
+	EXPECT_EQ(HotspotComponent->GetIsSpawnPoint(), true);
+	EXPECT_EQ(HotspotComponent->GetIsTeleportPoint(), false);
 	EXPECT_EQ(HotspotComponent->GetName(), "HotspotName");
 
 	SpaceSystem->ExitSpace(


### PR DESCRIPTION
[OF-1359] refac: Update the hotspot component type properties

- Removed the hotspot space component get/set hotspot type methods and associated property
- Removed the enum for HotspotType
- Added get/set IsTeleportPoint and IsSpawnPoint methods both storing their values in boolean properties
- Updated the hotspot space component script interface
- Updated the hostspot space component tests

[OF-1359]: https://magnopus.atlassian.net/browse/OF-1359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ