### PR TITLE
[OB-3719] fix: static initialization

### DIFF
--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -69,9 +69,14 @@ void HotspotSpaceComponent::SetIsSpawnPoint(bool Value)
 
 const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
 {
-	static csp::common::String UniqueComponentId = std::to_string(Parent->GetId()).c_str();
-	UniqueComponentId += ":";
-	UniqueComponentId += std::to_string(Id).c_str();
+	static csp::common::String UniqueComponentId;
+
+	if (UniqueComponentId.Length() == 0)
+	{
+		UniqueComponentId = std::to_string(Parent->GetId()).c_str();
+		UniqueComponentId += ":";
+		UniqueComponentId += std::to_string(Id).c_str();
+	}
 
 	return UniqueComponentId;
 }

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -110,6 +110,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 
 	EXPECT_EQ(HotspotUniqueComponentId, UniqueComponentId);
 
+	// Test again to ensure internal static variable is set correctly
+	const csp::common::String& HotspotUniqueComponentId2 = HotspotComponent->GetUniqueComponentId();
+
+	EXPECT_EQ(HotspotUniqueComponentId2, UniqueComponentId);
+
 	// Set new values
 
 	HotspotComponent->SetPosition(csp::common::Vector3::One());


### PR DESCRIPTION
- Internal static component id now checks if it has been initialized to prevent it concantinating
- Test has been updates to test for this case