### PR TITLE
[OF-1419] feat: hotspot names support the space character

### DIFF
--- a/Library/src/Common/Encode.cpp
+++ b/Library/src/Common/Encode.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Common/Encode.h"
+#include "Poco/URI.h"
+
+namespace csp::common
+{
+
+csp::common::String Encode::URI(const csp::common::String& UriToEncode, bool DoubleEncode)
+{
+    std::string RawString(UriToEncode.c_str());
+	std::string EncodedString;
+    Poco::URI::encode(RawString, "", EncodedString);
+
+    csp::common::String ReturnValue(EncodedString.c_str());
+
+    if(DoubleEncode)
+    {
+	    ReturnValue = Encode::URI(ReturnValue);
+    }
+
+	return ReturnValue;
+}
+
+csp::common::String Decode::URI(const csp::common::String& UriToDecode, bool DoubleDecode)
+{
+    std::string EncodedString(UriToDecode.c_str());
+    std::string RawString;
+    Poco::URI::decode(EncodedString, RawString);
+
+    csp::common::String ReturnValue(RawString.c_str());
+
+    if(DoubleDecode)
+    {
+	    ReturnValue = Decode::URI(ReturnValue);
+    }
+
+	return ReturnValue;
+}
+
+}; // namespace csp::common

--- a/Library/src/Common/Encode.cpp
+++ b/Library/src/Common/Encode.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "Common/Encode.h"
-#include "Poco/URI.h"
 
 namespace csp::common
 {

--- a/Library/src/Common/Encode.cpp
+++ b/Library/src/Common/Encode.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Common/Encode.h"
+#include <string>
 
 namespace csp::common
 {

--- a/Library/src/Common/Encode.cpp
+++ b/Library/src/Common/Encode.cpp
@@ -24,7 +24,37 @@ csp::common::String Encode::URI(const csp::common::String& UriToEncode, bool Dou
 {
     std::string RawString(UriToEncode.c_str());
 	std::string EncodedString;
-    Poco::URI::encode(RawString, "", EncodedString);
+
+	for (auto Char : RawString)
+	{
+        // Covering alphanumeric characters.
+		if ((Char >= 'a' && Char <= 'z') ||
+		    (Char >= 'A' && Char <= 'Z') ||
+		    (Char >= '0' && Char <= '9') ||
+		    Char == '-' || Char == '_' ||
+		    Char == '.' || Char == '~')
+		{
+			EncodedString += Char;
+		}
+		else
+		{
+            // A non-alphanumeric character needs encoding with the 0xXX pattern.
+            char Buffer[10];
+			sprintf(Buffer, "%X", Char);
+            if(Char < 16)
+            {
+                // Single hex value with a preceding 0 will suffice
+	            EncodedString += "%0"; 
+            }
+            else
+            {
+                // Needs both hex values to represent it.
+                EncodedString += "%";
+            }
+
+            EncodedString += Buffer;
+        }
+	}
 
     csp::common::String ReturnValue(EncodedString.c_str());
 
@@ -40,7 +70,22 @@ csp::common::String Decode::URI(const csp::common::String& UriToDecode, bool Dou
 {
     std::string EncodedString(UriToDecode.c_str());
     std::string RawString;
-    Poco::URI::decode(EncodedString, RawString);
+
+    for (int i = 0; i < EncodedString.length(); i++)
+    {
+        if(EncodedString[i] != '%')
+        {
+            RawString += EncodedString[i]; // Just a regular character.
+        }
+    	else
+        {
+            // We have an encoded character. Decode to int, cast to char, and append.
+            int CharInteger = 0x0;
+            sscanf(EncodedString.substr(i + 1, 2).c_str(), "%x", &CharInteger);
+            RawString += static_cast<char>(CharInteger);
+            i = i + 2; // done, skip the entire hex value and move onto the next character.
+        }
+    }
 
     csp::common::String ReturnValue(RawString.c_str());
 

--- a/Library/src/Common/Encode.h
+++ b/Library/src/Common/Encode.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+
+#include "CSP/Common/String.h"
+
+namespace csp::common
+{
+	/// @brief Utility class containing static helper functions for encoding data.
+    class Encode
+    {
+    public:
+        /// @brief URI-encodes the given string by escaping reserved and non-ASCII characters.
+        /// @param UriToEncode const csp::common::String&: The string to encode.
+        /// @param DoubleEncode bool: Whether to doubly encode the string. Typically necessary for GET requests that include a URL-like parameter.
+        static csp::common::String URI(const csp::common::String& UriToEncode, bool DoublEncode = false);
+    };
+
+	/// @brief Utility class containing static helper functions for decoding data.
+    class Decode
+    {
+    public:
+        /// @brief URI-decodes the given string by replacing percent-encoded characters with the actual character.
+        /// @param UriToDecode const csp::common::String&: The string to decode.
+        /// @param DoubleDecode bool: Whether to doubly decode the string.
+        static csp::common::String URI(const csp::common::String& UriToDecode, bool DoubleDecode = false);
+    };
+};

--- a/Library/src/Multiplayer/EventSerialisation.cpp
+++ b/Library/src/Multiplayer/EventSerialisation.cpp
@@ -18,6 +18,7 @@
 
 #include "Debug/Logging.h"
 #include "Multiplayer/MultiplayerConstants.h"
+#include "Common/Encode.h"
 
 #include <regex>
 
@@ -338,12 +339,12 @@ void csp::multiplayer::SequenceChangedEventDeserialiser::Parse(const std::vector
 
 	EventParams.UpdateType = ESequenceUpdateIntToUpdateType(UpdateType);
 
-	EventParams.Key = EventData[1].GetString();
+	EventParams.Key = csp::common::Decode::URI(EventData[1].GetString());
 
 	// Optional parameter for when a key is changed
 	if (EventData[2].GetReplicatedValueType() == ReplicatedValueType::String)
 	{
-		EventParams.NewKey = EventData[2].GetString();
+		EventParams.NewKey = csp::common::Decode::URI(EventData[2].GetString());
 	}
 }
 

--- a/Library/src/Multiplayer/EventSerialisation.cpp
+++ b/Library/src/Multiplayer/EventSerialisation.cpp
@@ -344,6 +344,7 @@ void csp::multiplayer::SequenceChangedEventDeserialiser::Parse(const std::vector
 	// Optional parameter for when a key is changed
 	if (EventData[2].GetReplicatedValueType() == ReplicatedValueType::String)
 	{
+        // Sequence keys are URI encoded to support reserved characters.
 		EventParams.NewKey = csp::common::Decode::URI(EventData[2].GetString());
 	}
 }
@@ -361,7 +362,9 @@ void csp::multiplayer::SequenceHierarchyChangedEventDeserialiser::Parse(const st
 	int64_t UpdateType	   = EventData[0].GetInt();
 	EventParams.UpdateType = ESequenceUpdateIntToUpdateType(UpdateType);
 
-	csp::common::String Key	   = EventData[1].GetString();
+    // Sequence keys are URI encoded to support reserved characters.
+	csp::common::String Key	   = csp::common::Decode::URI(EventData[1].GetString());
+
 	std::string ParentIdString = GetSequenceKeyIndex(Key, 2).c_str();
 	csp::common::Optional<uint64_t> ParentId;
 

--- a/Library/src/Systems/Sequence/Sequence.cpp
+++ b/Library/src/Systems/Sequence/Sequence.cpp
@@ -18,6 +18,7 @@
 
 #include "CSP/Systems/Sequence/SequenceSystem.h"
 #include "Common/Convert.h"
+#include "Common/Encode.h"
 #include "Services/AggregationService/Api.h"
 
 using namespace csp;
@@ -29,7 +30,7 @@ namespace
 {
 void SequenceDtoToSequence(const chs::SequenceDto& Dto, systems::Sequence& Sequence)
 {
-	Sequence.Key		   = Dto.GetKey();
+	Sequence.Key		   = csp::common::Decode::URI(Dto.GetKey());
 	Sequence.ReferenceType = Dto.GetReferenceType();
 	Sequence.ReferenceId   = Dto.GetReferenceId();
 	Sequence.Items		   = Convert(Dto.GetItems());

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -155,8 +155,15 @@ void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys,
 		}
 
         // We URI-encode sequence keys to support reserved characters.
-        EncodedSequenceKeys[i] = csp::common::Encode::URI(InSequenceKeys[i], true);
+        EncodedSequenceKeys[i] = csp::common::Encode::URI(InSequenceKeys[i]);
 	}
+
+    // Regexes may also include reserved characters which require encoding.
+    Optional<String> Regex;
+    if(InKeyRegex.HasValue())
+    {
+		Regex = csp::common::Encode::URI(*InKeyRegex);
+    }
 
 	if (InReferenceType.HasValue() && InReferenceIds.IsEmpty() || !InReferenceIds.IsEmpty() && !InReferenceType.HasValue())
 	{
@@ -166,7 +173,7 @@ void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys,
 	}
 
 	std::optional<std::vector<String>> SequenceKeys = Convert(EncodedSequenceKeys);
-	std::optional<String> KeyRegex					= Convert(InKeyRegex);
+	std::optional<String> KeyRegex					= Convert(Regex);
 	std::optional<String> ReferenceType				= Convert(InReferenceType);
 	std::optional<std::vector<String>> ReferenceIds = Convert(InReferenceIds);
 

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -21,7 +21,6 @@
 #include "Common/Encode.h"
 #include "Services/AggregationService/Api.h"
 #include "Systems/ResultHelpers.h"
-#include "Poco/URI.h"
 
 using namespace csp;
 using namespace csp::common;

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -37,7 +37,7 @@ std::shared_ptr<chs::SequenceDto> CreateSequenceDto(const String& SequenceKey,
 													const csp::common::Map<csp::common::String, csp::common::String>& MetaData)
 {
 	auto SequenceInfo = std::make_shared<chs::SequenceDto>();
-	SequenceInfo->SetKey(csp::common::Encode::URI(SequenceKey)); // We encoce the sequence key in order to allow keys to include reserved characters.
+	SequenceInfo->SetKey(csp::common::Encode::URI(SequenceKey)); // We encode the sequence key in order to allow keys to include reserved characters.
 	SequenceInfo->SetReferenceType(ReferenceType);
 	SequenceInfo->SetReferenceId(ReferenceId);
 	SequenceInfo->SetItems(Convert(Items));

--- a/Library/src/Systems/WebService.cpp
+++ b/Library/src/Systems/WebService.cpp
@@ -18,46 +18,6 @@
 #include "Services/ApiBase/ApiBase.h"
 
 
-namespace
-{
-std::map<csp::common::String, csp::systems::ERequestFailureReason> XErrorCodeToFailureReason = {
-	{"join_onbehalfnotallowed", csp::systems::ERequestFailureReason::AddUserToSpaceDenied},
-	{"join_guestnotallowed", csp::systems::ERequestFailureReason::UserSpaceAccessDenied},
-	{"join_userbanned", csp::systems::ERequestFailureReason::UserSpaceBannedAccessDenied},
-	{"join_groupfull", csp::systems::ERequestFailureReason::UserSpaceFullAccessDenied},
-	{"join_groupinviteexpired", csp::systems::ERequestFailureReason::UserSpaceInviteExpired},
-	{"group_duplicatename", csp::systems::ERequestFailureReason::SpacePublicNameDuplicate},
-	{"group_spaceownerquota", csp::systems::ERequestFailureReason::UserMaxSpaceLimitReached},
-	{"user_accountlocked", csp::systems::ERequestFailureReason::UserAccountLocked},
-	{"user_emptypassword", csp::systems::ERequestFailureReason::UserMissingPassword},
-	{"user_emailnotconfirmed", csp::systems::ERequestFailureReason::UserUnverifiedEmail},
-	{"user_bannedfromgroup", csp::systems::ERequestFailureReason::UserBannedFromSpace},
-	{"user_emaildomainnotallowed", csp::systems::ERequestFailureReason::UserInvalidEmailDomain},
-	{"user_sociallogininvalid", csp::systems::ERequestFailureReason::UserInvalidThirdPartyAuth},
-	{"user_agenotverified", csp::systems::ERequestFailureReason::UserAgeNotVerified},
-	{"user_guestlogindisallowed", csp::systems::ERequestFailureReason::UserGuestLoginDisallowed},
-	{"user_tokenrefreshfailed", csp::systems::ERequestFailureReason::UserTokenRefreshFailed},
-	{"prototype_reservedkeysnotallowed", csp::systems::ERequestFailureReason::PrototypeReservedKeysNotAllowed},
-	{"assetdetail_invalidfilecontents", csp::systems::ERequestFailureReason::AssetInvalidFileContents},
-	{"assetdetail_invalidfiletype", csp::systems::ERequestFailureReason::AssetInvalidFileType},
-	{"assetdetail_audiovideoquota", csp::systems::ERequestFailureReason::AssetAudioVideoLimitReached},
-	{"assetdetail_objectcapturequota", csp::systems::ERequestFailureReason::AssetObjectCaptureLimitReached},
-	{"assetdetail_totaluploadsizeinkilobytes", csp::systems::ERequestFailureReason::AssetTotalUploadSizeLimitReached},
-	{"applyticket_unknownticketnumber", csp::systems::ERequestFailureReason::TicketUnknownNumber},
-	{"applyticket_emaildoesntmatch", csp::systems::ERequestFailureReason::TicketEmailMismatch},
-	{"vendoroauthexchange_failuretoexchangecode", csp::systems::ERequestFailureReason::TicketVendorOAuthFailure},
-	{"applyticket_invalidauthtoken", csp::systems::ERequestFailureReason::TicketOAuthTokenInvalid},
-	{"applyticket_alreadyapplied", csp::systems::ERequestFailureReason::TicketAlreadyApplied},
-	{"shopify_vendorconnectionbroken", csp::systems::ERequestFailureReason::ShopifyConnectionBroken},
-	{"shopify_invalidstorename", csp::systems::ERequestFailureReason::ShopifyInvalidStoreName},
-	{"agoraoperation_groupownerquota", csp::systems::ERequestFailureReason::UserAgoraLimitReached},
-	{"openaioperation_userquota", csp::systems::ERequestFailureReason::UserOpenAILimitReached},
-	{"ticketedspaces_userquota", csp::systems::ERequestFailureReason::UserTicketedSpacesLimitReached},
-	{"shopify_userquota", csp::systems::ERequestFailureReason::UserShopifyLimitReached},
-	{"scopes_concurrentusersquota", csp::systems::ERequestFailureReason::UserSpaceConcurrentUsersLimitReached},
-};
-}
-
 namespace csp::systems
 {
 systems::ResultBase::ResultBase() : FailureReason(ERequestFailureReason::None)
@@ -152,9 +112,47 @@ void ResultBase::SetResult(csp::systems::EResultCode ResCode, uint16_t HttpResCo
 
 ERequestFailureReason ResultBase::ParseErrorCode(const csp::common::String& Value)
 {
-	if (XErrorCodeToFailureReason.find(Value) != XErrorCodeToFailureReason.end())
+	static const std::map<csp::common::String, csp::systems::ERequestFailureReason> XErrorCodeToFailureReason = {
+		{"join_onbehalfnotallowed", csp::systems::ERequestFailureReason::AddUserToSpaceDenied},
+		{"join_guestnotallowed", csp::systems::ERequestFailureReason::UserSpaceAccessDenied},
+		{"join_userbanned", csp::systems::ERequestFailureReason::UserSpaceBannedAccessDenied},
+		{"join_groupfull", csp::systems::ERequestFailureReason::UserSpaceFullAccessDenied},
+		{"join_groupinviteexpired", csp::systems::ERequestFailureReason::UserSpaceInviteExpired},
+		{"group_duplicatename", csp::systems::ERequestFailureReason::SpacePublicNameDuplicate},
+		{"group_spaceownerquota", csp::systems::ERequestFailureReason::UserMaxSpaceLimitReached},
+		{"user_accountlocked", csp::systems::ERequestFailureReason::UserAccountLocked},
+		{"user_emptypassword", csp::systems::ERequestFailureReason::UserMissingPassword},
+		{"user_emailnotconfirmed", csp::systems::ERequestFailureReason::UserUnverifiedEmail},
+		{"user_bannedfromgroup", csp::systems::ERequestFailureReason::UserBannedFromSpace},
+		{"user_emaildomainnotallowed", csp::systems::ERequestFailureReason::UserInvalidEmailDomain},
+		{"user_sociallogininvalid", csp::systems::ERequestFailureReason::UserInvalidThirdPartyAuth},
+		{"user_agenotverified", csp::systems::ERequestFailureReason::UserAgeNotVerified},
+		{"user_guestlogindisallowed", csp::systems::ERequestFailureReason::UserGuestLoginDisallowed},
+		{"user_tokenrefreshfailed", csp::systems::ERequestFailureReason::UserTokenRefreshFailed},
+		{"prototype_reservedkeysnotallowed", csp::systems::ERequestFailureReason::PrototypeReservedKeysNotAllowed},
+		{"assetdetail_invalidfilecontents", csp::systems::ERequestFailureReason::AssetInvalidFileContents},
+		{"assetdetail_invalidfiletype", csp::systems::ERequestFailureReason::AssetInvalidFileType},
+		{"assetdetail_audiovideoquota", csp::systems::ERequestFailureReason::AssetAudioVideoLimitReached},
+		{"assetdetail_objectcapturequota", csp::systems::ERequestFailureReason::AssetObjectCaptureLimitReached},
+		{"assetdetail_totaluploadsizeinkilobytes", csp::systems::ERequestFailureReason::AssetTotalUploadSizeLimitReached},
+		{"applyticket_unknownticketnumber", csp::systems::ERequestFailureReason::TicketUnknownNumber},
+		{"applyticket_emaildoesntmatch", csp::systems::ERequestFailureReason::TicketEmailMismatch},
+		{"vendoroauthexchange_failuretoexchangecode", csp::systems::ERequestFailureReason::TicketVendorOAuthFailure},
+		{"applyticket_invalidauthtoken", csp::systems::ERequestFailureReason::TicketOAuthTokenInvalid},
+		{"applyticket_alreadyapplied", csp::systems::ERequestFailureReason::TicketAlreadyApplied},
+		{"shopify_vendorconnectionbroken", csp::systems::ERequestFailureReason::ShopifyConnectionBroken},
+		{"shopify_invalidstorename", csp::systems::ERequestFailureReason::ShopifyInvalidStoreName},
+		{"agoraoperation_groupownerquota", csp::systems::ERequestFailureReason::UserAgoraLimitReached},
+		{"openaioperation_userquota", csp::systems::ERequestFailureReason::UserOpenAILimitReached},
+		{"ticketedspaces_userquota", csp::systems::ERequestFailureReason::UserTicketedSpacesLimitReached},
+		{"shopify_userquota", csp::systems::ERequestFailureReason::UserShopifyLimitReached},
+		{"scopes_concurrentusersquota", csp::systems::ERequestFailureReason::UserSpaceConcurrentUsersLimitReached},
+	};
+
+    const auto Reason = XErrorCodeToFailureReason.find(Value);
+	if (Reason != XErrorCodeToFailureReason.end())
 	{
-		return XErrorCodeToFailureReason[Value];
+		return Reason->second;
 	}
 
 	CSP_LOG_ERROR_FORMAT(

--- a/Tests/src/InternalTests/EncodeTests.cpp
+++ b/Tests/src/InternalTests/EncodeTests.cpp
@@ -45,6 +45,14 @@ CSP_INTERNAL_TEST(CSPEngine, EncodeTests, EncodeURI)
 		csp::common::String DecodedString = csp::common::Decode::URI(EncodedString);
 		EXPECT_EQ(DecodedString, OriginalURL);
 	}
+
+	{
+		// Double encoding and double decoding should produce the same end-result.
+		const csp::common::String OriginalURL("abc defghij*zlmnopqrst#uvwxyz");
+		csp::common::String EncodedString = csp::common::Encode::URI(OriginalURL, true);
+		csp::common::String DecodedString = csp::common::Decode::URI(EncodedString, true);
+		EXPECT_EQ(DecodedString, OriginalURL);
+	}
 }
 
 #endif

--- a/Tests/src/InternalTests/EncodeTests.cpp
+++ b/Tests/src/InternalTests/EncodeTests.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SKIP_INTERNAL_TESTS
+
+#include "TestHelpers.h"
+#include "Common/Encode.h"
+
+#include "gtest/gtest.h"
+
+CSP_INTERNAL_TEST(CSPEngine, EncodeTests, EncodeURI)
+{
+	{
+		// Encoding a string with no reserved characters should produce the same string.
+		const csp::common::String StringWithNoReservedCharacters = "abcdefghijzlmnopqrstuvwxyz";
+		csp::common::String EncodedString = csp::common::Encode::URI(StringWithNoReservedCharacters);
+		EXPECT_EQ(EncodedString, StringWithNoReservedCharacters);
+	}
+
+	{
+		// Encoding a string with reserved characters should produce a version of the string that uses the standard URI character encoding scheme.
+		const csp::common::String StringWithReservedCharacters = " *";
+		csp::common::String EncodedString = csp::common::Encode::URI(StringWithReservedCharacters);
+		EXPECT_NE(EncodedString, StringWithReservedCharacters);
+		EXPECT_EQ(EncodedString, "%20%2A");
+	}
+
+	{
+		// Encoding a string with reserved characters and then decoding it should produce a result equal to the original string.
+		const csp::common::String OriginalURL("abc defghij*zlmnopqrst#uvwxyz");
+		csp::common::String EncodedString = csp::common::Encode::URI(OriginalURL);
+		csp::common::String DecodedString = csp::common::Decode::URI(EncodedString);
+		EXPECT_EQ(DecodedString, OriginalURL);
+	}
+}
+
+#endif

--- a/Tests/src/PublicAPITests/SequenceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceSystemTests.cpp
@@ -243,7 +243,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceTest)
 
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -259,8 +259,25 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceTest)
 				   csp::systems::ERequestFailureReason::None,
 				   200);
 
-	// Delete sequence
-	DeleteSequences(SequenceSystem, {Sequence.Key}, csp::systems::EResultCode::Success, csp::systems::ERequestFailureReason::None, 204);
+	// Create sequence with reserved characters in the sequenceID (which is allowed).
+	const char* TestReservedCharsSequenceKey = "CSP UNITTEST SEQUENCE MAG";
+	char UniqueReservedCharsSequenceName[256];
+	SPRINTF(UniqueReservedCharsSequenceName, "%s-%s", TestReservedCharsSequenceKey, GetUniqueString().c_str());
+
+	csp::systems::Sequence ReservedCharsSequence;
+	CreateSequence(SequenceSystem,
+				   UniqueReservedCharsSequenceName,
+				   "GroupId",
+				   Space.Id,
+				   SequenceItems,
+				   {},
+				   ReservedCharsSequence,
+				   csp::systems::EResultCode::Success,
+				   csp::systems::ERequestFailureReason::None,
+				   200);
+
+	// Delete sequences
+	DeleteSequences(SequenceSystem, {Sequence.Key, ReservedCharsSequence.Key}, csp::systems::EResultCode::Success, csp::systems::ERequestFailureReason::None, 204);
 
 	// Delete space
 	DeleteSpace(SpaceSystem, Space.Id);
@@ -294,8 +311,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceInvalidKeyTest)
 	csp::systems::Space Space;
 	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
 
-	// Any attempt to get a sequence with key containing an invalid character
-	// Space, / or % will result in a failure
+	// Any attempt to get a sequence with key containing an / or % will result in a failure.
 	// Create sequence with / character
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
 	const char* TestSequenceKey = "CSP-UNITTEST/SEQUENCE-MAG";
@@ -313,20 +329,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceInvalidKeyTest)
 				   csp::systems::EResultCode::Failed,
 				   csp::systems::ERequestFailureReason::InvalidSequenceKey,
 				   0);
-	// Create sequence with a space in the name
-	const char* TestSequenceKeySpace = "CSP-UNITTEST SEQUENCE-MAG";
-	char UniqueSequenceNameSpace[256];
-	SPRINTF(UniqueSequenceNameSpace, "%s-%s", TestSequenceKeySpace, GetUniqueString().c_str());
-	CreateSequence(SequenceSystem,
-				   UniqueSequenceNameSpace,
-				   "GroupId",
-				   Space.Id,
-				   SequenceItems,
-				   {},
-				   Sequence,
-				   csp::systems::EResultCode::Failed,
-				   csp::systems::ERequestFailureReason::InvalidSequenceKey,
-				   0);
+
 	// Create sequence with % in the name
 	const char* TestSequenceKeyMod = "CSP-UNITTEST%SEQUENCE-MAG";
 	char UniqueSequenceNameMod[256];
@@ -376,7 +379,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoItemsTest)
 
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems;
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -410,7 +413,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoSpaceTest)
 
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -451,7 +454,11 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceTest)
 
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+
+	// Note that the sequence key uses reserved characters.
+	// We expect CSP to correctly handle the encoding and decoding of these characters for us.
+	const char* TestSequenceKey = "**CSP UNITTEST SEQUENCE MAG**";
+
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -500,8 +507,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceInvalidKeyTest)
 
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
 
