### PR TITLE
[OF-1442] feat: Material Overrides

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -60,6 +60,7 @@ enum class AnimatedModelPropertyKeys
 	IsARVisible,
 	ThirdPartyComponentRef,
 	IsShadowCaster,
+	MaterialOverrides,
 	Num
 };
 
@@ -139,6 +140,22 @@ public:
 	/// @brief Sets the index of the currently active animation.
 	/// @return The index of the currently active animation.
 	void SetAnimationIndex(int64_t Value);
+
+	/// @brief Gets the material overrides of this component.
+	/// Should be in the format:
+	/// Key = Path to the model
+	/// Value = The material asset id
+	/// @return The material overrides on this component.
+	csp::common::Map<csp::common::String, csp::common::String> GetMaterialOverrides() const;
+
+	/// @brief Adds a new material override to this component.
+	/// @param The path to the models material to override.
+	/// @param The asset id of the material to override with.
+	void AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId);
+
+	/// @brief Removes a material override from this component.
+	/// @param The path to the models material to override to be removed.
+	void RemoveMaterialOverride(const csp::common::String& ModelPath);
 
 	/// \addtogroup IVisibleComponent
 	/// @{

--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -144,13 +144,13 @@ public:
 	/// @brief Gets the material overrides of this component.
 	/// Should be in the format:
 	/// Key = Path to the model
-	/// Value = The material asset id
+	/// Value = The material id
 	/// @return The material overrides on this component.
 	csp::common::Map<csp::common::String, csp::common::String> GetMaterialOverrides() const;
 
 	/// @brief Adds a new material override to this component.
 	/// @param The path to the models material to override.
-	/// @param The asset id of the material to override with.
+	/// @param The id of the material to override with.
 	void AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId);
 
 	/// @brief Removes a material override from this component.

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -45,6 +45,7 @@ enum class StaticModelPropertyKeys
 	IsARVisible,
 	ThirdPartyComponentRef,
 	IsShadowCaster,
+	MaterialOverrides,
 	Num
 };
 
@@ -82,6 +83,22 @@ public:
 	/// @note To retrieve this component's static asset, both the Asset ID and the Asset Collection ID are required.
 	/// @param Value The ID of the asset collection associated with this component.
 	void SetExternalResourceAssetCollectionId(const csp::common::String& Value) override;
+
+	/// @brief Gets the material overrides of this component.
+	/// Should be in the format:
+	/// Key = Path to the model
+	/// Value = The material asset id
+	/// @return The material overrides on this component.
+	csp::common::Map<csp::common::String, csp::common::String> GetMaterialOverrides() const;
+
+	/// @brief Adds a new material override to this component.
+	/// @param The path to the models material to override.
+	/// @param The asset id of the material to override with.
+	void AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId);
+
+	/// @brief Removes a material override from this component.
+	/// @param The path to the models material to override to be removed.
+	void RemoveMaterialOverride(const csp::common::String& ModelPath);
 
 	/// \addtogroup ITransformComponent
 	/// @{

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -97,7 +97,7 @@ public:
 	void AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId);
 
 	/// @brief Removes a material override from this component.
-	/// @param The path to the models material to override to be removed.
+	/// @param The path to the models material override to be removed.
 	void RemoveMaterialOverride(const csp::common::String& ModelPath);
 
 	/// \addtogroup ITransformComponent

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -87,17 +87,17 @@ public:
 	/// @brief Gets the material overrides of this component.
 	/// Should be in the format:
 	/// Key = Path to the model
-	/// Value = The material asset id
+	/// Value = The material id
 	/// @return The material overrides on this component.
 	csp::common::Map<csp::common::String, csp::common::String> GetMaterialOverrides() const;
 
 	/// @brief Adds a new material override to this component.
 	/// @param The path to the models material to override.
-	/// @param The asset id of the material to override with.
+	/// @param The id of the material to override with.
 	void AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId);
 
 	/// @brief Removes a material override from this component.
-	/// @param The path to the models material override to be removed.
+	/// @param The path to the models material to override to be removed.
 	void RemoveMaterialOverride(const csp::common::String& ModelPath);
 
 	/// \addtogroup ITransformComponent

--- a/Library/include/CSP/Systems/Assets/Material.h
+++ b/Library/include/CSP/Systems/Assets/Material.h
@@ -41,26 +41,26 @@ public:
 	/// @return csp::common::String&
 	const csp::common::String& GetName() const;
 
-	/// @brief Gets the asset collection id for where this material is stored
+	/// @brief Gets the collection id for the material
 	/// @return const csp::common::String&
-	const csp::common::String& GetAssetCollectionId() const;
+	const csp::common::String& GetMaterialCollectionId() const;
 
