### PR TITLE
[OB-3674] fix: Do not encode already encoded URLs

### DIFF
--- a/Library/src/Systems/Assets/Asset.cpp
+++ b/Library/src/Systems/Assets/Asset.cpp
@@ -50,7 +50,7 @@ csp::systems::EAssetType ConvertDTOAssetDetailType(const csp::common::String& DT
 		return csp::systems::EAssetType::HOLOCAP_AUDIO;
 	else if (DTOAssetDetailType == "Audio")
 		return csp::systems::EAssetType::AUDIO;
-    else if(DTOAssetDetailType == "GaussianSplat")
+	else if (DTOAssetDetailType == "GaussianSplat")
 		return csp::systems::EAssetType::GAUSSIAN_SPLAT;
 	else
 	{
@@ -156,7 +156,7 @@ void AssetDetailDtoToAsset(const chs::AssetDetailDto& Dto, csp::systems::Asset& 
 
 	if (Dto.HasUri())
 	{
-		Asset.Uri = web::Uri::Encode(Dto.GetUri());
+		Asset.Uri = Dto.GetUri();
 	}
 
 	if (Dto.HasChecksum())

--- a/Tests/assets/TestWith Space.json
+++ b/Tests/assets/TestWith Space.json
@@ -1,0 +1,4 @@
+{
+  "is_test_data": "true",
+  "meaning_of_life": 42
+}

--- a/Tests/assets/TestWithEncoded%20Space.json
+++ b/Tests/assets/TestWithEncoded%20Space.json
@@ -1,0 +1,4 @@
+{
+  "is_test_data": "true",
+  "meaning_of_life": 42
+}

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -1515,6 +1515,159 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileNoSpaceTest)
 }
 #endif
 
+#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_WITH_UNENCODED_SPACE_TEST
+CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetWithUnencodedSpace)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* AssetSystem	 = SystemsManager.GetAssetSystem();
+
+	constexpr char* TestSpaceName			= "OLY-UNITTEST-SPACE-REWIND";
+	constexpr char* TestSpaceDescription	= "OLY-UNITTEST-SPACEDESC-REWIND";
+	constexpr char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
+	constexpr char* TestAssetName			= "OLY-UNITTEST-ASSET-REWIND";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	char UniqueAssetCollectionName[256];
+	SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
+
+	char UniqueAssetName[256];
+	SPRINTF(UniqueAssetName, "%s-%s", TestAssetName, GetUniqueString().c_str());
+
+	csp::common::String UserId;
+
+	// Log in
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem,
+				UniqueSpaceName,
+				TestSpaceDescription,
+				csp::systems::SpaceAttributes::Private,
+				nullptr,
+				nullptr,
+				nullptr,
+				nullptr,
+				Space);
+
+	// Create asset collection
+	csp::systems::AssetCollection AssetCollection;
+	CreateAssetCollection(AssetSystem, Space.Id, nullptr, UniqueAssetCollectionName, nullptr, nullptr, AssetCollection);
+
+	// Create asset
+	csp::systems::Asset Asset;
+	CreateAsset(AssetSystem, AssetCollection, UniqueAssetName, nullptr, nullptr, Asset);
+	auto FilePath = std::filesystem::absolute("assets/TestWith Space.json");
+	csp::systems::FileAssetDataSource Source;
+	Source.FilePath = FilePath.u8string().c_str();
+
+	// Upload data
+	auto [UploadResult] = AWAIT_PRE(AssetSystem, UploadAssetData, RequestPredicateWithProgress, AssetCollection, Asset, Source);
+	EXPECT_EQ(UploadResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	// Get uploaded asset
+	auto [AssetResult] = AWAIT_PRE(AssetSystem, GetAssetById, RequestPredicate, AssetCollection.Id, Asset.Id);
+	std::string UriStr = AssetResult.GetAsset().Uri;
+
+	// Check uri is encoded as expected
+	EXPECT_TRUE(UriStr.find("TestWith%20Space") != std::string::npos);
+
+	// Delete asset
+	DeleteAsset(AssetSystem, AssetCollection, Asset);
+
+	// Delete asset collection
+	DeleteAssetCollection(AssetSystem, AssetCollection);
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_WITH_ENCODED_SPACE_TEST
+CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetWithEncodedSpace)
+{
+	SetRandSeed();
+
+	auto& SystemsManager = csp::systems::SystemsManager::Get();
+	auto* UserSystem	 = SystemsManager.GetUserSystem();
+	auto* SpaceSystem	 = SystemsManager.GetSpaceSystem();
+	auto* AssetSystem	 = SystemsManager.GetAssetSystem();
+
+	constexpr char* TestSpaceName			= "OLY-UNITTEST-SPACE-REWIND";
+	constexpr char* TestSpaceDescription	= "OLY-UNITTEST-SPACEDESC-REWIND";
+	constexpr char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
+	constexpr char* TestAssetName			= "OLY-UNITTEST-ASSET-REWIND";
+
+	char UniqueSpaceName[256];
+	SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+	char UniqueAssetCollectionName[256];
+	SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
+
+	char UniqueAssetName[256];
+	SPRINTF(UniqueAssetName, "%s-%s", TestAssetName, GetUniqueString().c_str());
+
+	csp::common::String UserId;
+
+	// Log in
+	LogIn(UserSystem, UserId);
+
+	// Create space
+	csp::systems::Space Space;
+	CreateSpace(SpaceSystem,
+				UniqueSpaceName,
+				TestSpaceDescription,
+				csp::systems::SpaceAttributes::Private,
+				nullptr,
+				nullptr,
+				nullptr,
+				nullptr,
+				Space);
+
+	// Create asset collection
+	csp::systems::AssetCollection AssetCollection;
+	CreateAssetCollection(AssetSystem, Space.Id, nullptr, UniqueAssetCollectionName, nullptr, nullptr, AssetCollection);
+
+	// Create asset
+	csp::systems::Asset Asset;
+	CreateAsset(AssetSystem, AssetCollection, UniqueAssetName, nullptr, nullptr, Asset);
+	auto FilePath = std::filesystem::absolute("assets/TestWithEncoded%20Space.json");
+	csp::systems::FileAssetDataSource Source;
+	Source.FilePath = FilePath.u8string().c_str();
+
+	// Upload data
+	auto [UploadResult] = AWAIT_PRE(AssetSystem, UploadAssetData, RequestPredicateWithProgress, AssetCollection, Asset, Source);
+	EXPECT_EQ(UploadResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+	// Get uploaded asset
+	auto [AssetResult] = AWAIT_PRE(AssetSystem, GetAssetById, RequestPredicate, AssetCollection.Id, Asset.Id);
+	std::string UriStr = AssetResult.GetAsset().Uri;
+
+	// Check uri is encoded as expected
+	EXPECT_TRUE(UriStr.find("TestWithEncoded%20Space") != std::string::npos);
+
+	// Delete asset
+	DeleteAsset(AssetSystem, AssetCollection, Asset);
+
+	// Delete asset collection
+	DeleteAssetCollection(AssetSystem, AssetCollection);
+
+	// Delete space
+	DeleteSpace(SpaceSystem, Space.Id);
+
+	// Log out
+	LogOut(UserSystem);
+}
+#endif
 
 #if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_AS_BUFFER_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsBufferTest)


### PR DESCRIPTION
CSP made a change in March to encode URLs in asset details. We added this encode earlier than that to workaround the issue for a client team, but now it's causing double encode errors, so we should remove it.

Added a couple of tests so we'd know if this changes again.

(Magnopus slack confirming this change : https://magnopus.slack.com/archives/C02T07E8P2B/p1732097572110679)