-	// Any attempt to get a sequence with key containing an invalid character
-	// Space, / or % will result in a failure
+	// Any attempt to get a sequence with key containing an / or % will result in a failure.
 
 	// Get sequence with invalid / key
 	const char* TestSequenceKey = "CSP-UNITTEST/SEQUENCE-MAG";
@@ -516,17 +522,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceInvalidKeyTest)
 				csp::systems::EResultCode::Failed,
 				csp::systems::ERequestFailureReason::InvalidSequenceKey,
 				0);
-	// get sequence with invalid space key
-	const char* TestSequenceKeySpace = "CSP-UNITTEST SEQUENCE-MAG";
-	char UniqueSequenceNameSpace[256];
-	SPRINTF(UniqueSequenceNameSpace, "%s-%s", TestSequenceKeySpace, Unique.c_str());
 
-	GetSequence(SequenceSystem,
-				UniqueSequenceNameSpace,
-				RetrievedSequence,
-				csp::systems::EResultCode::Failed,
-				csp::systems::ERequestFailureReason::InvalidSequenceKey,
-				0);
 	// get sequence with invalid % key
 	const char* TestSequenceKeyMod = "CSP-UNITTEST%SEQUENCE-MAG";
 	char UniqueSequenceNameMod[256];
@@ -572,7 +568,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, UpdateSequenceTest)
 
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -637,10 +633,10 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, UpdateSequenceInvalidKeyTest)
 	// Update sequence
 	csp::common::Array<csp::common::String> UpdatedSequenceItems {"Hotspot4", "Hotspot5"};
 
