### PR TITLE
CSP 5.4.0 - fix to build script required.

### DIFF
--- a/teamcity/PublishCSPForUnity.py
+++ b/teamcity/PublishCSPForUnity.py
@@ -23,7 +23,7 @@ def main():
     arg_parser.add_argument(
         "--npm_publish_flag",
         help="Whether the package should be published to NPM. Default == True",
-        default=True)
+        default="True")
 
     PrepareUnityPackage.add_args(arg_parser)
 


### PR DESCRIPTION
A change to one of the TeamCity Unity publish build scripts was required to ensure that a script argument is correctly evaluated.