### PR TITLE
[NT-0] doc: updating PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,2 @@
-connected-spaces-platform Pull Request
-
-**For the reviewer**
-
-* [ ] If required, are the changes covered by appropriate tests?
-* [ ] Are any public-facing API changes well documented?
-* [ ] Is the code easily readable and extensible and/or follow existing conventions?
+Please write a short description of what this change does and what problem it solves.
+For more information, see our [CONTRIBUTING](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/.github/CONTRIBUTING.md) page.


### PR DESCRIPTION
The previous check-box-oriented template was underutilized and frequently left unmodified upon merge.

Updating the template to be more of a call to action, in an effort to encourage contributors to include descriptive PR messages.