-	// Any attempt to get a sequence with key containing an invalid character
-	// Space, / or % will result in a failure
+	// Any attempt to get a sequence with key containing an / or % will result in a failure
 	csp::systems::Sequence UpdatedSequence;
 	MetaData["Foo"] = "Bar";
+
 	// Verify cannot update sequence with a key that contains /
 	UpdateSequence(SequenceSystem,
 				   UniqueSequenceName,
@@ -652,17 +648,8 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, UpdateSequenceInvalidKeyTest)
 				   csp::systems::EResultCode::Failed,
 				   csp::systems::ERequestFailureReason::InvalidSequenceKey,
 				   0);
-	// Verify cannot update sequence with a key that contains a space
-	UpdateSequence(SequenceSystem,
-				   UniqueSequenceNameSpace,
-				   "GroupId",
-				   Space.Id,
-				   UpdatedSequenceItems,
-				   MetaData,
-				   UpdatedSequence,
-				   csp::systems::EResultCode::Failed,
-				   csp::systems::ERequestFailureReason::InvalidSequenceKey,
-				   0);
+
+
 	// Verify cannot update sequence with a key that contains %
 	UpdateSequence(SequenceSystem,
 				   UniqueSequenceNameMod,
@@ -710,7 +697,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceTest)
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
 
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -718,7 +705,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceTest)
 	CreateSequence(SequenceSystem, UniqueSequenceName, "GroupId", Space.Id, SequenceItems, {}, Sequence);
 
 	// Rename sequence
