### PR TITLE
[NT-0] fix: crash on DLL load for CPP apps

### DIFF
--- a/Library/include/CSP/Multiplayer/SequenceHierarchy.h
+++ b/Library/include/CSP/Multiplayer/SequenceHierarchy.h
@@ -92,10 +92,6 @@ private:
 	csp::common::Array<SequenceHierarchy> SequenceHierarchyCollection;
 };
 
-CSP_START_IGNORE
-static inline const csp::common::String SequenceHierarchyName = "EntityHierarchy";
-CSP_END_IGNORE
-
 typedef std::function<void(const SequenceHierarchyResult& Result)> SequenceHierarchyResultCallback;
 typedef std::function<void(const SequenceHierarchyCollectionResult& Result)> SequenceHierarchyCollectionResultCallback;
 

--- a/Library/include/CSP/Systems/Sequence/Sequence.h
+++ b/Library/include/CSP/Systems/Sequence/Sequence.h
@@ -20,11 +20,6 @@
 namespace csp::systems
 {
 
-CSP_START_IGNORE
-// Prefix needed when storing multiplayer unsigned integer ids in keys
-static inline const csp::common::String SequenceIdPrefix = "m_Id_";
-CSP_END_IGNORE
-
 /// @ingroup Sequence System
 /// @brief A basic class abstraction for a sequence, including key, and reference variables, and items.
 class CSP_API Sequence

--- a/Library/src/Multiplayer/EventSerialisation.cpp
+++ b/Library/src/Multiplayer/EventSerialisation.cpp
@@ -17,7 +17,7 @@
 #include "Multiplayer/EventSerialisation.h"
 
 #include "Debug/Logging.h"
-#include "Multiplayer/MultiplayerKeyConstants.h"
+#include "Multiplayer/MultiplayerConstants.h"
 
 #include <regex>
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -24,7 +24,7 @@
 #include "Debug/Logging.h"
 #include "Events/EventSystem.h"
 #include "Multiplayer/EventSerialisation.h"
-#include "Multiplayer/MultiplayerKeyConstants.h"
+#include "Multiplayer/MultiplayerConstants.h"
 #include "Multiplayer/SignalR/SignalRClient.h"
 #include "Multiplayer/SignalR/SignalRConnection.h"
 #include "NetworkEventManagerImpl.h"

--- a/Library/src/Multiplayer/MultiplayerConstants.cpp
+++ b/Library/src/Multiplayer/MultiplayerConstants.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Multiplayer/MultiplayerConstants.h"
+
+namespace csp::multiplayer
+{
+
+csp::common::String SequenceConstants::GetHierarchyName()
+{
+	const csp::common::String SequenceHierarchyName = "EntityHierarchy";
+	return SequenceHierarchyName;
+}
+
+csp::common::String SequenceConstants::GetIdPrefix()
+{
+	const csp::common::String SequenceIdPrefix = "m_Id_";
+	return SequenceIdPrefix;		
+}
+
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/MultiplayerConstants.h
+++ b/Library/src/Multiplayer/MultiplayerConstants.h
@@ -33,8 +33,6 @@ enum ComponentKeys : uint64_t
 	ENTITY_SCALE	= 1003,
 };
 
-
-
 namespace msgpack_typeids
 {
 
@@ -98,6 +96,13 @@ enum ItemComponentData : uint64_t
 	STRING_DICTIONARY
 };
 
-}
+} // namespace msgpack_typeids
+
+	// For uniquely identifying sequences which relate to a space entity hierarchy.
+	static csp::common::String GetSequenceHierarchyName()
+	{
+		const csp::common::String SequenceHierarchyName = "EntityHierarchy";
+		return SequenceHierarchyName;
+	}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/MultiplayerConstants.h
+++ b/Library/src/Multiplayer/MultiplayerConstants.h
@@ -105,4 +105,11 @@ enum ItemComponentData : uint64_t
 		return SequenceHierarchyName;
 	}
 