-	/// @brief Gets the asset id for where this material is stored
+	/// @brief Gets the id for the material
 	/// @return const csp::common::String&
-	const csp::common::String& GetAssetId() const;
+	const csp::common::String& GetMaterialId() const;
 
 	/// @brief Constructor which links the material to an asset
-	/// @param AssetCollectionId const csp::common::String& : The asset collection where the material info is stored
-	/// @param AssetId const csp::common::String& : The asset where the material info is stored
-	Material(const csp::common::String& AssetCollectionId, const csp::common::String& AssetId);
+	/// @param MaterialCollectionId const csp::common::String& : The asset collection where the material info is stored
+	/// @param MaterialId const csp::common::String& : The asset where the material info is stored
+	Material(const csp::common::String& MaterialCollectionId, const csp::common::String& MaterialId);
 	Material() = default;
 
 protected:
 	csp::common::String Name;
 	EShaderType Type;
 
-	csp::common::String AssetCollectionId;
-	csp::common::String AssetId;
+	csp::common::String CollectionId;
+	csp::common::String Id;
 };
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Assets/Material.h
+++ b/Library/include/CSP/Systems/Assets/Material.h
@@ -34,7 +34,7 @@ class CSP_API Material
 {
 public:
 	/// @brief Sets the user-defined name of the material
-	/// @param ComponentId const csp::common::String&
+	/// @param Name const csp::common::String&
 	void SetName(const csp::common::String& Name);
 
 	/// @brief Gets the user-defined name of the material

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -151,10 +151,19 @@ void AnimatedModelSpaceComponent::SetAnimationIndex(int64_t Value)
 csp::common::Map<csp::common::String, csp::common::String> AnimatedModelSpaceComponent::GetMaterialOverrides() const
 {
 	// Convert replicated values map to string values
-	const auto& ReplicatedOverrides = GetMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
+	common::Map<multiplayer::ReplicatedValue, multiplayer::ReplicatedValue> ReplicatedOverrides
+		= GetMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
+
 	csp::common::Map<csp::common::String, csp::common::String> Overrides;
 
-	const auto* Keys = ReplicatedOverrides.Keys();
+	auto Deleter = [](const common::Array<multiplayer::ReplicatedValue>* Ptr)
+	{
+		CSP_DELETE(Ptr);
+	};
+
+	std::unique_ptr<common::Array<multiplayer::ReplicatedValue>, decltype(Deleter)> Keys(
+		const_cast<common::Array<multiplayer::ReplicatedValue>*>(ReplicatedOverrides.Keys()),
+		Deleter);
 
 	for (size_t i = 0; i < Keys->Size(); ++i)
 	{
@@ -162,15 +171,13 @@ csp::common::Map<csp::common::String, csp::common::String> AnimatedModelSpaceCom
 		Overrides[CurrentKey.GetString()] = ReplicatedOverrides[CurrentKey].GetString();
 	}
 
-	CSP_DELETE(Keys);
-
 	return Overrides;
 }
 
-void AnimatedModelSpaceComponent::AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId)
+void AnimatedModelSpaceComponent::AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialId)
 {
 	auto ReplicatedOverrides	   = GetMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
-	ReplicatedOverrides[ModelPath] = MaterialAssetId;
+	ReplicatedOverrides[ModelPath] = MaterialId;
 
 	SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -28,16 +28,18 @@ AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(SpaceEntity* Parent) : 
 {
 	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ExternalResourceAssetId)]			= "";
 	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ExternalResourceAssetCollectionId)] = "";
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::Position)]							= csp::common::Vector3 {0, 0, 0};
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::Rotation)]							= csp::common::Vector4 {0, 0, 0, 1};
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::Scale)]								= csp::common::Vector3 {1, 1, 1};
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsLoopPlayback)]					= false;
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsPlaying)]							= false;
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVisible)]							= true;
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::AnimationIndex)]					= static_cast<int64_t>(-1);
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible)]						= true;
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)]			= "";
-	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)]					= true;
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides)]
+		= csp::common::Map<csp::multiplayer::ReplicatedValue, csp::multiplayer::ReplicatedValue>();
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::Position)]				 = csp::common::Vector3 {0, 0, 0};
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::Rotation)]				 = csp::common::Vector4 {0, 0, 0, 1};
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::Scale)]					 = csp::common::Vector3 {1, 1, 1};
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsLoopPlayback)]		 = false;
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsPlaying)]				 = false;
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVisible)]				 = true;
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::AnimationIndex)]		 = static_cast<int64_t>(-1);
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible)]			 = true;
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)] = "";
+	Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)]		 = true;
 
 	SetScriptInterface(CSP_NEW AnimatedModelSpaceComponentScriptInterface(this));
 }
