### PR TITLE
[nt-0] test whether osx builds work at head revision

### DIFF
--- a/Tools/WrapperGenerator/CSharpWrapperGenerator.py
+++ b/Tools/WrapperGenerator/CSharpWrapperGenerator.py
@@ -706,6 +706,7 @@ class CSharpWrapperGenerator:
                 )
 
         # Format output with CSharpier
+        # NOTE: This code will fail on OSX since it's not running using the `dotnet` command
         scriptDirectory = os.path.dirname(os.path.realpath(__file__))
         subprocess.run(
             f'"{ scriptDirectory }\\Formatters\\CSharpier\\dotnet-csharpier.exe" "{self.__OUTPUT_DIRECTORY}"',


### PR DESCRIPTION
#491 is failing due to running `dotnet-csharpier.exe` on OSX but this clause in `CSharpWrapperGenerator.py` has not been modified:

```python
        # Format output with CSharpier
        # NOTE: This code will fail on OSX since it's not running using the `dotnet` command
        scriptDirectory = os.path.dirname(os.path.realpath(__file__))
        subprocess.run(
            f'"{ scriptDirectory }\\Formatters\\CSharpier\\dotnet-csharpier.exe" "{self.__OUTPUT_DIRECTORY}"',
            shell=True,
        )
```