+	// Prefix needed when storing multiplayer unsigned integer ids in keys
+	static csp::common::String GetSequenceIdPrefix()
+	{
+		const csp::common::String SequenceIdPrefix = "m_Id_";
+		return SequenceIdPrefix;		
+	}
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/MultiplayerConstants.h
+++ b/Library/src/Multiplayer/MultiplayerConstants.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+#include "CSP/Common/String.h"
 
 namespace csp::multiplayer
 {
@@ -98,18 +99,14 @@ enum ItemComponentData : uint64_t
 
 } // namespace msgpack_typeids
 
+class SequenceConstants
+{
+public:
 	// For uniquely identifying sequences which relate to a space entity hierarchy.
-	static csp::common::String GetSequenceHierarchyName()
-	{
-		const csp::common::String SequenceHierarchyName = "EntityHierarchy";
-		return SequenceHierarchyName;
-	}
+	static csp::common::String GetHierarchyName();
 
 	// Prefix needed when storing multiplayer unsigned integer ids in keys
-	static csp::common::String GetSequenceIdPrefix()
-	{
-		const csp::common::String SequenceIdPrefix = "m_Id_";
-		return SequenceIdPrefix;		
-	}
+	static csp::common::String GetIdPrefix();
+};
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -18,7 +18,7 @@
 
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/ReplicatedValue.h"
-#include "Multiplayer/MultiplayerKeyConstants.h"
+#include "Multiplayer/MultiplayerConstants.h"
 #include "Multiplayer/SignalR/SignalRClient.h"
 #include "Multiplayer/SignalR/SignalRConnection.h"
 #include "CallHelpers.h"

