### PR TITLE
[OF-1439] feat: Added map generic map support to ReplicatedValue

### DIFF
--- a/Library/include/CSP/Common/Map.h
+++ b/Library/include/CSP/Common/Map.h
@@ -114,7 +114,15 @@ public:
 			return *this;
 		}
 
-		Container->~MapType();
+		if (Container)
+		{
+			Container->~MapType();
+		}
+		else
+		{
+			Container = (MapType*) csp::memory::DllAlloc(sizeof(MapType));
+		}
+
 		new (Container) MapType(*Other.Container);
 
 		return *this;
@@ -130,10 +138,29 @@ public:
 			return *this;
 		}
 
-		Container->~MapType();
+		if (Container)
+		{
+			Container->~MapType();
+		}
+		else
+		{
+			Container = (MapType*) csp::memory::DllAlloc(sizeof(MapType));
+		}
+
 		new (Container) MapType(*Other.Container);
 
 		return *this;
+	}
+
+
+	CSP_NO_EXPORT bool operator==(const Map<TKey, TValue>& OtherValue) const
+	{
+		return *Container == *OtherValue.Container;
+	}
+
+	CSP_NO_EXPORT bool operator!=(const Map<TKey, TValue>& OtherValue) const
+	{
+		return *Container != *OtherValue.Container;
 	}
 
 	/// @brief Returns the number of elements in this map.

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -159,6 +159,7 @@ protected:
 	const csp::common::Vector2& GetVector2Property(uint32_t Key) const;
 	const csp::common::Vector3& GetVector3Property(uint32_t Key) const;
 	const csp::common::Vector4& GetVector4Property(uint32_t Key) const;
+	const csp::common::Map<ReplicatedValue, ReplicatedValue>& GetMapProperty(uint32_t Key) const;
 
 	void SetProperty(uint32_t Key, const ReplicatedValue& Value);
 	void RemoveProperty(uint32_t Key);

--- a/Library/include/CSP/Multiplayer/ReplicatedValue.h
+++ b/Library/include/CSP/Multiplayer/ReplicatedValue.h
@@ -223,6 +223,10 @@ public:
 	/// @brief Set a Map value for this replicated value from a csp::common::Map, will overwrite and previous value.
 	void SetMap(const csp::common::Map<ReplicatedValue, ReplicatedValue>& InValue);
 
+	/// @brief Get a generic default Map.
+	/// @return The default Map.
+	CSP_NO_EXPORT static const csp::common::Map<ReplicatedValue, ReplicatedValue>& GetDefaultMap();
+
 	/// @brief returns the size of the stored internal value.
 	/// @return size_t size of the internal value.
 	CSP_NO_EXPORT static size_t GetSizeOfInternalValue();

--- a/Library/include/CSP/Multiplayer/ReplicatedValue.h
+++ b/Library/include/CSP/Multiplayer/ReplicatedValue.h
@@ -17,6 +17,7 @@
 
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/Array.h"
+#include "CSP/Common/Map.h"
 #include "CSP/Common/String.h"
 #include "CSP/Common/Vector.h"
 
@@ -35,7 +36,8 @@ enum class ReplicatedValueType
 	String,
 	Vector2,
 	Vector3,
-	Vector4
+	Vector4,
+	Map
 };
 
 /// @brief ReplicatedValue is an intermediate class that enables clients to pack data into types that are supported by Connected Spaces Platform
@@ -80,6 +82,10 @@ public:
 	/// @param InVector4Value csp::common::Vector4 : Initial value.
 	ReplicatedValue(const csp::common::Vector4& InVector4Value);
 
+	/// @brief Construct a ReplicatedValue based on an csp::common::Map type.
+	/// @param InMapValue csp::common::Map : Initial value.
+	ReplicatedValue(const csp::common::Map<ReplicatedValue, ReplicatedValue>& InMapValue);
+
 	/// @brief Copy constructor
 	/// @param Other csp::multiplayer::ReplicatedValue& : The value to copy.
 	ReplicatedValue(const ReplicatedValue& Other);
@@ -98,6 +104,14 @@ public:
 	/// @brief Non equality operator overload.
 	/// @param ReplicatedValue : Other value to compare to.
 	bool operator!=(const ReplicatedValue& OtherValue) const;