@@ -144,6 +146,41 @@ int64_t AnimatedModelSpaceComponent::GetAnimationIndex() const
 void AnimatedModelSpaceComponent::SetAnimationIndex(int64_t Value)
 {
 	SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::AnimationIndex), Value);
+}
+
+csp::common::Map<csp::common::String, csp::common::String> AnimatedModelSpaceComponent::GetMaterialOverrides() const
+{
+	// Convert replicated values map to string values
+	const auto& ReplicatedOverrides = GetMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
+	csp::common::Map<csp::common::String, csp::common::String> Overrides;
+
+	const auto* Keys = ReplicatedOverrides.Keys();
+
+	for (size_t i = 0; i < Keys->Size(); ++i)
+	{
+		const auto& CurrentKey			  = (*Keys)[i];
+		Overrides[CurrentKey.GetString()] = ReplicatedOverrides[CurrentKey].GetString();
+	}
+
+	CSP_DELETE(Keys);
+
+	return Overrides;
+}
+
+void AnimatedModelSpaceComponent::AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId)
+{
+	auto ReplicatedOverrides	   = GetMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
+	ReplicatedOverrides[ModelPath] = MaterialAssetId;
+
+	SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
+}
+
+void AnimatedModelSpaceComponent::RemoveMaterialOverride(const csp::common::String& ModelPath)
+{
+	auto ReplicatedOverrides = GetMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
+	ReplicatedOverrides.Remove(ModelPath);
+
+	SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }
 
 /* IVisibleComponent */

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -28,13 +28,15 @@ StaticModelSpaceComponent::StaticModelSpaceComponent(SpaceEntity* Parent) : Comp
 {
 	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ExternalResourceAssetId)]			  = "";
 	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ExternalResourceAssetCollectionId)] = "";
-	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::Position)]						  = csp::common::Vector3::Zero();
-	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::Rotation)]						  = csp::common::Vector4::Identity();
-	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::Scale)]							  = csp::common::Vector3::One();
-	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVisible)]						  = true;
-	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible)]						  = true;
-	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)]			  = "";
-	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)]					  = true;
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides)]
+		= csp::common::Map<csp::multiplayer::ReplicatedValue, csp::multiplayer::ReplicatedValue>();
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::Position)]			   = csp::common::Vector3::Zero();
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::Rotation)]			   = csp::common::Vector4::Identity();
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::Scale)]				   = csp::common::Vector3::One();
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVisible)]			   = true;
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible)]			   = true;
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)] = "";
+	Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)]		   = true;
 
 	SetScriptInterface(CSP_NEW StaticModelSpaceComponentScriptInterface(this));
 }
@@ -60,6 +62,41 @@ const csp::common::String& StaticModelSpaceComponent::GetExternalResourceAssetCo
 void StaticModelSpaceComponent::SetExternalResourceAssetCollectionId(const csp::common::String& Value)
 {
 	SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ExternalResourceAssetCollectionId), Value);
+}
+
+csp::common::Map<csp::common::String, csp::common::String> StaticModelSpaceComponent::GetMaterialOverrides() const
+{
+	// Convert replicated values map to string values
+	const auto& ReplicatedOverrides = GetMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
+	csp::common::Map<csp::common::String, csp::common::String> Overrides;
+
+	const auto* Keys = ReplicatedOverrides.Keys();
+
+	for (size_t i = 0; i < Keys->Size(); ++i)
+	{
+		const auto& CurrentKey			  = (*Keys)[i];
+		Overrides[CurrentKey.GetString()] = ReplicatedOverrides[CurrentKey].GetString();
+	}
+
+	CSP_DELETE(Keys);
+
+	return Overrides;
+}
+
+void StaticModelSpaceComponent::AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId)
+{
+	auto ReplicatedOverrides	   = GetMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
+	ReplicatedOverrides[ModelPath] = MaterialAssetId;
+
+	SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
+}
+
+void StaticModelSpaceComponent::RemoveMaterialOverride(const csp::common::String& ModelPath)
+{
+	auto ReplicatedOverrides = GetMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
+	ReplicatedOverrides.Remove(ModelPath);
+
+	SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }
 
 /* ITransformComponent */

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -67,10 +67,19 @@ void StaticModelSpaceComponent::SetExternalResourceAssetCollectionId(const csp::
 csp::common::Map<csp::common::String, csp::common::String> StaticModelSpaceComponent::GetMaterialOverrides() const
 {
 	// Convert replicated values map to string values
-	const auto& ReplicatedOverrides = GetMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
+	common::Map<multiplayer::ReplicatedValue, multiplayer::ReplicatedValue> ReplicatedOverrides
+		= GetMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
+
 	csp::common::Map<csp::common::String, csp::common::String> Overrides;
 
-	const auto* Keys = ReplicatedOverrides.Keys();
+	auto Deleter = [](const common::Array<multiplayer::ReplicatedValue>* Ptr)
+	{
+		CSP_DELETE(Ptr);
+	};
+
+	std::unique_ptr<common::Array<multiplayer::ReplicatedValue>, decltype(Deleter)> Keys(
+		const_cast<common::Array<multiplayer::ReplicatedValue>*>(ReplicatedOverrides.Keys()),
+		Deleter);
 
 	for (size_t i = 0; i < Keys->Size(); ++i)
 	{
@@ -78,15 +87,15 @@ csp::common::Map<csp::common::String, csp::common::String> StaticModelSpaceCompo
 		Overrides[CurrentKey.GetString()] = ReplicatedOverrides[CurrentKey].GetString();
 	}
 
-	CSP_DELETE(Keys);
-
 	return Overrides;
 }
 
-void StaticModelSpaceComponent::AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialAssetId)
+void StaticModelSpaceComponent::AddMaterialOverride(const csp::common::String& ModelPath, const csp::common::String& MaterialId)
 {
-	auto ReplicatedOverrides	   = GetMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
-	ReplicatedOverrides[ModelPath] = MaterialAssetId;
+	common::Map<multiplayer::ReplicatedValue, multiplayer::ReplicatedValue> ReplicatedOverrides
+		= GetMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
+
+	ReplicatedOverrides[ModelPath] = MaterialId;
 
 	SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }

