### PR TITLE
[OB-3653] fix: sync ~MultiplayerConnection()

### DIFF
--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -131,27 +131,21 @@ MultiplayerConnection::~MultiplayerConnection()
 	{
 		if (Connected)
 		{
-			const auto _Connection			  = Connection;
-			const auto _WebSocketClient		  = WebSocketClient;
-			const auto _NetworkEventManager	  = NetworkEventManager;
-			const auto _ConversationSystemPtr = ConversationSystemPtr;
+			Poco::Event shutdownEvent;
 
 			DisconnectWithReason("MultiplayerConnection shutting down.",
-								 [_Connection, _WebSocketClient, _NetworkEventManager, _ConversationSystemPtr](ErrorCode)
+								 [&shutdownEvent](ErrorCode)
 								 {
-									 CSP_DELETE(_Connection);
-									 CSP_DELETE(_WebSocketClient);
-									 CSP_DELETE(_NetworkEventManager);
-									 CSP_DELETE(_ConversationSystemPtr);
+									 shutdownEvent.set();
 								 });
+
+			shutdownEvent.wait();
 		}
-		else
-		{
-			CSP_DELETE(Connection);
-			CSP_DELETE(WebSocketClient);
-			CSP_DELETE(NetworkEventManager);
-			CSP_DELETE(ConversationSystemPtr);
-		}
+
+		CSP_DELETE(Connection);
+		CSP_DELETE(WebSocketClient);
+		CSP_DELETE(NetworkEventManager);
+		CSP_DELETE(ConversationSystemPtr);
 	}
 }
 


### PR DESCRIPTION
Use the callback to block the thread until the disconnection is complete ensuring that any callbacks fired during the shutdown process are completely handled before the system is destroyed.

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
