### PR TITLE
[NT-0] fix: Update the Unity publish script

### DIFF
--- a/teamcity/PublishCSPForUnity.py
+++ b/teamcity/PublishCSPForUnity.py
@@ -23,7 +23,7 @@ def main():
     arg_parser.add_argument(
         "--npm_publish_flag",
         help="Whether the package should be published to NPM. Default == True",
-        default=True)
+        default="True")
 
     PrepareUnityPackage.add_args(arg_parser)
 


### PR DESCRIPTION
Updated the default type of an argument to be a string so that is can be correctly evaluated.

This argument is evaluated to a bool as it will be a string by default when passed in. This means the default value must also be a string.