+
+	/// @brief Less than operator overload.
+	/// @param ReplicatedValue : Other value to compare to.
+	bool operator<(const ReplicatedValue& OtherValue) const;
+
+	/// @brief Greater than operator overload.
+	/// @param ReplicatedValue : Other value to compare to.
+	bool operator>(const ReplicatedValue& OtherValue) const;
 
 	/// @brief Gets the type of replicated value.
 	/// @return ReplicatedValueType: Enum representing all supported replication base types.
@@ -198,6 +212,17 @@ public:
 	/// @return The default Vector4.
 	CSP_NO_EXPORT static const csp::common::Vector4& GetDefaultVector4();
 
+
+	/// @brief Get a csp::common::Map value from this replicated value, will assert if not a csp::common::Map type.
+	///
+	/// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
+	///
+	/// @return csp::common::Map
+	const csp::common::Map<ReplicatedValue, ReplicatedValue>& GetMap() const;
+
+	/// @brief Set a Map value for this replicated value from a csp::common::Map, will overwrite and previous value.
+	void SetMap(const csp::common::Map<ReplicatedValue, ReplicatedValue>& InValue);
+
 	/// @brief returns the size of the stored internal value.
 	/// @return size_t size of the internal value.
 	CSP_NO_EXPORT static size_t GetSizeOfInternalValue();
@@ -218,6 +243,7 @@ private:
 		csp::common::Vector2 Vector2;
 		csp::common::Vector3 Vector3;
 		csp::common::Vector4 Vector4;
+		csp::common::Map<ReplicatedValue, ReplicatedValue> Map;
 	};
 
 	InternalValue Value;

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -36,6 +36,7 @@ class CSPEngine_SerialisationTests_SpaceEntityUserSignalRSerialisationTest_Test;
 class CSPEngine_SerialisationTests_SpaceEntityUserSignalRSerialisationTest_Test;
 class CSPEngine_SerialisationTests_SpaceEntityObjectSignalRDeserialisationTest_Test;
 class CSPEngine_SerialisationTests_SpaceEntityObjectSignalRDeserialisationTest_Test;
+class CSPEngine_SerialisationTests_MapDeserialisationTest_Test;
 #endif
 CSP_END_IGNORE
 
@@ -109,6 +110,7 @@ class CSP_API SpaceEntity
 	friend class ::CSPEngine_SerialisationTests_SpaceEntityUserSignalRDeserialisationTest_Test;
 	friend class ::CSPEngine_SerialisationTests_SpaceEntityObjectSignalRSerialisationTest_Test;
 	friend class ::CSPEngine_SerialisationTests_SpaceEntityObjectSignalRDeserialisationTest_Test;
+	friend class ::CSPEngine_SerialisationTests_MapDeserialisationTest_Test;
 #endif
 	/** @endcond */
 	CSP_END_IGNORE

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -171,6 +171,20 @@ const csp::common::Vector4& ComponentBase::GetVector4Property(uint32_t Key) cons
 	return ReplicatedValue::GetDefaultVector4();
 }
 
+const csp::common::Map<ReplicatedValue, ReplicatedValue>& ComponentBase::GetMapProperty(uint32_t Key) const
+{
+	const auto& RepVal = GetProperty(Key);
+
+	if (RepVal.GetReplicatedValueType() == ReplicatedValueType::Map)
+	{
+		return RepVal.GetMap();
+	}
+
+	CSP_LOG_ERROR_MSG("Underlying ReplicatedValue not a valid Map type");
+
+	return ReplicatedValue::GetDefaultMap();
+}
+
 void ComponentBase::SetProperty(uint32_t Key, const ReplicatedValue& Value)
 {
 	if (Properties.HasKey(Key) && Value.GetReplicatedValueType() != Properties[Key].GetReplicatedValueType())

--- a/Library/src/Multiplayer/MultiplayerConstants.h
+++ b/Library/src/Multiplayer/MultiplayerConstants.h
@@ -94,7 +94,8 @@ enum ItemComponentData : uint64_t
 	UINT16_ARRAY,
 	NULLABLE_UINT16_ARRAY,
 	UINT16_DICTIONARY,
-	STRING_DICTIONARY
+	STRING_DICTIONARY,
+	GENERIC_MAP
 };
 
 } // namespace msgpack_typeids

--- a/Library/src/Multiplayer/ReplicatedValue.cpp
+++ b/Library/src/Multiplayer/ReplicatedValue.cpp
@@ -35,6 +35,10 @@ ReplicatedValue::~ReplicatedValue()
 	{
 		Value.String.~String();
 	}
