### PR TITLE
[nt-0] fix: move dispose to NativeClassWrapper

### DIFF
--- a/Library/CSharpWrapper/src/NativeClassWrapper.cs
+++ b/Library/CSharpWrapper/src/NativeClassWrapper.cs
@@ -21,7 +21,7 @@ namespace Csp
         public static NativePointer Zero => new NativePointer(IntPtr.Zero, 0);
     }
 
-    public class NativeClassWrapper
+    public class NativeClassWrapper : IDisposable
     {
         internal IntPtr _ptr;
         internal bool _ownsPtr;
@@ -37,6 +37,53 @@ namespace Csp
         {
             _ptr = ptr.Pointer;
             _ownsPtr = ptr.OwnsOwnData;
+        }
+
+        protected virtual void DisposeNativeObject() { }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                try
+                {
+                    if (_ownsPtr)
+                    {
+                        if (!disposing)
+                        {
+                            //TODO: Log that the object wasn't disposed and is being destroyed by finalizer
+                        }
+
+                        if (_ptr == IntPtr.Zero)
+                        {
+                            throw new InvalidOperationException("Internal pointer was null");
+                        }
+
+                        if (CSPFoundation.GetIsInitialised())
+                        {
+                            DisposeNativeObject();
+                        }
+                    }
+                }
+                finally
+                {
+                    _ptr = IntPtr.Zero;
+                    _disposed = true;
+                }
+            }
+        }
+
+        ~NativeClassWrapper()
+        {
+             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+             Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Method/Destructor.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Method/Destructor.mustache
@@ -1,23 +1,8 @@
 {{# should_dispose }}
 {{^ is_private }}
-~{{ parent_class.name }}()
+protected override void DisposeNativeObject()
 {
-    //RealDispose();
-}
-
-void RealDispose() {
-    if (_ownsPtr && !_disposed)
-    {
-        {{ unique_name }}(_ptr);
-        _disposed = true;
-    }
-
-    _disposed = true;
-}
-
-{{# has_base_type }}new {{/ has_base_type }}public void Dispose() {
-    RealDispose();
-    GC.SuppressFinalize(this);
+    {{ unique_name }}(_ptr);
 }
 {{/ is_private }}
 {{/ should_dispose }}

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Template/Method/Destructor.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Template/Method/Destructor.mustache
@@ -1,21 +1,6 @@
 {{^ is_private }}
-~{{ definition.name }}()
+protected override void DisposeNativeObject()
 {
-    //RealDispose();
-}
-
-void RealDispose() {
-    if (_ownsPtr && !_disposed)
-    {
-        {{ unique_name }}(_ptr);
-        _disposed = true;
-    }
-
-    _disposed = true;
-}
-
-public void Dispose() {
-    RealDispose();
-    GC.SuppressFinalize(this);
+    {{ unique_name }}(_ptr);
 }
 {{/ is_private }}


### PR DESCRIPTION
Ensure that the destructor is called on wrapped classes during finalization if
* they own the pointer
* CSP is still initialized