### PR TITLE
[OF-1370] Added ParentId support to SpaceEntitySystem and SpaceEntity

### DIFF
--- a/Library/include/CSP/Common/Optional.h
+++ b/Library/include/CSP/Common/Optional.h
@@ -192,11 +192,6 @@ public:
 			ValueDestructor(Value);
 		}
 
-		if (!Other.Value)
-		{
-			return *this;
-		}
-
 		Value = (T*) csp::memory::DllAlloc(sizeof(T));
 		new (Value) T(*Other.Value);
 
@@ -211,11 +206,6 @@ public:
 		if (Value)
 		{
 			ValueDestructor(Value);
-		}
-
-		if (!Other.Value)
-		{
-			return *this;
 		}
 
 		Value		= Other.Value;

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -90,6 +90,7 @@ enum SpaceEntityUpdateFlags
 	UPDATE_FLAGS_SELECTION_ID		  = 32,
 	UPDATE_FLAGS_THIRD_PARTY_REF	  = 64,
 	UPDATE_FLAGS_THIRD_PARTY_PLATFORM = 128,
+	UPDATE_FLAGS_PARENT				  = 256,
 };
 
 /// @brief Primary multiplayer object that can have associated scripts and many multiplayer components created within it.
@@ -205,6 +206,13 @@ public:
 	/// @brief Get SpaceEntitySystem Object
 	/// @return SpaceEntitySystem
 	SpaceEntitySystem* GetSpaceEntitySystem();
+
+	void SetParentEntity(SpaceEntity* Parent);
+	void RemoveParentEntity();
+
+	SpaceEntity* GetParentEntity() const;
+
+	const csp::common::List<SpaceEntity*>* GetChildEntities() const;
 
 	/// @brief Queues an update which will be executed on next Tick() or ProcessPendingEntityOperations(). Not a blocking or async function.
 	void QueueUpdate();
@@ -336,6 +344,10 @@ private:
 
 	ComponentBase* FindFirstComponentOfType(ComponentType Type, bool SearchDirtyComponents = false) const;
 
+	void AddChildEntitiy(SpaceEntity* ChildEntity);
+
+	bool ResolveEntityHierarchy();
+
 	SpaceEntitySystem* EntitySystem;
 
 	SpaceEntityType Type;
@@ -344,11 +356,16 @@ private:
 	bool IsPersistant;
 	uint64_t OwnerId;
 	csp::common::Optional<uint64_t> ParentId;
+	bool ShouldUpdateParent;
+
 	csp::common::String Name;
 	SpaceTransform Transform;
 	csp::systems::EThirdPartyPlatform ThirdPartyPlatform;
 	csp::common::String ThirdPartyRef;
 	uint64_t SelectedId;
+
+	SpaceEntity* Parent;
+	csp::common::List<SpaceEntity*> ChildEntities;
 
 	UpdateCallback EntityUpdateCallback;
 	DestroyCallback EntityDestroyCallback;

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -86,9 +86,11 @@ SpaceEntity::SpaceEntity()
 	, RefCount(CSP_NEW std::atomic_int(0))
 	, SelectedId(0)
 	, ParentId(nullptr)
+	, ShouldUpdateParent(false)
 	, ThirdPartyRef("")
 	, ThirdPartyPlatform(csp::systems::EThirdPartyPlatform::NONE)
 	, TimeOfLastPatch(0)
+	, Parent(nullptr)
 {
 }
 
@@ -109,9 +111,11 @@ SpaceEntity::SpaceEntity(SpaceEntitySystem* InEntitySystem)
 	, RefCount(CSP_NEW std::atomic_int(0))
 	, SelectedId(0)
 	, ParentId(nullptr)
+	, ShouldUpdateParent(false)
 	, ThirdPartyRef("")
 	, ThirdPartyPlatform(csp::systems::EThirdPartyPlatform::NONE)
 	, TimeOfLastPatch(0)
+	, Parent(nullptr)
 {
 }
 
@@ -315,6 +319,28 @@ SpaceEntitySystem* SpaceEntity::GetSpaceEntitySystem()
 	return EntitySystem;
 }
 
