### PR TITLE
refac: simplify dllimports

### DIFF
--- a/Library/CSharpWrapper/src/Constants.cs
+++ b/Library/CSharpWrapper/src/Constants.cs
@@ -1,0 +1,13 @@
+﻿namespace Csp
+{
+    internal class Constants
+    {
+#if !UNITY_EDITOR && (UNITY_IOS || UNITY_VISIONOS)
+        internal const string DllName = "__Internal";
+#elif DEBUG && !UNITY_EDITOR_OSX && !UNITY_STANDALONE_OSX
+        internal const string DllName = "ConnectedSpacesPlatform_D";
+#else
+        internal const string DllName = "ConnectedSpacesPlatform";
+#endif
+    }
+}

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/DllImport.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/DllImport.mustache
@@ -1,9 +1,2 @@
-[DllImport(
-#if !UNITY_EDITOR && (UNITY_IOS || UNITY_VISIONOS)
-    "__Internal"
-#elif DEBUG && !UNITY_EDITOR_OSX && !UNITY_STANDALONE_OSX
-    "ConnectedSpacesPlatform_D"
-#else
-    "ConnectedSpacesPlatform"
-#endif
-), SuppressUnmanagedCodeSecurity]
+[DllImport(Csp.Constants.DllName)]
+[SuppressUnmanagedCodeSecurity]


### PR DESCRIPTION
Small refactor that makes the generated C# code a little less verbose

- Moved conditional compilation into a constant
- Simplified template/generated code

**For the reviewer**

* [ ] If required, are the changes covered by appropriate tests?
* [ ] Are any public-facing API changes well documented?
* [ ] Is the code easily readable and extensible and/or follow existing conventions?
