### PR TITLE
[OF-1378] fix: Add Async macros to API and remove optional parameter tags

### DIFF
--- a/Library/include/CSP/Systems/Sequence/Sequence.h
+++ b/Library/include/CSP/Systems/Sequence/Sequence.h
@@ -75,11 +75,14 @@ private:
 };
 
 /// @brief Callback containing a sequence.
+/// @param Result SequenceResult : result class
 typedef std::function<void(const SequenceResult& Result)> SequenceResultCallback;
 
 /// @brief Callback containing array of sequences.
+/// @param Result SequenceResult : result class
 typedef std::function<void(const SequencesResult& Result)> SequencesResultCallback;
 
 /// @brief Callback containing array of sequences.
+/// @param Result SequenceResult : result class
 typedef std::function<void(const SequencesResult& Result)> SequenceUpdatedResultCallback;
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Sequence/SequenceSystem.h
+++ b/Library/include/CSP/Systems/Sequence/SequenceSystem.h
@@ -51,18 +51,18 @@ class CSP_API SequenceSystem : public SystemBase
 	/** @endcond */
 	CSP_END_IGNORE
 public:
-	/// @brief Creates a new sequence. If a sequence already exists with this key, it will overwrite the current one. This call will fail if the user
-	/// isn't a creator of the space.
+	/// @brief Creates a new sequence. If a sequence already exists with this key, it will overwrite the current one.
+	/// This call will fail if the user isn't a creator of the space.
 	/// @param SequenceKey csp::common::String : The unique grouping name. The suggested convention is: Type:[Id]
 	/// @param ReferenceType csp::common::String : The type of reference (GroupId, SpaceId etc.)
 	/// @param ReferenceId csp::common::String : The id of the reference
 	/// @param Items csp::common::Array<csp::common::String> : An ordered array of members
 	/// @param Callback SequenceResultCallback : callback to call when a response is received
-	void CreateSequence(const csp::common::String& SequenceKey,
-						const csp::common::String& ReferenceType,
-						const csp::common::String& ReferenceId,
-						const csp::common::Array<csp::common::String>& Items,
-						SequenceResultCallback Callback);
+	CSP_ASYNC_RESULT void CreateSequence(const csp::common::String& SequenceKey,
+										 const csp::common::String& ReferenceType,
+										 const csp::common::String& ReferenceId,
+										 const csp::common::Array<csp::common::String>& Items,
+										 SequenceResultCallback Callback);
 
 	/// @brief Updates an existing sequence. This call will fail if the user isn't a creator of the space.
 	/// @param SequenceKey csp::common::String : The unique grouping name. The suggested convention is: Type:[Id]
@@ -70,39 +70,40 @@ public:
 	/// @param ReferenceId csp::common::String : The id of the reference
 	/// @param Items csp::common::Array<csp::common::String> : An ordered array of members
 	/// @param Callback SequenceResultCallback : callback to call when a response is received
-	void UpdateSequence(const csp::common::String& SequenceKey,
-						const csp::common::String& ReferenceType,
-						const csp::common::String& ReferenceId,
-						const csp::common::Array<csp::common::String>& Items,
-						SequenceResultCallback Callback);
+	CSP_ASYNC_RESULT void UpdateSequence(const csp::common::String& SequenceKey,
+										 const csp::common::String& ReferenceType,
+										 const csp::common::String& ReferenceId,
+										 const csp::common::Array<csp::common::String>& Items,
+										 SequenceResultCallback Callback);
 
 	/// @brief Renames a given sequence. This call will fail if the user isn't a creator of the space.
 	/// @param OldSequenceKey csp::common::String : The current sequence key name
 	/// @param NewSequenceKey csp::common::String : The new sequence key name
 	/// @param Callback SequenceResultCallback : callback to call when a response is received
-	void RenameSequence(const csp::common::String& OldSequenceKey, const csp::common::String& NewSequenceKey, SequenceResultCallback Callback);
+	CSP_ASYNC_RESULT void
+		RenameSequence(const csp::common::String& OldSequenceKey, const csp::common::String& NewSequenceKey, SequenceResultCallback Callback);
 
 	/// @brief Finds sequences based on the given criteria
 	/// @param SequenceKeys csp::common::Array<csp::common::String> : An array of sequence keys to search for
 	/// @param SequenceKeys csp::common::Optional<csp::common::String> : An optional regex string for searching keys
 	/// @param ReferenceType csp::common::String : The type of reference (GroupId, SpaceId etc.). Must be used with ReferenceIds
