### PR TITLE
[NT-0] feat: Querying for local POIs by type

### DIFF
--- a/Library/include/CSP/Systems/Spatial/PointOfInterest.h
+++ b/Library/include/CSP/Systems/Spatial/PointOfInterest.h
@@ -65,6 +65,7 @@ public:
 	csp::common::String Owner;
 	csp::systems::GeoLocation Location;
 	csp::common::String AssetCollectionId;
+    csp::common::String SpaceId;
 	/** @} */
 };
 

--- a/Library/include/CSP/Systems/Spatial/PointOfInterest.h
+++ b/Library/include/CSP/Systems/Spatial/PointOfInterest.h
@@ -40,7 +40,8 @@ namespace csp::systems
 
 enum class EPointOfInterestType
 {
-	DEFAULT
+	DEFAULT,
+    SPACE
 };
 
 /// @ingroup Point Of Interest System

--- a/Library/include/CSP/Systems/Spatial/PointOfInterestSystem.h
+++ b/Library/include/CSP/Systems/Spatial/PointOfInterestSystem.h
@@ -96,12 +96,13 @@ public:
 	/// @param Callback NullResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void DeletePOI(const PointOfInterest& POI, NullResultCallback Callback);
 
-	/// @brief Retrieves an array with all the Points of Interest that are located inside the circular area defined by the parameters
-	/// @param OriginLocation csp::systems::GeoLocation : latitude and longitude coordinates of the circular area origin
-	/// @param AreaRadius double : radius of the circular area origin
-	/// @param Callback POICollectionResultCallback : callback when asynchronous task finishes
+	/// @brief Retrieves an array with all the Points of Interest that are located inside the circular area defined by the parameters..
+	/// @param OriginLocation csp::systems::GeoLocation : The latitude and longitude coordinates of origin of the search location.
+	/// @param AreaRadius double : The Radius of the circular area to search around the provided origin.
+	/// @param Type csp::common::Optional<EPointOfInterestType> : The type of POI to search for. If none is specified, all types will be included in the returned set.
+	/// @param Callback POICollectionResultCallback : callback when asynchronous task finishes.
 	CSP_ASYNC_RESULT void
-		GetPOIsInArea(const csp::systems::GeoLocation& OriginLocation, const double AreaRadius, POICollectionResultCallback Callback);
+		GetPOIsInArea(const csp::systems::GeoLocation& OriginLocation, const double AreaRadius, const csp::common::Optional<EPointOfInterestType>& Type, POICollectionResultCallback Callback);
 	///@}
 
 protected:

--- a/Library/src/Systems/Spatial/PointOfInterest.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterest.cpp
@@ -78,6 +78,11 @@ void PointOfInterestDtoToPointOfInterest(const chs::PointOfInterestDto& Dto, csp
 		// TODO: Find out why we're using name instead of Id here
 		POI.AssetCollectionId = Dto.GetPrototypeName();
 	}
+
+    if(Dto.HasGroupId())
+    {
+	    POI.SpaceId = Dto.GetGroupId();
+    }
 }
 
 } // namespace

--- a/Library/src/Systems/Spatial/PointOfInterest.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "CSP/Systems/Spatial/PointOfInterest.h"
+#include "Systems/Spatial/PointOfInterestHelpers.h"
 
 #include "Services/SpatialDataService/Api.h"
 #include "Services/SpatialDataService/Dto.h"