--- a/Library/src/Systems/Assets/GLTFMaterial.cpp
+++ b/Library/src/Systems/Assets/GLTFMaterial.cpp
@@ -124,22 +124,27 @@ void FromJson(const csp::json::JsonDeserializer& Deserializer, csp::systems::GLT
 	if (Deserializer.HasProperty("baseColorTexture"))
 	{
 		Deserializer.DeserializeMember("baseColorTexture", Obj.BaseColorTexture);
+		Obj.BaseColorTexture.SetTexture(true);
 	}
 	if (Deserializer.HasProperty("metallicRoughnessTexture"))
 	{
 		Deserializer.DeserializeMember("metallicRoughnessTexture", Obj.MetallicRoughnessTexture);
+		Obj.MetallicRoughnessTexture.SetTexture(true);
 	}
 	if (Deserializer.HasProperty("normalTexture"))
 	{
 		Deserializer.DeserializeMember("normalTexture", Obj.NormalTexture);
+		Obj.NormalTexture.SetTexture(true);
 	}
 	if (Deserializer.HasProperty("occlusionTexture"))
 	{
 		Deserializer.DeserializeMember("occlusionTexture", Obj.OcclusionTexture);
+		Obj.OcclusionTexture.SetTexture(true);
 	}
 	if (Deserializer.HasProperty("emissiveTexture"))
 	{
 		Deserializer.DeserializeMember("emissiveTexture", Obj.EmissiveTexture);
+		Obj.EmissiveTexture.SetTexture(true);
 	}
 }
 

--- a/Library/src/Systems/Assets/Material.cpp
+++ b/Library/src/Systems/Assets/Material.cpp
@@ -24,7 +24,7 @@ namespace csp::systems
 {
 
 Material::Material(const csp::common::String& InAssetCollectionId, const csp::common::String& InAssetId)
-	: AssetCollectionId(InAssetCollectionId), AssetId(InAssetId), Name(""), Type(EShaderType::Standard)
+	: CollectionId(InAssetCollectionId), Id(InAssetId), Name(""), Type(EShaderType::Standard)
 {
 }
 
@@ -38,14 +38,14 @@ const csp::common::String& Material::GetName() const
 	return Name;
 }
 
-const csp::common::String& Material::GetAssetCollectionId() const
+const csp::common::String& Material::GetMaterialCollectionId() const
 {
-	return AssetCollectionId;
+	return CollectionId;
 }
 
-const csp::common::String& Material::GetAssetId() const
+const csp::common::String& Material::GetMaterialId() const
 {
-	return AssetId;
+	return Id;
 }
 
 } // namespace csp::systems

--- a/Tests/src/InternalTests/MaterialTests.cpp
+++ b/Tests/src/InternalTests/MaterialTests.cpp
@@ -234,11 +234,11 @@ CSP_INTERNAL_TEST(CSPEngine, MaterialTests, MaterialJsonSerializationTest)
 	EXPECT_EQ(DeserializedMaterial.GetEmissiveTexture().GetUVScale(), TestEmissiveTextureUVScale);
 	EXPECT_EQ(DeserializedMaterial.GetEmissiveTexture().GetTexCoord(), TestEmissiveTextureTexCoord);
 