-	/// @param ReferenceIds csp::common::Optional<csp::common::Array<csp::common::String>> : The ids of the reference. Must be used with ReferenceType
+	/// @param ReferenceIds csp::common::Array<csp::common::String> : The ids of the reference. Must be used with ReferenceType
 	/// @param Callback SequencesResultCallback : callback to call when a response is received
-	void GetSequencesByCriteria(const csp::common::Optional<csp::common::Array<csp::common::String>>& SequenceKeys,
-								const csp::common::Optional<csp::common::String>& KeyRegex,
-								const csp::common::Optional<csp::common::String>& ReferenceType,
-								const csp::common::Optional<csp::common::Array<csp::common::String>>& ReferenceIds,
-								SequencesResultCallback Callback);
+	CSP_ASYNC_RESULT void GetSequencesByCriteria(const csp::common::Array<csp::common::String>& SequenceKeys,
+												 const csp::common::Optional<csp::common::String>& KeyRegex,
+												 const csp::common::Optional<csp::common::String>& ReferenceType,
+												 const csp::common::Array<csp::common::String>& ReferenceIds,
+												 SequencesResultCallback Callback);
 
 	/// @brief Gets a sequence by it's key
 	/// @param SequenceKey csp::common::String : The unique grouping name
 	/// @param Callback SequenceResultCallback : callback to call when a response is received
-	void GetSequence(const csp::common::String& SequenceKey, SequenceResultCallback Callback);
+	CSP_ASYNC_RESULT void GetSequence(const csp::common::String& SequenceKey, SequenceResultCallback Callback);
 
 	/// @brief Deletes the given sequences. This call will fail if the user isn't a creator of the space
 	/// @param SequenceKeys csp::common::Array<csp::common::String> : An array of sequence keys to delete
 	/// @param Callback NullResultCallback : callback to call when a response is received
-	void DeleteSequences(const csp::common::Array<csp::common::String>& SequenceKeys, NullResultCallback Callback);
+	CSP_ASYNC_RESULT void DeleteSequences(const csp::common::Array<csp::common::String>& SequenceKeys, NullResultCallback Callback);
 
 private:
 	SequenceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -78,13 +78,13 @@ void SequenceSystem::RenameSequence(const String& OldSequenceKey, const String& 
 		);
 }
 
