### PR TITLE
CSP 5.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ ARM64/*
 **/node_modules/**
 *.log
 *.npmrc
+app.config
 
 # Allows Project files for Examples
 !/Examples/**/**.sln

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,12 +8,6 @@
 [submodule "modules/mimalloc"]
 	path = modules/mimalloc
 	url = https://github.com/microsoft/mimalloc
-[submodule "modules/msgpack"]
-	path = modules/msgpack
-	url = https://github.com/msgpack/msgpack-c
-[submodule "modules/openssl"]
-	path = modules/openssl
-	url = https://github.com/openssl/openssl
 [submodule "modules/poco"]
 	path = modules/poco
 	url = https://github.com/pocoproject/poco

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -78,6 +78,7 @@ class CSP_API ComponentBase
 	CSP_START_IGNORE
 	/** @cond DO_NOT_DOCUMENT */
 	friend class SpaceEntity;
+	friend class SpaceEntitySystem;
 	friend class EntityScriptInterface;
 #ifdef CSP_TESTS
 	friend class ::CSPEngine_SerialisationTests_SpaceEntityUserSignalRSerialisationTest_Test;
@@ -165,7 +166,14 @@ protected:
 
 	virtual void SetPropertyFromPatch(uint32_t Key, const ReplicatedValue& Value);
 
+	// Called whenever an entity is removed from the system.
+	// Used to shutdown any behaviour managed by the entity.
 	virtual void OnRemove();
+
+	// Called when the component is locally deleted from the space,
+	// or the entity the component is attached to is locally deleted.
+	// Used for handling behaviour when a client first deletes the component.
+	virtual void OnLocalDelete();
 
 	CSP_START_IGNORE
 	void SetScriptInterface(ComponentScriptInterface* ScriptInterface);

--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -25,6 +25,7 @@
 #include "CSP/Multiplayer/Components/Interfaces/IPositionComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IRotationComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
+#include "CSP/Systems/SystemsResult.h"
 
 
 namespace csp::multiplayer
@@ -109,6 +110,9 @@ public:
 	/// @copydoc IVisibleComponent::SetIsARVisible()
 	void SetIsARVisible(bool InValue) override;
 	/// @}
+
+private:
+	void OnLocalDelete() override;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -80,7 +80,7 @@ public:
 	/// @brief Gets a unique identifier for this component in the hierarchy.
 	/// @note This does not give a complete hierarchy path, only the entityId of the parent for the component.
 	/// @return A string composed of 'parentId:componentId'.
-	const csp::common::String& GetUniqueComponentId() const;
+	csp::common::String GetUniqueComponentId() const;
 
 	/// \addtogroup IPositionComponent
 	/// @{

--- a/Library/include/CSP/Multiplayer/EventParameters.h
+++ b/Library/include/CSP/Multiplayer/EventParameters.h
@@ -96,7 +96,8 @@ enum class ESequenceUpdateType
 	Create,
 	Update,
     Rename,
-	Delete
+	Delete,
+    Invalid
 };
 
 class CSP_API SequenceChangedParams
@@ -123,6 +124,22 @@ public:
 
 	/// @brief True if this is the root hierarchy.
 	bool IsRoot;
+};
+
+class CSP_API SequenceHotspotChangedParams
+{
+public:
+	/// @brief The type of update to the sequence.
+	ESequenceUpdateType UpdateType;
+
+    /// @brief The unique identifier of the space that this hotspot sequence belongs to.
+	csp::common::String SpaceId;
+
+	/// @brief The name of the hotspot group that has been changed.
+	csp::common::String Name;
+
+	/// @brief If a hotspot sequence is renamed, this will be the new name.
+	csp::common::String NewName;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -125,6 +125,9 @@ public:
 	// Callback to receive sequence changes, contains a SequenceChangedParams with the details.
 	typedef std::function<void(const SequenceChangedParams&)> SequenceChangedCallbackHandler;
 
+	// Callback to receive hotspot sequence changes, contains a SequenceHotspotChangedParams with the details.
+	typedef std::function<void(const SequenceHotspotChangedParams&)> HotspotSequenceChangedCallbackHandler;
+
 	/// @brief Sends a network event by EventName to all currently connected clients.
 	/// @param EventName csp::common::String : The identifying name for the event.
 	/// @param Args csp::common::Array<ReplicatedValue> : An array of arguments (ReplicatedValue) to be passed as part of the event payload.
@@ -171,6 +174,10 @@ public:
 	/// @brief Sets a callback for a sequence changed event.
 	/// @param Callback SequenceChangedCallbackHandler: Callback to receive data for the sequence that has been changed.
 	CSP_EVENT void SetSequenceChangedCallback(SequenceChangedCallbackHandler Callback);
+
+	/// @brief Sets a callback to be fired when a hotspot sequence is changed.
+	/// @param Callback HotspotSequenceChangedCallbackHandler: Callback to receive data for the hotspot sequence that has been changed.
+	CSP_EVENT void SetHotspotSequenceChangedCallback(HotspotSequenceChangedCallbackHandler Callback);
 
 	/// @brief Registers a callback to listen for the named event.
 	/// @param EventName csp::common::String : The identifying name for the event to listen for.
@@ -257,7 +264,9 @@ private:
 	AssetDetailBlobChangedCallbackHandler AssetDetailBlobChangedCallback;
 	ConversationSystemCallbackHandler ConversationSystemCallback;
 	UserPermissionsChangedCallbackHandler UserPermissionsChangedCallback;
+
 	SequenceChangedCallbackHandler SequenceChangedCallback;
+    HotspotSequenceChangedCallbackHandler HotspotSequenceChangedCallback;
 
 	// TODO: Replace these with pointers! We can't use STL containers as class fields due to the fact that the class size will
 	//   change depending on which runtime is used.

--- a/Library/include/CSP/Systems/HotspotSequence/HotspotSequenceSystem.h
+++ b/Library/include/CSP/Systems/HotspotSequence/HotspotSequenceSystem.h
@@ -98,6 +98,12 @@ public:
 	CSP_ASYNC_RESULT void DeleteHotspotGroup(const csp::common::String& GroupName, NullResultCallback Callback);
 	~HotspotSequenceSystem();
 
+	/// @brief This will delete any groups which only contain this item
+	/// For any groups which contanin the given item and additional items, it will just update the group by removing the given item.
+	/// @param ItemName csp::common::String : An item to update all sequences containing.
+	/// @param Callback NullResultCallback : callback to call when a response is received
+	CSP_ASYNC_RESULT void RemoveItemFromGroups(const csp::common::String& ItemName, csp::systems::NullResultCallback Callback);
+
 private:
 	HotspotSequenceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
 	csp::systems::SequenceSystem* SequenceSystem;

--- a/Library/include/CSP/Systems/Sequence/SequenceSystem.h
+++ b/Library/include/CSP/Systems/Sequence/SequenceSystem.h
@@ -107,6 +107,16 @@ public:
 												 const csp::common::Map<csp::common::String, csp::common::String>& MetaData,
 												 SequencesResultCallback Callback);
 