-	EXPECT_EQ(Material.GetBaseColorTexture().IsSet(), true);
-	EXPECT_EQ(Material.GetMetallicRoughnessTexture().IsSet(), true);
-	EXPECT_EQ(Material.GetNormalTexture().IsSet(), true);
-	EXPECT_EQ(Material.GetOcclusionTexture().IsSet(), true);
-	EXPECT_EQ(Material.GetEmissiveTexture().IsSet(), true);
+	EXPECT_EQ(DeserializedMaterial.GetBaseColorTexture().IsSet(), true);
+	EXPECT_EQ(DeserializedMaterial.GetMetallicRoughnessTexture().IsSet(), true);
+	EXPECT_EQ(DeserializedMaterial.GetNormalTexture().IsSet(), true);
+	EXPECT_EQ(DeserializedMaterial.GetOcclusionTexture().IsSet(), true);
+	EXPECT_EQ(DeserializedMaterial.GetEmissiveTexture().IsSet(), true);
 }
 
 CSP_INTERNAL_TEST(CSPEngine, MaterialTests, TextureInfoDefaultConstructorTest)

--- a/Tests/src/InternalTests/MaterialTests.cpp
+++ b/Tests/src/InternalTests/MaterialTests.cpp
@@ -32,8 +32,8 @@ CSP_INTERNAL_TEST(CSPEngine, MaterialTests, MaterialConstructorTest)
 	GLTFMaterial Material(TestAssetCollectionId, TestAssetId);
 
 	// Test constructor params