-void SequenceSystem::GetSequencesByCriteria(const Optional<Array<String>>& InSequenceKeys,
+void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys,
 											const Optional<String>& InKeyRegex,
 											const Optional<String>& InReferenceType,
-											const Optional<Array<String>>& InReferenceIds,
+											const Array<String>& InReferenceIds,
 											SequencesResultCallback Callback)
 {
-	if (InReferenceType.HasValue() && InReferenceIds.HasValue() == false || InReferenceIds.HasValue() && InReferenceType.HasValue() == false)
+	if (InReferenceType.HasValue() && InReferenceIds.IsEmpty() || InReferenceIds.IsEmpty() && InReferenceType.HasValue())
 	{
 		CSP_LOG_ERROR_MSG("InReferenceType and InReferenceIds need to be used together");
 		INVOKE_IF_NOT_NULL(Callback, MakeInvalid<SequencesResult>());

--- a/Tests/src/PublicAPITests/SequenceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceSystemTests.cpp
@@ -170,10 +170,10 @@ void RenameSequence(csp::systems::SequenceSystem* SequenceSystem,
 }
 
 void GetSequencesByCriteria(csp::systems::SequenceSystem* SequenceSystem,
-							const csp::common::Optional<csp::common::Array<csp::common::String>>& SequenceKeys,
+							const csp::common::Array<csp::common::String>& SequenceKeys,
 							const csp::common::Optional<csp::common::String>& KeyRegex,
 							const csp::common::Optional<csp::common::String>& ReferenceType,
-							const csp::common::Optional<csp::common::Array<csp::common::String>>& ReferenceIds,
+							const csp::common::Array<csp::common::String>& ReferenceIds,
 							csp::common::Array<csp::systems::Sequence>& OutSequences,
 							csp::systems::EResultCode ExpectedResultCode				  = csp::systems::EResultCode::Success,
 							csp::systems::ERequestFailureReason ExpectedResultFailureCode = csp::systems::ERequestFailureReason::None)
@@ -524,38 +524,38 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaTest)
 	// Test Sequence key search
 
 	// Get the first sequence
-	GetSequencesByCriteria(SequenceSystem, {{Sequence.Key}}, nullptr, nullptr, nullptr, RetrievedSequences);
+	GetSequencesByCriteria(SequenceSystem, {Sequence.Key}, nullptr, nullptr, {}, RetrievedSequences);
 	EXPECT_EQ(RetrievedSequences.Size(), 1);
 	CompareSequences(RetrievedSequences[0], Sequence);
 
 	// Get the second sequence
-	GetSequencesByCriteria(SequenceSystem, {{Sequence2.Key}}, nullptr, nullptr, nullptr, RetrievedSequences);
+	GetSequencesByCriteria(SequenceSystem, {Sequence2.Key}, nullptr, nullptr, {}, RetrievedSequences);
 	EXPECT_EQ(RetrievedSequences.Size(), 1);
 	CompareSequences(RetrievedSequences[0], Sequence2);
 
 	// Try and get an invalid sequence
-	GetSequencesByCriteria(SequenceSystem, {{"Unknown Key"}}, nullptr, nullptr, nullptr, RetrievedSequences);
+	GetSequencesByCriteria(SequenceSystem, {"Unknown Key"}, nullptr, nullptr, {}, RetrievedSequences);
 	EXPECT_EQ(RetrievedSequences.Size(), 0);
 
 	// Test Regex search
-	GetSequencesByCriteria(SequenceSystem, nullptr, UniqueSequenceName2, nullptr, nullptr, RetrievedSequences);
+	GetSequencesByCriteria(SequenceSystem, {}, UniqueSequenceName2, nullptr, {}, RetrievedSequences);
 	EXPECT_EQ(RetrievedSequences.Size(), 1);
 	CompareSequences(RetrievedSequences[0], Sequence2);
 
 	// Test reference type and id search
 
 	// Get the first sequence
-	GetSequencesByCriteria(SequenceSystem, nullptr, nullptr, "Group1", {{Space.Id}}, RetrievedSequences);
+	GetSequencesByCriteria(SequenceSystem, {}, nullptr, "Group1", {{Space.Id}}, RetrievedSequences);
 	EXPECT_EQ(RetrievedSequences.Size(), 1);
 	CompareSequences(RetrievedSequences[0], Sequence);
 
 	// Get the second sequence
-	GetSequencesByCriteria(SequenceSystem, nullptr, nullptr, "Group2", {{Space.Id}}, RetrievedSequences);
+	GetSequencesByCriteria(SequenceSystem, {}, nullptr, "Group2", {{Space.Id}}, RetrievedSequences);
 	EXPECT_EQ(RetrievedSequences.Size(), 1);
 	CompareSequences(RetrievedSequences[0], Sequence2);
 
 	// Try and get an invalid sequence
-	GetSequencesByCriteria(SequenceSystem, nullptr, nullptr, "Group3", {{Space.Id}}, RetrievedSequences);
+	GetSequencesByCriteria(SequenceSystem, {}, nullptr, "Group3", {{Space.Id}}, RetrievedSequences);
 	EXPECT_EQ(RetrievedSequences.Size(), 0);
 
 	// Delete sequence

--- a/Tools/WrapperGenerator/CSharpWrapperGenerator.py
+++ b/Tools/WrapperGenerator/CSharpWrapperGenerator.py
@@ -545,6 +545,7 @@ class CSharpWrapperGenerator:
                         tag = comment[:comment_index]
 
                         if tag != "@param":
+                            error_in_file(m.header_file or "", -1, "Error in comment: " + comment)
                             error_in_file(m.header_file or "", -1, "Last doc comment must describe callback parameter")
 
                         content = comment[comment_index + 1 :]


### PR DESCRIPTION
Updated Sequence result doxygen comments
Added ASYNC macro to sequence API
Removed optional constraint from API
updated sentinal check in SequenceSystem
Updated test to consume new API
Added better error reporting to wrapper gen