+	else if (ReplicatedType == ReplicatedValueType::Map)
+	{
+		Value.Map.~Map();
+	}
 }
 
 ReplicatedValue::ReplicatedValue(bool InValue) : ReplicatedType(ReplicatedValueType::Boolean)
@@ -75,6 +79,11 @@ ReplicatedValue::ReplicatedValue(const csp::common::Vector3& InValue) : Replicat
 ReplicatedValue::ReplicatedValue(const csp::common::Vector4& InValue) : ReplicatedType(ReplicatedValueType::Vector4)
 {
 	Value.Vector4 = InValue;
+}
+
+ReplicatedValue::ReplicatedValue(const csp::common::Map<ReplicatedValue, ReplicatedValue>& InMapValue) : ReplicatedType(ReplicatedValueType::Map)
+{
+	Value.Map = InMapValue;
 }
 
 ReplicatedValue::ReplicatedValue(const ReplicatedValue& OtherValue)
@@ -119,6 +128,11 @@ ReplicatedValue& ReplicatedValue::operator=(const ReplicatedValue& InValue)
 		case ReplicatedValueType::Vector4:
 		{
 			SetVector4(InValue.GetVector4());
+			break;
+		}
+		case ReplicatedValueType::Map:
+		{
+			SetMap(InValue.GetMap());
 			break;
 		}
 		case ReplicatedValueType::InvalidType:
@@ -178,6 +192,10 @@ bool ReplicatedValue::operator==(const ReplicatedValue& OtherValue) const
 				IsEqual = GetVector4() == OtherValue.GetVector4();
 				break;
 			}