-	EXPECT_EQ(Material.GetAssetCollectionId(), TestAssetCollectionId);
-	EXPECT_EQ(Material.GetAssetId(), TestAssetId);
+	EXPECT_EQ(Material.GetMaterialCollectionId(), TestAssetCollectionId);
+	EXPECT_EQ(Material.GetMaterialId(), TestAssetId);
 
 	// Test defaults
 	EXPECT_EQ(Material.GetName(), "");

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../SpaceSystemTestHelpers.h"
+#include "../UserSystemTestHelpers.h"
+#include "Awaitable.h"
+#include "CSP/CSPFoundation.h"
+#include "CSP/Common/Optional.h"
+#include "CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h"
+#include "CSP/Multiplayer/MultiPlayerConnection.h"
+#include "CSP/Multiplayer/Script/EntityScript.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
+#include "TestHelpers.h"
+
+#include "gtest/gtest.h"
+#include <chrono>
+#include <thread>
+
+using namespace csp::multiplayer;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+bool RequestPredicate(const csp::systems::ResultBase& Result)
+{
+	return Result.GetResultCode() != csp::systems::EResultCode::InProgress;
+}
+
+} // namespace
+
+#if RUN_ALL_UNIT_TESTS || RUN_ANIMATED_MODEL_TESTS || RUN_ANIMATED_MODEL_TEST
+CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* Connection	 = SystemsManager.GetMultiplayerConnection();
+	auto* EntitySystem	 = SystemsManager.GetSpaceEntitySystem();
+
+	const char* TestSpaceName		 = "CSP-UNITTEST-SPACE-MAG";
+	const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	// Log in
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	{
+		auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+		EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+		EntitySystem->SetEntityCreatedCallback(
+			[](csp::multiplayer::SpaceEntity* Entity)
+			{
+			});
+
+		csp::common::String ObjectName = "Object 1";
+		SpaceTransform ObjectTransform = {csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One()};
+		auto [CreatedObject]		   = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+
+		// Create custom component
+		auto* AnimatedModelComponent = (AnimatedModelSpaceComponent*) CreatedObject->AddComponent(ComponentType::AnimatedModel);
+
+		constexpr const char* TestExternalResourceAssetCollectionId = "TestExternalResourceAssetCollectionId";
+		constexpr const char* TestExternalResourceAssetId			= "TestExternalResourceAssetId";
+		constexpr const char* TestMaterialPath						= "TestMaterialPath";
+		constexpr const char* TestMaterialAssetId					= "TestMaterialAssetId";
+		const csp::common::Vector3 TestPosition(1.f, 1.f, 1.f);
+		const csp::common::Vector4 TestRotation(1.f, 1.f, 1.f, 1.f);
+		const csp::common::Vector3 TestScale(2.f, 2.f, 2.f);
+		const SpaceTransform TestTransform(TestPosition, TestRotation, TestScale);
+		constexpr const bool TestIsLoopPlayback			 = true;
+		constexpr const bool TestIsPlaying				 = true;
+		constexpr const int TestAnimationIndex			 = 1;
+		constexpr const bool TestIsVisible				 = false;
+		constexpr const bool TestIsARVisible			 = false;
+		constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
+		constexpr const bool TestIsShadowCaster			 = false;
+
+		// Test defaults
+		EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), "");
+		EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetId(), "");
+		EXPECT_EQ(AnimatedModelComponent->GetMaterialOverrides().Size(), 0);
+		EXPECT_EQ(AnimatedModelComponent->GetPosition(), csp::common::Vector3::Zero());
+		EXPECT_EQ(AnimatedModelComponent->GetRotation(), csp::common::Vector4::Identity());
+		EXPECT_EQ(AnimatedModelComponent->GetScale(), csp::common::Vector3::One());
+		EXPECT_EQ(AnimatedModelComponent->GetTransform(), csp::multiplayer::SpaceTransform());
+		EXPECT_EQ(AnimatedModelComponent->GetIsLoopPlayback(), false);
+		EXPECT_EQ(AnimatedModelComponent->GetIsPlaying(), false);
+		EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), -1);
+		EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), true);
+		EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), true);
+		EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), "");
+		EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), true);
+
+		AnimatedModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
+		AnimatedModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
+		AnimatedModelComponent->AddMaterialOverride(TestMaterialPath, TestMaterialAssetId);
+		AnimatedModelComponent->SetPosition(TestPosition);
+		AnimatedModelComponent->SetRotation(TestRotation);
+		AnimatedModelComponent->SetScale(TestScale);
+		AnimatedModelComponent->SetIsLoopPlayback(TestIsLoopPlayback);
+		AnimatedModelComponent->SetIsPlaying(TestIsPlaying);
+		AnimatedModelComponent->SetAnimationIndex(TestAnimationIndex);
+		AnimatedModelComponent->SetIsVisible(TestIsVisible);
+		AnimatedModelComponent->SetIsARVisible(TestIsARVisible);
+		AnimatedModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
+		AnimatedModelComponent->SetIsShadowCaster(TestIsShadowCaster);
+
+		// Test new values
+		EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
+		EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetId(), TestExternalResourceAssetId);
+		EXPECT_EQ(AnimatedModelComponent->GetMaterialOverrides().Size(), 1);
+		EXPECT_TRUE(AnimatedModelComponent->GetMaterialOverrides().HasKey(TestMaterialPath));
+		EXPECT_EQ(AnimatedModelComponent->GetPosition(), TestPosition);
+		EXPECT_EQ(AnimatedModelComponent->GetRotation(), TestRotation);
+		EXPECT_EQ(AnimatedModelComponent->GetScale(), TestScale);
+		EXPECT_EQ(AnimatedModelComponent->GetIsLoopPlayback(), TestIsLoopPlayback);
+		EXPECT_EQ(AnimatedModelComponent->GetIsPlaying(), TestIsPlaying);
+		EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), TestAnimationIndex);
+		EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), TestIsVisible);
+		EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), TestIsARVisible);
+		EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
+		EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
+
+		// Test transform separately, as this just sets position, rotation, scale
+		AnimatedModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
+
+		EXPECT_EQ(AnimatedModelComponent->GetTransform(), csp::multiplayer::SpaceTransform());
+
+		AnimatedModelComponent->SetTransform(TestTransform);
+
+		EXPECT_EQ(AnimatedModelComponent->GetTransform(), TestTransform);
+
+		// Also test we can remove a material override
+		AnimatedModelComponent->RemoveMaterialOverride(TestMaterialPath);
+
+		EXPECT_EQ(AnimatedModelComponent->GetMaterialOverrides().Size(), 0);
+
+		auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+	}
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_ANIMATED_MODEL_TESTS || RUN_ANIMATED_MODEL_SCRIPT_INTERFACE_TEST
+CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* Connection	 = SystemsManager.GetMultiplayerConnection();
+	auto* EntitySystem	 = SystemsManager.GetSpaceEntitySystem();
+
+	const char* TestSpaceName		 = "OLY-UNITTEST-SPACE-REWIND";
+	const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	// Log in
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+	EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	EntitySystem->SetEntityCreatedCallback(
+		[](csp::multiplayer::SpaceEntity* Entity)
+		{
+		});
+
+	// Create object to represent the fog
+	csp::common::String ObjectName = "Object 1";
+	SpaceTransform ObjectTransform = {csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One()};
+	auto [CreatedObject]		   = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+
+	// Create fog component
+	auto* AnimatedModelComponent = (AnimatedModelSpaceComponent*) CreatedObject->AddComponent(ComponentType::AnimatedModel);
+
+	CreatedObject->QueueUpdate();
+	EntitySystem->ProcessPendingEntityOperations();
+
+	// Setup script
+	const std::string StaticModelScriptText = R"xx(
+		var model = ThisEntity.getAnimatedModelComponents()[0];
+		model.externalResourceAssetCollectionId = "TestExternalResourceAssetCollectionId";
+		model.externalResourceAssetId = "TestExternalResourceAssetId";
+		model.position = [1, 1, 1];
+		model.rotation = [1, 1, 1, 1];
+		model.scale = [2, 2, 2];
+		model.isLoopPlayback = false;
+		model.isPlaying = false;
+		model.isVisible = false;
+		model.animationIndex = 1;
+    )xx";
+
+	CreatedObject->GetScript()->SetScriptSource(StaticModelScriptText.c_str());
+	CreatedObject->GetScript()->Invoke();
+
+	EntitySystem->ProcessPendingEntityOperations();
+
+	// Test new values
+	EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), "TestExternalResourceAssetCollectionId");
+	EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetId(), "TestExternalResourceAssetId");
+	EXPECT_EQ(AnimatedModelComponent->GetPosition(), csp::common::Vector3::One());
+	EXPECT_EQ(AnimatedModelComponent->GetRotation(), csp::common::Vector4::One());
+	EXPECT_EQ(AnimatedModelComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+	EXPECT_EQ(AnimatedModelComponent->GetIsLoopPlayback(), false);
+	EXPECT_EQ(AnimatedModelComponent->GetIsPlaying(), false);
+	EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), false);
+	EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), 1);
+
+	auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../SpaceSystemTestHelpers.h"
+#include "../UserSystemTestHelpers.h"
+#include "Awaitable.h"
+#include "CSP/CSPFoundation.h"
+#include "CSP/Common/Optional.h"
+#include "CSP/Multiplayer/Components/StaticModelSpaceComponent.h"
+#include "CSP/Multiplayer/MultiPlayerConnection.h"
+#include "CSP/Multiplayer/Script/EntityScript.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
+#include "TestHelpers.h"
+
+#include "gtest/gtest.h"
+#include <chrono>
+#include <thread>
+
+using namespace csp::multiplayer;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+bool RequestPredicate(const csp::systems::ResultBase& Result)
+{
+	return Result.GetResultCode() != csp::systems::EResultCode::InProgress;
+}
+
+} // namespace
+
+#if RUN_ALL_UNIT_TESTS || RUN_STATIC_MODEL_TESTS || RUN_STATIC_MODEL_TEST
+CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* Connection	 = SystemsManager.GetMultiplayerConnection();
+	auto* EntitySystem	 = SystemsManager.GetSpaceEntitySystem();
+
+	const char* TestSpaceName		 = "CSP-UNITTEST-SPACE-MAG";
+	const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	// Log in
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	{
+		auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+		EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+		EntitySystem->SetEntityCreatedCallback(
+			[](csp::multiplayer::SpaceEntity* Entity)
+			{
+			});
+
+		csp::common::String ObjectName = "Object 1";
+		SpaceTransform ObjectTransform = {csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One()};
+		auto [CreatedObject]		   = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+
+		// Create custom component
+		auto* StaticModelComponent = (StaticModelSpaceComponent*) CreatedObject->AddComponent(ComponentType::StaticModel);
+
+		constexpr const char* TestExternalResourceAssetCollectionId = "TestExternalResourceAssetCollectionId";
+		constexpr const char* TestExternalResourceAssetId			= "TestExternalResourceAssetId";
+		constexpr const char* TestMaterialPath						= "TestMaterialPath";
+		constexpr const char* TestMaterialAssetId					= "TestMaterialAssetId";
+		const csp::common::Vector3 TestPosition(1.f, 1.f, 1.f);
+		const csp::common::Vector4 TestRotation(1.f, 1.f, 1.f, 1.f);
+		const csp::common::Vector3 TestScale(2.f, 2.f, 2.f);
+		const SpaceTransform TestTransform(TestPosition, TestRotation, TestScale);
+		constexpr const bool TestIsVisible				 = false;
+		constexpr const bool TestIsARVisible			 = false;
+		constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
+		constexpr const bool TestIsShadowCaster			 = false;
+
+		// Test defaults
+		EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), "");
+		EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetId(), "");
+		EXPECT_EQ(StaticModelComponent->GetMaterialOverrides().Size(), 0);
+		EXPECT_EQ(StaticModelComponent->GetPosition(), csp::common::Vector3::Zero());
+		EXPECT_EQ(StaticModelComponent->GetRotation(), csp::common::Vector4::Identity());
+		EXPECT_EQ(StaticModelComponent->GetScale(), csp::common::Vector3::One());
+		EXPECT_EQ(StaticModelComponent->GetTransform(), csp::multiplayer::SpaceTransform());
+		EXPECT_EQ(StaticModelComponent->GetIsVisible(), true);
+		EXPECT_EQ(StaticModelComponent->GetIsARVisible(), true);
+		EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), "");
+		EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), true);
+
+		StaticModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
+		StaticModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
+		StaticModelComponent->AddMaterialOverride(TestMaterialPath, TestMaterialAssetId);
+		StaticModelComponent->SetPosition(TestPosition);
+		StaticModelComponent->SetRotation(TestRotation);
+		StaticModelComponent->SetScale(TestScale);
+		StaticModelComponent->SetIsVisible(TestIsVisible);
+		StaticModelComponent->SetIsARVisible(TestIsARVisible);
+		StaticModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
+		StaticModelComponent->SetIsShadowCaster(TestIsShadowCaster);
+
+		// Test new values
+		EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
+		EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetId(), TestExternalResourceAssetId);
+		EXPECT_EQ(StaticModelComponent->GetMaterialOverrides().Size(), 1);
+		EXPECT_TRUE(StaticModelComponent->GetMaterialOverrides().HasKey(TestMaterialPath));
+		EXPECT_EQ(StaticModelComponent->GetPosition(), TestPosition);
+		EXPECT_EQ(StaticModelComponent->GetRotation(), TestRotation);
+		EXPECT_EQ(StaticModelComponent->GetScale(), TestScale);
+		EXPECT_EQ(StaticModelComponent->GetIsVisible(), TestIsVisible);
+		EXPECT_EQ(StaticModelComponent->GetIsARVisible(), TestIsARVisible);
+		EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
+		EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
+
+		// Test transform separately, as this just sets position, rotation, scale
+		StaticModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
+
+		EXPECT_EQ(StaticModelComponent->GetTransform(), csp::multiplayer::SpaceTransform());
+
+		StaticModelComponent->SetTransform(TestTransform);
+
+		EXPECT_EQ(StaticModelComponent->GetTransform(), TestTransform);
+
+		// Also test we can remove a material override
+		StaticModelComponent->RemoveMaterialOverride(TestMaterialPath);
+
+		EXPECT_EQ(StaticModelComponent->GetMaterialOverrides().Size(), 0);
+
+		auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+	}
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_STATIC_MODEL_TESTS || RUN_STATIC_MODEL_SCRIPT_INTERFACE_TEST
+CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* Connection	 = SystemsManager.GetMultiplayerConnection();
+	auto* EntitySystem	 = SystemsManager.GetSpaceEntitySystem();
+
+	const char* TestSpaceName		 = "OLY-UNITTEST-SPACE-REWIND";
+	const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	// Log in
+	csp::common::String UserId;
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, Space);
+
+	auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+	EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	EntitySystem->SetEntityCreatedCallback(
+		[](csp::multiplayer::SpaceEntity* Entity)
+		{
+		});
+
+	// Create object to represent the fog
+	csp::common::String ObjectName = "Object 1";
+	SpaceTransform ObjectTransform = {csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One()};
+	auto [CreatedObject]		   = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+
+	// Create fog component
+	auto* StaticModelComponent = (StaticModelSpaceComponent*) CreatedObject->AddComponent(ComponentType::StaticModel);
+
+	CreatedObject->QueueUpdate();
+	EntitySystem->ProcessPendingEntityOperations();
+
+	// Setup script
+	const std::string StaticModelScriptText = R"xx(
+		var model = ThisEntity.getStaticModelComponents()[0];
+		model.externalResourceAssetCollectionId = "TestExternalResourceAssetCollectionId";
+		model.externalResourceAssetId = "TestExternalResourceAssetId";
+		model.position = [1, 1, 1];
+		model.rotation = [1, 1, 1, 1];
+		model.scale = [2, 2, 2];
+		model.isVisible = false;
+    )xx";
+
+	CreatedObject->GetScript()->SetScriptSource(StaticModelScriptText.c_str());
+	CreatedObject->GetScript()->Invoke();
+
+	EntitySystem->ProcessPendingEntityOperations();
+
+	// Test new values
+	EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), "TestExternalResourceAssetCollectionId");
+	EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetId(), "TestExternalResourceAssetId");
+	EXPECT_EQ(StaticModelComponent->GetPosition(), csp::common::Vector3::One());
+	EXPECT_EQ(StaticModelComponent->GetRotation(), csp::common::Vector4::One());
+	EXPECT_EQ(StaticModelComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+	EXPECT_EQ(StaticModelComponent->GetIsVisible(), false);
+
+	auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif


### PR DESCRIPTION
- Added material overrides props to static/animated model components
- Setup tests for static/animated model components
- put scripted properties on hold as this is not part of p0 and quickjs has issues with maps