### PR TITLE
[nt-0] fix: remove missing submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,12 +8,6 @@
 [submodule "modules/mimalloc"]
 	path = modules/mimalloc
 	url = https://github.com/microsoft/mimalloc
-[submodule "modules/msgpack"]
-	path = modules/msgpack
-	url = https://github.com/msgpack/msgpack-c
-[submodule "modules/openssl"]
-	path = modules/openssl
-	url = https://github.com/openssl/openssl
 [submodule "modules/poco"]
 	path = modules/poco
 	url = https://github.com/pocoproject/poco


### PR DESCRIPTION
`modules/msgpack` and `modules/openssl` don't have corresponding `gitlink`s so their entries in `.gitmodules` are incorrect

Further discussion in [this Slack thread](https://magnopus.slack.com/archives/C037VC209QT/p1728074303456579)