+			case ReplicatedValueType::Map:
+			{
+				IsEqual = GetMap() == OtherValue.GetMap();
+			}
 			default:
 			{
 				assert(0 && "Unhandled replicated value type!");
@@ -190,6 +208,66 @@ bool ReplicatedValue::operator==(const ReplicatedValue& OtherValue) const
 bool ReplicatedValue::operator!=(const ReplicatedValue& OtherValue) const
 {
 	return (*this == OtherValue) == false;
+}
+
+bool ReplicatedValue::operator<(const ReplicatedValue& OtherValue) const
+{
+	switch (OtherValue.GetReplicatedValueType())
+	{
+		case ReplicatedValueType::Boolean:
+		{
+			return GetBool() < OtherValue.GetBool();
+		}
+		case ReplicatedValueType::Integer:
+		{
+			return GetInt() < OtherValue.GetInt();
+		}
+		case ReplicatedValueType::Float:
+		{
+			return GetFloat() < OtherValue.GetFloat();
+		}
+		case ReplicatedValueType::String:
+		{
+			return GetString() < OtherValue.GetString();
+		}
+		default:
+		{
+			assert(0 && "Unhandled replicated value type!");
+			break;
+		}
+	}
+
+	return false;
+}
+
+bool ReplicatedValue::operator>(const ReplicatedValue& OtherValue) const
+{
+	switch (OtherValue.GetReplicatedValueType())
+	{
+		case ReplicatedValueType::Boolean:
+		{
+			return GetBool() > OtherValue.GetBool();
+		}
+		case ReplicatedValueType::Integer:
+		{
+			return GetInt() > OtherValue.GetInt();
+		}
+		case ReplicatedValueType::Float:
+		{
+			return GetFloat() > OtherValue.GetFloat();
+		}
+		case ReplicatedValueType::String:
+		{
+			return GetString() > OtherValue.GetString();
+		}
+		default:
+		{
+			assert(0 && "Unhandled replicated value type!");
+			break;
+		}
+	}
+
+	return false;
 }
 
 void ReplicatedValue::SetBool(bool InValue)
@@ -301,6 +379,18 @@ const csp::common::Vector4& ReplicatedValue::GetVector4() const
 const csp::common::Vector4& ReplicatedValue::GetDefaultVector4()
 {
 	return InvalidVector4;
+}
+
+const csp::common::Map<ReplicatedValue, ReplicatedValue>& ReplicatedValue::GetMap() const
+{
+	assert(ReplicatedType == ReplicatedValueType::Map);
+	return Value.Map;
+}
+
+void ReplicatedValue::SetMap(const csp::common::Map<ReplicatedValue, ReplicatedValue>& InValue)
+{
+	ReplicatedType = ReplicatedValueType::Map;
+	Value.Map	   = InValue;
 }
 
 size_t ReplicatedValue::GetSizeOfInternalValue()

--- a/Library/src/Multiplayer/ReplicatedValue.cpp
+++ b/Library/src/Multiplayer/ReplicatedValue.cpp
@@ -20,9 +20,10 @@
 
 namespace csp::multiplayer
 {
-static const csp::common::Vector2 InvalidVector2 = csp::common::Vector2();
-static const csp::common::Vector3 InvalidVector3 = csp::common::Vector3();
-static const csp::common::Vector4 InvalidVector4 = csp::common::Vector4();
+static const csp::common::Vector2 InvalidVector2						   = csp::common::Vector2();
+static const csp::common::Vector3 InvalidVector3						   = csp::common::Vector3();
+static const csp::common::Vector4 InvalidVector4						   = csp::common::Vector4();
+static const csp::common::Map<ReplicatedValue, ReplicatedValue> InvalidMap = csp::common::Map<ReplicatedValue, ReplicatedValue>();
 
 ReplicatedValue::ReplicatedValue()
 {
@@ -195,6 +196,7 @@ bool ReplicatedValue::operator==(const ReplicatedValue& OtherValue) const
 			case ReplicatedValueType::Map:
 			{
 				IsEqual = GetMap() == OtherValue.GetMap();
+				break;
 			}
 			default:
 			{
@@ -391,6 +393,11 @@ void ReplicatedValue::SetMap(const csp::common::Map<ReplicatedValue, ReplicatedV
 {
 	ReplicatedType = ReplicatedValueType::Map;
 	Value.Map	   = InValue;
+}
+
+const csp::common::Map<ReplicatedValue, ReplicatedValue>& ReplicatedValue::GetDefaultMap()
+{
+	return InvalidMap;
 }
 
 size_t ReplicatedValue::GetSizeOfInternalValue()

--- a/Tests/src/PublicAPITests/ReplicatedValueTests2.cpp
+++ b/Tests/src/PublicAPITests/ReplicatedValueTests2.cpp
@@ -185,4 +185,45 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringLiteralAssignmentTest)
 	EXPECT_TRUE(MyValue.GetReplicatedValueType() == ReplicatedValueType::String);
 	EXPECT_TRUE(MyValue.GetString() == "This is a string");
 }
+
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapConstructorTest)
+{
+	csp::common::Map<ReplicatedValue, ReplicatedValue> MyMap;
+	MyMap[1ll] = "Test1";
+	MyMap[2ll] = "Test2";
+	MyMap[3ll] = "Test3";
+
+	ReplicatedValue MyValue(MyMap);
+
+	EXPECT_TRUE(MyValue.GetReplicatedValueType() == ReplicatedValueType::Map);
+	EXPECT_TRUE(MyValue.GetMap() == MyMap);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetMapTest)
+{
+	ReplicatedValue MyValue;
+	csp::common::Map<ReplicatedValue, ReplicatedValue> MyMap;
+	MyMap[1ll] = "Test1";
+	MyMap[2ll] = "Test2";
+	MyMap[3ll] = "Test3";
+
+	MyValue.SetMap(MyMap);
+
+	EXPECT_TRUE(MyValue.GetReplicatedValueType() == ReplicatedValueType::Map);
+	EXPECT_TRUE(MyValue.GetMap() == MyMap);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapAssignmentTest)
+{
+	ReplicatedValue MyValue;
+	csp::common::Map<ReplicatedValue, ReplicatedValue> MyMap;
+	MyMap[1ll] = "Test1";
+	MyMap[2ll] = "Test2";
+	MyMap[3ll] = "Test3";
+
+	MyValue = MyMap;
+
+	EXPECT_TRUE(MyValue.GetReplicatedValueType() == ReplicatedValueType::Map);
+	EXPECT_TRUE(MyValue.GetMap() == MyMap);
+}
 #endif


### PR DESCRIPTION
- Map<ReplicatedValue, ReplicatedValue> can now be set as a ReplicatedValue
- Added ReplicatedValue operators to support maps
- Tests exist to validate this
- Maps can now be serialized to signalr value through a custom structure
- Maps can also be deserialized
- Tests exist to validate this
-  Bug fixes for map copy assignments to work correctly with unions