+void SpaceEntity::SetParentEntity(SpaceEntity* InParent)
+{
+	ParentId		   = InParent->GetId();
+	ShouldUpdateParent = true;
+}
+
+void SpaceEntity::RemoveParentEntity()
+{
+	ParentId		   = nullptr;
+	ShouldUpdateParent = true;
+}
+
+SpaceEntity* SpaceEntity::GetParentEntity() const
+{
+	return Parent;
+}
+
+const csp::common::List<SpaceEntity*>* SpaceEntity::GetChildEntities() const
+{
+	return &ChildEntities;
+}
+
 void SpaceEntity::QueueUpdate()
 {
 	if (EntitySystem)
@@ -439,8 +465,8 @@ void SpaceEntity::SerialisePatch(IEntitySerialiser& Serialiser) const
 		Serialiser.WriteBool(false); // Destroy
 		Serialiser.BeginArray();	 // ParentId
 		{
-			Serialiser.WriteBool(false);
-			Serialiser.WriteNull();
+			Serialiser.WriteBool(ShouldUpdateParent);
+			ParentId.HasValue() ? Serialiser.WriteUInt64(*ParentId) : Serialiser.WriteNull();
 		}
 		Serialiser.EndArray();
 
@@ -645,16 +671,41 @@ void SpaceEntity::Deserialise(IEntityDeserialiser& Deserialiser)
 
 void SpaceEntity::DeserialiseFromPatch(IEntityDeserialiser& Deserialiser)
 {
+	SpaceEntityUpdateFlags UpdateFlags = SpaceEntityUpdateFlags(0);
+
+	if (ShouldUpdateParent)
+	{
+		uint32_t size = 0;
+		Deserialiser.EnterArray(size);
+		{
+			ShouldUpdateParent = Deserialiser.ReadBool();
+
+			if (Deserialiser.NextValueIsNull())
+			{
+				Deserialiser.Skip();
+			}
+			else
+			{
+				ParentId = Deserialiser.ReadUInt64();
+			}
+
+			UpdateFlags = SpaceEntityUpdateFlags(UpdateFlags | UPDATE_FLAGS_PARENT);
+		}
+		Deserialiser.LeaveArray();
+
+		ResolveEntityHierarchy();
+	}
+
 	std::scoped_lock<std::mutex> ComponentsLocker(*ComponentsLock);
+
+	csp::common::Array<ComponentUpdateInfo> ComponentUpdates(0);
 
 	if (!Deserialiser.NextValueIsNull()) // It is valid for entities to not have components
 	{
 		Deserialiser.EnterComponents();
 		{
 			auto RealComponentCount = Deserialiser.GetNumRealComponents();
-
-			SpaceEntityUpdateFlags UpdateFlags = SpaceEntityUpdateFlags(0);
-			csp::common::Array<ComponentUpdateInfo> ComponentUpdates(RealComponentCount);
+			ComponentUpdates		= csp::common::Array<ComponentUpdateInfo>(RealComponentCount);
 
 			uint16_t ComponentKey;
 			uint64_t _ComponentType;
@@ -771,13 +822,13 @@ void SpaceEntity::DeserialiseFromPatch(IEntityDeserialiser& Deserialiser)
 					Deserialiser.LeaveComponent();
 				}
 			}
-
-			if (EntityUpdateCallback != nullptr)
-			{
-				EntityUpdateCallback(this, UpdateFlags, ComponentUpdates);
-			}
 		}
 		Deserialiser.LeaveComponents();
+	}
+
+	if (UpdateFlags != 0 && EntityUpdateCallback != nullptr)
+	{
+		EntityUpdateCallback(this, UpdateFlags, ComponentUpdates);
 	}
 }
 
@@ -916,6 +967,11 @@ void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback)
 
 			TransientDeletionComponentIds.Clear();
 			CSP_DELETE(DirtyComponentKeys);
+		}
+
+		if (ResolveEntityHierarchy())
+		{
+			UpdateFlags = static_cast<SpaceEntityUpdateFlags>(UpdateFlags | UPDATE_FLAGS_PARENT);
 		}
 
 		if (InvokeUpdateCallback && EntityUpdateCallback != nullptr)
@@ -1189,6 +1245,52 @@ ComponentBase* SpaceEntity::FindFirstComponentOfType(ComponentType Type, bool Se
 
 
 	return LocatedComponent;
+}
+
+void SpaceEntity::AddChildEntitiy(SpaceEntity* ChildEntity)
+{
+	ChildEntities.Append(ChildEntity);
+}
+
+bool SpaceEntity::ResolveEntityHierarchy()
+{
+	if (ShouldUpdateParent == false)
+	{
+		return false;
+	}
+
+	// Entity has been re-parented
+	if (ParentId.HasValue())
+	{
+		// Entity was previously parented to another object, so cleanup
+		if (Parent != nullptr)
+		{
+			Parent->ChildEntities.RemoveItem(this);
+		}
+
+		// Set our new parent
+		Parent = GetSpaceEntitySystem()->FindSpaceEntityById(*ParentId);
+
+		if (Parent != nullptr)
+		{
+			Parent->ChildEntities.Append(this);
+		}
+		else
+		{
+			CSP_LOG_ERROR_MSG("SpaceEntity unable to find parent");
+		}
+	}
+	else
+	{
+		if (Parent != nullptr)
+		{
+			Parent->ChildEntities.RemoveItem(this);
+			Parent = nullptr;
+		}
+	}
+
+	ShouldUpdateParent = false;
+	return true;
 }
 
 csp::multiplayer::EntityScriptInterface* SpaceEntity::GetScriptInterface()

--- a/Tests/src/InternalTests/CommonTypeTests/Optional.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Optional.cpp
@@ -379,4 +379,15 @@ CSP_INTERNAL_TEST(CSPEngine, CommonOptionalTests, OptionalNoValueOptionalTypeMov
 		FAIL();
 	}
 }
+
+CSP_INTERNAL_TEST(CSPEngine, CommonOptionalTests, OptionalAssignNull)
+{
+	csp::common::Optional<uint64_t> OptionalInstance = 5;
+
+	EXPECT_EQ(*OptionalInstance, 5);
+
+	OptionalInstance = nullptr;
+
+	EXPECT_FALSE(OptionalInstance.HasValue());
+}
 #endif


### PR DESCRIPTION
- Fixed bug with setting Optional to nullptr
- Added ability to set, get and remove ParentId
- Added serialisation/deserialisation for ParentId
- Added patch serialisation/deserialisation for ParentId
- Added tests for all functionality
- Added new SpaceEntityUpdateFlag for ParentId
- Also completed ApplyIncomingPatch work for OF-1372 to prevent deserialisation crashes