-	const char* TestUpdatedSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG-UPDATED";
+	const char* TestUpdatedSequenceKey = "*CSP UNITTEST SEQUENCE MAG*-UPDATED";
 	char UniqueUpdatedSequenceName[256];
 	SPRINTF(UniqueUpdatedSequenceName, "%s-%s", TestUpdatedSequenceKey, GetUniqueString().c_str());
 
@@ -763,7 +750,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceInvalidKeyTest)
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
 
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -772,8 +759,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceInvalidKeyTest)
 	std::string UniqueString = GetUniqueString();
 
 
-	// Any attempt to get a sequence with key containing an invalid character
-	// Space, / or % will result in a failure
+	// Any attempt to get a sequence with key containing an / or % will result in a failure
 	// Rename sequence
 	const char* TestUpdatedSequenceKey = "CSP-UNITTEST/SEQUENCE-MAG-UPDATED";
 	char UniqueUpdatedSequenceName[256];
@@ -797,14 +783,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceInvalidKeyTest)
 				   csp::systems::EResultCode::Failed,
 				   csp::systems::ERequestFailureReason::InvalidSequenceKey,
 				   0);
-	// sequence name with a space fails
-	RenameSequence(SequenceSystem,
-				   UniqueSequenceName,
-				   UniqueUpdatedSequenceNameSpace,
-				   UpdatedSequence,
-				   csp::systems::EResultCode::Failed,
-				   csp::systems::ERequestFailureReason::InvalidSequenceKey,
-				   0);
+
 	// sequence name with a % fails
 	RenameSequence(SequenceSystem,
 				   UniqueSequenceName,
@@ -813,8 +792,6 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceInvalidKeyTest)
 				   csp::systems::EResultCode::Failed,
 				   csp::systems::ERequestFailureReason::InvalidSequenceKey,
 				   0);
