### PR TITLE
[OB-3836] fix: Corrected FOV calculation for cinematic camera component

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
@@ -64,7 +64,7 @@ public:
 	CinematicCameraSpaceComponent(SpaceEntity* Parent);
 
 	/// @brief Gived the sensor size and focal length, return the horizonal fov
-	/// @return FOV in degrees
+	/// @return FOV in radians
 	float GetFov() const;
 
 	/// \addtogroup IPositionComponent

--- a/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
@@ -48,7 +48,7 @@ CinematicCameraSpaceComponent::CinematicCameraSpaceComponent(SpaceEntity* Parent
 
 float CinematicCameraSpaceComponent::GetFov() const
 {
-	return 2.0f * atan(GetSensorSize().X / 2.0f * GetFocalLength()) * 1000.0f;
+	return 2.0f * atan(GetSensorSize().X / (2.0f * GetFocalLength()));
 }
 
 // transforms

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -212,7 +212,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CINEMATIC_CAMERA_TESTS || RUN_CinematicCamera_SCRIPT_INTERFACE_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_CINEMATIC_CAMERA_TESTS || RUN_CINEMATIC_CAMERA_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceTest)
 {
 	SetRandSeed();


### PR DESCRIPTION
[OB-3836] fix: Corrected FOV calculation for cinematic camera component

- Fixed calculation in `CinematicCameraSpaceComponent::GetFov`
- Added test for FOV calculation