--- a/Library/src/Multiplayer/SequenceHierarchy.cpp
+++ b/Library/src/Multiplayer/SequenceHierarchy.cpp
@@ -23,7 +23,7 @@ common::String CreateSequenceKey(common::Optional<uint64_t> ParentId, const comm
 
 	if (ParentId.HasValue())
 	{
-		Key += ":" + systems::SequenceIdPrefix + std::to_string(*ParentId).c_str();
+		Key += ":" + csp::multiplayer::GetSequenceIdPrefix() + std::to_string(*ParentId).c_str();
 	}
 
 	return Key;

--- a/Library/src/Multiplayer/SequenceHierarchy.cpp
+++ b/Library/src/Multiplayer/SequenceHierarchy.cpp
@@ -19,11 +19,11 @@ void SequenceHierarchyResult::OnResponse(const csp::services::ApiResponseBase* A
 
 common::String CreateSequenceKey(common::Optional<uint64_t> ParentId, const common::String& SpaceId)
 {
-	common::String Key = csp::multiplayer::GetSequenceHierarchyName() + ":" + SpaceId;
+	common::String Key = csp::multiplayer::SequenceConstants::GetHierarchyName() + ":" + SpaceId;
 
 	if (ParentId.HasValue())
 	{
-		Key += ":" + csp::multiplayer::GetSequenceIdPrefix() + std::to_string(*ParentId).c_str();
+		Key += ":" + csp::multiplayer::SequenceConstants::GetIdPrefix() + std::to_string(*ParentId).c_str();
 	}
 
 	return Key;

--- a/Library/src/Multiplayer/SequenceHierarchy.cpp
+++ b/Library/src/Multiplayer/SequenceHierarchy.cpp
@@ -1,6 +1,7 @@
 #include "CSP/Multiplayer/SequenceHierarchy.h"
 
 #include "CSP/Systems/Sequence/Sequence.h"
+#include "Multiplayer/MultiplayerConstants.h"
 
 #include <string>
 
@@ -18,7 +19,7 @@ void SequenceHierarchyResult::OnResponse(const csp::services::ApiResponseBase* A
 
 common::String CreateSequenceKey(common::Optional<uint64_t> ParentId, const common::String& SpaceId)
 {
-	common::String Key = SequenceHierarchyName + ":" + SpaceId;
+	common::String Key = csp::multiplayer::GetSequenceHierarchyName() + ":" + SpaceId;
 
 	if (ParentId.HasValue())
 	{

--- a/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
+++ b/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
@@ -17,7 +17,7 @@
 
 #include "Memory/Memory.h"
 #include "Multiplayer/SpaceEntityKeys.h"
-#include "MultiplayerKeyConstants.h"
+#include "MultiplayerConstants.h"
 
 #include <Debug/Logging.h>
 #include <cassert>

--- a/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.h
+++ b/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.h
@@ -17,7 +17,7 @@
 
 #include "CSP/Multiplayer/IEntitySerialiser.h"
 #include "Memory/Memory.h"
-#include "MultiplayerKeyConstants.h"
+#include "MultiplayerConstants.h"
 
 #include <msgpack/pack.hpp>
 #include <msgpack/sbuffer.hpp>

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -1163,7 +1163,7 @@ void SpaceEntitySystem::GetAllSequenceHierarchies(SequenceHierarchyCollectionRes
 	};
 
 	auto SequenceSystem = csp::systems::SystemsManager::Get().GetSequenceSystem();
-	SequenceSystem->GetSequencesByCriteria({}, csp::multiplayer::GetSequenceHierarchyName(), "GroupId", {SpaceId}, {}, GetSequencesCallback);
+	SequenceSystem->GetSequencesByCriteria({}, csp::multiplayer::SequenceConstants::GetHierarchyName(), "GroupId", {SpaceId}, {}, GetSequencesCallback);
 }
 
 void SpaceEntitySystem::DeleteSequenceHierarchy(const csp::common::Optional<uint64_t>& ParentId, systems::NullResultCallback Callback)

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -31,7 +31,7 @@
 #include "Events/EventSystem.h"
 #include "Memory/Memory.h"
 #include "Multiplayer/Election/ClientElectionManager.h"
-#include "Multiplayer/MultiplayerKeyConstants.h"
+#include "Multiplayer/MultiplayerConstants.h"
 #include "Multiplayer/Script/EntityScriptBinding.h"
 #include "Multiplayer/SignalR/SignalRClient.h"
 #include "Multiplayer/SignalR/SignalRConnection.h"
@@ -1163,7 +1163,7 @@ void SpaceEntitySystem::GetAllSequenceHierarchies(SequenceHierarchyCollectionRes
 	};
 
 	auto SequenceSystem = csp::systems::SystemsManager::Get().GetSequenceSystem();
-	SequenceSystem->GetSequencesByCriteria({}, SequenceHierarchyName, "GroupId", {SpaceId}, {}, GetSequencesCallback);
+	SequenceSystem->GetSequencesByCriteria({}, csp::multiplayer::GetSequenceHierarchyName(), "GroupId", {SpaceId}, {}, GetSequencesCallback);
 }
 
 void SpaceEntitySystem::DeleteSequenceHierarchy(const csp::common::Optional<uint64_t>& ParentId, systems::NullResultCallback Callback)

--- a/Tests/src/PublicAPITests/SequenceHierarchyTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceHierarchyTests.cpp
@@ -165,7 +165,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceHierarchyTests, CreateSequenceKeyTest)
 		const csp::common::String SpaceId = "12345";
 		const csp::common::String Key	  = csp::multiplayer::CreateSequenceKey(ParentId, SpaceId);
 
-		EXPECT_EQ(Key, "EntityHierarchy:" + SpaceId + ":" + csp::systems::SequenceIdPrefix + std::to_string(ParentId).c_str());
+		EXPECT_EQ(Key, "EntityHierarchy:" + SpaceId + ":" + "m_Id_" + std::to_string(ParentId).c_str());
 	}
 }
 #endif


### PR DESCRIPTION
### Bug & Fix

This change concerns moving a static string declaration in the global scope out of a public header. Specifically `SequenceHierarchyName`.

Global variable strings within CSP can cause apps using CSP dlls to *crash on load* of the DLL, as it leads to the application attempting to instantiate the global-scope string variable on DLL-load, _before_ CSP has initialised its memory allocators, which the string class depends upon. The end result is a null dereference crash.

The fix though is to _not_ declare this string variable at the global scope, because this will always be risky with respect to CSP's memory allocators. Instead it is retrieved through a global-scope static function, which more or less guarantees that it will only ever be called after the allocators have been initialised.

### Additionally...

Since in this case, since the variable is only used internally within CSP, it has also been moved to an internal source file.

To avoid creating a brand new header for a single constant, the `MultiplayerKeyConstants.h` file has been used for this and renamed to the more generic `MultiplayerConstants.h`.