+	/// @brief Finds all sequences that contain the given items
+	/// @param Items csp::common::Array<csp::common::String> : An array of items which should be searched for
+	/// @param ReferenceType csp::common::String : The type of reference (GroupId etc.). Must be used with ReferenceIds
+	/// @param ReferenceIds csp::common::Array<csp::common::String> : The ids of the reference. Must be used with ReferenceType
+	/// @param Callback SequencesResultCallback : callback to call when a response is received
+	CSP_ASYNC_RESULT void GetAllSequencesContainingItems(const csp::common::Array<csp::common::String>& Items,
+														 const csp::common::Optional<csp::common::String>& ReferenceType,
+														 const csp::common::Array<csp::common::String>& ReferenceIds,
+														 SequencesResultCallback Callback);
+
 	/// @brief Gets a sequence by it's key
 	/// @note This call will fail (Reason InvalidSequenceKey) if the SequenceKey parameter contains invalid keys, such as spaces, '/' or '%'
 	/// @param SequenceKey csp::common::String : The unique grouping name

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -233,6 +233,10 @@ SpaceEntity* ComponentBase::GetParent()
 	return Parent;
 }
 
+void ComponentBase::OnLocalDelete()
+{
+}
+
 void ComponentBase::SetScriptInterface(ComponentScriptInterface* InScriptInterface)
 {
 	ScriptInterface = InScriptInterface;

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -67,7 +67,7 @@ void HotspotSpaceComponent::SetIsSpawnPoint(bool Value)
 	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint), Value);
 }
 
-const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
+csp::common::String HotspotSpaceComponent::GetUniqueComponentId() const
 {
 	csp::common::String UniqueComponentId = std::to_string(Parent->GetId()).c_str();
 	UniqueComponentId += ":";

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -69,7 +69,7 @@ void HotspotSpaceComponent::SetIsSpawnPoint(bool Value)
 
 const csp::common::String& HotspotSpaceComponent::GetUniqueComponentId() const
 {
-	static csp::common::String UniqueComponentId = std::to_string(Parent->GetId()).c_str();
+	csp::common::String UniqueComponentId = std::to_string(Parent->GetId()).c_str();
 	UniqueComponentId += ":";
 	UniqueComponentId += std::to_string(Id).c_str();
 

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -16,6 +16,8 @@
 #include "CSP/Multiplayer/Components/HotspotSpaceComponent.h"
 
 #include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/HotspotSequence/HotspotSequenceSystem.h"
+#include "CSP/Systems/SystemsManager.h"
 #include "Debug/Logging.h"
 #include "Memory/Memory.h"
 #include "Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h"
@@ -121,4 +123,15 @@ void HotspotSpaceComponent::SetIsARVisible(bool Value)
 {
 	SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible), Value);
 }
+
+void HotspotSpaceComponent::OnLocalDelete()
+{
+	auto CB = [](const csp::systems::NullResult& Result)
+	{
+
+	};
+
+	systems::SystemsManager::Get().GetHotspotSequenceSystem()->RemoveItemFromGroups(GetUniqueComponentId(), CB);
+}
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/EventSerialisation.cpp
+++ b/Library/src/Multiplayer/EventSerialisation.cpp
@@ -28,26 +28,38 @@ namespace
 {
 ESequenceUpdateType ESequenceUpdateIntToUpdateType(uint64_t UpdateType)
 {
-	if (UpdateType == 0)
-	{
-		return ESequenceUpdateType::Create;
-	}
-	else if (UpdateType == 1)
-	{
-		return ESequenceUpdateType::Update;
-	}
-	else if (UpdateType == 2)
-	{
-		return ESequenceUpdateType::Rename;
-	}
-	else if (UpdateType == 3)
-	{
-		return ESequenceUpdateType::Delete;
-	}
-	else
-	{
-		CSP_LOG_ERROR_MSG("SequenceChangedEvent - Detected an unsupported update type.");
-	}
+    ESequenceUpdateType SequenceUpdateType = ESequenceUpdateType::Invalid;
+
+    switch(UpdateType)
+    {
+    	case 0:
+    	{
+            SequenceUpdateType = ESequenceUpdateType::Create;
+    		break;
+    	}
+        case 1:
+    	{
+            SequenceUpdateType = ESequenceUpdateType::Update;
+    		break;
+    	}
+        case 2:
+    	{
+            SequenceUpdateType = ESequenceUpdateType::Rename;
+    		break;
+    	}
+        case 3:
+    	{
+            SequenceUpdateType = ESequenceUpdateType::Delete;
+    		break;
+    	}
+    	default:
+    	{
+            CSP_LOG_ERROR_MSG("SequenceChangedEvent - Detected an unsupported update type.");
+    		break;
+    	}
+    }
+
+    return SequenceUpdateType;
 }
 
 std::string RemoveIdPrefix(const std::string& Id)
@@ -60,13 +72,20 @@ std::string RemoveIdPrefix(const std::string& Id)
 	return Id;
 }
 