-
-
 
 	// Delete sequence
 	DeleteSequences(SequenceSystem, {UniqueSequenceName}, csp::systems::EResultCode::Success, csp::systems::ERequestFailureReason::None, 204);
@@ -853,7 +830,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaTest)
 
 	// Create sequences
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -861,7 +838,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaTest)
 	CreateSequence(SequenceSystem, UniqueSequenceName, "Group1", Space.Id, SequenceItems, {}, Sequence);
 
 	csp::common::Array<csp::common::String> SequenceItems2 {"Hotspot4", "Hotspot5", "Hotspot6"};
-	const char* TestSequenceKey2 = "CSP-UNITTEST-SEQUENCE-MAG2";
+	const char* TestSequenceKey2 = "*CSP UNITTEST SEQUENCE MAG*2";
 	char UniqueSequenceName2[256];
 	SPRINTF(UniqueSequenceName2, "%s-%s", TestSequenceKey2, GetUniqueString().c_str());
 
@@ -961,8 +938,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaInvalidKey
 	char UniqueSequenceNameMod[256];
 	SPRINTF(UniqueSequenceNameMod, "%s-%s", TestSequenceKeyMod, GetUniqueString().c_str());
 
-	// Any attempt to get a sequence with key containing an invalid character
-	// Space, / or % will result in a failure
+	// Any attempt to get a sequence with key containing an / or % will result in a failure.
 	// verify get fails when using a key name with a / character
 	GetSequencesByCriteria(SequenceSystem,
 						   {UniqueSequenceName},
@@ -973,16 +949,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaInvalidKey
 						   csp::systems::EResultCode::Failed,
 						   csp::systems::ERequestFailureReason::InvalidSequenceKey,
 						   0);
