### PR TITLE
[NT-0] fix: hotspot unique ID accessor

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -80,7 +80,7 @@ public:
 	/// @brief Gets a unique identifier for this component in the hierarchy.
 	/// @note This does not give a complete hierarchy path, only the entityId of the parent for the component.
 	/// @return A string composed of 'parentId:componentId'.
-	const csp::common::String& GetUniqueComponentId() const;
+	csp::common::String GetUniqueComponentId() const;
 
 	/// \addtogroup IPositionComponent
 	/// @{

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -67,7 +67,7 @@ void HotspotSpaceComponent::SetIsSpawnPoint(bool Value)
 	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint), Value);
 }
 
-const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
+csp::common::String HotspotSpaceComponent::GetUniqueComponentId() const
 {
 	csp::common::String UniqueComponentId = std::to_string(Parent->GetId()).c_str();
 	UniqueComponentId += ":";

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -106,12 +106,12 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 	UniqueComponentId += ":";
 	UniqueComponentId += std::to_string(HotspotComponent->GetId()).c_str();
 
-	const csp::common::String& HotspotUniqueComponentId = HotspotComponent->GetUniqueComponentId();
+	const csp::common::String HotspotUniqueComponentId = HotspotComponent->GetUniqueComponentId();
 
 	EXPECT_EQ(HotspotUniqueComponentId, UniqueComponentId);
 
 	// Test again to ensure getter works with multiple calls.
-	const csp::common::String& HotspotUniqueComponentId2 = HotspotComponent->GetUniqueComponentId();
+	const csp::common::String HotspotUniqueComponentId2 = HotspotComponent->GetUniqueComponentId();
 
 	EXPECT_EQ(HotspotUniqueComponentId2, UniqueComponentId);
 


### PR DESCRIPTION
The function was returning a reference to a string local variable declared in the function.

Fixed by returning by value instead.