+csp::common::String DecodeSequenceKey(csp::multiplayer::ReplicatedValue& RawValue)
+{
+	// Sequence keys are URI encoded to support reserved characters.
+	return csp::common::Decode::URI(RawValue.GetString());
+}
+
 } // namespace
 
-csp::common::String csp::multiplayer::GetSequenceKeyIndex(const csp::common::String& SequenceKey, int i)
+csp::common::String csp::multiplayer::GetSequenceKeyIndex(const csp::common::String& SequenceKey, unsigned int Index)
 {
 	const std::string SequenceKeyString(SequenceKey.c_str());
-	// Match item after second ':' to get our parent id
-	const std::regex Expression("^(?:[^:]*\:){" + std::to_string(i) + "}([^:]*)");
+	// Match item after second ':' to get our parent Id.
+    // See CreateKey in HotSpotSequenceSystem for more info on the pattern.
+	const std::regex Expression("^(?:[^:]*\:){" + std::to_string(Index) + "}([^:]*)");
 	std::smatch Match;
 	const bool Found = std::regex_search(std::begin(SequenceKeyString), std::end(SequenceKeyString), Match, Expression);
 
@@ -104,7 +123,6 @@ void EventDeserialiser::ParseCommon(const std::vector<signalr::value>& EventValu
 	EventType	   = (csp::common::String) EventValues[0].as_string().c_str();
 	SenderClientId = EventValues[1].as_uinteger();
 }
-
 
 void EventDeserialiser::Parse(const std::vector<signalr::value>& EventValues)
 {
@@ -339,7 +357,7 @@ void csp::multiplayer::SequenceChangedEventDeserialiser::Parse(const std::vector
 
 	EventParams.UpdateType = ESequenceUpdateIntToUpdateType(UpdateType);
 
-	EventParams.Key = csp::common::Decode::URI(EventData[1].GetString());
+	EventParams.Key = DecodeSequenceKey(EventData[1]);
 
 	// Optional parameter for when a key is changed
 	if (EventData[2].GetReplicatedValueType() == ReplicatedValueType::String)
@@ -362,9 +380,7 @@ void csp::multiplayer::SequenceHierarchyChangedEventDeserialiser::Parse(const st
 	int64_t UpdateType	   = EventData[0].GetInt();
 	EventParams.UpdateType = ESequenceUpdateIntToUpdateType(UpdateType);
 
-    // Sequence keys are URI encoded to support reserved characters.
-	csp::common::String Key	   = csp::common::Decode::URI(EventData[1].GetString());
-
+    const csp::common::String Key = DecodeSequenceKey(EventData[1]);
 	std::string ParentIdString = GetSequenceKeyIndex(Key, 2).c_str();
 	csp::common::Optional<uint64_t> ParentId;
 
@@ -383,5 +399,38 @@ void csp::multiplayer::SequenceHierarchyChangedEventDeserialiser::Parse(const st
 	{
 		EventParams.IsRoot	 = true;
 		EventParams.ParentId = 0;
+	}
+}
+
+void SequenceHotspotChangedEventDeserialiser::Parse(const std::vector<signalr::value>& EventValues)
+{
+	EventDeserialiser::Parse(EventValues);
+
+	if (EventData.Size() != 3)
+	{
+		CSP_LOG_ERROR_FORMAT("SequenceHotspotChangedEvent - Invalid arguments. Expected 3 arguments but got %i.", EventData.Size());
+		return;
+	}
+
+	int64_t UpdateType	   = EventData[0].GetInt();
+	EventParams.UpdateType = ESequenceUpdateIntToUpdateType(UpdateType);
+
+    const csp::common::String Key = DecodeSequenceKey(EventData[1]);
+    EventParams.SpaceId = GetSequenceKeyIndex(Key, 1);
+    EventParams.Name = GetSequenceKeyIndex(Key, 2);
+    
+    if (EventParams.UpdateType == ESequenceUpdateType::Rename)
+	{
+        // When a key is changed (renamed) then we get an additional parameter describing the new key.
+        // The usual event data describing the name in this instance will describe the _old_ key.
+		if(EventData[2].GetReplicatedValueType() == ReplicatedValueType::String)
+		{
+            const csp::common::String NewKey = DecodeSequenceKey(EventData[2]);
+			EventParams.NewName = GetSequenceKeyIndex(NewKey, 2);
+		}
+        else
+        {
+	        CSP_LOG_ERROR_MSG("SequenceHotspotChangedEvent - The expected new name of the hotspot sequence was not found in the event payload.");
+        }
 	}
 }

--- a/Library/src/Multiplayer/EventSerialisation.h
+++ b/Library/src/Multiplayer/EventSerialisation.h
@@ -26,7 +26,7 @@
 namespace csp::multiplayer
 {
 
-csp::common::String GetSequenceKeyIndex(const csp::common::String& SequenceKey, int i);
+csp::common::String GetSequenceKeyIndex(const csp::common::String& SequenceKey, unsigned int Index);
 
 // Generic deserialiser for multiplayer events. It can be derived from and
 // its behaviour can be overridden if specialised handling is needed for
@@ -129,7 +129,7 @@ private:
 };
 
 /// A deserialiser for getting SequenceHierarchy data from an event:
-/// UpdateType - The update type for the Sequence Hierarchy: Created, Updated, Deleted
+/// UpdateType - The update type for the Sequence Hierarchy: Create, Update, Rename, Delete
 /// ParentId - The parent id of the Sequence
 /// IsRoot - Whether this is the root hierarchy of the space
 class SequenceHierarchyChangedEventDeserialiser : public EventDeserialiser
@@ -144,6 +144,25 @@ public:
 
 private:
 	SequenceHierarchyChangedParams EventParams;
+};
+
+/// A deserialiser for getting SequenceHotspot data from an event:
+/// UpdateType - The update type for the Sequence Hierarchy: Create, Update, Rename, Delete
+/// SpaceId - The unique identifer of the space this hotspot sequence relates to.
+/// Name - The name of the hotspot which has been changed.
+/// NewName - In the case of renames, describes the new name of the sequence.
+class SequenceHotspotChangedEventDeserialiser : public EventDeserialiser
+{
+public:
+	virtual void Parse(const std::vector<signalr::value>& EventValues) override;
+
+	const SequenceHotspotChangedParams& GetEventParams() const
+	{
+		return EventParams;
+	}
+
+private:
+	SequenceHotspotChangedParams EventParams;
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -1020,6 +1020,9 @@ void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback)
 			{
 				if (Components.HasKey(TransientDeletionComponentIds[i]))
 				{
+					ComponentBase* Component = GetComponent(TransientDeletionComponentIds[i]);
+					Component->OnLocalDelete();
+
 					DestroyComponent(TransientDeletionComponentIds[i]);
 
 					// Start indexing from the end of the section reserved for DirtyComponents.

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -378,6 +378,18 @@ void SpaceEntitySystem::DestroyEntity(SpaceEntity* Entity, CallbackHandler Callb
 														  },
 														  Components};
 
+
+	auto EntityComponents = Entity->GetComponents();
+	auto Keys			  = EntityComponents->Keys();
+
+	for (size_t i = 0; i < Keys->Size(); ++i)
+	{
+		auto EntityComponent = Entity->GetComponent((*Keys)[i]);
+		EntityComponent->OnLocalDelete();
+	}
+
+	CSP_DELETE(Keys);
+
 	// We break the usual pattern of not considering local state to be true until we get the ack back from CHS here
 	// and instead immediately delete the local view of the entity before issuing the delete for the remote view.
 	// We do this so that clients can immediately respond to the deletion and avoid sending further updates for the
@@ -1163,7 +1175,8 @@ void SpaceEntitySystem::GetAllSequenceHierarchies(SequenceHierarchyCollectionRes
 	};
 
 	auto SequenceSystem = csp::systems::SystemsManager::Get().GetSequenceSystem();
-	SequenceSystem->GetSequencesByCriteria({}, csp::multiplayer::SequenceConstants::GetHierarchyName(), "GroupId", {SpaceId}, {}, GetSequencesCallback);
+	SequenceSystem
+		->GetSequencesByCriteria({}, csp::multiplayer::SequenceConstants::GetHierarchyName(), "GroupId", {SpaceId}, {}, GetSequencesCallback);
 }
 
 void SpaceEntitySystem::DeleteSequenceHierarchy(const csp::common::Optional<uint64_t>& ParentId, systems::NullResultCallback Callback)

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -127,10 +127,10 @@ void SequenceSystem::RenameSequence(const String& OldSequenceKey, const String& 
 		= SequenceAPI->CreateHandler<SequenceResultCallback, SequenceResult, void, chs::SequenceDto>(Callback, nullptr);
 
 	static_cast<chs::SequenceApi*>(SequenceAPI)
-		->apiV1SequencesKeysOldKeyKeyPut(csp::common::Encode::URI(OldSequenceKey, true),    // OldKey, URI-encoded to support reserved characters.
-										 csp::common::Encode::URI(NewSequenceKey),          // NewKey, URI-encoded to support reserved characters.
-										 ResponseHandler,			                        // ResponseHandler
-										 CancellationToken::Dummy()                         // CancellationToken
+		->apiV1SequencesKeysOldKeyKeyPut(csp::common::Encode::URI(OldSequenceKey, true), // OldKey, URI-encoded to support reserved characters.
+										 csp::common::Encode::URI(NewSequenceKey),		 // NewKey, URI-encoded to support reserved characters.
+										 ResponseHandler,								 // ResponseHandler
+										 CancellationToken::Dummy()						 // CancellationToken
 		);
 }
 
@@ -153,16 +153,16 @@ void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys,
 			return;
 		}
 
-        // We URI-encode sequence keys to support reserved characters.
-        EncodedSequenceKeys[i] = csp::common::Encode::URI(InSequenceKeys[i]);
+		// We URI-encode sequence keys to support reserved characters.
+		EncodedSequenceKeys[i] = csp::common::Encode::URI(InSequenceKeys[i]);
 	}
 
-    // Regexes may also include reserved characters which require encoding.
-    Optional<String> Regex;
-    if(InKeyRegex.HasValue())
-    {
+	// Regexes may also include reserved characters which require encoding.
+	Optional<String> Regex;
+	if (InKeyRegex.HasValue())
+	{
 		Regex = csp::common::Encode::URI(*InKeyRegex);
-    }
+	}
 
 	if (InReferenceType.HasValue() && InReferenceIds.IsEmpty() || !InReferenceIds.IsEmpty() && !InReferenceType.HasValue())
 	{
@@ -184,6 +184,34 @@ void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys,
 							KeyRegex,				   // Regex
 							ReferenceType,			   // ReferenceType
 							ReferenceIds,			   // ReferenceIds
+							std::nullopt,			   // Items
+							std::nullopt,			   // MetaData
+							std::nullopt,			   // Skip
+							std::nullopt,			   // Limit
+							ResponseHandler,		   // ResponseHandler
+							CancellationToken::Dummy() // CancellationToken
+		);
+}
+
+
+void SequenceSystem::GetAllSequencesContainingItems(const Array<String>& InItems,
+													const Optional<String>& InReferenceType,
+													const Array<String>& InReferenceIds,
+													SequencesResultCallback Callback)
+{
+	std::optional<std::vector<String>> Items		= Convert(InItems);
+	std::optional<String> ReferenceType				= Convert(InReferenceType);
+	std::optional<std::vector<String>> ReferenceIds = Convert(InReferenceIds);
+
+	csp::services::ResponseHandlerPtr ResponseHandler
+		= SequenceAPI->CreateHandler<SequencesResultCallback, SequencesResult, void, csp::services::DtoArray<chs::SequenceDto>>(Callback, nullptr);
+
+	static_cast<chs::SequenceApi*>(SequenceAPI)
+		->apiV1SequencesGet(std::nullopt,			   // Keys
+							std::nullopt,			   // Regex
+							ReferenceType,			   // ReferenceType
+							ReferenceIds,			   // ReferenceIds
+							Items,					   // Items
 							std::nullopt,			   // MetaData
 							std::nullopt,			   // Skip
 							std::nullopt,			   // Limit
@@ -206,15 +234,15 @@ void SequenceSystem::GetSequence(const String& SequenceKey, SequenceResultCallba
 		= SequenceAPI->CreateHandler<SequenceResultCallback, SequenceResult, void, chs::SequenceDto>(Callback, nullptr);
 
 	static_cast<chs::SequenceApi*>(SequenceAPI)
-		->apiV1SequencesKeysKeyGet(csp::common::Encode::URI(SequenceKey, true),	// Key
-								   ResponseHandler,			                    // ResponseHandler
-								   CancellationToken::Dummy()                   // CancellationToken
+		->apiV1SequencesKeysKeyGet(csp::common::Encode::URI(SequenceKey, true), // Key
+								   ResponseHandler,								// ResponseHandler
+								   CancellationToken::Dummy()					// CancellationToken
 		);
 }
 
 void SequenceSystem::DeleteSequences(const Array<String>& InSequenceKeys, NullResultCallback Callback)
 {
-    Array<String> EncodedSequenceKeys(InSequenceKeys.Size());
+	Array<String> EncodedSequenceKeys(InSequenceKeys.Size());
 	for (size_t i = 0; i < InSequenceKeys.Size(); i++)
 	{
 		if (!ValidateKey(InSequenceKeys[i]))
@@ -226,8 +254,8 @@ void SequenceSystem::DeleteSequences(const Array<String>& InSequenceKeys, NullRe
 			return;
 		}
 
-        // We URI-encode sequence keys to support reserved characters.
-        EncodedSequenceKeys[i] = csp::common::Encode::URI(InSequenceKeys[i]);
+		// We URI-encode sequence keys to support reserved characters.
+		EncodedSequenceKeys[i] = csp::common::Encode::URI(InSequenceKeys[i]);
 	}
 	csp::services::ResponseHandlerPtr ResponseHandler
 		= SequenceAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback,

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -110,6 +110,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 
 	EXPECT_EQ(HotspotUniqueComponentId, UniqueComponentId);
 
+	// Test again to ensure getter works with multiple calls.
+	const csp::common::String& HotspotUniqueComponentId2 = HotspotComponent->GetUniqueComponentId();
+
+	EXPECT_EQ(HotspotUniqueComponentId2, UniqueComponentId);
+
 	// Set new values
 
 	HotspotComponent->SetPosition(csp::common::Vector3::One());

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -106,7 +106,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 	UniqueComponentId += ":";
 	UniqueComponentId += std::to_string(HotspotComponent->GetId()).c_str();
 
-	const csp::common::String HotspotUniqueComponentId = HotspotComponent->GetUniqueComponentId();
+  const csp::common::String HotspotUniqueComponentId = HotspotComponent->GetUniqueComponentId();
 
 	EXPECT_EQ(HotspotUniqueComponentId, UniqueComponentId);
 

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -106,12 +106,12 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 	UniqueComponentId += ":";
 	UniqueComponentId += std::to_string(HotspotComponent->GetId()).c_str();
 
-	const csp::common::String& HotspotUniqueComponentId = HotspotComponent->GetUniqueComponentId();
+	const csp::common::String HotspotUniqueComponentId = HotspotComponent->GetUniqueComponentId();
 
 	EXPECT_EQ(HotspotUniqueComponentId, UniqueComponentId);
 
 	// Test again to ensure getter works with multiple calls.
-	const csp::common::String& HotspotUniqueComponentId2 = HotspotComponent->GetUniqueComponentId();
+	const csp::common::String HotspotUniqueComponentId2 = HotspotComponent->GetUniqueComponentId();
 
 	EXPECT_EQ(HotspotUniqueComponentId2, UniqueComponentId);
 

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -206,14 +206,15 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
 
 	// Validate sequence creation events.
 	bool CallbackCalled = false;
-	auto* Connection = SystemsManager.GetMultiplayerConnection();
-	Connection->SetHotspotSequenceChangedCallback([&CallbackCalled, &Space, &TestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
-	{
-		EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Create);
-		EXPECT_EQ(Params.SpaceId, Space.Id);
-		EXPECT_EQ(Params.Name, TestGroupName);
-		CallbackCalled = true; 
-	});
+	auto* Connection	= SystemsManager.GetMultiplayerConnection();
+	Connection->SetHotspotSequenceChangedCallback(
+		[&CallbackCalled, &Space, &TestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
+		{
+			EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Create);
+			EXPECT_EQ(Params.SpaceId, Space.Id);
+			EXPECT_EQ(Params.Name, TestGroupName);
+			CallbackCalled = true;
+		});
 
 	csp::systems::HotspotGroup HotspotGroup;
 	CreateHotspotgroup(HotspotSystem, TestGroupName, GroupItems, HotspotGroup);
@@ -221,14 +222,15 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
 	WaitForCallback(CallbackCalled);
 	CallbackCalled = false;
 
-	// Validate sequence deletion events.	
-	Connection->SetHotspotSequenceChangedCallback([&CallbackCalled, &Space, &TestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
-	{
-		EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Delete);
-		EXPECT_EQ(Params.SpaceId, Space.Id);
-		EXPECT_EQ(Params.Name, TestGroupName);
-		CallbackCalled = true;
-	});
+	// Validate sequence deletion events.
+	Connection->SetHotspotSequenceChangedCallback(
+		[&CallbackCalled, &Space, &TestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
+		{
+			EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Delete);
+			EXPECT_EQ(Params.SpaceId, Space.Id);
+			EXPECT_EQ(Params.Name, TestGroupName);
+			CallbackCalled = true;
+		});
 
 	// Delete sequence
 	DeleteHotspotGroup(HotspotSystem, TestGroupName);
@@ -335,14 +337,15 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, UpdateHotspotGroupTest)
 
 	// Validate sequence update events.
 	bool CallbackCalled = false;
-	auto* Connection = SystemsManager.GetMultiplayerConnection();
-	Connection->SetHotspotSequenceChangedCallback([&CallbackCalled, &Space, &TestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
-	{
-		EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Update);
-		EXPECT_EQ(Params.SpaceId, Space.Id);
-		EXPECT_EQ(Params.Name, TestGroupName);
-		CallbackCalled = true;
-	});
+	auto* Connection	= SystemsManager.GetMultiplayerConnection();
+	Connection->SetHotspotSequenceChangedCallback(
+		[&CallbackCalled, &Space, &TestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
+		{
+			EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Update);
+			EXPECT_EQ(Params.SpaceId, Space.Id);
+			EXPECT_EQ(Params.Name, TestGroupName);
+			CallbackCalled = true;
+		});
 
 	csp::systems::HotspotGroup Expected;
 	Expected.Name  = HotspotGroup1.Name;
@@ -403,38 +406,42 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameHotspotGroupTest)
 	CreateHotspotgroup(HotspotSystem, OldTestGroupName, SequenceItems, HotspotGroup);
 	EXPECT_EQ(HotspotGroup.Name, OldTestGroupName);
 
-	bool CallbackCalled = false;
+	bool ReceivedUpdateCallback = false;
 	bool ReceivedRenameCallback = false;
-	auto* Connection = SystemsManager.GetMultiplayerConnection();
-	Connection->SetHotspotSequenceChangedCallback([&CallbackCalled, &ReceivedRenameCallback, &Space, &OldTestGroupName, &NewTestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
-	{
-		// When renaming a hotspot group, we expect two callbacks - the first is the rename of the group.
-		// The second is an update, as CSP will also update the group's metadata to reflect the new name.
-		if(ReceivedRenameCallback == false)
+	auto* Connection			= SystemsManager.GetMultiplayerConnection();
+	Connection->SetHotspotSequenceChangedCallback(
+		[&ReceivedUpdateCallback, &ReceivedRenameCallback, &Space, &OldTestGroupName, &NewTestGroupName](
+			const csp::multiplayer::SequenceHotspotChangedParams& Params)
 		{
-			EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Rename);
+			// When renaming a hotspot group, we expect two callbacks - the first is the rename of the group.
+			// The second is an update, as CSP will also update the group's metadata to reflect the new name.
+			if (Params.UpdateType == csp::multiplayer::ESequenceUpdateType::Rename)
+			{
+				// With rename events, we expect to be able to receive both the old and new names.
+				EXPECT_EQ(Params.Name, OldTestGroupName);
+				EXPECT_EQ(Params.NewName, NewTestGroupName);
 
-			// With rename events, we expect to be able to receive both the old and new names.
-			EXPECT_EQ(Params.Name, OldTestGroupName);
-			EXPECT_EQ(Params.NewName, NewTestGroupName);			
+				ReceivedRenameCallback = true;
+			}
+			else if (Params.UpdateType == csp::multiplayer::ESequenceUpdateType::Update)
+			{
+				EXPECT_EQ(Params.Name, NewTestGroupName);
+				ReceivedUpdateCallback = true; // Both the rename and update callbacks have now fired. That's all the expected events.
+			}
 
-			ReceivedRenameCallback = true;
-		}
-		else
-		{
-			EXPECT_EQ(Params.UpdateType, csp::multiplayer::ESequenceUpdateType::Update);
-			EXPECT_EQ(Params.Name, NewTestGroupName);
-			CallbackCalled = true; // Both the rename and update callbacks have now fired. That's all the expected events.
-		}
 
-		
-		EXPECT_EQ(Params.SpaceId, Space.Id);
-	});
+			EXPECT_EQ(Params.SpaceId, Space.Id);
+		});
 
 	RenameHotspotGroup(HotspotSystem, OldTestGroupName, NewTestGroupName, HotspotGroup);
 	EXPECT_EQ(HotspotGroup.Name, NewTestGroupName);
 
-	WaitForCallback(CallbackCalled);
+	WaitForCallback(ReceivedRenameCallback);
+	WaitForCallback(ReceivedUpdateCallback);
+
+	EXPECT_TRUE(ReceivedRenameCallback);
+	EXPECT_TRUE(ReceivedUpdateCallback);
+
 	Connection->SetHotspotSequenceChangedCallback(nullptr);
 
 	// Delete sequence

--- a/ThirdParty/quickjs/src/quickjs.c
+++ b/ThirdParty/quickjs/src/quickjs.c
@@ -12172,7 +12172,7 @@ int JS_IsObjectPlain(JSContext *ctx, JSValueConst val)
 }
 
 
-static double js_pow(double a, double b)
+static double js_math_pow(double a, double b)
 {
     if (unlikely(!isfinite(b)) && fabs(a) == 1) {
         /* not compatible with IEEE 754 */
@@ -13577,7 +13577,7 @@ static no_inline __exception int js_binary_arith_slow(JSContext *ctx, JSValue *s
             break;
         case OP_pow:
             if (!is_math_mode(ctx)) {
-                sp[-2] = JS_NewFloat64(ctx, js_pow(v1, v2));
+				sp[-2] = JS_NewFloat64(ctx, js_math_pow(v1, v2));
                 return 0;
             } else {
                 goto handle_bigint;
@@ -13630,7 +13630,7 @@ static no_inline __exception int js_binary_arith_slow(JSContext *ctx, JSValue *s
                 dr += d2;
             break;
         case OP_pow:
-            dr = js_pow(d1, d2);
+			dr = js_math_pow(d1, d2);
             break;
         default:
             abort();
@@ -14462,7 +14462,7 @@ static no_inline __exception int js_binary_arith_slow(JSContext *ctx, JSValue *s
         r = fmod(d1, d2);
         break;
     case OP_pow:
-        r = js_pow(d1, d2);
+		r = js_math_pow(d1, d2);
         break;
     default:
         abort();
@@ -42384,42 +42384,143 @@ static JSValue js_math_random(JSContext *ctx, JSValueConst this_val,
     return __JS_NewFloat64(ctx, u.d - 1.0);
 }
 
-static double js_math_floor(double x) { return floor(x); }
-static double js_math_ceil(double x) { return ceil(x); }
+/* use local wrappers for math functions to
+   - avoid initializing data with dynamic library entry points.
+   - avoid some overhead if the call can be inlined at compile or link time.
+ */
+static double js_math_fabs(double d)
+{
+	return fabs(d);
+}
+static double js_math_floor(double d)
+{
+	return floor(d);
+}
+static double js_math_ceil(double d)
+{
+	return ceil(d);
+}
+static double js_math_sqrt(double d)
+{
+	return sqrt(d);
+}
+static double js_math_acos(double d)
+{
+	return acos(d);
+}
+static double js_math_asin(double d)
+{
+	return asin(d);
+}
+static double js_math_atan(double d)
+{
+	return atan(d);
+}
+static double js_math_atan2(double a, double b)
+{
+	return atan2(a, b);
+}
+static double js_math_cos(double d)
+{
+	return cos(d);
+}
+static double js_math_exp(double d)
+{
+	return exp(d);
+}
+static double js_math_log(double d)
+{
+	return log(d);
+}
+static double js_math_sin(double d)
+{
+	return sin(d);
+}
+static double js_math_tan(double d)
+{
+	return tan(d);
+}
+static double js_math_trunc(double d)
+{
+	return trunc(d);
+}
+static double js_math_cosh(double d)
+{
+	return cosh(d);
+}
+static double js_math_sinh(double d)
+{
+	return sinh(d);
+}
+static double js_math_tanh(double d)
+{
+	return tanh(d);
+}
+static double js_math_acosh(double d)
+{
+	return acosh(d);
+}
+static double js_math_asinh(double d)
+{
+	return asinh(d);
+}
+static double js_math_atanh(double d)
+{
+	return atanh(d);
+}
+static double js_math_expm1(double d)
+{
+	return expm1(d);
+}
+static double js_math_log1p(double d)
+{
+	return log1p(d);
+}
+static double js_math_log2(double d)
+{
+	return log2(d);
+}
+static double js_math_log10(double d)
+{
+	return log10(d);
+}
+static double js_math_cbrt(double d)
+{
+	return cbrt(d);
+}
 
 static const JSCFunctionListEntry js_math_funcs[] = {
-    JS_CFUNC_MAGIC_DEF("min", 2, js_math_min_max, 0 ),
-    JS_CFUNC_MAGIC_DEF("max", 2, js_math_min_max, 1 ),
-    JS_CFUNC_SPECIAL_DEF("abs", 1, f_f, fabs ),
-    JS_CFUNC_SPECIAL_DEF("floor", 1, f_f, js_math_floor),
-    JS_CFUNC_SPECIAL_DEF("ceil", 1, f_f, js_math_ceil ),
-    JS_CFUNC_SPECIAL_DEF("round", 1, f_f, js_math_round ),
-    JS_CFUNC_SPECIAL_DEF("sqrt", 1, f_f, sqrt ),
-
-    JS_CFUNC_SPECIAL_DEF("acos", 1, f_f, acos ),
-    JS_CFUNC_SPECIAL_DEF("asin", 1, f_f, asin ),
-    JS_CFUNC_SPECIAL_DEF("atan", 1, f_f, atan ),
-    JS_CFUNC_SPECIAL_DEF("atan2", 2, f_f_f, atan2 ),
-    JS_CFUNC_SPECIAL_DEF("cos", 1, f_f, cos ),
-    JS_CFUNC_SPECIAL_DEF("exp", 1, f_f, exp ),
-    JS_CFUNC_SPECIAL_DEF("log", 1, f_f, log ),
-    JS_CFUNC_SPECIAL_DEF("pow", 2, f_f_f, js_pow ),
-    JS_CFUNC_SPECIAL_DEF("sin", 1, f_f, sin ),
-    JS_CFUNC_SPECIAL_DEF("tan", 1, f_f, tan ),
-    /* ES6 */
-    JS_CFUNC_SPECIAL_DEF("trunc", 1, f_f, trunc ),
-    JS_CFUNC_SPECIAL_DEF("sign", 1, f_f, js_math_sign ),
-    JS_CFUNC_SPECIAL_DEF("cosh", 1, f_f, cosh ),
-    JS_CFUNC_SPECIAL_DEF("sinh", 1, f_f, sinh ),
-    JS_CFUNC_SPECIAL_DEF("tanh", 1, f_f, tanh ),
-    JS_CFUNC_SPECIAL_DEF("acosh", 1, f_f, acosh ),
-    JS_CFUNC_SPECIAL_DEF("asinh", 1, f_f, asinh ),
-    JS_CFUNC_SPECIAL_DEF("atanh", 1, f_f, atanh ),
-    JS_CFUNC_SPECIAL_DEF("expm1", 1, f_f, expm1 ),
-    JS_CFUNC_SPECIAL_DEF("log1p", 1, f_f, log1p ),
-    JS_CFUNC_SPECIAL_DEF("log2", 1, f_f, log2 ),
-    JS_CFUNC_SPECIAL_DEF("log10", 1, f_f, log10 ),
-    JS_CFUNC_SPECIAL_DEF("cbrt", 1, f_f, cbrt ),
+	JS_CFUNC_MAGIC_DEF("min", 2, js_math_min_max, 0),
+	JS_CFUNC_MAGIC_DEF("max", 2, js_math_min_max, 1),
+	JS_CFUNC_SPECIAL_DEF("abs", 1, f_f, js_math_fabs),
+	JS_CFUNC_SPECIAL_DEF("floor", 1, f_f, js_math_floor),
+	JS_CFUNC_SPECIAL_DEF("ceil", 1, f_f, js_math_ceil),
+	JS_CFUNC_SPECIAL_DEF("round", 1, f_f, js_math_round),
+	JS_CFUNC_SPECIAL_DEF("sqrt", 1, f_f, js_math_sqrt),
+	JS_CFUNC_SPECIAL_DEF("acos", 1, f_f, js_math_acos),
+	JS_CFUNC_SPECIAL_DEF("asin", 1, f_f, js_math_asin),
+	JS_CFUNC_SPECIAL_DEF("atan", 1, f_f, js_math_atan),
+	JS_CFUNC_SPECIAL_DEF("atan2", 2, f_f_f, js_math_atan2),
+	JS_CFUNC_SPECIAL_DEF("cos", 1, f_f, js_math_cos),
+	JS_CFUNC_SPECIAL_DEF("exp", 1, f_f, js_math_exp),
+	JS_CFUNC_SPECIAL_DEF("log", 1, f_f, js_math_log),
+	JS_CFUNC_SPECIAL_DEF("pow", 2, f_f_f, js_math_pow),
+	JS_CFUNC_SPECIAL_DEF("sin", 1, f_f, js_math_sin),
+	JS_CFUNC_SPECIAL_DEF("tan", 1, f_f, js_math_tan),
+	/* ES6 */
+	JS_CFUNC_SPECIAL_DEF("trunc", 1, f_f, js_math_trunc),
+	JS_CFUNC_SPECIAL_DEF("sign", 1, f_f, js_math_sign),
+	JS_CFUNC_SPECIAL_DEF("cosh", 1, f_f, js_math_cosh),
+	JS_CFUNC_SPECIAL_DEF("sinh", 1, f_f, js_math_sinh),
+	JS_CFUNC_SPECIAL_DEF("tanh", 1, f_f, js_math_tanh),
+	JS_CFUNC_SPECIAL_DEF("acosh", 1, f_f, js_math_acosh),
+	JS_CFUNC_SPECIAL_DEF("asinh", 1, f_f, js_math_asinh),
+	JS_CFUNC_SPECIAL_DEF("atanh", 1, f_f, js_math_atanh),
+	JS_CFUNC_SPECIAL_DEF("expm1", 1, f_f, js_math_expm1),
+	JS_CFUNC_SPECIAL_DEF("log1p", 1, f_f, js_math_log1p),
+	JS_CFUNC_SPECIAL_DEF("log2", 1, f_f, js_math_log2),
+	JS_CFUNC_SPECIAL_DEF("log10", 1, f_f, js_math_log10),
+	JS_CFUNC_SPECIAL_DEF("cbrt", 1, f_f, js_math_cbrt),
     JS_CFUNC_DEF("hypot", 2, js_math_hypot ),
     JS_CFUNC_DEF("random", 0, js_math_random ),
     JS_CFUNC_SPECIAL_DEF("fround", 1, f_f, js_math_fround ),

--- a/generate_solution.bat
+++ b/generate_solution.bat
@@ -36,5 +36,5 @@ call npm install
 
 cd ../..
 
-"modules/premake/bin/release/premake5.exe" vs2019 %*
+"modules/premake/bin/release/premake5.exe" vs2022 %*
 pause

--- a/install_prerequisites.ps1
+++ b/install_prerequisites.ps1
@@ -7,9 +7,9 @@ if (!(Test-Path -Path "$env:ProgramData\Chocolatey")) {
   Invoke-Expression((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 }
 
-$Packages = 'git', 'vscode', 'python', 'llvm', 'docker-desktop', 'cmake'
+$Packages = 'git', 'vscode', 'python', 'llvm --version=17.0.1', 'docker-desktop', 'cmake'
 
-ForEach ($PackageName in $Packages)
+ForEach ($PackageInformation in $Packages)
 {
-    choco install $PackageName -y
+    choco install $PackageInformation.split(" ",[System.StringSplitOptions]::RemoveEmptyEntries) -y
 }


### PR DESCRIPTION
- Hotspot sequences are automatically deleted when components are deleted
- Project defaults to VS 2022
- GetUniqueComponentId bug fix
- Removed unused submodules
- Disabled unreliable tests