-	// verify get fails when using a key name with a space character
-	GetSequencesByCriteria(SequenceSystem,
-						   {UniqueSequenceNameSpace},
-						   nullptr,
-						   nullptr,
-						   {},
-						   RetrievedSequences,
-						   csp::systems::EResultCode::Failed,
-						   csp::systems::ERequestFailureReason::InvalidSequenceKey,
-						   0);
+
 	// verify get fails when using a key name with a % character
 	GetSequencesByCriteria(SequenceSystem,
 						   {UniqueSequenceNameMod},
@@ -1033,7 +1000,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RegisterSequenceUpdatedTest)
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
 
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -1054,7 +1021,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RegisterSequenceUpdatedTest)
 	EXPECT_TRUE(CallbackCalled);
 
 	// Rename sequence
-	const char* TestUpdatedSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG-UPDATED";
+	const char* TestUpdatedSequenceKey = "*CSP UNITTEST SEQUENCE MAG*-UPDATED";
 	char UniqueUpdatedSequenceName[256];
 	SPRINTF(UniqueUpdatedSequenceName, "%s-%s", TestUpdatedSequenceKey, GetUniqueString().c_str());
 
@@ -1131,7 +1098,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, SequencePermissionsTest)
 	// Create sequence
 	csp::common::Array<csp::common::String> SequenceItems {"Hotspot1", "Hotspot2", "Hotspot3"};
 
-	const char* TestSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG";
+	const char* TestSequenceKey = "*CSP UNITTEST SEQUENCE MAG*";
 	char UniqueSequenceName[256];
 	SPRINTF(UniqueSequenceName, "%s-%s", TestSequenceKey, GetUniqueString().c_str());
 
@@ -1166,7 +1133,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, SequencePermissionsTest)
 				   403);
 
 	// Rename sequence
-	const char* TestUpdatedSequenceKey = "CSP-UNITTEST-SEQUENCE-MAG-UPDATED";
+	const char* TestUpdatedSequenceKey = "*CSP UNITTEST SEQUENCE MAG*-UPDATED";
 	char UniqueUpdatedSequenceName[256];
 	SPRINTF(UniqueUpdatedSequenceName, "%s-%s", TestUpdatedSequenceKey, GetUniqueString().c_str());
 


### PR DESCRIPTION
CSP client applications can now reason about sequence keys that include characters usually reserved in URIs, such as spaces.

As part of this work, we have introduced a new set of encoding source files for future encode/decode behaviour.

During development, we discovered that there are some service endpoints currently expecting the provided keys to be _doubly_ encoded. The current approach takes this into account and double-encodes where necessary from a services point of view.