@@ -49,15 +50,7 @@ void PointOfInterestDtoToPointOfInterest(const chs::PointOfInterestDto& Dto, csp
 
 	if (Dto.HasType())
 	{
-		// TODO Move this to a separate function when we have some different values than DEFAULT
-        if(Dto.GetType() == "Default")
-        {
-			POI.Type = csp::systems::EPointOfInterestType::DEFAULT;
-        }
-        else if(Dto.GetType() == "OKOSpaceGeoLocation")
-        {
-	        POI.Type = csp::systems::EPointOfInterestType::SPACE;
-        }
+		POI.Type = csp::systems::PointOfInterestHelpers::StringToType(Dto.GetType());
 	}
 
 	if (Dto.HasTags())
@@ -103,8 +96,6 @@ namespace csp::systems
 PointOfInterest::PointOfInterest() : Type(EPointOfInterestType::DEFAULT)
 {
 }
-
-
 
 PointOfInterest& POIResult::GetPointOfInterest()
 {

--- a/Library/src/Systems/Spatial/PointOfInterest.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterest.cpp
@@ -50,7 +50,14 @@ void PointOfInterestDtoToPointOfInterest(const chs::PointOfInterestDto& Dto, csp
 	if (Dto.HasType())
 	{
 		// TODO Move this to a separate function when we have some different values than DEFAULT
-		POI.Type = csp::systems::EPointOfInterestType::DEFAULT;
+        if(Dto.GetType() == "Default")
+        {
+			POI.Type = csp::systems::EPointOfInterestType::DEFAULT;
+        }
+        else if(Dto.GetType() == "OKOSpaceGeoLocation")
+        {
+	        POI.Type = csp::systems::EPointOfInterestType::SPACE;
+        }
 	}
 
 	if (Dto.HasTags())
@@ -64,7 +71,10 @@ void PointOfInterestDtoToPointOfInterest(const chs::PointOfInterestDto& Dto, csp
 		}
 	}
 
-	POI.Owner = Dto.GetOwner();
+    if(Dto.HasOwner())
+    {
+		POI.Owner = Dto.GetOwner();
+    }
 
 	if (Dto.HasLocation())
 	{

--- a/Library/src/Systems/Spatial/PointOfInterestHelpers.h
+++ b/Library/src/Systems/Spatial/PointOfInterestHelpers.h
@@ -43,7 +43,7 @@ public:
     		}
     		default:
     		{
-	            CSP_LOG_ERROR_MSG("Unkwnown POI type detected when attempting to derive it's string representation. The type string being returned will be empty.");
+	            CSP_LOG_ERROR_MSG("Unkwnown POI type detected when attempting to derive its string representation. The type string being returned will be empty.");
     			break;
     		}
 	    }

--- a/Library/src/Systems/Spatial/PointOfInterestHelpers.h
+++ b/Library/src/Systems/Spatial/PointOfInterestHelpers.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "Debug/Logging.h"
+
+namespace csp::systems
+{
+
+class PointOfInterestHelpers
+{
+public:
+    // Enum to string conversion utilities. This rovides a centralized mechanism for mapping between the two
+    // and should be used for all POI type/string conversions internally.
+    static csp::common::String TypeToString(EPointOfInterestType Type)
+	{
+		csp::common::String String;
+
+	    switch(Type)
+	    {
+    		case EPointOfInterestType::SPACE:
+    		{
+	            String = "SpaceGeoLocation";
+    			break;
+    		}
+	        case EPointOfInterestType::DEFAULT:
+    		{
+	            String = "Default";
+    			break;
+    		}
+    		default:
+    		{
+	            CSP_LOG_ERROR_MSG("Unkwnown POI type detected when attempting to derive it's string representation. The type string being returned will be empty.");
+    			break;
+    		}
+	    }
+
+	    return String;
+	}
+
+	static EPointOfInterestType StringToType(const csp::common::String& String)
+	{
+	    EPointOfInterestType Type = EPointOfInterestType::DEFAULT;
+
+		if(String == "Default")
+		{
+			Type = csp::systems::EPointOfInterestType::DEFAULT;
+		}
+	    // Two terms map to space geolocation, because `OKOSpaceGeoLocation` is a legacy term, preserved for compatibility reasons.
+		else if((String == csp::common::String("SpaceGeoLocation")) || (String == csp::common::String("OKOSpaceGeoLocation")))
+		{
+			Type = csp::systems::EPointOfInterestType::SPACE;
+		}
+
+	    return Type;
+	}
+};
+
+} // namespace csp::systems

--- a/Library/src/Systems/Spatial/PointOfInterestInternalSystem.h
+++ b/Library/src/Systems/Spatial/PointOfInterestInternalSystem.h
@@ -18,7 +18,7 @@
 #include "CSP/Systems/Spaces/Site.h"
 #include "CSP/Systems/Spatial/PointOfInterestSystem.h"
 #include "Web/WebClient.h"
-
+#include "Debug/Logging.h"
 
 namespace csp::systems
 {
@@ -26,7 +26,7 @@ namespace csp::systems
 class PointOfInterestInternalSystem : public PointOfInterestSystem
 {
 public:
-	PointOfInterestInternalSystem(csp::web::WebClient* InWebClient) : PointOfInterestSystem(InWebClient) {};
+    PointOfInterestInternalSystem(csp::web::WebClient* InWebClient) : PointOfInterestSystem(InWebClient) {};
 
 	void CreateSite(const Site& Site, SiteResultCallback Callback)
 	{

--- a/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CSP/Systems/Spatial/PointOfInterestSystem.h"
+#include "Systems/Spatial/PointOfInterestHelpers.h"
 
 #include "CSP/Systems/Assets/AssetCollection.h"
 #include "CSP/Systems/Spaces/Space.h"
@@ -88,9 +89,8 @@ CSP_ASYNC_RESULT void PointOfInterestSystem::CreatePOI(const csp::common::String
 		POIInfo->SetTags(DTOTags);
 	}
 
-	// TODO Move this to a separate function when we have some different values than DEFAULT
-	const auto DefaultPOIType = "Default";
-	POIInfo->SetType(DefaultPOIType);
+    const csp::common::String TypeString = PointOfInterestHelpers::TypeToString(EPointOfInterestType::DEFAULT);
+	POIInfo->SetType(TypeString);
 
 	POIInfo->SetOwner(Owner);
 
@@ -118,6 +118,7 @@ void PointOfInterestSystem::DeletePOI(const PointOfInterest& POI, NullResultCall
 
 void PointOfInterestSystem::GetPOIsInArea(const csp::systems::GeoLocation& OriginLocation,
 										  const double AreaRadius,
+                                          const csp::common::Optional<EPointOfInterestType>& Type,
 										  POICollectionResultCallback Callback)
 {
 	csp::services::ResponseHandlerPtr ResponseHandler
@@ -126,9 +127,17 @@ void PointOfInterestSystem::GetPOIsInArea(const csp::systems::GeoLocation& Origi
 			nullptr,
 			csp::web::EResponseCodes::ResponseOK);
 
+    // If the user has provided a type of POI to search for, prepare the corresponding search term string.
+    // Otherwise, leave the term as null, to search for all POI types.
+	std::optional<csp::services::utility::string_t> TypeOption = std::nullopt;
+	if (Type.HasValue())
+	{
+		TypeOption = PointOfInterestHelpers::TypeToString(*Type).c_str();
+	}
+
 	static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiGet(std::nullopt,
 																  std::nullopt,
-																  std::nullopt,
+																  TypeOption,
 																  std::nullopt,
 																  std::nullopt,
 																  std::nullopt,
@@ -171,9 +180,8 @@ CSP_ASYNC_RESULT void PointOfInterestSystem::CreateSite(const Site& Site, SiteRe
 	uniqueName.Append(Site.SpaceId);
 	POIInfo->SetName(uniqueName);
 
-	// TODO Move this to a separate function when we have some different values than DEFAULT
-	const auto DefaultPOIType = "Default";
-	POIInfo->SetType(DefaultPOIType);
+    const csp::common::String TypeString = PointOfInterestHelpers::TypeToString(EPointOfInterestType::DEFAULT);
+	POIInfo->SetType(TypeString);
 
 	POIInfo->SetOwner(Site.SpaceId);
 
@@ -262,18 +270,18 @@ void PointOfInterestSystem::AddSpaceGeoLocation(const csp::common::String& Space
 {
 	auto POIInfo = std::make_shared<chs::PointOfInterestDto>();
 
-	const auto SpacePOIType = "OKOSpaceGeoLocation";
-	POIInfo->SetType(SpacePOIType);
+    const csp::common::String TypeString = PointOfInterestHelpers::TypeToString(EPointOfInterestType::SPACE);
+	POIInfo->SetType(TypeString);
 
 	chs::LocalizedString POITitle;
-	POITitle.SetValue(SpacePOIType);
+	POITitle.SetValue(TypeString);
 	POITitle.SetLanguageCode(ENGLISH_LANGUAGE_CODE);
 	std::vector<std::shared_ptr<chs::LocalizedString>> DTOTitles;
 	DTOTitles.push_back(std::make_shared<chs::LocalizedString>(POITitle));
 	POIInfo->SetTitle(DTOTitles);
 
 	// the POI Name needs to be unique
-	csp::common::String uniqueName = SpacePOIType;
+	csp::common::String uniqueName = TypeString;
 	uniqueName.Append("_");
 	uniqueName.Append(SpaceId);
 	POIInfo->SetName(uniqueName);
@@ -376,18 +384,18 @@ void PointOfInterestSystem::UpdateSpaceGeoLocation(const csp::common::String& Sp
 {
 	auto POIInfo = std::make_shared<chs::PointOfInterestDto>();
 
-	const auto SpacePOIType = "OKOSpaceGeoLocation";
-	POIInfo->SetType(SpacePOIType);
+	const csp::common::String TypeString = PointOfInterestHelpers::TypeToString(EPointOfInterestType::SPACE);
+	POIInfo->SetType(TypeString);
 
 	chs::LocalizedString POITitle;
-	POITitle.SetValue(SpacePOIType);
+	POITitle.SetValue(TypeString);
 	POITitle.SetLanguageCode(ENGLISH_LANGUAGE_CODE);
 	std::vector<std::shared_ptr<chs::LocalizedString>> DTOTitles;
 	DTOTitles.push_back(std::make_shared<chs::LocalizedString>(POITitle));
 	POIInfo->SetTitle(DTOTitles);
 
 	// the POI Name needs to be unique
-	csp::common::String uniqueName = SpacePOIType;
+	csp::common::String uniqueName = TypeString;
 	uniqueName.Append("_");
 	uniqueName.Append(SpaceId);
 	POIInfo->SetName(uniqueName);

--- a/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
@@ -492,7 +492,7 @@ void PointOfInterestSystem::UpdateSpaceGeoLocation(const csp::common::String& Sp
 
 void PointOfInterestSystem::GetSpaceGeoLocation(const csp::common::String& SpaceId, SpaceGeoLocationResultCallback Callback)
 {
-	const auto SpacePOIType = "OKOSpaceGeoLocation";
+    const csp::common::String SpacePOIType = PointOfInterestHelpers::TypeToString(EPointOfInterestType::SPACE);
 
 	std::vector<csp::common::String> SpaceIds({SpaceId});
 

--- a/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
@@ -120,9 +120,6 @@ void PointOfInterestSystem::GetPOIsInArea(const csp::systems::GeoLocation& Origi
 										  const double AreaRadius,
 										  POICollectionResultCallback Callback)
 {
-	// TODO Move this to a separate function when we have some different values than DEFAULT
-	const auto DefaultPOIType = "Default";
-
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= POIApiPtr->CreateHandler<POICollectionResultCallback, POICollectionResult, void, csp::services::DtoArray<chs::PointOfInterestDto>>(
 			Callback,
@@ -131,7 +128,7 @@ void PointOfInterestSystem::GetPOIsInArea(const csp::systems::GeoLocation& Origi
 
 	static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiGet(std::nullopt,
 																  std::nullopt,
-																  DefaultPOIType,
+																  std::nullopt,
 																  std::nullopt,
 																  std::nullopt,
 																  std::nullopt,
@@ -211,9 +208,6 @@ void PointOfInterestSystem::DeleteSite(const Site& Site, NullResultCallback Call
 
 void PointOfInterestSystem::GetSites(const csp::common::String& SpaceId, SitesCollectionResultCallback Callback)
 {
-	// TODO Move this to a separate function when we have some different values than DEFAULT
-	const auto DefaultPOIType = "Default";
-
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= POIApiPtr->CreateHandler<SitesCollectionResultCallback, SitesCollectionResult, void, csp::services::DtoArray<chs::PointOfInterestDto>>(
 			Callback,
@@ -224,7 +218,7 @@ void PointOfInterestSystem::GetSites(const csp::common::String& SpaceId, SitesCo
 
 	static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiGet(std::nullopt,
 																  std::nullopt,
-																  DefaultPOIType,
+																  std::nullopt,
 																  std::nullopt,
 																  std::nullopt,
 																  std::nullopt,

--- a/Tests/CSharp/src/Tests/PointOfInterestSystemTests.cs
+++ b/Tests/CSharp/src/Tests/PointOfInterestSystemTests.cs
@@ -116,7 +116,7 @@ namespace CSPEngine
             var searchRadius = 130000.0;
 
             // Get POIs
-            using var result = poiSystem.GetPOIsInArea(searchLocationOrigin, searchRadius).Result;
+            using var result = poiSystem.GetPOIsInArea(searchLocationOrigin, searchRadius, Csp.Systems.EPointOfInterestType.DEFAULT).Result;
             var resCode = result.GetResultCode();
 
             Assert.AreEqual(resCode, Systems.EResultCode.Success);

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -365,10 +365,8 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 
 	// Create a space POI and a default POI.
 	{
-		// Use a unfiform random value to get a latitude.
-		SpaceGeolocation.Latitude	= (RandomUniformDouble() * 2.0 - 1.0) * 90.0;
-		// Use a unfiform random value to get a longitude.
-		SpaceGeolocation.Longitude	= (RandomUniformDouble() * 2.0 - 1.0) * 180.0;
+		SpaceGeolocation.Latitude	= RandomRangeDouble(-90.0f, 90.0f);
+		SpaceGeolocation.Longitude	= RandomRangeDouble(-180.0f, 180.0f);
 
 		float SpaceOrientation = 90.0f;
 

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -335,8 +335,8 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_POISYSTEM_TESTS || RUN_POISYSTEM_GET_SPACE_TEST || 1
-CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOITest)
+#if RUN_ALL_UNIT_TESTS || RUN_POISYSTEM_TESTS || RUN_POISYSTEM_QUERY_SPACE_POI_TEST || 1
+CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 {
 	SetRandSeed();
 
@@ -362,8 +362,10 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
 
 	// Associate a geolocation with the space.
 	{
-		SpaceGeolocation.Latitude	= 1.1;
-		SpaceGeolocation.Longitude	= 2.2;
+		// Use a unfiform random value to get a latitude.
+		SpaceGeolocation.Latitude	= (RandomUniformDouble() * 2.0 - 1.0) * 90.0;
+		// Use a unfiform random value to get a longitude.
+		SpaceGeolocation.Longitude	= (RandomUniformDouble() * 2.0 - 1.0) * 180.0;
 
 		float SpaceOrientation = 90.0f;
 
@@ -386,11 +388,11 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
 		SpaceGeofence[2]	= GeoFence2;
 
 		auto [AddGeoResult] = AWAIT_PRE(SpaceSystem, UpdateSpaceGeoLocation, RequestPredicate, Space.Id, SpaceGeolocation, SpaceOrientation, SpaceGeofence);
-		EXPECT_EQ(AddGeoResult.GetResultCode(), csp::systems::EResultCode::Success);
+		EXPECT_EQ(AddGeoResult.GetResultCode(), csp::systems::EResultCode::Success); 
 	}
 
-	// Test retriving the space via the POI system.
-	auto [GetPOIsResult] = AWAIT_PRE(POISystem, GetPOIsInArea, RequestPredicate, SpaceGeolocation, 100.0f);
+	// Test retrieving the space via the POI system.
+	auto [GetPOIsResult] = AWAIT_PRE(POISystem, GetPOIsInArea, RequestPredicate, SpaceGeolocation, 5.0f);
 	EXPECT_EQ(GetPOIsResult.GetResultCode(), csp::systems::EResultCode::Success);
 
 	const csp::common::Array<csp::systems::PointOfInterest>& POIs = GetPOIsResult.GetPOIs();
@@ -402,6 +404,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
 	{
 		if(POIs[i].SpaceId == Space.Id)
 		{
+			EXPECT_EQ(POIs[i].Type, csp::systems::EPointOfInterestType::SPACE);
 			FoundSpacePOI = true;
 			break;
 		}

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -249,7 +249,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaT
 	double SearchRadius			   = 130000;
 
 	auto [Result]
-		= Awaitable(&csp::systems::PointOfInterestSystem::GetPOIsInArea, POISystem, SearchLocationOrigin, SearchRadius).Await(RequestPredicate);
+		= Awaitable(&csp::systems::PointOfInterestSystem::GetPOIsInArea, POISystem, SearchLocationOrigin, SearchRadius, csp::systems::EPointOfInterestType::DEFAULT).Await(RequestPredicate);
 
 	EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 

--- a/Tests/src/TestHelpers.h
+++ b/Tests/src/TestHelpers.h
@@ -177,6 +177,14 @@ inline double RandomUniformDouble()
 	return UniformDouble(Rand);
 }
 
+inline double RandomRangeDouble(double Min, double Max)
+{
+	const double RandomUniform = RandomUniformDouble();
+	const double Range = Max - Min;
+
+	return (RandomUniform * Range) + Min;
+}
+
 // This function creates a unique string by randomly selecting a values from a epoch time stamp and random values from a string
 inline std::string GetUniqueString(int Length = 16)
 {

--- a/Tests/src/TestHelpers.h
+++ b/Tests/src/TestHelpers.h
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <thread>
+#include <random>
 
 inline const char* TESTS_CLIENT_SKU = "CPPTest";
 
@@ -162,6 +163,20 @@ inline void SetRandSeed()
 {
 	std::srand(static_cast<unsigned int>(std::time(nullptr)));
 }
+
+inline double RandomUniformDouble()
+{
+	 std::uniform_real_distribution<double> UniformDouble;
+
+	// Seed using the current time.
+	std::mt19937_64 Rand;
+	auto CurrentTime		= std::chrono::high_resolution_clock::now();
+	auto CurrentNanoseconds = std::chrono::time_point_cast<std::chrono::nanoseconds>(CurrentTime);
+	Rand.seed(CurrentNanoseconds.time_since_epoch().count());
+	
+	return UniformDouble(Rand);
+}
+
 // This function creates a unique string by randomly selecting a values from a epoch time stamp and random values from a string
 inline std::string GetUniqueString(int Length = 16)
 {


### PR DESCRIPTION
Discovered whilst writing spatial services documentation for CSP, there was a client-application-level feature missing, where whilst the client app is able to associate a POI with a space using the `UpdateSpaceGeoLocation` method on `SpaceSystem`, they had no affordance via the POISystem to later query for POIs associated with spaces.

In fact, the POISystem was deliberately filtering out POIs that were associated with spaces, and only ever returning `DEFAULT` type POIs.

This change introduces a new optional parameter to the POI System, `Type`, which allows the client to query for only POIs of a certain type. 
* If all types are desired to be included in the returned results, the optional value should not be specified.
* If the previous behaviour of CSP when returning results is preferred, please pass in the `DEFAULT` type.
* If the application wishes to filter for only spaces of type `SPACE`, please pass this as the argument.

The change also addresses some technical debt, where the strings denoting default and space type POIs were previously hard-coded in  several methods. They have all been unified to rely on a single set of type/string conversion helper functions.