### PR TITLE
[NT-0] doc: CSP Learning Documentation

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs post-checkout "$@"

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs post-commit "$@"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs post-merge "$@"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs pre-push "$@"

--- a/Library/docs/requirements.txt
+++ b/Library/docs/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==5.0.2
 sphinx-rtd-theme==1.0.0
+sphinx-rtd-dark-mode==1.3.0
 breathe==4.35.0
 exhale==0.3.7
 recommonmark==0.7.1

--- a/Library/docs/requirements.txt
+++ b/Library/docs/requirements.txt
@@ -4,4 +4,4 @@ sphinx-rtd-dark-mode==1.3.0
 breathe==4.35.0
 exhale==0.3.7
 recommonmark==0.7.1
-sphinx-markdown-tables=0.0.17
+sphinx-markdown-tables==0.0.17

--- a/Library/docs/requirements.txt
+++ b/Library/docs/requirements.txt
@@ -1,5 +1,5 @@
-Sphinx==4.5.0
+Sphinx==5.0.2
 sphinx-rtd-theme==1.0.0
-breathe==4.32.0
-exhale==0.3.5
+breathe==4.35.0
+exhale==0.3.7
 recommonmark==0.7.1

--- a/Library/docs/requirements.txt
+++ b/Library/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-rtd-dark-mode==1.3.0
 breathe==4.35.0
 exhale==0.3.7
 recommonmark==0.7.1
+sphinx-markdown-tables=0.0.17

--- a/Library/docs/source/_static/building/android_cfg.png
+++ b/Library/docs/source/_static/building/android_cfg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d4d706dcfca99716724cf45cfd10269e903b1a0d6bb1155941c2300930f089f
+size 33740

--- a/Library/docs/source/_static/building/android_sln.png
+++ b/Library/docs/source/_static/building/android_sln.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c171204b7f4f71bd932c6e41a00fbd621e75c152dd30371f0f9667f7b72807f
+size 224984

--- a/Library/docs/source/_static/building/cpp_cfg.png
+++ b/Library/docs/source/_static/building/cpp_cfg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d4d706dcfca99716724cf45cfd10269e903b1a0d6bb1155941c2300930f089f
+size 33740

--- a/Library/docs/source/_static/building/cpp_sln.png
+++ b/Library/docs/source/_static/building/cpp_sln.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d4d706dcfca99716724cf45cfd10269e903b1a0d6bb1155941c2300930f089f
+size 33740

--- a/Library/docs/source/_static/building/csharp_cfg.png
+++ b/Library/docs/source/_static/building/csharp_cfg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d4d706dcfca99716724cf45cfd10269e903b1a0d6bb1155941c2300930f089f
+size 33740

--- a/Library/docs/source/_static/building/csharp_sln.png
+++ b/Library/docs/source/_static/building/csharp_sln.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c171204b7f4f71bd932c6e41a00fbd621e75c152dd30371f0f9667f7b72807f
+size 224984

--- a/Library/docs/source/_static/custom.css
+++ b/Library/docs/source/_static/custom.css
@@ -1,6 +1,11 @@
 @media (prefers-color-scheme: dark) {
-	/* We override the colorisation of class names so that it looks good in both light and dark modes. */
+	/* We override the colorization of class names so that it looks good in both light and dark modes. */
 	.descclassname, .descname {
 		color: darkorange !important;
+	}
+	
+	/* We disable search result background highlighting as we feel it is visually distracting to the reader. */
+	.rst-content .highlighted {
+		background: transparent;
 	}
 }

--- a/Library/docs/source/_static/custom.css
+++ b/Library/docs/source/_static/custom.css
@@ -1,0 +1,6 @@
+@media (prefers-color-scheme: dark) {
+	/* We override the colorisation of class names so that it looks good in both light and dark modes. */
+	.descclassname, .descname {
+		color: darkorange !important;
+	}
+}

--- a/Library/docs/source/_static/debugging/insights.png
+++ b/Library/docs/source/_static/debugging/insights.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2b775f4f90a4aa4580f6375b98868f1a32476a36814fcd972c02a50781d4fef
+size 592276

--- a/Library/docs/source/_static/getting_started/install_package.png
+++ b/Library/docs/source/_static/getting_started/install_package.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fce39f398d485e35cd144787692f2fb096a57955acd02cb5253e7cf06f083b9
+size 70592

--- a/Library/docs/source/_static/getting_started/myregistry.png
+++ b/Library/docs/source/_static/getting_started/myregistry.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f07ee022b42882bcc30209997f26391c42db208efbb972218455465c3f9f88f5
+size 88948

--- a/Library/docs/source/_static/getting_started/npmjs_registry.png
+++ b/Library/docs/source/_static/getting_started/npmjs_registry.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e188c72cb21daccfa43cf85d9b0dc0a8d82edfd9f7506169940b639f3dded0cb
+size 77590

--- a/Library/docs/source/_static/logo.png
+++ b/Library/docs/source/_static/logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f402a00ee8ad6eea6350dba89719e42ac0cd67671fcca7e3faaafa7bdfc23000
+size 23432

--- a/Library/docs/source/_static/mcs/aggregation_service.png
+++ b/Library/docs/source/_static/mcs/aggregation_service.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f8189085992fb3a7678ac2c12ffc8013769f78e7696b19a0ad576c33179dc10
+size 19601

--- a/Library/docs/source/_static/mcs/asset_service.png
+++ b/Library/docs/source/_static/mcs/asset_service.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79f1c0f34ab0cdb8dc99560d077a2f89b6d06fd72bfff7e1a3e1e0749f205c1a
+size 34100

--- a/Library/docs/source/_static/mcs/multiplayer_service.png
+++ b/Library/docs/source/_static/mcs/multiplayer_service.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfcdf888171ed988b9e354481c5d35f4023b9a9bd21841449e227c394dc18fca
+size 31934

--- a/Library/docs/source/_static/mcs/ranking_service.png
+++ b/Library/docs/source/_static/mcs/ranking_service.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cba8679bcfb7d1095f7f448ba2713bd4c988929de778e1e1ed80e4d3621a838
+size 32492

--- a/Library/docs/source/_static/mcs/spatialdata_service.png
+++ b/Library/docs/source/_static/mcs/spatialdata_service.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6feaa302429b26a0088430c1d9b67527b3f269cd4749120ce94f5e5991c4f05
+size 27372

--- a/Library/docs/source/_static/mcs/user_service.png
+++ b/Library/docs/source/_static/mcs/user_service.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64b3790facca9e3eb2b23eb6993a1facefc61f24ba0b82f7de478dfc1bd54168
+size 31100

--- a/Library/docs/source/_static/stack.png
+++ b/Library/docs/source/_static/stack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c45ca97ab4ee75d757c3257624a98235a74a4aed5ac7e9e8348ba7a86782bbf4
+size 98440

--- a/Library/docs/source/_static/tenants/tenant_flow_csp.png
+++ b/Library/docs/source/_static/tenants/tenant_flow_csp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4af8339ba5a68921029fdef4e1cc3163a7a37677a279e148dad593631ab92bb2
+size 157234

--- a/Library/docs/source/articles/overview/mcs.md
+++ b/Library/docs/source/articles/overview/mcs.md
@@ -1,0 +1,191 @@
+# Magnopus Cloud Services (MCS)
+CSP-enabled applications rely on cloud-hosted services to function effectively. Magnopus offers a set of cloud-hosted services, known as Magnopus Cloud Services (MCS), specifically designed for the Connected Space Platform. These services act as an independent layer that supports both the CSP and client applications. It is not required to use MCS with the Connected Spaces platform.
+
+It is however recommended to use MCS with CSP, as MCS helps developers simplify development by providing ready-to-use tools and services, reducing the complexity of building and maintaining applications. Selecting MCS as the backend service provider allows the developer to not worry about the services themselves, and exclusively focus on building their spatial-web application using the CSP API.
+
+### Importance of MCS in the CSP Ecosystem
+* **Scalability**: MCS allows CSP-enabled applications to scale their operations seamlessly to accommodate growing users and applications without compromising performance. It adjusts resources dynamically to handle peak periods, keeping services running without interruptions.
+
+* **Flexibility:** MCS components ensure CSP applications adjust to new needs and features. This flexibility lets the applications deploy updates fast, listen to user feedback, and stay updated with technology trends.
+
+* **Interoperability:** MCS allows seamless integration with various external systems and services, hence offering both flexibility and usability of CSP. This interoperability allows CSP to connect with third-party applications, APIs, and tools, expanding the ecosystem's functionality and reach.
+
+* **Increased Developer Experience:** MCS lets developers focus on building and innovating instead of managing infrastructure by providing comprehensive tools, APIs, and services. 
+
+* **User engagement:** MCS provides an interactive environment through various services, including user management, social connections, and multi-users services. These services improve user satisfaction by allowing customized experiences, collaboration, and community-building.  
+
+### What are the Core Components of MCS?
+
+**1\. User Accounts & Management**
+
+User Accounts & Management handles user authentication, authorization, and profile management. This component ensures that users can securely log in, manage their profiles, and access the appropriate services and features within the CSP environment.
+
+**2\. Security & Access Control**
+
+Security & Access Control is responsible for protecting data and ensuring that only authorized users can access certain parts of the platform. This component uses various security measures, such as encryption and permissions, to safeguard sensitive information and maintain privacy.
+
+**3\. Groups, Organizations, and Social Connections**
+
+This component facilitates social interactions and organizational structures within the CSP. Users can form groups, join organizations, and connect with others to collaborate and share experiences. It helps build a community and enhances user engagement.
+
+**4\. Referential Object Definitions and Instances**
+
+Referential Object Definitions and Instances manage objects and their references within the platform. It creates, stores, and retrieves digital assets like 3D models, avatars, and virtual objects, ensuring they are consistently available and up-to-date for CSP-enabled applications.
+
+**5\. Persistent Multiplayer Services**
+
+Persistent Multiplayer Services support continuous, scalable and synchronized multi-users experiences. This component ensures that users can interact in real-time within shared virtual spaces, providing a seamless multi-user environment that is always available.
+
+**6\. Geospatial Databases**
+
+Geospatial Databases handle spatial data, which is crucial for accurate and reliable interactions in connected spaces. This component manages information about the physical location and positioning of objects and users within the virtual environment, enabling precise and consistent experiences across both the digital and spatial domains.
+
+**7\. Economic Engine Interfaces**
+
+Economic Engine Interfaces integrate economic models and transactions into the CSP. This component allows for creating and managing e-commerce and e-ticketing platforms like Shopify and Eventbrite, providing a framework for monetization and financial interactions.
+
+## Services Offered by MCS
+
+### **User Service**
+
+The User Service is the backbone of user management within the MCS platform. This service handles:
+
+* User Registration: Allowing new users to create accounts.  
+* Authentication: Verifying user identities during login.  
+* Authorization: Assigning roles and permissions to users.  
+* Profile Management: Enabling users to update their personal information.
+
+Key Features:
+
+* Secure access to the platform.  
+* Maintains user data integrity.  
+* Includes password management and session control.
+
+### **Ranking Service**
+
+The Ranking Service is designed to evaluate and compare user activities. This service helps in:
+
+* Tracking Performance: Monitoring user activities and contributions.  
+* Creating Leaderboards: Displaying rankings based on predefined criteria.  
+* Awarding Badges: Recognizing achievements to motivate users.
+
+Key Features:
+
+* Enhances user engagement through gamification.  
+* Supports various ranking metrics
+
+### **Asset Service**
+
+The Asset Service manages all digital assets within the platform. It includes:
+
+* Storage: Keeping 3D models, images, audio files, and multimedia.  
+* Retrieval: Fetching assets as needed by users or applications.  
+* Versioning: Managing different versions of assets.  
+* Distribution: Ensuring assets are available and up-to-date.
+
+Key Features:
+
+* Efficient management of digital resources.  
+* Supports a wide range of file types.
+
+### **Multiplayer Service**
+
+The Multiplayer Service enables real-time interactions between users. This service is crucial for:
+
+* Session Creation: Starting multi-users sessions.  
+* User Connectivity: Connecting users to the same session.  
+* State Synchronization: Ensuring all users see the same state in real time.
+
+Key Features:
+
+* Supports collaborative and competitive interactions.  
+* Ensures a seamless multi-user experience.
+
+### **Spatial Data Service**
+
+The Spatial Data Service handles geospatial information within the platform. This service supports:
+
+* Storage: Keeping geospatial data.  
+* Retrieval: Accessing spatial data as needed.  
+* Analysis: Performing spatial queries and analysis.
+
+Key Features:
+
+* Enables accurate positioning in virtual environments.  
+* Supports mapping and location-based services.
+
+### **Aggregation Service**
+
+The Aggregation Service combines data from various sources to provide a unified view. This service performs:
+
+* Data Collection: Gathering data from different systems.  
+* Normalization: Standardizing data formats.  
+* Transformation: Converting data to a usable form.  
+* Aggregation: Summarizing data for analysis.
+
+Key Features:
+
+* Integrates data seamlessly from multiple sources.  
+* Supports comprehensive data analysis.
+
+## Callbacks and Result Objects in CSP
+
+CSP relies on a set of cloud-hosted services. To perform asynchronous operations in CSP, like fetching and storing data from servers, there are two key patterns to be aware of: Callbacks and the Result Object. 
+
+### Callbacks
+
+Callbacks are functions passed as arguments to other functions or methods. They allow a program to continue executing while waiting for an asynchronous operation to complete. When the operation finishes, the callback function is invoked, allowing the client application to handle the result.
+
+In CSP, callbacks handle asynchronous responses from cloud-hosted services. An example of a callback in CSP is an instance of the AssetCollectionResultCallback class. This callback is primarily responsible for handling results from requests to retrieve asset collections.
+
+```
+/// @brief Callback containing asset collection.
+/// @param Result AssetCollectionResult
+std::function<void(const AssetCollectionResult& Result)>  AssetCollectionResultCallback;
+```
+
+The typedef (Type Definition) keyword declares an alias for an std::function in the code snippet.  Instances of this type store callable routines  such as functions or lambda expressions. The callable routine returns void and takes a const reference to an AssetCollectionResult object as an argument.
+
+### Using Callbacks
+
+One common technique for managing asynchronous tasks in MCS is through the use of callbacks. 
+
+**Example: Retrieving an Asset Collection**  
+Consider the method GetAssetCollectionById in the AssetSystem class, which demonstrates how callbacks are used to retrieve an asset collection by its AssetCollectionId. Within CSP, the method initiates a request to a service and, upon receiving a response, invokes a callback for the client application to handle the retrieved data.
+
+```
+void AssetSystem::GetAssetCollectionById(const String& AssetCollectionId, AssetCollectionResultCallback Callback)
+{
+    services::ResponseHandlerPtr ResponseHandler = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdGet(AssetCollectionId, ResponseHandler);
+}
+```
+
+* Within CSP, the GetAssetCollectionById method, the AssetCollectionId is used to fetch an AssetCollection from the services. 
+
+* The Callback object is then invoked by the ResponseHandler (once it has converted an HttpResponse into a Result Object) to notify the client application and provide them with the result.
+
+### Result Objects
+
+A Result Object contains response data retrieved from an asynchronous operation in CSP. The object transforms raw data received from the services into interoperable, strongly typed formats.
+
+An example of a Result Object is AssetCollectionResult.The AssetCollectionResult class is a result object that stores information about an asset collection.
+
+```
+class CSP_API AssetCollectionResult : public csp::systems::ResultBase
+{
+public:
+	AssetCollection& GetAssetCollection();
+	const AssetCollection& GetAssetCollection() const;
+private:
+	AssetCollectionResult(void*);
+	void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+	AssetCollection AssetCollection;
+};
+```
+
+* The Result Object contains an associated object, AssetCollection, stored as a private member.
+
+* The AssetCollectionResult defines two getters to get the AssetCollection by reference or by const reference.
+
+* The `AssetCollectionResult` includes an `OnResponse` method that is used internally within CSP to transform the DTO (Data Transfer Object)  received from services into a strongly typed CSP object, `AssetCollection`.

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -50,7 +50,7 @@ breathe_default_project = "Connected Spaces Platform"
 exhale_args = {
     "containmentFolder":     "./api",
     "rootFileName":          "library_root.rst",
-    "rootFileTitle":         "API Documentation",
+    "rootFileTitle":         "API DOCUMENTATION",
     "doxygenStripFromPath":  "..",
     "createTreeView":        True,
 }

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -83,6 +83,8 @@ html_theme = 'sphinx_rtd_theme'
 
 html_logo = '_static/logo.png'
 
+html_css_files = ["custom.css"]
+
 # Don't show the 'View page source' link at the top
 html_show_sourcelink = False
 

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -50,7 +50,7 @@ breathe_default_project = "Connected Spaces Platform"
 exhale_args = {
     "containmentFolder":     "./api",
     "rootFileName":          "library_root.rst",
-    "rootFileTitle":         "Library API",
+    "rootFileTitle":         "API Documentation",
     "doxygenStripFromPath":  "..",
     "createTreeView":        True,
 }

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'exhale',
     'sphinx_rtd_theme',
     'sphinx_rtd_dark_mode',
+    'sphinx_markdown_tables',
     'recommonmark'
 ]
 

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -83,6 +83,8 @@ html_theme = 'sphinx_rtd_theme'
 
 html_logo = '_static/logo.png'
 
+html_title = 'Connected Spaces Platform'
+
 html_css_files = ["custom.css"]
 
 # Don't show the 'View page source' link at the top

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'breathe',
     'exhale',
     'sphinx_rtd_theme',
+    'sphinx_rtd_dark_mode',
     'recommonmark'
 ]
 
@@ -74,6 +75,9 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
+
+default_dark_mode = True
+
 html_theme = 'sphinx_rtd_theme'
 
 html_logo = '_static/logo.png'

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -19,7 +19,7 @@ from recommonmark.transform import AutoStructify
 # -- Project information -----------------------------------------------------
 
 project = 'Connected Spaces Platform'
-copyright = '2023, Magnopus'
+copyright = 'Magnopus'
 author = 'Magnopus'
 
 # The full version, including alpha/beta/rc tags
@@ -76,11 +76,15 @@ exclude_patterns = []
 # a list of builtin themes.
 #
 
+# Default theme to dark mode (togglable on the page back to light mode)
 default_dark_mode = True
 
 html_theme = 'sphinx_rtd_theme'
 
 html_logo = '_static/logo.png'
+
+# Don't show the 'View page source' link at the top
+html_show_sourcelink = False
 
 html_theme_options = {
     'logo_only': True,

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -76,8 +76,10 @@ exclude_patterns = []
 #
 html_theme = 'sphinx_rtd_theme'
 
+html_logo = '_static/logo.png'
+
 html_theme_options = {
-    'logo_only': False,
+    'logo_only': True,
     'collapse_navigation': False,
     'navigation_depth': -1
 }
@@ -86,7 +88,6 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-
 
 # Sphinx runs this for every module imported, app = instance of Sphinx
 # This enables AutoStructify and recommonmark for markdown and enables embedded rst in md

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -97,6 +97,13 @@ html_theme_options = {
     'navigation_depth': -1
 }
 
+html_context = {
+    'display_github': True,
+    'github_user': 'magnopus-opensource',
+    'github_repo': 'bconnected-spaces-platform',
+    'github_version': 'develop/Library/docs/source/',
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/Library/docs/source/conf.py
+++ b/Library/docs/source/conf.py
@@ -100,7 +100,7 @@ html_theme_options = {
 html_context = {
     'display_github': True,
     'github_user': 'magnopus-opensource',
-    'github_repo': 'bconnected-spaces-platform',
+    'github_repo': 'connected-spaces-platform',
     'github_version': 'develop/Library/docs/source/',
 }
 

--- a/Library/docs/source/index.md
+++ b/Library/docs/source/index.md
@@ -61,5 +61,6 @@ Examples for each supported language are below.
    :hidden:
 
    learn/learn
+   manual/manual
    api/library_root
 ```

--- a/Library/docs/source/index.md
+++ b/Library/docs/source/index.md
@@ -1,3 +1,5 @@
+# Overview
+
 Interoperability is the foundation of the spatial internet. We need experiences to move across multiple technologies in harmony, bridging applications and devices so that we can move beyond a series of disconnected islands.
 
 ![image info](./_static/interop.gif)

--- a/Library/docs/source/index.md
+++ b/Library/docs/source/index.md
@@ -67,6 +67,7 @@ Examples for each supported language are below.
 .. toctree::
    :maxdepth: 2
 
+   articles/overview/mcs
    api/library_root
 ```
 

--- a/Library/docs/source/index.md
+++ b/Library/docs/source/index.md
@@ -1,7 +1,6 @@
 ## Overview
 Interoperability is the foundation of the spatial internet. We need experiences to move across multiple technologies in harmony, bridging applications and devices so that we can move beyond a series of disconnected islands.
 
-
 ![image info](./_static/interop.gif)
 
 The Connected Spaces Platform is a library that provides developers across a range of language and platforms with a means to build *interoperable, cross-reality, multi-user applications*.
@@ -61,6 +60,6 @@ Examples for each supported language are below.
    :maxdepth: 2
    :hidden:
 
-   articles/overview/mcs
+   learn/learn
    api/library_root
 ```

--- a/Library/docs/source/index.md
+++ b/Library/docs/source/index.md
@@ -1,4 +1,3 @@
-## Overview
 Interoperability is the foundation of the spatial internet. We need experiences to move across multiple technologies in harmony, bridging applications and devices so that we can move beyond a series of disconnected islands.
 
 ![image info](./_static/interop.gif)
@@ -38,7 +37,6 @@ Build instructions for each supported language are below.
 ## 🖥️ Usage
 Examples for each supported language are below.
 
-- WebAssembly 
 - WebAssembly 
     - [Web Initialising Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Initialising%20Foundation/Web)
     - [Web Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/Web)

--- a/Library/docs/source/index.md
+++ b/Library/docs/source/index.md
@@ -1,14 +1,4 @@
-# 🌎 Connected Spaces Platform
-
-_"An interoperable communication library for the spatial internet."_
-
-⚡️ Current Supported Languages : C++, C#, Web Assembly
-
-🖥️ Current Supported Platforms : Windows, Android, IOS and MacOS
-
-****
-
-## Background
+## Overview
 Interoperability is the foundation of the spatial internet. We need experiences to move across multiple technologies in harmony, bridging applications and devices so that we can move beyond a series of disconnected islands.
 
 
@@ -62,16 +52,15 @@ Examples for each supported language are below.
     - [Unity C# Basic Framework Example](https://github.com/magnopus-opensource/connected-spaces-platform/tree/main/Examples/Basic%20Framework/CSharp/Foundation-Unity-Example)
 
 ****
- ## 📖 Api Documentation
+ ## ©️ License
+
+ [Apache-2.0](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/LICENSE)
+
 ```eval_rst
 .. toctree::
    :maxdepth: 2
+   :hidden:
 
    articles/overview/mcs
    api/library_root
 ```
-
-****
- ## ©️ License
-
- [Apache-2.0](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/LICENSE)

--- a/Library/docs/source/learn/learn.md
+++ b/Library/docs/source/learn/learn.md
@@ -82,7 +82,7 @@ Key components of the layer include:
 
 * **Economic Engine Interfaces:** Integrates economic models and transactions.
 
-## Topics
+## Overview
 
 This series will introduce you to CSP and give you an overview of its features. 
 
@@ -95,4 +95,7 @@ You will learn about how CSP functions and whether it makes sense for your use-c
 
    overview/mcs
    overview/tenants
+   overview/protocols
+   overview/graphql
+   overview/logging
 ```

--- a/Library/docs/source/learn/learn.md
+++ b/Library/docs/source/learn/learn.md
@@ -1,0 +1,97 @@
+# LEARN
+
+Developing applications across today's fragmented internet is difficult. Most solutions require development across multiple platforms, making them expensive and complicated. An ideal approach should support open standards for seamless work across environments.
+
+The Connected Space Platform (CSP) is an open-source, client-side library designed to make it easy for developers to create interoperable, cross-reality, multi-user applications. The main goal of CSP is to create an interoperability system for the spatial web, where different devices and applications can smoothly work together. Users can interact with any digital content without worrying about what technology or platform they're using. 
+
+Architecturally, CSP functions as a bridge between the client applications and a set of cloud services.
+
+## Prerequisites
+
+Before diving into the details of CSP, it is beneficial to have a foundational understanding of the following key concepts and technologies:
+
+* **Basic Networking Concepts:** Understanding of basic networking principles such as HTTP, WebSockets, and data routing.
+
+* **Cloud Computing Fundamentals:** Familiarity with cloud services, especially concepts related to scalability, storage, and cloud-based applications.
+
+* **Programming and Scripting:** Basic knowledge of programming languages like JavaScript, C\#, or C++ is helpful, particularly in understanding the API and CSP scripting engine.
+
+* **Game Engines and Development Tools**: Awareness of game engines like Unity, Unreal Engine and development environments for AR/VR applications.
+
+## General Architecture
+
+Understanding the general architecture provides a valuable context on how various applications and cloud services interact with CSP.
+
+![image info](../_static/stack.png)
+
+### Apps, Plugins & Integration Layer
+
+This layer represents client applications which use CSP. These may be in any number of forms, ranging from lightweight plugins and libraries for various software development environments and operating systems, to applications built with engines such as Unreal, Unity, Godot or PlayCanvas. They may be deployed on Windows, MacOS,  iOS, Android or VisionOS. Here are some features that they may include:
+
+* **Creator Tools**: For developers to build and design applications.
+
+* **Game Engine-Specific Plugins & Interfaces**: Custom plugins and interfaces for different game engines.
+
+* **Connected Space Primitives**: Building blocks for many spatial web primitives, including avatars, 3D objects, images, and videos.
+
+* **Available Cross-Platform Coherence**: Ensures consistent experiences across different platforms.
+
+* **Event Listeners and Actors**: Mechanisms to handle events and interactions within the platform.
+
+* **User Interface Abstractions**: Simplified UI components to enhance user interaction.
+
+* **Support for Custom Engine Functionality for Rapid Prototyping:** Allows developers to create and test new features quickly.
+
+### CSP Layer
+
+Architecturally, the Connected Space Platform is an interoperability layer. It acts as a translator that allows different software and applications to communicate and share data, ensuring seamless integration and interaction across various systems.
+
+Key components of this layer include:
+
+* **Open Source SDK:** Helps developers create apps that work with different systems and services by providing reusable components and documentation.
+
+* **Language and Engine-Specific Interfaces**: Interfaces for different programming languages and engines, such as JavaScript, C\#, and C++.
+
+* **Logic Aggregations for Scene Graphs, Object Hierarchies, and Visibility Scopes**: Manages complex data structures and their relationships.
+
+* **Event Routing**: Route events to the appropriate handlers.
+
+* **JavaScript Scripting Engine:** Allows developers to write scripts that can interact with various components of CSP.
+
+* **Data Marshaling between Cloud Services and Engines**: Converts data into a suitable format across different systems.
+
+* **External API Connectors**: Integrates external data sources and services like IoT devices.
+
+### Cloud Service Layer
+
+The cloud service layer relies on a stable internet connection to provide users with seamless interaction with the Connected Space Platform.
+
+Key components of the layer include:
+
+* **User Accounts & Management:** Handles user authentication, authorization, and profile management.
+
+* **Security & Access Control:** Ensures data security and proper access control measures.
+
+* **Groups, Organizations, and Social Connections:** Facilitates social interactions and organizational structures.
+
+* **Referential Object Definitions and Instances:** Manages objects and their references within the platform.
+
+* **Persistent Multiplayer Services:** Supports continuous and synchronized multi-users experiences.
+
+* **Geospatial Databases:** Manages spatial data for accurate and reliable virtual interactions.
+
+* **Economic Engine Interfaces:** Integrates economic models and transactions.
+
+## Topics
+
+This series will introduce you to CSP and give you an overview of its features. 
+
+You will learn about how CSP functions and whether it makes sense for your use-case. We will also go into detail on CSP's most essential concepts and features.
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   overview/mcs
+```

--- a/Library/docs/source/learn/learn.md
+++ b/Library/docs/source/learn/learn.md
@@ -2,7 +2,7 @@
 
 Developing applications across today's fragmented internet is difficult. Most solutions require development across multiple platforms, making them expensive and complicated. An ideal approach should support open standards for seamless work across environments.
 
-The Connected Space Platform (CSP) is an open-source, client-side library designed to make it easy for developers to create interoperable, cross-reality, multi-user applications. The main goal of CSP is to create an interoperability system for the spatial web, where different devices and applications can smoothly work together. Users can interact with any digital content without worrying about what technology or platform they're using. 
+The Connected Spaces Platform (CSP) is an open-source, client-side library designed to make it easy for developers to create interoperable, cross-reality, multi-user applications. The main goal of CSP is to create an interoperability system for the spatial web, where different devices and applications can smoothly work together. Users can interact with any digital content without worrying about what technology or platform they're using. 
 
 Architecturally, CSP functions as a bridge between the client applications and a set of cloud services.
 
@@ -44,7 +44,7 @@ This layer represents client applications which use CSP. These may be in any num
 
 ### CSP Layer
 
-Architecturally, the Connected Space Platform is an interoperability layer. It acts as a translator that allows different software and applications to communicate and share data, ensuring seamless integration and interaction across various systems.
+Architecturally, the Connected Spaces Platform is an interoperability layer. It acts as a translator that allows different software and applications to communicate and share data, ensuring seamless integration and interaction across various systems.
 
 Key components of this layer include:
 
@@ -64,7 +64,7 @@ Key components of this layer include:
 
 ### Cloud Service Layer
 
-The cloud service layer relies on a stable internet connection to provide users with seamless interaction with the Connected Space Platform.
+The cloud service layer relies on a stable internet connection to provide users with seamless interaction with the Connected Spaces Platform.
 
 Key components of the layer include:
 
@@ -98,4 +98,5 @@ You will learn about how CSP functions and whether it makes sense for your use-c
    overview/protocols
    overview/graphql
    overview/logging
+   overview/maintenance_windows
 ```

--- a/Library/docs/source/learn/learn.md
+++ b/Library/docs/source/learn/learn.md
@@ -94,4 +94,5 @@ You will learn about how CSP functions and whether it makes sense for your use-c
    :titlesonly:
 
    overview/mcs
+   overview/tenants
 ```

--- a/Library/docs/source/learn/overview/graphql.md
+++ b/Library/docs/source/learn/overview/graphql.md
@@ -1,0 +1,404 @@
+# GraphQL
+
+GraphQL is an open-source data query and manipulation language for APIs and a runtime for executing queries. GraphQL was developed internally by Meta in 2012 before being publicly released in 2015\. It allows the client's application to request specific data from a database. 
+
+Unlike REST, where each API endpoint must return a fixed structure, GraphQL allows clients to define the structure of the response. GraphQL is designed to make APIs fast, flexible, and developer-friendly.
+
+## Key Features
+
+* **Query Language:** GraphQL uses a query language that allows clients to specify the data they need. This reduces over-fetching or under-fetching of data.
+
+* **Types:** GraphQL types define the data structure and ensure that queries and responses follow a consistent format. They include various kinds: **scalar types, object types, enum type**s, and **input types.** 
+
+* **Schema:** A GraphQL schema defines the data types that can be queried and how they are connected. This schema has strict rules, so queries are checked to ensure they are correct before executing. 
+
+* **Resolvers:** Resolvers are functions that retrieve data for a particular field in a query or mutation. It executes the request sent from the client application and fetches data from the database based on the type of operation specified.
+
+Compared to REST, GraphQL offers more flexibility by allowing clients to request only the specific data they need in a single request, reducing the number of requests and the amount of data transferred.
+
+## Core Concepts
+
+### Schema Definition
+
+A GraphQL schema is a contract that defines the capabilities of the GraphQL server. It specifies the types of data available and the queries and mutations that can be performed on that data.
+
+The schema is defined using the GraphQL Schema Definition Language (SDL) and includes types, fields, and operations (queries, mutations, and subscriptions).
+
+### Scalar, Object, Custom, and Input Types
+
+#### Scalar Types
+
+Scalar Types are basic data types that represent a single value. GraphQL includes built-in scalar types such as:
+
+*  `Int`: A signed 32-bit integer.
+
+*  `Float`: A signed double-precision floating-point value.
+
+*  `String`: A UTF-8 character sequence.
+
+*  `Boolean`: A true or false value.
+
+*  `ID`: A unique identifier, typically used for fetching objects or as keys for caches.
+
+#### Object Types
+
+**Object Types** are complex types that represent objects with multiple fields. Each field can have its own type, which can be a scalar type or another object type.
+
+```
+type User {
+	id: ID!
+	name: String!
+	email: String!
+}
+```
+
+#### Custom Types
+
+**Custom Types** are types defined by the user to represent complex structures. These can include:
+
+* **Enums:** They are a special kind of scalar that restricts a field to a specified set of values.
+
+```
+enum Role {
+	ADMIN
+	USER
+	GUEST
+}
+```
+
+#### Input Types 
+
+**Input Types** are used to define complex arguments for queries and mutations. They cannot be used as output types.
+
+```
+input UserInput {
+	name: String!
+	email: String!
+}
+```
+
+Please Note: 
+
+Output types in GraphQL are types that can be used in the response of a query or mutation. They define the structure of the data that will be returned to the client. Output types include:
+
+* **Object Types**  
+* **Scalar Types**  
+* **Custom Types**
+
+## Queries and Mutations
+
+Queries are used to fetch data from the server. They specify what data is required and the structure of the response.
+
+```
+query {
+	user(id: "1") {
+		id
+		name
+		email
+	}
+}
+```
+
+Queries can also include arguments to filter or modify the data returned.
+
+```
+query getUser($id: ID!) {
+	user(id: $id) {
+		id
+		name
+		email
+	}
+}
+```
+
+### Mutations
+
+Mutations are used to modify data on the server. They have a similar structure to queries but represent operations that change data (e.g., creating, updating, deleting).
+
+```
+mutation {
+	createUser(input: { name: "John", email: "john@example.com" }) {
+		id
+		name
+		email
+	}
+}
+```
+
+Mutations can also accept arguments and return specific fields from the modified data.
+
+```
+mutation createUser($input: UserInput!) {
+	createUser(input: $input) {
+		id
+		name
+		email
+	}
+}
+```
+
+### Differences Between Queries and Mutations
+
+* Purpose: Queries are for reading data (fetching information), while mutations are for writing data (modifying information).
+
+* Execution: Queries are typically idempotent (repeated executions yield the same result without side effects), whereas mutations are not (they cause changes to the state of the data).
+
+* Keywords: Queries use the keyword `query`, while mutations use the keyword `mutation`.
+
+## Performing Complex Queries with GraphQL
+
+GraphQL is a query language that can handle complex queries that traditional REST APIs cannot. For many applications, GraphQL's flexibility and efficiency are essential because it enables the retrieval of the exact data needed in a single request, thereby reducing network traffic and improving performance. 
+
+Here are some of the methods to perform complex queries in GraphQL.
+
+### Nested Queries
+
+Nested queries in GraphQL allow you to retrieve related data within a single query. This means you can fetch an object and its related objects in one request. For example, in CSP, nested queries can be used to fetch a space and its associated users and assets.
+
+```
+{
+space(id: "101") {
+	name
+	users {
+		name
+		role
+	}
+	assets {
+		title
+		type
+	}
+}
+}
+```
+
+### Use Cases
+
+* **Reducing Network Requests:** Instead of making multiple requests to fetch related data, nested queries allow retrieval of all necessary information with a single request to the API.
+
+* **Improving Performance:** By minimizing the number of requests, nested queries can enhance the performance of the application.
+
+* **Simplifying Code:** Nested queries reduce the complexity of client-side code, as there is no need to handle multiple asynchronous requests.
+
+## Aliases and Fragments
+
+Aliases in GraphQL allow you to rename the result of a field to avoid conflicts and make the response more readable. This is particularly useful when querying the same field multiple times with different arguments.
+
+Here is a syntax of Aliases:
+
+```
+{
+	admin: user(id: "1") {
+		name
+	}
+	guest: user(id: "2") {
+		name
+	}
+}
+```
+
+In this example, two different users are queried, and aliases are used to distinguish them in the response.
+
+### Simplify Queries with Fragments
+
+In GraphQL, fragments are reusable query components. They eliminate duplication by allowing related fields to be defined in a fragment and reused across multiple queries.
+
+Here is an example of a Fragment: 
+
+```
+fragment userFields on User {
+	id
+	name
+	email
+	role
+}
+
+{
+	admin: user(id: "1") {
+		...userFields
+	}
+	guest: user(id: "2") {
+		...userFields
+	}
+}
+```
+
+In this example, the `userFields` fragment is defined once and reused for both `admin` and `guest` queries, making the query simpler.
+
+### Benefits of Fragments
+
+* **Code Reusability:** Fragments allow you to define commonly used fields once and reuse them across multiple queries, reducing code duplication.
+
+* **Maintainability:** Updating the fields in one place (the fragment) automatically updates all queries using that fragment, making the code easier to maintain.
+
+* **Readability:** Fragments can make queries more readable by breaking down complex queries into smaller, manageable parts.
+
+## Variables and Directives
+
+Variables in GraphQL make queries more flexible and reusable. Instead of hardcoding values, you can use variables to pass values into queries dynamically. 
+
+Here is an example: 
+
+```
+query GetUser($id: ID!) {
+	user(id: $id) {
+		name
+		email
+	}
+}
+
+{ "id": "1" }
+```
+
+In this example, the `$id` variable is used to pass the user ID dynamically.
+
+### Dynamic Query Execution with Directives
+
+Directives in GraphQL control how queries can be executed based on a specific condition. The @include and @skip directives are commonly used for this purpose.
+
+Here is an example: 
+
+```
+	query GetUser($withEmail: Boolean!) {
+	user(id: "1") {
+		name
+		email @include(if: $withEmail)
+	}
+}
+
+{ "withEmail": true }
+```
+
+In this example, the `email` field is included only if `withEmail` is true.
+
+### Benefits of Variables and Directives
+
+* **Flexibility:** Using variables, values can be passed dynamically to make queries adaptable to different use cases.
+
+* **Efficiency:** Directives control how queries are executed by retrieving only the necessary data based on predefined conditions.
+
+* **Reusability:** Variables and directives reduce code duplication, making queries cleaner and more maintainable.
+
+## GraphQL in CSP
+
+GraphQL is considered an advanced feature for developers who have mastered the standard CSP systems. GraphQL plays a unique role in CSP by allowing client applications to create their own specific queries. Unlike other protocols where CSP defines the queries, GraphQL enables clients to specify the data they need. This flexibility is crucial for handling complex data retrieval scenarios that standard CSP APIs may not cover. CSP's GraphQL system is designed to accept query strings from client applications, transmit these queries securely via HTTPS, and return the requested data.
+
+*It is important to note that CSP does not allow client applications to mutate data directly using GraphQL. This restriction ensures that CSP maintains control over the schema and ensures data consistency.*
+
+### Example of a CSP GraphQL Query
+
+In CSP, GraphQL queries can retrieve detailed information across multiple databases. For instance, a client application might query for user details along with their related projects and tasks in a single request. 
+
+Here’s an example of a GraphQL query in CSP:
+
+```
+{
+	prototype(filters: { groupIds: \["659bf45f5sf871cm7501c71c"\], types: \["Default"\] }) {
+		items {
+			id
+			name
+			type
+			createdBy
+			metadata {
+				key
+				value
+			}
+			assets(assetTypes: \["Thumbnail", "Model", "Video", "Image", "Audio",\]) {
+				uri
+				name
+				assetType
+				checksum
+				fileName
+				id
+				mimeType
+				prototypeId
+				version
+			}
+		}   
+	}
+}
+```
+
+In the example, you can also observe that much of the Connected Spaces Platform domain language is absent. There are no references to spaces or asset collections, but in their place there are references to group IDs and prototypes.
+
+This is an example of another limitation when directly using GraphQL queries. Since the client application is effectively speaking directly with the server when issuing queries, the query schema and terms available to the application can and do vary depending on the services that the developer has elected to use.
+
+### Benefits and Limitations 
+
+**Benefits:**
+
+* **Flexibility:** GraphQL allows client applications to request the exact data needed, reducing over-fetching and under-fetching.
+
+* **Efficiency:** Multiple related pieces of data can be retrieved in a single request, minimizing the number of API calls.
+
+* **Specificity:** Developers can tailor queries to their exact needs, enabling more refined data retrieval.
+
+**Limitations:**
+
+* **Complexity:** Using GraphQL requires a deep understanding of the schema and the specific terms defined at the service level.
+
+* **Responsibility:** Developers must create and manage their queries, which can be more challenging than standard CSP APIs.
+
+* **No Data Mutation:** CSP restricts data mutations via GraphQL to maintain control over the schema and ensure data consistency.
+
+* **No CSP Domain Language:** Since queries are issued directly to the server, the client application must reason about server-level domain language, which may differ from CSP-level domain language.
+
+## Summary
+
+* **GraphQL** is an open-source data query and manipulation language for APIs and a runtime for executing queries, developed by Meta. It allows clients to request specific data, offering flexibility and efficiency over traditional REST APIs.
+
+**Key Characteristics of GraphQL**
+
+* **Query Language**: Clients specify the exact data they need.  
+* **Types**: Defines data structures, including scalar types, object types, enum types, and input types.  
+* **Schema**: Defines data types and their relationships, ensuring query validation.  
+* **Resolvers**: Functions that provide the logic for fetching and modifying data.
+
+### Core Concepts of GraphQL
+
+**Schema and Types**
+
+* **Schema**: Defines the capabilities of the GraphQL server using the Schema Definition Language (SDL).
+
+* **Types**:  
+  * **Scalar Types**: Basic data types like `Int`, `Float`, `String`, `Boolean`, and `ID`.  
+  * **Object Types**: Complex types with multiple fields.  
+  * **Custom Types**: Enums and input types for complex structures.
+
+**Queries and Mutations**
+
+**Queries**: Fetch data from the server.
+
+```
+query {
+	user(id: "1") {
+		id
+		name
+		email
+	}
+}
+```
+
+**Mutations**: Modify data on the server.
+
+```
+mutation {
+	createUser(input: { name: "John", email: "john@example.com" }) {
+		id
+		name
+		email
+	}
+}
+```
+
+* **Differences**: Queries read data; mutations write data. Queries are idempotent; mutations are not.
+
+### Complex Queries in GraphQL
+
+* **Nested Queries**: Retrieve related data in a single query.  
+* **Aliases and Fragments**: Aliases rename fields; fragments allow reusable query components.  
+* **Variables and Directives**: Variables make queries flexible; directives control query execution based on conditions.
+
+### GraphQL in CSP
+
+* **Benefits**: Flexibility, efficiency, and specificity in data retrieval.  
+* **Limitations**: Complexity, developer responsibility, loss of CSP domain language, and no data mutations to ensure schema control and data consistency.

--- a/Library/docs/source/learn/overview/graphql.md
+++ b/Library/docs/source/learn/overview/graphql.md
@@ -44,7 +44,7 @@ Scalar Types are basic data types that represent a single value. GraphQL include
 
 **Object Types** are complex types that represent objects with multiple fields. Each field can have its own type, which can be a scalar type or another object type.
 
-```
+```text
 type User {
 	id: ID!
 	name: String!
@@ -58,7 +58,7 @@ type User {
 
 * **Enums:** They are a special kind of scalar that restricts a field to a specified set of values.
 
-```
+```text
 enum Role {
 	ADMIN
 	USER
@@ -70,7 +70,7 @@ enum Role {
 
 **Input Types** are used to define complex arguments for queries and mutations. They cannot be used as output types.
 
-```
+```text
 input UserInput {
 	name: String!
 	email: String!
@@ -89,7 +89,7 @@ Output types in GraphQL are types that can be used in the response of a query or
 
 Queries are used to fetch data from the server. They specify what data is required and the structure of the response.
 
-```
+```text
 query {
 	user(id: "1") {
 		id
@@ -101,7 +101,7 @@ query {
 
 Queries can also include arguments to filter or modify the data returned.
 
-```
+```text
 query getUser($id: ID!) {
 	user(id: $id) {
 		id
@@ -115,7 +115,7 @@ query getUser($id: ID!) {
 
 Mutations are used to modify data on the server. They have a similar structure to queries but represent operations that change data (e.g., creating, updating, deleting).
 
-```
+```text
 mutation {
 	createUser(input: { name: "John", email: "john@example.com" }) {
 		id
@@ -127,7 +127,7 @@ mutation {
 
 Mutations can also accept arguments and return specific fields from the modified data.
 
-```
+```text
 mutation createUser($input: UserInput!) {
 	createUser(input: $input) {
 		id
@@ -155,7 +155,7 @@ Here are some of the methods to perform complex queries in GraphQL.
 
 Nested queries in GraphQL allow you to retrieve related data within a single query. This means you can fetch an object and its related objects in one request. For example, in CSP, nested queries can be used to fetch a space and its associated users and assets.
 
-```
+```text
 {
 space(id: "101") {
 	name
@@ -185,7 +185,7 @@ Aliases in GraphQL allow you to rename the result of a field to avoid conflicts 
 
 Here is a syntax of Aliases:
 
-```
+```text
 {
 	admin: user(id: "1") {
 		name
@@ -204,7 +204,7 @@ In GraphQL, fragments are reusable query components. They eliminate duplication 
 
 Here is an example of a Fragment: 
 
-```
+```text
 fragment userFields on User {
 	id
 	name
@@ -238,7 +238,7 @@ Variables in GraphQL make queries more flexible and reusable. Instead of hardcod
 
 Here is an example: 
 
-```
+```text
 query GetUser($id: ID!) {
 	user(id: $id) {
 		name
@@ -257,7 +257,7 @@ Directives in GraphQL control how queries can be executed based on a specific co
 
 Here is an example: 
 
-```
+```text
 	query GetUser($withEmail: Boolean!) {
 	user(id: "1") {
 		name
@@ -290,7 +290,7 @@ In CSP, GraphQL queries can retrieve detailed information across multiple databa
 
 Here’s an example of a GraphQL query in CSP:
 
-```
+```text
 {
 	prototype(filters: { groupIds: \["659bf45f5sf871cm7501c71c"\], types: \["Default"\] }) {
 		items {
@@ -368,7 +368,7 @@ This is an example of another limitation when directly using GraphQL queries. Si
 
 **Queries**: Fetch data from the server.
 
-```
+```text
 query {
 	user(id: "1") {
 		id
@@ -380,7 +380,7 @@ query {
 
 **Mutations**: Modify data on the server.
 
-```
+```text
 mutation {
 	createUser(input: { name: "John", email: "john@example.com" }) {
 		id

--- a/Library/docs/source/learn/overview/logging.md
+++ b/Library/docs/source/learn/overview/logging.md
@@ -1,0 +1,262 @@
+# Logging
+
+Logging is an essential process in software development and system management that involves recording events, messages, and errors during the execution of an application. These log entries provide valuable insights into the system's behavior, helping developers and administrators understand what is happening at various stages of the application's lifecycle.
+
+1. **Debugging**: Logs are crucial for debugging purposes. When an error occurs, logs can provide detailed information about the state of the application, the sequence of operations, and the exact point of failure. This information is vital for diagnosing issues and finding solutions quickly.
+
+2. **Monitoring**: Continuous monitoring of logs helps in identifying potential issues before they become critical. By analyzing log patterns, administrators can detect anomalies, performance bottlenecks, and security threats, allowing them to take proactive measures.
+
+3. **Auditing**: Logs serve as an audit trail, recording significant events and actions within the system. This is important for compliance with regulatory requirements and for forensic analysis in the event of a security breach.
+
+4. **Performance Analysis**: Logs provide data that can be analyzed to understand the system's performance characteristics. This helps in optimizing the application and ensuring it runs efficiently.
+
+5. **User Behavior Analysis**: Logs can capture user interactions with the system, providing insights into user behavior and preferences. This information can be used to improve the user experience and guide future development.
+
+## CSP-Specific Logging Features
+
+The Connected Spaces Platform (CSP) incorporates a logging system designed to meet the needs of modern applications. Here are some key features:
+
+1. **System-Level Logging**: CSP allows you to set the verbosity of logging at a system-wide level. This means you can control the amount of detail logged, from critical errors to informational debug messages.
+
+   * **SetSystemLevel**: Adjusts the verbosity level for logging.
+
+   * **GetSystemLevel**: Retrieves the current verbosity level.
+
+   * **LoggingEnabled**: Checks if logging is enabled for a specified verbosity level.
+
+2. **Event Logging**: CSP supports logging specific events, which can be used for monitoring significant occurrences within the system.
+
+   * **LogEvent**: Records an event in the log.
+
+3. **Marker Events**: CSP introduces the concept of marker events to indicate the beginning and end of specific processes, providing a clear outline of operations within the logs.
+
+   * **BeginMarker**: Specifies the start of a marker event.
+
+   * **EndMarker**: Indicates the end of a marker event.
+
+4. **Callback System**: One of the standout features of CSP's logging system is the ability to set callbacks for various types of logs. This allows client applications to react to specific logs or events in real-time.
+
+   * **SetLogCallback**: Sets a callback for handling log messages.
+
+   * **SetEventCallback**: Sets a callback for handling event logs.
+
+   * **SetBeginMarkerCallback**: Sets a callback for handling the start of marker events.
+
+   * **SetEndMarkerCallback**: Sets a callback for handling the end of marker events.
+
+   * **ClearAllCallbacks**: Clears all logging callbacks, providing a way to reset the logging behavior.
+
+5. **Message Logging**: CSP also allows the client application to  provide log  messages at specific verbosity levels, providing detailed information based on the set logging level.
+
+   * **LogMsg**: Logs a message with a specified verbosity level.
+
+## CSP Log Categories
+
+### System Logs
+
+System logs capture and record the operational activities of  CSP. They help in diagnosing issues, tracking the platform's health, and auditing system behaviors.
+
+**Examples of System Logs:**
+
+* **Startup Logs:** Records details when the system starts.
+
+* **Shutdown Logs:** Captures information during system shutdown.
+
+* **Error Logs:** Logs system errors that occur during operation.
+
+* **Performance Logs:** Tracks performance metrics and system efficiency.
+
+
+### Event Logs
+
+Event logs record specific actions or occurrences within the CSP. They are essential for monitoring user activities, tracking events, and understanding system interactions.
+
+**Examples of Event Logs:**
+
+* **User Login Events:** Logs details when a user logs in.
+
+* **File Upload Events:** Captures information about file uploads.
+
+* **Data Access Events:** Records access to specific data or resources.
+
+* **Transaction Events:** Tracks transactions within the system.
+
+
+### Marker Logs
+
+Marker logs are used to identify certain points or stages within a process. In the context of CSP, the process refers to any operation or sequence of actions within the platform that you want to monitor or debug. 
+
+Here are some examples of processes where marker logs can be useful:
+
+* **Data Processing:** Tracking the start and end of data processing tasks to ensure they complete successfully and within expected time frames.
+
+* **API Calls:** Monitoring the flow of API requests and responses to identify any issues or delays.
+
+* **User Workflows**: Following the steps a user takes through a particular workflow, such as a multi-step form submission.
+
+* **Background Jobs:** Logging the phases of background tasks, like batch processing or scheduled maintenance activities.
+
+* **Transaction Handling:** Marking the points in a financial or data transaction to ensure all steps are executed correctly.
+
+**Usage Scenarios for Marker Logs:**
+
+* **Debugging:** Use markers to pinpoint the beginning and end of a function to identify where issues may occur.
+
+* **Performance Monitoring:** Track the duration of specific operations to optimize performance.
+
+* **Process Tracking:** Follow the sequence of complex processes to ensure each step completes correctly.
+
+## Setting Up Logging in Your Client Application
+
+To effectively monitor and debug your application, you must set up logging. This process involves configuring various callback handlers that allow you to capture and manage log messages, events, and markers within the Connected Spaces Platform (CSP).
+
+### Pre-requisites:
+
+Before setting up logging in your client application, ensure you have:
+
+* Integrated the CSP library into your project.
+
+* A basic understanding of callbacks and logging mechanisms in CSP.
+
+### Log Callback Handlers
+
+Log callback handlers allow you to specify specific actions that should be performed when a log message is generated or a CSP event occurs. They help to capture and process log messages as they occur.
+
+### How to Define and Set a Log Callback Handler 
+
+1. **Define the Callback Handler:** Create a function that will handle log messages.
+
+```
+void MyLogCallback(const csp::common::String& logMessage)
+{
+	std::cout << "Log: " << logMessage << std::endl;
+}
+```
+
+2. **Set the Callback Handler:** Use the SetLogCallback function to set your custom handler.
+
+```
+LogSystem.SetLogCallback(MyLogCallback);
+```
+
+### Event Callback Handlers
+
+Event callback handlers identify and respond to specified events within CSP. They allow you to run a custom code when certain events occur.
+
+### How to Define and Set an Event Callback Handler:
+
+1. **Define the Callback Handler:** Create a function that will handle event messages.
+
+```
+void MyEventCallback(const csp::common::String& eventMessage) { 
+	std::cout << "Event: " << eventMessage << std::endl; 
+}
+```
+
+2\.  **Set the Callback Handler:** Use the SetEventCallback function to set your custom handler. 
+
+```
+LogSystem.SetEventCallback(MyEventCallback);
+```
+
+### Begin Marker Callback Handlers
+
+Begin marker callback handlers mark the start of a specific process or phase. They help in tracking the beginning of operations for debugging or monitoring.
+
+### How to Define and Set an Begin Marker Callback Handler:
+
+1. **Define the Callback Handler:** Create a function that will handle the beginning of markers.
+
+```
+void MyBeginMarkerCallback(const csp::common::String& beginMarker) { 
+	std::cout << "Begin Marker: " << beginMarker << std::endl; 
+}
+```
+
+2\. **Set the Callback Handler:** Use the SetBeginMarkerCallback function to set your custom handler. 
+
+```
+LogSystem.SetBeginMarkerCallback(MyBeginMarkerCallback);
+```
+
+### End Marker Callback Handlers
+
+End marker callback handlers mark the end of a specific process or phase. They help in tracking the completion of operations for debugging or monitoring.
+
+### How to Define and Set an End Marker Callback Handler:
+
+1. **Define the Callback Handler:** Create a function that will handle the end of markers.
+
+```
+void MyEndMarkerCallback() { 
+	std::cout << "End Marker " << std::endl;
+}
+```
+
+2\. **Set the Callback Handler:** Use the SetEndMarkerCallback function to set your custom handler. 
+
+```
+LogSystem.SetEndMarkerCallback(MyEndMarkerCallback);
+```
+
+By following these steps, you can effectively set up logging in your client application, enabling detailed monitoring and debugging of your CSP processes.
+
+## Configuring Logging Verbosity
+
+Understanding the various log levels is important for system monitoring and troubleshooting. Each log level has a specific semantic, and properly configuring the level will ensure that your log has the right information, allowing you to maintain and troubleshoot your system more quickly. 
+
+Here's an overview of the log levels used in CSP systems:
+
+1. **Error:** Describes critical issues that need immediate attention. These indicate severe problems that could cause the system to crash.
+
+```
+LogSystem.LogMsg(csp::systems::LogLevel::Error, "Critical error encountered.");
+```
+
+2. **Warning:** This represents potential issues that might not immediately affect the system but should be monitored. These help in identifying areas that might become problematic.
+
+```
+LogSystem.LogMsg(csp::systems::LogLevel::Warning, "Potential issue detected.");
+```   
+
+3. **Info:** This represents general information about the system's operation. These messages provide insights into the system's normal functioning.
+
+```
+LogSystem.LogMsg(csp::systems::LogLevel::Info, "System operation details.");
+```   
+
+4. **Debug:** It represents detailed information useful for debugging. Messages are more verbose and are typically used during development or troubleshooting.
+
+```
+LogSystem.LogMsg(csp::systems::LogLevel::Debug, "Debugging details.");
+```   
+
+By setting the appropriate log level, you can control the amount and type of information captured in your logs, making it easier to monitor and debug your system.
+
+## System-Wide Log Level
+
+Use the SetSystemLevel function to set the system's log level. This determines the verbosity of logs generated by the system. Higher verbosity levels include all lower levels, meaning setting a higher log level, like Debug, will also capture logs from Error, Warning, and Info levels. For example: 
+
+```
+LogSystem.SetSystemLevel(csp::systems::LogLevel::Debug);
+```
+
+### Retrieving the current log level
+
+Use the GetSystemLevel function, to check the current log level. This helps you understand the current verbosity setting. For example: 
+
+```
+csp::systems::LogLevel currentLevel = LogSystem.GetSystemLevel();
+```
+
+### Checking the Logging Status of Specific Log Levels 
+
+Use the LoggingEnabled function, to see if a specific log level is currently being logged. This ensures that your logs are being captured at the desired level. For example: 
+
+```
+bool isLogging = LogSystem.LoggingEnabled(csp::systems::LogLevel::Info);
+```
+
+# Summary and Recap
+
+Logging is essential in software development and system management, capturing events, messages, and errors during application execution. It provides insights into system behavior, aiding in debugging, monitoring, auditing, performance analysis, and user behavior analysis.

--- a/Library/docs/source/learn/overview/logging.md
+++ b/Library/docs/source/learn/overview/logging.md
@@ -18,37 +18,37 @@ The Connected Spaces Platform (CSP) incorporates a logging system designed to me
 
 1. **System-Level Logging**: CSP allows you to set the verbosity of logging at a system-wide level. This means you can control the amount of detail logged, from critical errors to informational debug messages.
 
-   * **SetSystemLevel**: Adjusts the verbosity level for logging.
+   * `SetSystemLevel`: Adjusts the verbosity level for logging.
 
-   * **GetSystemLevel**: Retrieves the current verbosity level.
+   * `GetSystemLevel`: Retrieves the current verbosity level.
 
-   * **LoggingEnabled**: Checks if logging is enabled for a specified verbosity level.
+   * `LoggingEnabled`: Checks if logging is enabled for a specified verbosity level.
 
 2. **Event Logging**: CSP supports logging specific events, which can be used for monitoring significant occurrences within the system.
 
-   * **LogEvent**: Records an event in the log.
+   * `LogEvent`: Records an event in the log.
 
 3. **Marker Events**: CSP introduces the concept of marker events to indicate the beginning and end of specific processes, providing a clear outline of operations within the logs.
 
-   * **BeginMarker**: Specifies the start of a marker event.
+   * `BeginMarker`: Specifies the start of a marker event.
 
-   * **EndMarker**: Indicates the end of a marker event.
+   * `EndMarker`: Indicates the end of a marker event.
 
 4. **Callback System**: One of the standout features of CSP's logging system is the ability to set callbacks for various types of logs. This allows client applications to react to specific logs or events in real-time.
 
-   * **SetLogCallback**: Sets a callback for handling log messages.
+   * `SetLogCallback`: Sets a callback for handling log messages.
 
-   * **SetEventCallback**: Sets a callback for handling event logs.
+   * `SetEventCallback`: Sets a callback for handling event logs.
 
-   * **SetBeginMarkerCallback**: Sets a callback for handling the start of marker events.
+   * `SetBeginMarkerCallback`: Sets a callback for handling the start of marker events.
 
-   * **SetEndMarkerCallback**: Sets a callback for handling the end of marker events.
+   * `SetEndMarkerCallback`: Sets a callback for handling the end of marker events.
 
-   * **ClearAllCallbacks**: Clears all logging callbacks, providing a way to reset the logging behavior.
+   * `ClearAllCallbacks`: Clears all logging callbacks, providing a way to reset the logging behavior.
 
 5. **Message Logging**: CSP also allows the client application to  provide log  messages at specific verbosity levels, providing detailed information based on the set logging level.
 
-   * **LogMsg**: Logs a message with a specified verbosity level.
+   * `LogMsg`: Logs a message with a specified verbosity level.
 
 ## CSP Log Categories
 

--- a/Library/docs/source/learn/overview/logging.md
+++ b/Library/docs/source/learn/overview/logging.md
@@ -257,6 +257,6 @@ Use the LoggingEnabled function, to see if a specific log level is currently bei
 bool isLogging = LogSystem.LoggingEnabled(csp::systems::LogLevel::Info);
 ```
 
-# Summary and Recap
+## Summary
 
 Logging is essential in software development and system management, capturing events, messages, and errors during application execution. It provides insights into system behavior, aiding in debugging, monitoring, auditing, performance analysis, and user behavior analysis.

--- a/Library/docs/source/learn/overview/maintenance_windows.md
+++ b/Library/docs/source/learn/overview/maintenance_windows.md
@@ -1,0 +1,240 @@
+# Maintenance Windows
+
+Maintenance windows play a vital role in the reliable and efficient operation of cloud-hosted services. They allow service providers to perform necessary updates, upgrades, and repairs on the system infrastructure without causing unexpected service interruptions.
+
+Scheduled maintenance ensures that Magnopus Cloud Service (MCS)s remain secure, performant, and up-to-date with the latest technological advancements. Here are some key reasons why maintenance may be required:
+
+* **System Reliability and Stability:** Regular maintenance helps prevent unexpected system failures and downtime by addressing potential issues proactively. Scheduled updates and fixes improve the overall stability of MCS, reducing the risk of unscheduled outages.
+
+* **Security Updates:** Maintenance windows allow service providers to implement security patches and updates that protect against vulnerabilities and threats. Regular updates help safeguard client data and maintain compliance with security standards.
+
+* **Performance Optimization:** Maintenance activities often include performance tuning and optimizations that enhance the speed and responsiveness of MCS. This ensures that clients experience consistent and reliable service quality.
+
+* **Infrastructure Upgrades:** Maintenance windows provide an opportunity to upgrade hardware, software, and network components. These upgrades can improve capacity, scalability, and the ability to handle increased demand from clients.
+
+* **Regulatory Compliance:** Scheduled maintenance helps ensure that MCScomply with industry regulations and standards. Regular audits and updates are necessary to maintain compliance and avoid potential penalties.
+
+## Definition and Purpose of Maintenance Windows
+
+A maintenance window is a predefined period during which MCS may be temporarily unavailable or degraded due to planned maintenance work. This time frame is carefully selected to minimize the impact on clients while allowing service providers to perform necessary tasks. Maintenance windows serve several important purposes:
+
+* **Minimized Disruption:** By scheduling maintenance during periods of low usage, service providers can minimize the impact on clients and reduce disruptions to their operations.
+
+* **Predictability:** Clients are informed in advance about upcoming maintenance windows, allowing them to plan and adjust their activities accordingly. This predictability helps maintain trust and transparency between service providers and clients.
+
+* **Efficient Resource Allocation:** Maintenance windows enable service providers to allocate resources and personnel efficiently, ensuring that maintenance tasks are completed within the scheduled time frame.
+
+* **Proactive Problem Resolution:** Regular maintenance allows service providers to identify and address potential issues before they escalate into major problems. This proactive approach helps maintain the overall health of the CHS infrastructure.
+
+* **Communication and Collaboration:** Maintenance windows facilitate effective communication and collaboration between service providers and clients. Clients receive timely updates and information about maintenance activities, fostering a collaborative relationship.
+
+## Understanding Maintenance Windows
+
+During a maintenance window, services may experience partial or complete outages. Users might be unable to access certain features or the entire service depending on the nature of the maintenance. While these windows are typically planned during off-peak hours to minimize user impact, it is essential for clients to be aware of these periods to prepare for potential downtime.
+
+### Scheduling and Communicating Maintenance Windows
+
+Maintenance windows are scheduled based on several factors, including the urgency of the maintenance tasks, user activity patterns, and the potential impact on service availability. MCS uses a structured process to plan these windows, aiming to balance the need for maintenance with minimizing disruption.
+
+Communication of maintenance windows is crucial for keeping clients informed. MCS typically announces scheduled maintenance well in advance through various channels, such as email notifications, dashboard alerts, and public status pages. This communication includes details about the maintenance purpose, the expected duration, and the services that may be affected. By providing this information, MCS ensures that clients can anticipate and prepare for any temporary service interruptions.
+
+## Maintenance System Architecture
+
+The Maintenance System is a critical component designed to manage and communicate upcoming scheduled maintenance activities that impact the availability of Magnopus Cloud Services. It provides clients with timely information about maintenance windows, ensuring that they are informed about periods when services might be unavailable due to planned maintenance work. 
+
+The system uses a structured approach to deliver maintenance updates, describing each window as a `MaintenanceInfo` object. These objects contain details about each maintenance window, such as the description, start time, and end time. By accessing this information through the `GetMaintenanceInfo` method, clients can retrieve up-to-date data regarding scheduled maintenance activities.
+
+The Maintenance System within CSP allows client applications to obtain details about upcoming scheduled maintenance windows. These windows indicate periods when MCS may be unavailable due to planned maintenance activities, either by MCS itself or third-party providers. Within CSP, maintenance windows are represented by MaintenanceInfo objects.
+
+### Structure and Components of MaintenanceInfo Objects
+
+Each `MaintenanceInfo` object contains key information about a scheduled maintenance window. The main components of a `MaintenanceInfo` object are:
+
+* `Description`: A brief summary of the maintenance activity.
+
+* `StartDateTimestamp`: The start time of the maintenance window, represented as a timestamp.
+
+* `EndDateTimestamp`: The end time of the maintenance window, represented as a timestamp.
+
+Additionally, the `MaintenanceInfo` class provides methods such as `IsInsideWindow()`, which checks if the current time falls within the maintenance window.
+
+Here is a code snippet of the primary components of a `MaintenanceInfo` object: 
+
+```
+class CSP_API MaintenanceInfo {
+public:
+    bool IsInsideWindow() const; 
+    csp::common::String Description;
+    csp::common::String StartDateTimestamp; 
+    csp::common::String EndDateTimestamp;
+}
+```
+
+### Relationship Between MaintenanceInfo Objects and the Maintenance System
+
+When a client application queries the Maintenance System for maintenance information, it calls the `GetMaintenanceInfo` method. This function uses a callback pattern to process the request and return a `MaintenanceInfoResult` object to the application.
+
+The `MaintenanceInfoResult` object contains an array of `MaintenanceInfo` objects, each representing a scheduled maintenance window. Clients can retrieve these objects and interrogate the data via various helper functions provided by the `MaintenanceInfoResult` class, such as:
+
+* `GetMaintenanceInfoResponses()`: Retrieves all maintenance information available in date order, from closest in the future to furthest.
+
+* `HasAnyMaintenanceWindows()`: Checks if any valid `MaintenanceInfo` objects have been returned, effectively telling the client application if there are any future maintenance windows planned..
+
+* `GetLatestMaintenanceInfo()`: Retrieves the `MaintenanceInfo` object closest to the current time.
+
+## Querying for Upcoming Maintenance Windows
+
+### Introduction to the GetMaintenanceInfo method
+
+The `GetMaintenanceInfo` method allows client applications to query for upcoming maintenance windows. This method provides crucial information about scheduled maintenance activities that might impact CSP-enabled applications. With this method, client applications will also receive details about when and why service interruptions may occur.
+
+The `GetMaintenanceInfo` method uses a callback pattern to handle asynchronous operations. This pattern ensures that the method does not block the application's main thread while waiting for a response. Instead, it uses a callback function to process the result once it becomes available. This approach improves the application's responsiveness and user experience.
+
+### CSP Implementation of the GetMaintenanceInfo Method
+
+```
+|  void MaintenanceSystem::GetMaintenanceInfo(MaintenanceInfoCallback Callback) {
+    const MaintenanceInfoCallback GetMaintenanceInfoCallback = [Callback](const MaintenanceInfoResult& Result) {
+        if (Result.GetResultCode() == InProgress) {
+            return;
+        }
+        if (Result.GetResultCode() == Failed) {
+            INVOKE_IF_NOT_NULL(Callback, MakeInvalid<MaintenanceInfoResult>());
+            return;
+        }
+        INVOKE_IF_NOT_NULL(Callback, Result);
+    };
+
+    csp::services::ResponseHandlerPtr MaintenanceResponseHandler =
+        MaintenanceAPI->CreateHandler<MaintenanceInfoCallback, MaintenanceInfoResult, void, csp::services::NullDto>(
+            GetMaintenanceInfoCallback, nullptr);
+
+    static_cast<chs::MaintenanceApi*>(MaintenanceAPI)->Query(
+        csp::CSPFoundation::GetClientUserAgentInfo().CHSEnvironment, MaintenanceResponseHandler);
+}  |
+```
+
+Explanation of Code Components
+
+* **Callback Declaration:** Defines a `GetMaintenanceInfoCallback` that handles the response.
+
+* **Result Handling:** Checks the result code to determine if the operation is still in progress or has failed. If it fails, it invokes the callback with an invalid result.
+
+* **Response Handler:** Creates a response handler using the `CreateHandler` method.
+
+* **Query Execution:** Calls the `Query` method on the `MaintenanceAPI` object, passing the client user agent information and the response handler.
+
+### Role of the MaintenanceInfo Callback
+
+The `MaintenanceInfoCallback` is a function that receives the result of the `GetMaintenanceInfo` method. It takes a `MaintenanceInfoResult` object as its argument and returns `void`. This callback is how client applications can handle the asynchronous response from the Maintenance System.
+
+Here is a code snippet: 
+
+```
+typedef std::function<void(const MaintenanceInfoResult& Result)> MaintenanceInfoCallback;
+```
+
+Explanation of Callback Mechanism
+
+* **Function Definition:** The `MaintenanceInfoCallback` is defined as a lambda that accepts a `const MaintenanceInfoResult&` and returns `void`.
+
+* **Callback Invocation:** The callback is invoked with the `MaintenanceInfoResult` once the asynchronous operation completes.
+
+* **Result Processing:** Inside the callback, the result can be processed based on the request’s  status (in progress, failed, or successful). This mechanism ensures that the client application can react appropriately to the maintenance information retrieved.
+
+## Handling MaintenanceInfo Results
+
+The `MaintenanceInfoResult` class provides a structured way to handle the results of maintenance queries. It contains an array of `MaintenanceInfo` objects, representing different scheduled maintenance windows. The class is designed to manage the retrieval and processing of this data efficiently, ensuring that client applications have access to accurate and timely maintenance information.
+
+### Key Properties and Methods
+
+* `MaintenanceInfoResponses`: An array of `MaintenanceInfo` objects, each representing a maintenance window.
+
+* `ResultCode`: Indicates the status of the query, such as success, failure, or in-progress.
+
+Key methods include:
+
+* `GetMaintenanceInfoResponses()`: Returns the array of MaintenanceInfo objects.
+
+* `HasAnyMaintenanceWindows()`: Checks if there are any maintenance windows scheduled.
+
+### Retrieving Maintenance Information
+
+To retrieve maintenance information, use the `GetMaintenanceInfoResponses()` method, which returns an array of `MaintenanceInfo` objects.
+
+Here is a code snippet demonstrating how to access maintenance window information from `MaintenanceInfoResult`.
+
+```
+MaintenanceInfoResult result = GetMaintenanceInfoResult();
+csp::common::Array<MaintenanceInfo> infoArray = result.GetMaintenanceInfoResponses();
+for (const auto& info : infoArray) {
+    std::cout << "Description: " << info.Description << std::endl;
+    std::cout << "Start Time: " << info.StartDateTimestamp << std::endl;
+    std::cout << "End Time: " << info.EndDateTimestamp << std::endl;
+}
+```
+
+**Explanation of Methods for Accessing MaintenanceInfo Data**
+
+* `GetMaintenanceInfoResponses()`: This method retrieves all the MaintenanceInfo objects within the result. It is useful for iterating over all the available maintenance windows.
+
+* `HasAnyMaintenanceWindows()`: This method returns a boolean indicating whether there are any maintenance windows available.
+
+## Checking for Maintenance Windows
+
+To check if there are any maintenance windows available, use the `HasAnyMaintenanceWindows()` method. This method returns true if there are windows available and false otherwise.
+
+### Retrieving the Latest MaintenanceInfo Object
+
+Use the `GetLatestMaintenanceInfo()` method to get the next upcoming `MaintenanceInfo` object. This is particularly useful when you need information about the maintenance window scheduled closest to the current time.
+
+Here is a code sample: 
+
+```
+if (result.HasAnyMaintenanceWindows()) {
+    MaintenanceInfo latestInfo \= result.GetLatestMaintenanceInfo();
+    std::cout \<\< "Latest Maintenance Description: " \<\< latestInfo.Description \<\< std::endl;
+}
+```
+
+## Summary
+
+The Maintenance System is designed to manage and communicate scheduled maintenance activities for MCS. It provides clients with information about maintenance windows, which are periods when services might be temporarily unavailable due to planned work. This system ensures transparency, minimizes disruptions, and allows clients to plan accordingly.
+
+Maintenance windows are crucial for:
+
+* **System Reliability:** Regular updates prevent unexpected failures and downtime.
+
+* **Security:** They allow for security patches and updates to protect against vulnerabilities.
+
+* **Performance:** Maintenance optimizes system performance, ensuring consistent service quality.
+
+* **Infrastructure Upgrades:** Scheduled updates improve capacity and scalability.
+
+* **Regulatory Compliance:** Maintenance ensures adherence to industry standards and regulations.
+
+### Maintenance Windows
+
+* **Definition:** A maintenance window is a scheduled period when MCS services may be unavailable.
+
+* **Purpose:** To minimize disruption, ensure predictability, allocate resources efficiently, resolve problems proactively, and foster communication with clients.
+
+### Maintenance System Architecture
+
+* `MaintenanceInfo` **Objects:** Represent scheduled maintenance windows, containing details like descriptions and timestamps.
+
+* `GetMaintenanceInfo` **Method:** Allows clients to query upcoming maintenance windows, using a callback pattern for asynchronous operations.
+
+### Querying Maintenance Windows
+
+* `MaintenanceInfo` Callback: It is a function that processes the result of the `GetMaintenanceInfo` method, by taking the `MaintenanceInfoResult` object as its argument and returns `void`. It is crucial for handling the asynchronous response from the Maintenance System.
+
+### Handling MaintenanceInfo Results
+
+* `MaintenanceInfoResult` **Class:** Contains an array of MaintenanceInfo objects and methods to access maintenance data.
+
+* **Key Methods:**
+
+  * `GetMaintenanceInfoResponses()`: Retrieves all maintenance information.
+
+  * `GetLatestMaintenanceInfo()`: Gets the most recent maintenance window.

--- a/Library/docs/source/learn/overview/maintenance_windows.md
+++ b/Library/docs/source/learn/overview/maintenance_windows.md
@@ -93,25 +93,25 @@ The `GetMaintenanceInfo` method uses a callback pattern to handle asynchronous o
 ### CSP Implementation of the GetMaintenanceInfo Method
 
 ```
-|  void MaintenanceSystem::GetMaintenanceInfo(MaintenanceInfoCallback Callback) {
-    const MaintenanceInfoCallback GetMaintenanceInfoCallback = [Callback](const MaintenanceInfoResult& Result) {
-        if (Result.GetResultCode() == InProgress) {
-            return;
-        }
-        if (Result.GetResultCode() == Failed) {
-            INVOKE_IF_NOT_NULL(Callback, MakeInvalid<MaintenanceInfoResult>());
-            return;
-        }
-        INVOKE_IF_NOT_NULL(Callback, Result);
-    };
+	void MaintenanceSystem::GetMaintenanceInfo(MaintenanceInfoCallback Callback) {
+	const MaintenanceInfoCallback GetMaintenanceInfoCallback = [Callback](const MaintenanceInfoResult& Result) {
+		if (Result.GetResultCode() == InProgress) {
+			return;
+		}
+		if (Result.GetResultCode() == Failed) {
+			INVOKE_IF_NOT_NULL(Callback, MakeInvalid<MaintenanceInfoResult>());
+			return;
+		}
+		INVOKE_IF_NOT_NULL(Callback, Result);
+	};
 
-    csp::services::ResponseHandlerPtr MaintenanceResponseHandler =
-        MaintenanceAPI->CreateHandler<MaintenanceInfoCallback, MaintenanceInfoResult, void, csp::services::NullDto>(
-            GetMaintenanceInfoCallback, nullptr);
+	csp::services::ResponseHandlerPtr MaintenanceResponseHandler =
+		MaintenanceAPI->CreateHandler<MaintenanceInfoCallback, MaintenanceInfoResult, void, csp::services::NullDto>(
+			GetMaintenanceInfoCallback, nullptr);
 
-    static_cast<chs::MaintenanceApi*>(MaintenanceAPI)->Query(
-        csp::CSPFoundation::GetClientUserAgentInfo().CHSEnvironment, MaintenanceResponseHandler);
-}  |
+	static_cast<chs::MaintenanceApi*>(MaintenanceAPI)->Query(
+		csp::CSPFoundation::GetClientUserAgentInfo().CHSEnvironment, MaintenanceResponseHandler);
+}
 ```
 
 Explanation of Code Components
@@ -192,8 +192,8 @@ Here is a code sample:
 
 ```
 if (result.HasAnyMaintenanceWindows()) {
-    MaintenanceInfo latestInfo \= result.GetLatestMaintenanceInfo();
-    std::cout \<\< "Latest Maintenance Description: " \<\< latestInfo.Description \<\< std::endl;
+    MaintenanceInfo latestInfo = result.GetLatestMaintenanceInfo();
+    std::cout << "Latest Maintenance Description: " << latestInfo.Description << std::endl;
 }
 ```
 

--- a/Library/docs/source/learn/overview/mcs.md
+++ b/Library/docs/source/learn/overview/mcs.md
@@ -1,5 +1,5 @@
 # Magnopus Cloud Services (MCS)
-CSP-enabled applications rely on cloud-hosted services to function effectively. Magnopus offers a set of cloud-hosted services, known as Magnopus Cloud Services (MCS), specifically designed for the Connected Space Platform. These services act as an independent layer that supports both the CSP and client applications. It is not required to use MCS with the Connected Spaces platform.
+CSP-enabled applications rely on cloud-hosted services to function effectively. Magnopus offers a set of cloud-hosted services, known as Magnopus Cloud Services (MCS), specifically designed for the Connected Spaces Platform. These services act as an independent layer that supports both the CSP and client applications. It is not required to use MCS with the Connected Spaces platform.
 
 It is however recommended to use MCS with CSP, as MCS helps developers simplify development by providing ready-to-use tools and services, reducing the complexity of building and maintaining applications. Selecting MCS as the backend service provider allows the developer to not worry about the services themselves, and exclusively focus on building their spatial-web application using the CSP API.
 

--- a/Library/docs/source/learn/overview/mcs.md
+++ b/Library/docs/source/learn/overview/mcs.md
@@ -189,3 +189,146 @@ private:
 * The AssetCollectionResult defines two getters to get the AssetCollection by reference or by const reference.
 
 * The `AssetCollectionResult` includes an `OnResponse` method that is used internally within CSP to transform the DTO (Data Transfer Object)  received from services into a strongly typed CSP object, `AssetCollection`.
+
+## Interaction Between Callbacks and Result Objects
+
+For asynchronous operations, the interaction between callbacks and result objects is essential. 
+
+Here is an example of a workflow:
+
+**1\. Client Code Initiates Request**:
+
+```
+csp::systems::AssetCollectionResultCallback GetAssetCollectionByIdCallback = [Callback, this](const csp::systems::AssetCollectionResult& Result)
+{
+	if (Response == EOKOResponse::Success)
+	{
+		const csp::systems::AssetCollection& RetrievedAssetCollection = Result.GetAssetCollection();
+		// Process the retrieved asset collection...
+	}
+};
+
+AssetSystem->GetAssetCollectionById(MyAssetCollectionId, GetAssetCollectionByIdCallback);
+```
+
+**2\. Request Handling**:
+
+1. The client code defines a callback (`GetAssetCollectionByIdCallback`) as a lambda expression.
+
+2. The client code calls the GetAssetCollectionById method, passing the asset collection ID and the callback as parameters.  
+   
+
+**3\. Services Response**:
+
+1. The services process the request and send a response.
+
+2. The CSP ResponseHandler generates an AssetCollectionResult object from the HTTP response.  
+   
+
+**4\. Callback Execution**:
+
+1. Within CSP, The OnResponse method of AssetCollectionResult parses the DTO into a CSP object.
+
+2. The callback is executed, allowing the client application to use the parsed data via the result object's getters.
+
+## Mapping Magnopus Cloud Services to CSP Systems
+
+Mapping MCS to CSP systems is crucial to understanding how various services and functionalities are used within CSP. This process involves aligning the core components of MCS with the corresponding systems and subsystems in CSP to ensure they work together smoothly and effectively to establish a strong operational connection
+
+The primary systems within CSP include:
+
+**1\. User System**
+
+The User System is responsible for managing user identities and credentials within CSP. It includes functionalities such as:
+
+* **User Authentication and Authorization**: Ensures that only authenticated users can access the platform and have the appropriate permissions for their roles.  
+* **Profile Management**: Allows users to create and update their profiles, including preferences and settings.  
+* **User Sessions**: Manages user sessions to maintain a consistent and secure experience across different devices and applications.
+
+**2\. Asset System**
+
+The Asset System manages the digital assets within CSP. Key features include:
+
+* **Asset Storage**: Securely stores digital assets, including 3D models, textures, audio files, and videos.  
+* **Asset Retrieval**: Provides efficient mechanisms for retrieving assets as needed by different applications and users.  
+* **Version Control**: Maintains different versions of assets to ensure that users can access the most up-to-date or preferred versions as required.
+
+**3\. Space System**
+
+The Space System manages the digital and physical spaces within CSP. It includes:
+
+* **Space Creation and Management**: Facilitates the creation, configuration, and maintenance of virtual spaces.  
+* **Access Control**: Ensures that spaces are accessible only to authorized users.  
+* **Content Management**: Manages the content within these spaces, including layout, visibility, and interaction rules.
+
+**4\. Multiplayer System**
+
+The Multiplayer System supports real-time, synchronous interactions among users. Features include:
+
+* **Session Management**: Manages multi-users sessions, ensuring users can join, interact, and leave sessions seamlessly.  
+* **State Synchronization**: Keeps the state of the virtual environment consistent across all users, enabling a shared experience.  
+* **Interaction Management**: Facilitates various forms of user interactions, such as communication, collaboration, and competition.
+
+**5\. Scripting System**
+
+The Scripting System allows developers to add custom behaviors and interactions within CSP. It provides:
+
+* **Script Execution**: Executes scripts that define how objects and environments behave.  
+* **Event Handling**: Manages events triggered by user actions or system changes, allowing for dynamic and responsive interactions.  
+* **Customization**: Supports customization of interactions and functionalities to meet specific application needs.
+
+**6\. Anchoring System**
+
+The Anchoring System links digital spaces to real-world locations, providing spatial accuracy. It includes:
+
+* **Geospatial Mapping**: Maps virtual objects to physical locations with high precision.  
+* **Spatial Anchoring**: Ensures that digital objects remain in their designated positions relative to the real world, even as users move around.  
+* **Augmented Reality Integration**: Integrates with AR systems to enhance the realism and utility of virtual overlays on physical spaces.
+
+## How do Specific MCS Services Map to CSP Systems
+
+**User Service**
+
+![image info](../../_static/mcs/user_service.png)
+
+The user service is integral to the CSP user system. It handles the creation and storage of user profiles, groups, and space information. Additionally, it provides secure authentication tokens for accessing CSP and premium services such as Agora, Eventbrite, Shopify, and single sign-on. This service ensures a structured framework for managing user identities, securing access, and facilitating efficient group interactions within the CSP environment.
+
+**Ranking Service**
+
+![image info](../../_static/mcs/ranking_service.png)
+
+The Ranking Service plays a crucial role within the CSP User System. It stores user preferences and settings, allowing applications to customize experiences for individual users. This service enables users to rank resources along application-specific dimensions, supporting features like "likes" and "favorites." The persistent nature of this information ensures a familiar yet unique user experience across all platforms.
+
+**Asset Service**
+
+![image info](../../_static/mcs/asset_service.png)
+
+The Asset Service is a key component of the CSP Asset System. It manages the storage and distribution of various digital assets, including metadata, 2D and 3D art, video, and audio files. The service also supports advanced features like Level of Detail (LOD) model generation and object capturing, which optimize content delivery and simplify asset management. By storing assets in the cloud, they become accessible from anywhere, ensuring efficient content management.
+
+**Multiplayer Service**
+
+![image info](../../_static/mcs/multiplayer_service.png)
+
+The Multiplayer Service enhances the CSP Multiplayer System by facilitating real-time networked experiences. It enables users to interact with each other and their environment in real time, using SignalR technology for low-latency, stable connections globally. Supported by services like Redis Backplane and MongoDB, this service ensures seamless interactions, regardless of users' physical locations. Additionally, it provides persistence, ensuring that user interactions extend beyond individual sessions, fostering a dynamic and interconnected community.
+
+**Spatial Data Service**
+
+![image info](../../_static/mcs/spatialdata_service.png)
+
+The Spatial Data Service is essential for the CSP Space and Anchoring Systems. It stores and accesses real-world geographical data, enabling location-based experiences. This service allows spaces, objects, and events to be geolocated and anchored to physical locations, bridging the gap between the digital and physical worlds. The spatial data service empowers users with personalized, interactive, and contextually relevant encounters in their surroundings, enhancing their experiences across various contexts.
+
+**Aggregation Service**
+
+![image info](../../_static/mcs/aggregation_service.png)
+
+The Aggregation Service simplifies data retrieval within the CSP User and Space Systems. Built with GraphQL, it optimizes querying by consolidating multiple API calls into single queries. This service streamlines data retrieval, reduces network overhead, and enhances performance, providing a seamless user experience.
+
+## Summary
+
+This topic explored how Magnopus Cloud Services (MCS) is essential to the  Connected Spaces Platform. It outlined key MCS components like user management, security, social connections, asset management, multiplayer services, geospatial databases, and economic interfaces. These components ensure that CSP-enabled applications can offer scalable, flexible, and reliable services.
+
+This topic also detailed how specific services, such as User Service, Ranking Service, Asset Service, Multiplayer Service, Spatial Data Service, and Aggregation Service, can enhance functionality and user experience in CSP.
+
+Callbacks and result objects are crucial for handling asynchronous operations in MCS. These functionalities enable efficient data retrieval and processing, ensuring smooth interactions in the platform.
+
+Overall, cloud-hosted services play a vital role in providing infrastructure and services to meet the dynamic needs of the CSP ecosystem, driving innovation and improving user experiences.

--- a/Library/docs/source/learn/overview/mcs.md
+++ b/Library/docs/source/learn/overview/mcs.md
@@ -130,7 +130,7 @@ Key Features:
 
 ## Callbacks and Result Objects in CSP
 
-CSP relies on a set of cloud-hosted services. To perform asynchronous operations in CSP, like fetching and storing data from servers, there are two key patterns to be aware of: Callbacks and the Result Object. 
+CSP relies on a set of cloud-hosted services. To perform asynchronous operations in CSP, like fetching and storing data from servers, there are two key patterns to be aware of: Callbacks and Result Objects.
 
 ### Callbacks
 

--- a/Library/docs/source/learn/overview/protocols.md
+++ b/Library/docs/source/learn/overview/protocols.md
@@ -1,0 +1,183 @@
+# Network Protocols
+
+A network protocol is a set of rules that control how data is delivered between devices inside the same network. It enables connected devices to interact with one another, independent of differences in internal operations, structure, or design. Network protocols are why people can use their devices to communicate with each other regardless of where they are in the world. Thus, network protocols play an important part in digital communications. 
+
+Just as speaking a common language improves communication between people, network protocols allow devices to engage with one another through preset rules built into the device’s software and hardware.
+
+## Overview of How Network Protocol Works
+
+Network protocols simplify large operations by breaking them into smaller, manageable functions. This occurs at every level of the network, with each function working together to complete the larger task. When two devices or applications communicate, they follow these processes to ensure data is correctly formatted, sent, and received. This process usually involves:
+
+1. **Data Formatting:** The protocols define how data is packaged into packets, specifying the format, headers, and footers.
+
+2. **Transmission:** The packets are sent over the network using specific addresses and routing information.
+
+3. **Error Handling:** The protocols include mechanisms to detect and correct errors during the transmission.
+
+4. **Data Processing:** The receiving devices unpack the data, interpret the headers, and process the information according to the protocol's rules.  
+   
+
+The following groups have developed, defined, and published different network protocols:
+
+* [The International Organization for Standardization (ISO)](https://www.iso.org/home.html)  
+* [The World Wide Web Consortium (W3C)](https://www.w3.org/)  
+* [The Internet Engineering Task Force (IETF)](https://www.ietf.org/)  
+* [The International Telecommunications Union (ITU)](https://www.itu.int/en/Pages/default.aspx)  
+* [The Institute of Electrical and Electronics Engineers (IEEE)](https://www.ieee.org/)
+
+## Role of Network Protocols in CSP
+
+Network protocols in CSP facilitate seamless data transmission, ensuring that all applications adhere to the same communication rules. This consistency allows for interoperability, enabling different applications to work together, share data, and perform tasks without compatibility issues.
+
+In CSP, network protocols are important. CSP connects client applications with cloud services. It requires all communication to go through CSP’s API, ensuring that all client applications use the same rules and formats. This guarantees consistent and reliable communication.
+
+### How Network Protocols Facilitate Communication in CSP
+
+1. **Standardized Communication:** Network protocols ensure that all client applications within the CSP ecosystem can exchange data uniformly and reliably. By using standardized protocols like HTTPS, and SignalR, CSP enables seamless communication between different applications, regardless of their internal structures or programming languages.
+
+2. **Data Transformation and Transmission:** Network protocols in CSP handle the conversion and transmission of data using predefined schemas. Protocols like HTTPS specify how data should be structured and transmitted over the network. This consistent formatting and transmission reduces the chances of errors and improves efficiency. 
+
+## What protocols does CSP use?
+
+CSP uses two main protocols to ensure efficient and secure data transmission between client applications and cloud services.
+
+1. **HTTPS:** This protocol is used for operations that do not require high-frequency traffic, such as general CRUD (Create, Read, Update, Delete) operations. HTTPS ensures that data is securely transmitted to a RESTful API endpoint. It is widely used in modern web applications and is the default choice for secure data transmission.
+
+2. **SignalR:** For operations requiring high-frequency data exchanges, such as multi-users updates, CSP uses SignalR. SignalR is developed by Microsoft. It enables real-time communication and is suitable for scenarios where multiple users need to see updates simultaneously. SignalR handles the serialization and transmission of data in a format compatible with its library, ensuring efficient communication between client applications and MCS.
+
+## HTTPS Protocol
+
+HTTPS (HyperText Transfer Protocol Secure) is an extension of HTTP. It provides secure communication over a network by encrypting data sent between a user's browser and a web server. This ensures the safety and security of the data being transmitted, protecting it from interception or modification.
+
+### Characteristics of HTTPS
+
+1. **Stateless:** Each HTTPS request is independent and does not retain any information from previous requests. The server does not remember past interactions.
+
+2. **Methods:** HTTPS supports various HTTP methods to perform actions on the web server. Common methods include:  
+   * **GET:** Retrieves data from the server.  
+   * **POST:** Sends data to the server.  
+   * **PUT:** Updates data on the server.  
+   * **DELETE:** Removes data from the server.
+
+3. **Status Codes:** These codes indicate the result of an HTTPS request. Common status codes include:  
+   * **200 OK:** The request was successful.  
+   * **404 Not Found:** The requested resource could not be found.  
+   * **500 Internal Server Error:** The server encountered an error.
+
+### RESTful API Over HTTPS
+
+REST (Representational State Transfer) is an architectural style for designing networked applications. It involves transferring the data of a resource between a client application and a web server, with the data represented in formats like JSON or XML. 
+
+REST provides flexible guidelines, not strict protocols, making it suitable for numerous use cases. RESTful APIs use standard HTTP methods like GET, POST, PUT, and DELETE to perform operations. They are simple, scalable, and easy to integrate.
+
+### How RESTful APIs Work with HTTPS
+
+RESTful APIs combine REST principles with HTTPS security. HTTPS encrypts the data when a client application requests a web server. This encryption ensures that the data is secure during transmission. The server then processes the request and sends back a response. The client application receives the response and decrypts it. This process ensures secure communication between the client application and the web server.
+
+### Examples and Use Cases in CSP
+
+In CSP, RESTful APIs work with HTTPS, and they are used in various scenarios:
+
+* **User Administration:** Managing user accounts, authentication, and permissions securely.
+
+* **Asset Management:** Creating, updating, and deleting assets like images, videos, and documents.
+
+* **Purchasing Processes:** Handling transactions, managing shopping carts, and processing payments securely.
+
+* **Querying Spaces:** Retrieving information about spaces and their attributes.
+
+### Benefits and Limitations
+
+**Benefits:**
+
+* **Security:** HTTPS ensures data is encrypted and secure.
+
+* **Scalability:** RESTful APIs can handle large numbers of requests efficiently.
+
+* **Simplicity:** They use standard HTTP methods, making them easy to understand and implement.
+
+* **Interoperability:** They can work with various client's applications and devices, ensuring full compatibility.
+
+**Limitations:**
+
+* **Stateless Nature:** Each request is independent, sometimes leading to redundant data transmission.  
+* **Limited by HTTP:** RESTful APIs are constrained by the limitations of the HTTP protocol.  
+* **Overhead:** HTTPS encryption adds some overhead, which can affect performance in high-frequency operations.
+
+## SignalR Protocol in CSP
+
+SignalR is a library for ASP.NET that simplifies adding real-time web functionality to applications. Real-time web functionality is the ability for server-side code to push content to connected clients as it happens in real time.
+
+#### Key Features
+
+1. **Real-Time Communication:** SignalR is ideal for applications that require live updates, such as chat applications, online gaming, and real-time dashboards. This is because it enables real-time communication between servers and clients, allowing instantaneous updates and interactions.  
+2. **Persistent Connections:** SignalR manages persistent connections and automatically handles connection management and reconnections. It removes the complexity of maintaining long-running connections, providing a stable communication channel.
+
+#### Comparison with WebSockets
+
+* **WebSockets:**  
+  * WebSockets provide a full-duplex communication channel over a single, long-lived connection, allowing real-time data exchange.  
+  * Requires client and server support, and may face compatibility issues with some older browsers and network configurations.  
+* **SignalR:**  
+  * Built on top of WebSockets but provides fallbacks to other techniques like Server-Sent Events (SSE) and Long Polling for environments where WebSockets are not supported.  
+  * Offers higher-level APIs that simplify the development process and ensure broader compatibility.
+
+#### How SignalR is Integrated into CSP
+
+SignalR is integrated into CSP to handle high-frequency, real-time communication scenarios like multi-user interactions within a space. It ensures all users see the same state updates in real time, maintaining consistency and synchronicity across the platform.
+
+1. **Data Serialization:**  
+   * CSP serializes data passed from the client application into a SignalR-compatible format.  
+   * This serialized data is transmitted as messages to the cloud-hosted services.  
+2. **State Management:**  
+   * CSP and the cloud-hosted services work together to manage the payload of messages.  
+   * Upon receiving a SignalR message indicating a state change, CSP only processes and transmits the delta (changed) state, optimizing bandwidth usage and performance.
+
+#### Practical Examples and Scenarios
+
+1. **Real-Time Chat Application:**  
+   * SignalR can be used to build a chat application where messages are instantly transmitted to all connected users.  
+   * Example: Users in a virtual space can send and receive messages without delays, fostering real-time communication.  
+2. **Online Multi-user Game:**  
+   * In a multi-user game, SignalR ensures that all users receive real-time updates about the game state, such as movements, actions, and events.  
+   * Example: Users see each other's moves and actions in real time, creating a synchronized gaming experience.  
+3. **Live Data Feeds:**  
+   * SignalR can stream live data feeds to all connected clients, such as stock prices, sports scores, or sensor data.  
+   * Example: A dashboard that displays real-time sensor data from IoT devices, updating instantly as new data arrives.
+
+## Summary
+
+Network protocols are essential rules that control how data is delivered between devices within a network. They enable seamless interaction between connected devices, regardless of internal operations, structure, or design differences. To ensure standardization and interoperability, key organizations such as ISO, W3C, IETF, ITU, and IEEE develop and define these protocols.
+
+#### HTTP and RESTful APIs
+
+HTTP (HyperText Transfer Protocol) is the foundation of data communication on the web, providing a standardized way for servers and clients to communicate. HTTPS (HTTP Secure) adds an encryption layer to ensure secure data transmission.
+
+RESTful APIs use HTTP methods to perform operations on web servers. These APIs follow REST (Representational State Transfer) principles, allowing for flexible, scalable, and easy-to-integrate networked applications. RESTful APIs are widely used in CSP for various operations, such as user administration, asset management, and querying spaces.
+
+**Key Characteristics of RESTful APIs:**
+
+* Stateless interactions  
+* Support for HTTP methods (GET, POST, PUT, DELETE)  
+* Use of status codes to indicate request results  
+* Data representation in formats like JSON or XML
+
+#### SignalR in the Multiplayer System
+
+SignalR is a library that simplifies adding real-time web functionality to applications. It manages persistent connections, enabling real-time communication between servers and clients.
+
+**Key Features of SignalR:**
+
+* Real-time communication: Ideal for applications requiring live updates, such as chat applications, online gaming, and real-time dashboards.  
+* Persistent connections: Automatically handles connection management and reconnections, providing a stable communication channel.
+
+**Comparison with WebSockets:**
+
+* WebSockets offer full-duplex communication but require support from both client and server.  
+* SignalR builds on WebSockets, providing fallbacks to Server-Sent Events (SSE) and Long Polling, ensuring broader compatibility and simpler development.
+
+**Integration into CSP:**
+
+* SignalR is used for high-frequency, real-time communication scenarios in CSP, such as multi-users interactions.  
+* CSP serializes data into a SignalR-compatible format and transmits it as messages to cloud-hosted services.  
+* State management optimizes only by processing and transmitting delta states, ensuring efficient bandwidth usage.

--- a/Library/docs/source/learn/overview/tenants.md
+++ b/Library/docs/source/learn/overview/tenants.md
@@ -1,0 +1,152 @@
+# Tenants
+
+A tenant is an instance dedicated to a specific customer. It segregates data from other tenants  secure resource and user management. Each tenant controls their own data, configurations, and policies, which isolates them from other tenants.
+
+Tenants are necessary for securely organizing and managing resources. They help to isolate data and applications for users.
+
+## What is an MCS Tenant?
+
+An MCS (Magnopus Cloud Services) tenant is a dedicated instance within the services backend specifically designed to segregate users and their data from others. Each MCS tenant operates independently, ensuring that data and interactions remain isolated.
+
+A developer building a CSP-powered application requires their own tenant to ensures that users of their application cannot interact with users of a different CSP-powered application.
+
+## Multi-Tenancy in MCS
+
+Multi-tenancy is an architecture where a single cloud hosted environment  and its supporting infrastructure are shared among two or more tenants at the same time. While each tenant’s data is isolated from the other tenants, each tenant shares a single database and SaaS server with the others.
+
+With MCS, this means that one environment can host multiple tenants, each with its own segregated data. 
+
+**Benefits for Clients:**
+
+* **Cost Savings:** Services are affordable as clients share the underlying infrastructure costs.
+
+* **Customizability:** Each tenant can customize its environment to meet specific needs.
+
+* **Security:** Isolation between tenants ensures that one tenant's data and activities do not affect another's.
+
+## Requesting an MCS Tenant
+
+### Prerequisites for Requesting a Tenant
+
+Before requesting an MCS (Magnopus Cloud Services) tenant, ensure you have:
+
+* **Company Name and Email:** A company name and email address is required. Personal email addresses are not accepted.
+
+### Step-by-Step Process to Request an MCS Tenant
+
+As a developer looking to use CSP and Magnopus Cloud Services, you must fill out an online form to request an MCS tenant. Follow these steps to complete your request:
+
+1. Go to [Magnopus CSP for Developers](https://www.magnopus.com/csp/for-developers#tenant-id).  
+2. Fill out the **Tenant Inquiry Form**  
+3. Review all the information you entered to ensure accuracy and click the **Submit Inquiry** button to send your request. You will receive a confirmation email acknowledging receipt of your request.  
+4. Tenant IDs requests are reviewed every two weeks, in line with Magnopus’ release schedule.  
+   If you have not heard back from the Magnopus team in two weeks confirming the creation of your tenant, please email [tenantkey@magnopus.com](mailto:tenantkey@magnopus.com).
+
+## Initializing CSP with a Tenant
+
+### How to Direct CSP to a Tenant
+
+Tenants are uniquely identified by a string that Magnopus will share with you once your tenancy request has been approved. 
+
+To direct CSP to a tenant, you need to specify the tenant string during the initialization of your application. This involves providing the tenant as an argument to the csp::CSPFoundation::Initialise function. This is expected to be the very first CSP invocation a client application makes in it’s lifecycle. 
+
+**Example Code Snippet:**
+
+Here is a code snippet demonstrating how to direct CSP to a specific tenant. 
+
+```
+int main()
+{
+	const csp::common::String Tenant = "MY_CSP_TENANT";
+	const csp::common::String EndpointRootURI = "https://ogs-ostage.magnoboard.com";
+	csp::CSPFoundation::Initialise(EndpointRootURI, Tenant);
+	// Additional initialization and application code follows
+}
+```
+
+**Explanation**
+
+* **Define the Tenant:** The tenant is defined as a constant string Tenant with the value `MY_CSP_TENANT`. Replace `MY_CSP_TENANT` with your specific tenant identifier.
+
+* **Define the Endpoint Root URI:** The endpoint root URI is defined as a constant string EndpointRootURI with the value `https://ogs-ostage.magnoboard.com`.
+
+* **Initialize CSP:** The `csp::CSPFoundation::Initialise` function is called with `EndpointRootURI` and `Tenant` as arguments. This initializes CSP to use the specified custom tenant.
+
+The following diagram illustrates the process flow for directing CSP to a custom tenant:
+
+![image info](../../_static/tenants/tenant_flow_csp.png)
+
+1. **Application Launched:** The application starts and launches successfully.
+
+2. **Calls CSP Initialize:** The application calls CSP Initialize with the endpoint and tenant arguments.
+
+3. **Registers with Services:** CSP uses the provided endpoint and tenant to register with the necessary services.
+
+4. **Application Loop:** The application runs its main loop, performing its intended tasks.
+
+5. **Invokes CSP Shutdown:** When the application is ready to terminate, it invokes the CSP shutdown process.
+
+6. **Tears Down Systems:** CSP tears down all systems, cleaning up resources.
+
+7. **Application Terminates:** The application completes its shutdown process and terminates.
+
+## Relationship Between Environments and Tenants
+
+The relationship between environments and tenants in CSP is foundational to maintaining a secure, compliant, and well-managed platform. Tenants provide the necessary isolation for users and their data, while environments ensure that different stages of application deployment are segregated and managed effectively. 
+
+### What is an Environment?
+
+An environment refers to the setting or context in which applications and services run. Environments can vary depending on their purpose, for example, development, testing, staging, or production. Each environment is isolated from the others; changes or issues in one environment do not affect the others.
+
+### Types of Environments
+
+* **Development Environment:** Used for building and developing applications.
+
+* **Testing Environment:** Used for testing applications to identify and fix bugs.
+
+* **Staging Environment:** Used for final testing before deployment to production.
+
+* **Production Environment:** Used for live applications accessible by end-users.
+
+### Differences between Tenants and Environments
+
+Understanding the differences between tenants and environments is important for managing and optimizing your use of the CSP platform. Although both concepts play important roles in resource management and application lifecycle, they serve different purposes within the system.
+
+|  | Environments | Tenants |
+| :---- | :---- | :---- |
+| Purpose | Serve different stages of application deployment, such as development, testing, staging, and production. | Provide isolation between different groups of users and their data, ensuring secure resource and user management. |
+| Isolation | Each environment operates independently to ensure that issues in one environment do not affect others. | Each tenant operates independently with its resources, ensuring data and interaction isolation |
+| Resource allocation | Resources are allocated to environments based on their purpose, ensuring appropriate resources for development, testing, or production. | Resources are allocated specifically for a tenant, ensuring each tenant has the necessary resources for its users. |
+| Security | Enhances security by isolating various stages of application development and deployment.  | Ensure data and user isolation, helping meet compliance requirements by containing sensitive data within a tenant. |
+
+### Mapping Tenants to Environments
+
+Mapping tenants to environments involves linking specific tenants to particular environments within CSP. This mapping ensures that each environment operates within the context of a designated tenant, providing a structured and efficient framework for development and deployment processes.
+
+### How Tenants are Linked to Specific Environments
+
+In CSP, tenants and environments are linked through configuration settings during the setup of each environment. Here’s how this is typically done:
+
+1. **Tenant Identification:** Each tenant is assigned a unique identifier. This identifier is used to specify the tenant within configuration files and during the initialization of applications.
+
+2. **Environment Configuration:** Each environment (development, testing, staging, production) is configured to use the tenant identifier. This configuration ensures that the environment operates within the context of the specified tenant.
+
+3. **Initialization:** During the startup of an application, the CSP initialization process includes the tenant identifier as part of the setup. This links the application to the specific tenant and its associated environment.
+
+### Example Configuration
+
+```
+const csp::common::String TenantID = "MY_CSP_TENANT";
+const csp::common::String EndpointRootURI = "https://ogs-ostage.magnoboard.com";
+csp::CSPFoundation::Initialise(EndpointRootURI, TenantID); |
+```
+
+In this example, TenantID specifies the tenant, and the initialization function links the application to this tenant within the given environment.
+
+## Summary
+
+A tenant is a dedicated instance that isolates users and their data to ensure security, compliance, and efficient resource management. Requesting a tenant involves filling out an online form. Tenant IDs are provided according to Magnopus' internal release schedule, typically every two weeks.
+
+Directing CSP to a custom tenant involves specifying the tenant during the initialization of your application. This step ensures that your application operates within the context of your dedicated tenant, providing isolation and customized settings that cater to your specific needs.
+
+Environments within a tenant, such as development, testing, staging, and production, are distinct backends that help manage different stages of the application lifecycle. Mapping tenants to these environments allows for efficient resource management, data isolation, and enhanced security and compliance.

--- a/Library/docs/source/manual/building/android.md
+++ b/Library/docs/source/manual/building/android.md
@@ -1,0 +1,46 @@
+# Building CSP for Android
+
+This page details how to Build foundation locally and build the Android DLLs.
+
+## Prerequisites 
+
+
+Windows: Please run the install script "install_prerequisites.ps1" in PowerShell as administrator.
+This script will install the Windows Package Manager Chocolatey and the following packages:
+ - git
+ - vscode
+ - python3
+ - llvm
+ - docker-desktop
+ - cmake
+
+***
+
+## Running docker-desktop with WSL2 (Windows)
+Windows: Docker-Desktop is known to have issues with WSL so some further steps are needed to function as expected
+1. Open PowerShell as Administrator and run `wsl --install` This will install WSL2
+2. Download WSL2 kernel patch [WSL2 Linux kernel update package for x64 machines](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi)
+3. Follow installation guide.
+3. Restart your computer
+
+***
+
+## Build Instructions
+Build instructions for the Connected Spaces Platform project are below.
+First of all you'll need to run the following script:
+1. Clone the Connected Spaces Platform Repositiory `git clone --recurse-submodules https://github.com/magnopus-opensource/connected-spaces-platform.git`.
+2. Open PowerShell as Administrator and run `install_prerequisites.ps1` to install Prerequisites if you haven't already.
+> If you would like to run docker-desktop using wsl please make sure sure you follow **Running docker-desktop with WSL2** above .
+3. Open Command Line and run `generate_solution.bat` to generate the Foundation solution.
+ > If you get an error with premake not found, this is the first module built so you'll need to checkout the submodules with `git submodule update --init --recursive`.
+4. Double click `OlympusFoundation.sln` to open up the Foundation Project in your chosen ide (For this walk through we will be using Rider).
+>  This will take some time but its loaded it should look like this:
+
+> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/6f0a48cb-29eb-479c-84b2-dc694915e993" width="50%" height="50%">
+
+5. Select the `ReleaseDLL` option in the build configuration settings alongside `x64` click the **Green Hammer** to start the build.
+> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/22b799ce-1162-4a75-bd9e-475573345c90" width="30%" height="30%">
+
+## Where is the file output?
+
+Once Foundation has finished building you will find the DLL has been generated in `connected-spaces-platform\Library\Binaries\Android\ReleaseDLL`.

--- a/Library/docs/source/manual/building/android.md
+++ b/Library/docs/source/manual/building/android.md
@@ -36,10 +36,10 @@ First of all you'll need to run the following script:
 4. Double click `OlympusFoundation.sln` to open up the Foundation Project in your chosen ide (For this walk through we will be using Rider).
 >  This will take some time but its loaded it should look like this:
 
-> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/6f0a48cb-29eb-479c-84b2-dc694915e993" width="50%" height="50%">
+> ![image info](../../_static/building/android_sln.png)
 
 5. Select the `ReleaseDLL` option in the build configuration settings alongside `x64` click the **Green Hammer** to start the build.
-> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/22b799ce-1162-4a75-bd9e-475573345c90" width="30%" height="30%">
+> ![image info](../../_static/building/android_cfg.png)
 
 ## Where is the file output?
 

--- a/Library/docs/source/manual/building/cpp.md
+++ b/Library/docs/source/manual/building/cpp.md
@@ -59,10 +59,10 @@ First of all you'll need to run the following script:
 4. Double click `ConnectedSpacesPlatform.sln` to open up the Foundation Project in your chosen IDE (For this walk through we will be using Rider).
 >  This will take some time but its loaded it should look like this:
 
-> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/6f0a48cb-29eb-479c-84b2-dc694915e993" width="50%" height="50%">
+> ![image info](../../_static/building/cpp_sln.png)
 
 5. Ensuring you have the `Tests` projected selected as your Startup Project, select the `ReleaseDLL` option in the build configuration settings alongside `x64` click the **Green Hammer** to start the build.
-> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/22b799ce-1162-4a75-bd9e-475573345c90" width="30%" height="30%">
+> ![image info](../../_static/building/cpp_cfg.png)
 
 ## Where is the file output?
 

--- a/Library/docs/source/manual/building/cpp.md
+++ b/Library/docs/source/manual/building/cpp.md
@@ -1,0 +1,72 @@
+# Building CSP for C++
+
+This page details how to Build foundation locally and build the C++ DLLs.
+
+## Prerequisites 
+
+The CSP solution targets Visual Studio 2022 by default.
+
+Windows: Please run the install script "install_prerequisites.ps1" in PowerShell as administrator.
+This script will install the Windows Package Manager Chocolatey and the following packages:
+ - git
+ - vscode
+ - python3
+ - llvm
+ - docker-desktop
+ - cmake
+
+***
+
+Once the prerequisites have been installed, please set your custom install path for **clang-format** in Visual Studio.
+This can be set via the Options menu here - Text Editor > C/C++ > Code Style > Formatting.
+Check the last option for `Use custom path to clang-format.exe` and then click browse to locate the executable in your llvm installation folder.
+
+Additionally, you will also need two specific SDK versions:
+* Windows SDK version 1809 (10.0.17763.0) - Required to build the C++ code.
+
+* .Net Developer Pack 4.7.1 - required to load and build the C# tests.
+
+These SDK versions are not available from within VS 2022 and will need to be downloaded directly:
+
+Windows SDK: https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/ search the page for "1809"
+
+or use chocolatey: `choco install windows-sdk-10-version-1809-all`
+
+.Net developer pack: https://dotnet.microsoft.com/en-us/download/visual-studio-sdks?cid=getdotnetsdk search the page for "4.7.1"
+
+or use chocolatey: `choco install netfx-4.7.1`
+
+You will also need to install the MSVC build tools v142 as an individual component in the Visual Studio Installer.
+
+## Running docker-desktop with WSL2 (Windows)
+Windows: Docker-Desktop is known to have issues with WSL so some further steps are needed to function as expected
+1. Open PowerShell as Administrator and run `wsl --install` This will install WSL2
+2. Download WSL2 kernel patch [WSL2 Linux kernel update package for x64 machines](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi)
+3. Follow installation guide.
+3. Restart your computer
+
+***
+
+## Build Instructions
+Build instructions for the Connected Spaces Platform project are below.
+First of all you'll need to run the following script:
+1. Clone the Connected Spaces Platform Repositiory `git clone --recurse-submodules https://github.com/magnopus-opensource/connected-spaces-platform.git`.
+2. Open PowerShell as Administrator and run `install_prerequisites.ps1` to install Prerequisites if you haven't already.
+> If you would like to run docker-desktop using wsl please make sure sure you follow **Running docker-desktop with WSL2** above .
+3. Open Command Line and run `generate_solution.bat` to generate the Foundation solution.
+ > If you get an error with premake not found, this is the first module built so you'll need to checkout the submodules with `git submodule update --init --recursive`.
+ > You may need to build premake manually to get past this step, by opening `"..\modules\premake\build\bootstrap\Premake5.sln"` in Visual Studio and building the solution.
+4. Double click `ConnectedSpacesPlatform.sln` to open up the Foundation Project in your chosen IDE (For this walk through we will be using Rider).
+>  This will take some time but its loaded it should look like this:
+
+> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/6f0a48cb-29eb-479c-84b2-dc694915e993" width="50%" height="50%">
+
+5. Ensuring you have the `Tests` projected selected as your Startup Project, select the `ReleaseDLL` option in the build configuration settings alongside `x64` click the **Green Hammer** to start the build.
+> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/22b799ce-1162-4a75-bd9e-475573345c90" width="30%" height="30%">
+
+## Where is the file output?
+
+Once Foundation has finished building you will find the DLL has been generated in `connected-spaces-platform\Library\Binaries\x64\ReleaseDLL`.
+
+
+

--- a/Library/docs/source/manual/building/csharp.md
+++ b/Library/docs/source/manual/building/csharp.md
@@ -36,10 +36,10 @@ First of all you'll need to run the following script:
 4. Double click `ConnectedSpacesPlatform.sln` to open up the Foundation Project in your chosen ide (For this walk through we will be using Rider).
 >  This will take some time but its loaded it should look like this:
 
-> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/6f0a48cb-29eb-479c-84b2-dc694915e993" width="50%" height="50%">
+> ![image info](../../_static/building/csharp_sln.png)
 
 5. Select the `ReleaseDLL-CSharp` option in the build configuration settings alongside `x64` click the **Green Hammer** to start the build.
-> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/22b799ce-1162-4a75-bd9e-475573345c90" width="30%" height="30%">
+> ![image info](../../_static/building/csharp_cfg.png)
 
 ## Where is the file output?
 

--- a/Library/docs/source/manual/building/csharp.md
+++ b/Library/docs/source/manual/building/csharp.md
@@ -1,0 +1,46 @@
+# Building CSP for C#
+
+This page details how to Build foundation locally and build the C# DLLs.
+
+## Prerequisites 
+
+
+Windows: Please run the install script "install_prerequisites.ps1" in PowerShell as administrator.
+This script will install the Windows Package Manager Chocolatey and the following packages:
+ - git
+ - vscode
+ - python3
+ - llvm
+ - docker-desktop
+ - cmake
+
+***
+
+## Running docker-desktop with WSL2 (Windows)
+Windows: Docker-Desktop is known to have issues with WSL so some further steps are needed to function as expected
+1. Open PowerShell as Administrator and run `wsl --install` This will install WSL2
+2. Download WSL2 kernel patch [WSL2 Linux kernel update package for x64 machines](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi)
+3. Follow installation guide.
+3. Restart your computer
+
+***
+
+## Build Instructions
+Build instructions for the Connected Spaces Platform project are below.
+First of all you'll need to run the following script:
+1. Clone the Connected Spaces Platform Repositiory `git clone --recurse-submodules https://github.com/magnopus/connected-spaces-platform.git`.
+2. Open PowerShell as Administrator and run `install_prerequisites.ps1` to install Prerequisites if you haven't already.
+> If you would like to run docker-desktop using wsl please make sure sure you follow **Running docker-desktop with WSL2** above .
+3. Open Command Line and run `generate_solution.bat` to generate the Foundation solution.
+ > If you get an error with premake not found, this is the first module built so you'll need to checkout the submodules with `git submodule update --init --recursive`.
+4. Double click `ConnectedSpacesPlatform.sln` to open up the Foundation Project in your chosen ide (For this walk through we will be using Rider).
+>  This will take some time but its loaded it should look like this:
+
+> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/6f0a48cb-29eb-479c-84b2-dc694915e993" width="50%" height="50%">
+
+5. Select the `ReleaseDLL-CSharp` option in the build configuration settings alongside `x64` click the **Green Hammer** to start the build.
+> <img src="https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/22b799ce-1162-4a75-bd9e-475573345c90" width="30%" height="30%">
+
+## Where is the file output?
+
+Once Foundation has finished building you will find the DLL has been generated in `connected-spaces-platform\Library\Binaries\x64\ReleaseDLL-CSharp`.

--- a/Library/docs/source/manual/building/ios.md
+++ b/Library/docs/source/manual/building/ios.md
@@ -1,0 +1,49 @@
+# Building CSP for iOS
+
+This page details how to Build foundation locally and build the IOS DLLs on OSX.
+
+## Prerequisites 
+
+Please install the following packages:
+
+* Install [HomeBrew](https://docs.brew.sh/Installation)
+* xcode (install through App Store)
+ - `brew install git`
+ - `brew install git-lfs`
+ - `brew install --cask visual-studio-code`
+ - `brew install python3`
+ - `brew install llvm`
+ - `brew install --cask docker`
+ - `brew install cmake`
+ - `pip3 install chevron`
+ - `pip3 install jinja2`
+ - `pip3 install gitpython`
+
+***
+
+## Build Instructions
+Build instructions for the Connected Spaces Platform project are below.
+First of all you'll need to run the following script:
+1. Clone the Connected Spaces Platform Repositiory `git clone --recurse-submodules https://github.com/magnopus-opensource/connected-spaces-platform.git`.
+3. Open Terminal and run `generate_solution_ios` to generate the Foundation solution.
+ > If you get an error with premake not found, this is the first module built so you'll need to checkout the submodules with `git submodule update --init --recursive`.
+4. Open up Terminal in the Foundation Root Folder and run :
+
+`xcodebuild -configuration ReleaseDLL -project Library/ConnectedSpacesPlatform_ios.xcodeproj`
+
+### Note
+
+To Build Debug DLLs replace `ReleaseDLL` with `DebugDLL` and likewise with the directory location
+
+
+## Where is the file output?
+
+Once Foundation has finished building you will find the DLL has been generated in `connected-spaces-platform\Library\Binaries\ios\ReleaseDLL`.
+
+## How to import to unity
+
+1. Open your unity project and click Assets in the top menu bar
+
+2. Click `Import New Asset` and select the `libConnectedSpacesPlatform.a`
+
+3. Double click inside Assets and the `libConnectedSpacesPlatform.a` will unzip

--- a/Library/docs/source/manual/building/ios.md
+++ b/Library/docs/source/manual/building/ios.md
@@ -31,16 +31,13 @@ First of all you'll need to run the following script:
 
 `xcodebuild -configuration ReleaseDLL -project Library/ConnectedSpacesPlatform_ios.xcodeproj`
 
-### Note
-
-To Build Debug DLLs replace `ReleaseDLL` with `DebugDLL` and likewise with the directory location
-
+_Note: To Build Debug DLLs replace `ReleaseDLL` with `DebugDLL` and likewise with the directory location._
 
 ## Where is the file output?
 
 Once Foundation has finished building you will find the DLL has been generated in `connected-spaces-platform\Library\Binaries\ios\ReleaseDLL`.
 
-## How to import to unity
+## How to import to Unity
 
 1. Open your unity project and click Assets in the top menu bar
 

--- a/Library/docs/source/manual/building/macos.md
+++ b/Library/docs/source/manual/building/macos.md
@@ -1,0 +1,41 @@
+# Building CSP for MacOS
+
+This page details how to Build foundation locally and build the MacOS DLLs on OSX.
+
+## Prerequisites 
+
+Please install the following packages:
+
+* Install [HomeBrew](https://docs.brew.sh/Installation)
+* xcode (install through App Store)
+ - `brew install git`
+ - `brew install git-lfs`
+ - `brew install --cask visual-studio-code`
+ - `brew install python3`
+ - `brew install llvm`
+ - `brew install --cask docker`
+ - `brew install cmake`
+ - `pip3 install chevron`
+ - `pip3 install jinja2`
+ - `pip3 install gitpython`
+
+***
+
+## Build Instructions
+Build instructions for the Connected Spaces Platform project are below.
+First of all you'll need to run the following script:
+1. Clone the Connected Spaces Platform Repositiory `git clone --recurse-submodules https://github.com/magnopus-opensource/connected-spaces-platform.git`.
+3. Open Terminal and run `generate_solution_mac` to generate the Foundation solution.
+ > If you get an error with premake not found, this is the first module built so you'll need to checkout the submodules with `git submodule update --init --recursive`.
+4. Open up Terminal in the Foundation Root Folder and run :
+
+`xcodebuild BITCODE_GENERATION_MODE=bitcode OTHER_CFLAGS="-fembed-bitcode" -configuration ReleaseDLL -project Library/ConnectedSpacesPlatform.xcodeproj`
+
+### Note
+
+To Build Debug DLLs replace `ReleaseDLL` with `DebugDLL` and likewise with the directory location
+
+
+## Where is the file output?
+
+Once Foundation has finished building you will find the DLL has been generated in `connected-spaces-platform\Library\Binaries\macosx\ReleaseDLL`.

--- a/Library/docs/source/manual/building/macos.md
+++ b/Library/docs/source/manual/building/macos.md
@@ -31,10 +31,7 @@ First of all you'll need to run the following script:
 
 `xcodebuild BITCODE_GENERATION_MODE=bitcode OTHER_CFLAGS="-fembed-bitcode" -configuration ReleaseDLL -project Library/ConnectedSpacesPlatform.xcodeproj`
 
-### Note
-
-To Build Debug DLLs replace `ReleaseDLL` with `DebugDLL` and likewise with the directory location
-
+_Note: To Build Debug DLLs replace `ReleaseDLL` with `DebugDLL` and likewise with the directory location._
 
 ## Where is the file output?
 

--- a/Library/docs/source/manual/building/web.md
+++ b/Library/docs/source/manual/building/web.md
@@ -1,0 +1,27 @@
+# Building CSP for Web
+
+## Prerequisites
+* git
+* vscode
+* python3
+* llvm
+* docker-desktop (must be started as Administrator)
+* cmake
+
+## Running the build
+
+To build with emscripten on Windows, simply run the bat file contained within `Tools/Emscripten`.
+
+These bat files also require an argument provided when running them, either _debug_ or _release_.
+
+EmscriptenFullBuildAndConfigure.bat will run generate_solution.bat and Premake. 
+
+e.g. EmscriptenFullBuildAndConfigure.bat release
+
+To run the Emscripten server locally call the python script: `Tools/Emscripten/StartEmscriptenServer.py`. 
+
+## Where is the file output?
+
+After the build is successful the local files will appear in `Tools/WrapperGenerator/Output/TypeScript`.
+
+You will also need to copy the Debug and/or Release folder from `Library/Binaries/wasm`.

--- a/Library/docs/source/manual/debugging/debugging_unity.md
+++ b/Library/docs/source/manual/debugging/debugging_unity.md
@@ -1,8 +1,6 @@
 # Debugging CSP for Unity
 
-> :warning: _This tutorial is for debugging the native CSP DLL. If you are trying to debug the C# wrapper code, you can do this directly from your Unity project's generated Visual Studio project._
-
-<br>
+_Note: This tutorial is for debugging the native CSP DLL. If you are trying to debug the C# wrapper code, you can do this directly from your Unity project's generated Visual Studio project._
 
 This guide assumes the developer is working on a Windows PC using Visual Studio.
 

--- a/Library/docs/source/manual/debugging/debugging_unity.md
+++ b/Library/docs/source/manual/debugging/debugging_unity.md
@@ -1,0 +1,25 @@
+# Debugging CSP for Unity
+
+> :warning: _This tutorial is for debugging the native CSP DLL. If you are trying to debug the C# wrapper code, you can do this directly from your Unity project's generated Visual Studio project._
+
+<br>
+
+This guide assumes the developer is working on a Windows PC using Visual Studio.
+
+1. If you haven't already done so already, please follow the [C# Buiild instructions](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-CSP-for-CSharp) to generate a locally debuggable version of the library.
+2. Navigate to your local CSP repository.
+3. Fetch the latest tags.
+    - `git fetch --all`
+4. Checkout the tag that matches your current CSP package version.
+    - eg. `git checkout tags/v3.1.245 -b v3.1.245-branch`
+    - This is required as the source you use to debug must be the same as the source that was used to build the Unity package. Visual Studio's debugger will load the required debug symbols from the PDB provided with the CSP package, so you do not need to build locally.
+5. Run `generate_solution.bat` to generate the CSP project and solution files.
+    - You _must_ re-run `generate_solution.bat` every time you pull latest, check out a different branch/tag, or make changes to the public headers.
+    - This will ensure that your project file is up-to-date in case any new files were added or old ones removed.
+6. Open `ConnectedSpacesPlatform.sln` in Visual Studio, switch to the `DebugDLL-CSharp` configuration, and make sure the target platform is x64 and not Android.
+7. Open your Unity project.
+8. Hit Play in Unity to start the session.
+9. In Visual Studio, press `Ctrl + Alt + P` to show the `Attach to Process` window and attach to `Unity.exe`.
+10. Set a breakpoint in some code you'd like to inspect in Visual Studio, then run your tests/press play in Unity.
+11. Your breakpoint within the library will now be hit when the corresponding line of code is executed.
+

--- a/Library/docs/source/manual/debugging/debugging_web.md
+++ b/Library/docs/source/manual/debugging/debugging_web.md
@@ -1,0 +1,26 @@
+# Debugging CSP for Web
+
+This guide explains how to debug Foundation for Web using Google Chrome.
+
+## Steps
+1. Install the [C/C++ DevTools Support (DWARF)](https://chrome.google.com/webstore/detail/cc%20%20-devtools-support-dwa/pdcpmagijalfljmkmjngeonclgbbannb) Chrome extension.
+2. Enable DWARF support for WASM debugging.
+    - Open the developer console (ctrl + shift + I).
+    - Open the settings panel (F1).
+    - Select `Experiments` in the side panel.
+    - Check `WebAssembly Debugging: Enable DWARF support`.
+3. Go to the settings page for C/C++ DevTools Support (chrome-extension://pdcpmagijalfljmkmjngeonclgbbannb/ExtensionOptions.html).
+4. Under `Path substitutions`, click `Add path substitution`.
+5. In the first text box, enter `/src/`.
+6. In the second text box, enter the path to your local CSP repository clone.
+7. Navigate to your web client application that uses CSP in Chrome.
+8. Open the developer console (ctrl + shift + I).
+9. Wait for a message similar to `[C/C++ DevTools Support (DWARF)] Loaded debug symbols for https://odev.magnoverse.space/b95515fc8363ec3f.wasm, found 1382 source file(s)`.
+10. Click the `Sources` tab in the developer console.
+11. Navigate to any file by expanding `file://`, then `<your_csp_repo_path>` in the Page sidebar on the left and locating your file, or by pressing Ctrl + P and typing the file name.
+12. You can now set any breakpoints you want and inspect call stack and variable values on the right.
+
+## Tips
+When you're working with a locally built web client and you would want to pull a fresh FDN package, this command needs to be ran. You'll need to replace the `1.2.3` with the version number you want to be pulled.
+
+`yarn remove @magnopus-opensource/connected-spaces-platform.web && yarn add @magnopus-opensource/connected-spaces-platform.web@1.2.3`

--- a/Library/docs/source/manual/debugging/performance_profiling.md
+++ b/Library/docs/source/manual/debugging/performance_profiling.md
@@ -1,0 +1,90 @@
+# Performance Profiling
+
+The Connected Spaces Platform library has support for low-level performance profiling of the library itself, which can be linked into existing client profiling tools such as Unreal Insights, Optick or Microprofile.
+
+## Internal Profiling Hooks
+The internal header `Debug/Logging.h` provides the following macros for instrumenting performance within the library.
+
+```
+FOUNDATION_PROFILE_SCOPED()
+
+FOUNDATION_PROFILE_BEGIN(TAG)                       
+FOUNDATION_PROFILE_END()
+
+FOUNDATION_PROFILE_BEGIN_FORMAT(FORMAT_STR, ...)
+FOUNDATION_PROFILE_SCOPED_FORMAT(FORMAT_STR, ...)   
+FOUNDATION_PROFILE_SCOPED_TAG(TAG)
+
+FOUNDATION_PROFILE_EVENT_TAG(TAG)                   
+FOUNDATION_PROFILE_EVENT_FORMAT(FORMAT_STR, ...)
+```
+
+These macros are compiled out in a Release build, or more specifically when profiling is disabled.
+
+```c++
+if !defined(FOUNDATION_PROFILING_ENABLED)
+  #if defined(NDEBUG)
+    // Disable profiling in release by default (change this to override)
+    #define FOUNDATION_PROFILING_ENABLED 0
+  #else
+    #define FOUNDATION_PROFILING_ENABLED 1
+  #endif
+#endif
+```
+
+Example use for function instrumentation.
+
+```c++
+void CSPFoundation::Tick()
+{
+    FOUNDATION_PROFILE_SCOPED();
+
+    csp::events::Event* TickEvent = csp::events::EventSystem::Get().AllocateEvent(csp::events::FOUNDATION_TICK_EVENT_ID); 
+    csp::events::EventSystem::Get().EnqueueEvent(TickEvent);
+
+    csp::events::EventSystem::Get().ProcessEvents();
+}
+```
+
+## Example - Binding to Unreal Insights
+
+The following snippet shows how an Unreal client can hook into the CSP profiling system. 
+
+In this case the client is calling [Unreal Insights](https://docs.unrealengine.com/5.1/en-US/unreal-insights-in-unreal-engine/) profiling calls, but could equally be calling macros for other systems such as [Optick](https://github.com/bombomby/optick) or [Microprofile](https://github.com/jonasmr/microprofile).
+
+![image](https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/de3c6049-05a4-4f14-bc87-9c42c0ba5484)
+
+```c++
+void FUnrealModule::RegisterCSPCallbacks()
+{
+#if !UE_BUILD_SHIPPING
+    Trace::ToggleChannel(TEXT("CSPTraceChannel"), true);
+
+    csp::systems::SystemsManager::Get().GetLogSystem()->RegisterEventCallback(
+        [this](oly_common::String InMessage)
+    {
+        TRACE_BOOKMARK(TEXT("%s"), *InMessage);
+    });
+
+    csp::systems::SystemsManager::Get().GetLogSystem()->RegisterBeginMarkerCallback(
+        [this](oly_common::String InMessage)
+    {
+        bool bChannelEnabled = UE_TRACE_CHANNELEXPR_IS_ENABLED(CSPTraceChannel);
+        if (bChannelEnabled)
+        {
+            unsigned int EventTag = FCpuProfilerTrace::OutputEventType(InMessage.c_str());
+            FCpuProfilerTrace::OutputBeginEvent(EventTag);
+        }
+    });
+
+    csp::systems::SystemsManager::Get().GetLogSystem()->RegisterEndMarkerCallback(
+        [this](void*)
+    {
+        bool bChannelEnabled = UE_TRACE_CHANNELEXPR_IS_ENABLED(CSPTraceChannel);
+        if (bChannelEnabled)
+        {
+            FCpuProfilerTrace::OutputEndEvent();
+        }
+    });
+#endif
+}

--- a/Library/docs/source/manual/debugging/performance_profiling.md
+++ b/Library/docs/source/manual/debugging/performance_profiling.md
@@ -52,7 +52,7 @@ The following snippet shows how an Unreal client can hook into the CSP profiling
 
 In this case the client is calling [Unreal Insights](https://docs.unrealengine.com/5.1/en-US/unreal-insights-in-unreal-engine/) profiling calls, but could equally be calling macros for other systems such as [Optick](https://github.com/bombomby/optick) or [Microprofile](https://github.com/jonasmr/microprofile).
 
-![image](https://github.com/magnopus-opensource/connected-spaces-platform/assets/99482500/de3c6049-05a4-4f14-bc87-9c42c0ba5484)
+![image info](../../_static/debugging/insights.png)
 
 ```c++
 void FUnrealModule::RegisterCSPCallbacks()

--- a/Library/docs/source/manual/documentation/adding_components.md
+++ b/Library/docs/source/manual/documentation/adding_components.md
@@ -1,7 +1,7 @@
 # Adding Components to CSP
 A common practice when developing in CSP is adding new Component classes to the library. This page details this process so that all the relevant steps are tackled and the new feature contains all the functionality expected of a new component.
 
-## Add the new Component class
+## Add a new Component class
 The first thing to do will be adding the new class files. The header files are to be added to `Library/include/CSP/Multiplayer/Components/`, while CPP files should go in `Library/src/Multiplayer/Components/`.
 
 Add your component code, using the other components as examples.

--- a/Library/docs/source/manual/documentation/adding_components.md
+++ b/Library/docs/source/manual/documentation/adding_components.md
@@ -1,0 +1,105 @@
+# Adding Components to CSP
+A common practice when developing in CSP is adding new Component classes to the library. This page details this process so that all the relevant steps are tackled and the new feature contains all the functionality expected of a new component.
+
+## Add the new Component class
+The first thing to do will be adding the new class files. The header files are to be added to `Library/include/CSP/Multiplayer/Components/`, while CPP files should go in `Library/src/Multiplayer/Components/`.
+
+Add your component code, using the other components as examples.
+
+**MyComponent.h**
+```cpp
+enum class MyPropertyKeys
+{
+	ImageURL,
+	Num
+};
+
+class CSP_API MyComponent : public ComponentBase
+{
+public:
+	MyComponent(SpaceEntity* Parent);
+	const csp::common::String& GetImageURL() const;
+	void SetImageURL(const csp::common::String& Value);
+};
+```
+
+**MyComponent.cpp**
+```cpp
+MyComponent::MyComponent(SpaceEntity* Parent) : ComponentBase(ComponentType::MyComponent, Parent)
+{
+	Properties[static_cast<uint32_t>(MyPropertyKeys::ImageURL)]				= "";
+
+	SetScriptInterface(CSP_NEW MyComponentScriptInterface(this));
+}
+
+const csp::common::String& MyComponent::GetImageURL() const
+{
+	return GetStringProperty(static_cast<uint32_t>(MyPropertyKeys::ImageURL));
+}
+
+void MyComponent::SetImageURL(const csp::common::String& Value)
+{
+	SetProperty(static_cast<uint32_t>(MyPropertyKeys::ImageURL), Value);
+}
+```
+
+## Add a ComponentType entry 
+In `Library/include/CSP/Multiplayer/ComponentBase.h`, add an enum entry to the `ComponentType` enum, with your component name, ensuring it is added to the end of the enum, and not inserted!
+
+```cpp
+enum class ComponentType
+{
+	Invalid,
+        MyComponent
+}
+```
+
+## Add a component instantiation case
+In `Library/src/Multiplayer/SpaceEntity.cpp`, in `InstantiateComponent`, add a case for your component type, so that it can be instantiated correctly.
+
+```cpp
+case ComponentType::MyComponent:
+	Component = CSP_NEW MyComponent(this);
+	break;
+```
+
+## Script Binding
+This part is more involved, but very important to be done correctly.
+
+First create a script interface header and cpp file both in this folder: `Library/src/Multiplayer/Script/ComponentBinding/`
+The header file should contain declarations of script properties, using the macro you see in other interface files. The CPP follows a similar process. Use the existing script interfaces as an example.
+
+**MyComponentScriptInterface.h**
+```cpp
+class MyComponentScriptInterface : public ComponentScriptInterface
+{
+public:
+	MyComponentScriptInterface(MyComponent* InComponent = nullptr);
+
+	DECLARE_SCRIPT_PROPERTY(std::string, ImageURL);
+}
+```
+**MyComponentScriptInterface.cpp**
+```cpp
+MyComponentScriptInterface::MyComponentScriptInterface(MyComponent* InComponent) : ComponentScriptInterface(InComponent)
+{
+}
+
+DEFINE_SCRIPT_PROPERTY_STRING(MyComponent, ImageURL);
+```
+
+Secondly, within `Library/src/Multiplayer/Script/EntityScriptBinding.cpp`, in the `Bind` and `BindComponents` functions, ensure that handling of your new component is added. This gives scripts access to properties and functions of the component.
+
+```js
+// BindComponents
+    Module->class_<MyComponentScriptInterface>("MyComponent")
+		.constructor<>()
+		.base<ComponentScriptInterface>()
+		.PROPERTY_GET_SET(MyComponent, ImageURL, "imageURL")
+
+// Bind
+.fun<&EntityScriptInterface::GetComponentsOfType<MyComponentScriptInterface, ComponentType::MyComponent>>("getMyComponents")
+```
+
+## Component Testing
+New components need a new unit test file, in the following folder `Tests/src/PublicAPITests/ComponentTests/`, use the existing files as examples for contents. Typically components are only expected to test that their fields set and get correctly, though any additional functionality should be tested also, especially if there are systems that tie in to the component itself.

--- a/Library/docs/source/manual/documentation/branching_strategy.md
+++ b/Library/docs/source/manual/documentation/branching_strategy.md
@@ -1,0 +1,81 @@
+# Branching Strategy
+
+This document outlines the branching strategy as defined by the team.
+
+## Branches
+
+### [develop](https://github.com/magnopus-opensource/connected-spaces-platform/tree/develop)
+
+The develop branch serves as the primary branch for ongoing development. It is locked to prevent direct commits. As such, any new features and fixes must go through the Pull Request (PR) approval process before landing in this branch. PRs at this level undergo build checks and tests, and require 2 review approvals to pass. PRs targeting `develop` should use the `Squash and merge` option in GitHub when the PR contains multiple commits to keep commit history clean. When doing so, please leave the commit description in its auto-generated form, as this helps generate correct changelog notes.
+
+### [Main](https://github.com/magnopus-opensource/connected-spaces-platform/tree/Main)
+
+The `Main` branch is used exclusively for hosting release versions of the Connected Spaces Platform library. It contains the code for the latest stable release, and tags are created against this branch to mark release builds. PR checks do not run on this branch.
+
+### Development Branches
+
+Akin to _Feature Branches_ in GitFlow, these cover any change needed to the codebase. They all follow the same conventions and standards. These branches are to be made as and when they are needed, though they must follow specific naming patterns.
+
+If the work being done is based on a Jira ticket, the ticket ID should be included in the branch name. If there is no ticket for the work, you may use `NT-0` in place of the ticket ID.
+
+> `<work type>/XX-YY_Title`
+> * work type - A label denoting what kind of work this branch covers. Should be one of either `fix`, `feature`, `doc`, or `misc`. `misc` branches cover refactoring work, style changes/fixes, and other work that does not fit in the aforementioned labels.
+> * XX-YY - Either a Jira ticket ID (such as `TIC-267`, or `TC-3012`), or `NT-0`.
+> * Title - The title should summarise the work being done in the branch. It should not be overly long or too technical, but it should give the reader a general idea of the branch's purpose. Any spaces that would be in the branch title should be replaced with underscores (_).
+
+Example branch names:
+
+* `fix/NT-0_Token_refresh_expiry_failure_hotfix`
+* `feature/TIC-456_Add_Geolocation_System`
+* `feature/TIC-5398_Create_new_doxygen_pages`
+* `misc/NT-0_Fix_broken_formatting_in_UserSystem`
+
+## Branching Workflow
+
+The workflow provides a structured approach to managing the development process.
+
+Here is a high-level overview of how a change moves from development through to release.
+
+### Development
+
+Developers create branches off the `develop` branch for implementing changes. Once complete, they initiate a PR to merge this branch back into `develop`. While not currently enforced by rule, we advise and expect that branches have a singular focus.
+This means that fixes should not appear in a feature branch, and should instead exist in a purpose-made branch and merged separately. The same expectation applies to documentation changes or refactors that are unrelated to a feature being developed. It is acceptable and expected to have tests included in branches where features or fixes require them.
+
+*Note that it is possible to work with multiple branches locally if there is a non-merged fix required for an in-development feature.* 
+
+### Release Preparation
+
+When the `develop` branch reaches a stable state with the desired set of features and fixes, it is merged into `Main` via PR.
+
+**PRs for merging the develop branch into the `Main` branch should be merged using a regular merge commit, NOT `Squash` or `Rebase`!**
+
+After merging to `Main`, the `Main` branch will not be one commit ahead of `develop`. To resolve this, you must rebase `Main` onto `develop` via the command line using the following:
+1. `git checkout Main`
+2. `git pull`
+3. `git checkout develop`
+4. `git rebase Main`
+
+### Release Deployment
+New CSP packages are published via the `Publish CSP` deploy step on Team City. This will create a new tag for the release on the `Main` branch, create a new GitHub release and push build artifacts, and publish new `CSP for Unity` and `CSP for Web` NPM packages to npmjs. 
+
+### Maintenance and Hotfixes
+
+If any critical issues arise in a release version, a hotfix must be created as a fix branch and merged into the `develop` branch, then go through the standard release process, with a relevant version number increment.
+
+## Examples
+
+Below are some example scenarios illustrating how the process and workflow works in practice.
+
+### Working on a new feature
+
+1. Clone `develop` branch.
+2. Create a new branch for your feature (Use the naming convention for branches as above).
+3. Submit a PR to the `develop` branch once work is complete.
+4. Await for PR build checks to validate the change is stable
+5. Gain approval from two members of the Connected Spaces platform team
+6. Merge to `develop`
+
+### Making a new release version
+
+1. Once `develop` has been validated as stable and complete, a PR is made to merge into `Main`.
+2. Once merged into `Main`, a tag is applied to mark the version, and builds are made of the associated packages.

--- a/Library/docs/source/manual/documentation/expected_application_flow.md
+++ b/Library/docs/source/manual/documentation/expected_application_flow.md
@@ -1,0 +1,89 @@
+# Expected Application Flow
+
+This document explains the CSP expectations of client implementations of multiplayer functionality, primarily focussed on the order of methods called and any relevant details. It should not be considered a comprehensive implementation guide, and as such will not go into details on parameter inputs for the API functions listed.
+
+The list reads numerically in the suggested order of execution. While some operations _may_ work or _appear_ to work when executed out of this order, it is not recommended and we cannot reasonably provide support in situations where this is the case.
+Language details and CSP API syntax may differ depending on the client.
+
+For details about the sending of data using the Multiplayer System, please see the following page:
+[Multiplayer and State Replication](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Multiplayer-and-State-Replication)
+
+## 1. Initialise CSP
+```c++
+bool CSPFoundation::Initialise(const csp::common::String& EndpointRootURI, const csp::common::String& InTenant)
+```
+
+This starts up CSP and its various systems, including the MultiplayerConnection.
+
+### a. Set UserAgent information
+```c++
+void CSPFoundation::SetClientUserAgentInfo(const csp::ClientUserAgent& ClientUserAgentHeader)
+```
+
+While not strictly necessary for multiplayer functionality, this is a recommended step which should be done following the initialisation of CSP.
+
+## 2. Log In
+```c++
+void UserSystem::Login(const csp::common::String& UserName,
+   			   const csp::common::String& Email,
+   			   const csp::common::String& Password,
+   			   const csp::common::Optional<bool>& UserHasVerifiedAge,
+   			   LoginStateResultCallback Callback)
+```
+
+This is the main point of authentication, and can be done at any stage after initialisation has completed, but is required to call the majority of the CSP endpoints.
+Note that there are several different methods of logging in, such as:
+* UserSystem::Login
+* UserSystem::LoginWithRefreshToken
+* UserSystem::LoginAsGuest
+* UserSystem::LoginToThirdPartyAuthenticationProvider
+
+This call also initiates the MultiplayerConnection, which will provide real time data replication to entities, and network events, later in the lifecycle.
+
+This call triggers a callback (provided in any above methods parameter list), which informs the client of a successful login attempt. Until this callback returns, the client cannot assume the user has logged in.
+
+### a. Tick
+Once Login is complete, the client application should consider starting to call Tick at a regular rate. This will be required to receive any event messages, including messages relating to forced disconnects, or messages relating to Organizations, for example.
+
+## 3. Set the EntityCreated Callback
+```c++
+void SpaceEntitySystem::SetEntityCreatedCallback(EntityCreatedCallback Callback)
+```
+
+This callback will be triggered any time the client receives a message from a space the user is subscribed to, stating that an Entity has been created. It is advised to call this just prior to entering a space, as once subscribed to a space, this callback will be triggered for each Entity currently in the space. The Client should use the data passed here to initialize any local representation of the entities in their application.
+
+This call does not need to be awaited, the callback passed in is immediately registered by CSP and is considered active as soon as this method is invoked. If this method is called multiple times, only the latest callback will be active, as the old ones will be discarded.
+
+## 4. Enter Space
+```c++
+void SpaceSystem::EnterSpace(const String& SpaceId, NullResultCallback Callback)
+```
+
+This call does several things:
+* First, it validates the user calling it has the relevant permissions to be in the space given. If not it will reject the call. 
+* Secondly, it sets ‘scopes’, which are a subscription to a set of Entity replication messages. At the time of writing there is a single scope for a space, so any Entity in that space is replicated to any other user in the space. This is due to change in future, with more complex scopes representing ‘layers’ that can be used to alter what data is replicated to which user.
+* Thirdly, it retrieves all Entities currently in the space. When received these will trigger the callback in the previous step, allowing the Client to create local representations based on their data.
+
+The Client must wait for the callback to be triggered before assuming the Space has been entered and performing any Entity operations.
+
+## 5. Exit Space
+```c++
+void SpaceSystem::ExitSpace(NullResultCallback Callback)
+```
+
+This call unsubscribes from the scopes that have been set so far. It also clears all local Entity objects within CSP, along with any pending updates.
+The client must wait for the callback to be triggered before assuming the Space has been left successfully.
+
+## 6. Log Out
+```c++
+void UserSystem::Logout(NullResultCallback Callback)
+```
+
+This call does 2 things, it revokes the users authentication (and associated session refresh tokens), and it also disconnects the MultiplayerConnection. Again, the callback must be triggered before the Client can assume that any of this process has occurred.
+
+## 7. Shutdown
+```c++
+bool CSPFoundation::Shutdown()
+```
+
+This call closes out CSP, destroying all Systems and unregistering listeners, tidying memory. It’s not a latent call, so once called, it should be assumed that CSP is now inactive.

--- a/Library/docs/source/manual/documentation/external_tools.md
+++ b/Library/docs/source/manual/documentation/external_tools.md
@@ -1,0 +1,15 @@
+# External Tools
+
+## Clang Format
+The formatter used in the project is Clang Format, the configuration file is contained at the root of the repository, ".clang-format".
+Clang is clever in the way that it searches for the format file upto the root of the project and applies it throughout, meaning it is simple to configure once and just run the tool.
+
+There is a Visual Studio Extension [available ](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.ClangFormat&ssr=false#overview).
+
+You can run Clang Format on the whole project by using [this python script](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/Tools/Formatter/RunFormatter.py). Simply run this from anywhere and it will apply to the whole project.
+
+To create a runnable external tool, simply go to **Tools -> External Tools... -> Add**
+>  - Title: Clang-Format File
+>  - Command: C:\Program Files\LLVM\bin\clang-format.exe
+>  - Arguments: -i "$(ItemPath)"
+>  - Use Output Window: Ticked

--- a/Library/docs/source/manual/documentation/multiplayer_state_replication.md
+++ b/Library/docs/source/manual/documentation/multiplayer_state_replication.md
@@ -1,0 +1,139 @@
+# Multiplayer and State Replication
+
+The following documentation describes the method of replication in the order of the operations that a data change to an entity will undergo to be replicated.
+
+We use an entity-component model to describe state within a space, which maps to the concept of objects and components used by SignalR, the library which is used internally to communicate with cloud-hosted services.
+
+## Setting Data
+A client will access the `SpaceEntity`, and the component of the Space Entity they wish to set a value on. This Component will contain setters for the data the client wishes to set.
+
+As an example, we will use `StaticModelSpaceComponent` to demonstrate, but this would be the same process for any component. Let’s say we wish to set the ModelAssetId of this component and replicate it to other clients. We would use something like the following...
+
+```c++
+auto& MyStaticModelComponent = (StaticModelSpaceComponent&) MyEntity->AddComponent(ComponentType::StaticModel);
+
+const oly_common::String ModelAssetId = "MyAssetId";
+MyStaticModelComponent.SetModelAssetId(ModelAssetId);
+```
+
+## Invoking a Patch Message
+
+Once the client has made their changes to the component properties they need to (They are free to make as many changes over any period of time, no replication will occur until they specify), they will queue up a patch message to be sent to cloud hosted services by invoking `QueueUpdate` on the space entity.
+
+```c++
+void SpaceEntity::SendUpdate(CallbackHandler Callback)
+```
+
+This calls into the `SpaceEntitySystem` (which manages all entities and is responsible for multiplayer service communication) and the entity will be enqueued for patch message transmission.
+
+## Patch Message Serialization
+
+When the entity update is dequeued by the `SpaceEntitySystem` and prepared for transmission, it is first serialised into the expected data format for SignalR and MsgPack, as the payload of `SendObjectPatch`.
+
+```c++
+SignalRMsgPackEntitySerialiser Serialiser;
+
+UpdatedEntity->SerialisePatch(Serialiser);
+auto SerialisedEntity = Serialiser.Finalise();
+
+std::vector<signalr::value> InvokeArguments = {SerialisedEntity};
+Connection->Invoke("SendObjectPatch", InvokeArguments, LocalCallback);
+```
+
+The serializer is set to parse over the `SpaceEntity` data in a specific way in order to format the message correctly. it starts with the Dto metadata of `Id`, `OwnerId`, `Destroy`, `ParentId`.
+
+```c++
+Serialiser.WriteUInt64(Id);
+Serialiser.WriteUInt64(OwnerId);
+Serialiser.WriteBool(false); // Destroy
+Serialiser.BeginArray();	 // ParentId
+{
+	Serialiser.WriteBool(false);
+	Serialiser.WriteNull();
+}
+Serialiser.EndArray();
+```
+
+Then we start the SignalR component processing, of which there are two types; View Components and CSP Components.
+
+### View Components
+
+A View Component is essentially a core property, present for any every Space Entity. These are:
+
+* Entity Name
+* Position
+* Rotation
+* Scale
+
+ View components are represented by _specific_ keys in the Component map, which are 1024 reserved keys at the end of the component map. These keys can be seen in [SpaceEntityKeys.h](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/Library/src/Multiplayer/SpaceEntityKeys.h).
+
+### CSP Components
+
+CSP components are the components that inherit from [ComponentBase](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/Library/include/CSP/Multiplayer/ComponentBase.h) (such as `StaticModelSpaceComponent`), and they utilise the component keys starting from zero and incrementing as new components are added to an entity.
+
+In order to serialise these components, we iterate over the `DirtyComponents` map, which contains pointers to all the components we've marked as dirty.
+
+```c++
+const oly_common::Array<uint16_t>* DirtyComponentKeys = DirtyComponents.Keys();
+
+for (int i = 0; i < DirtyComponentKeys->Size(); ++i)
+{
+    auto* Component = DirtyComponents[DirtyComponentKeys->operator[](i)].Component;
+
+    SerialiseComponent(Serialiser, Component);
+}
+```
+
+`SerialiseComponent` then iterates over all properties and writes them using MsgPack's property packing to convert the `ReplicatedValues`.
+
+```c++
+PropertyPacker.pack_uint64(Id);
+PropertyPacker.pack_uint64((uint64_t) Value.GetReplicatedValueType());
+
+switch (Value.GetReplicatedValueType())
+{
+	case ReplicatedValueType::Boolean:
+		Value.GetBool() ? PropertyPacker.pack_true() : PropertyPacker.pack_false();
+		Break;
+…
+```
+
+As you can see above, we first pack the `Id` for the property, so that we can apply to the correct property in the map on the receiving end. We then pack the type of the replicated value, so that we know what data we should expect when unpacking (This is important as we need to know how many bytes to read, especially for data like strings).
+
+Then, depending on the type of data, we use the appropriate packing function from MsgPack. The code above is clipped to save space, but it currently packs; Bools, Integers, Floats, Strings, Vector3’s and Vector4’s. More can be added if they are needed, but these have suited our use-cases so far.
+
+
+
+
+## Sending a Patch Message
+We touched on the code for sending a patch message previously, where clients call `SpaceEntity::Queue` and we internally queue the entity for serialization and transmission (using the `SendObjectPatch` multiplayer service call).
+
+When the patch is transmitted, we invoke a `ApplyLocalPatch` on the entity whose data is being transmitted. 
+
+This function emulates certain parts of the application of the patch message on the local sending client, so that it can ensure the state of its objects are the same as they would be on receiving clients. For this reason, it also invokes the `EntityUpdateCallback` bound to the entity, so that a client can respond to the update of an entity.
+
+Two of the essential parts of this callback are `SpaceEntityUpdateFlags`, which is a set of enum bit flags that tell the client if a property has been updated, and `ComponentUpdateInfo`, which is a set of enum bit flags that tell the client if a component has been added, deleted, or updated.
+
+Using these callbacks, a client application can update their client-level representation of the entity and the components the entity owns.
+
+> ℹ️ `EntityUpdateCallback` is called from both `ApplyLocalPatch` (local client) and `DeserialiseFromPatch` (remote client), which ensures the client implementations receive equivalent notifications and can apply this information whether it's a sending or receiving client.
+
+## Receiving a Patch Message
+
+When the `SpaceEntitySystem` sets the SignalR connection (`SpaceEntitySystem::SetConnection`), we set the callback for the `OnObjectPatch` multiplayer service invocation.
+
+This callback then fires when we receive a patch message from another client.
+
+When this happens, the callback uses the deserializer to iterate through the data received and unpack it to the relevant Components and Properties. This then fires the same callback as discussed previously, EntityUpdateCallback.
+
+One important thing we do here is handle the Destroy flag in the Dto metadata. If the flag is set, we find the entity and locally destroy it, removing it from CSP and also firing a callback to the client to deal with deletion on their side.
+
+## Deserialising Data & Firing Client Callbacks
+
+This part is very similar to the serialisation, for obvious reasons, and also quite similar to the code used in `ApplyLocalPatch`, especially in the case of the building of `UpdateFlags` and `ComponentUpdateInfo`.
+
+The basic idea here is to apply the received patch message data on the receiving clients' entities and components, while also firing a callback with information on what has changed.
+
+Data is updated as it gets deserialized, and the `UpdateFlags` and `ComponentUpdateInfo` structures are populated at the same time.
+
+Finally, at the end of the deserialization, the callback is fired to the client to let them know things have changed.

--- a/Library/docs/source/manual/documentation/multiplayer_state_replication.md
+++ b/Library/docs/source/manual/documentation/multiplayer_state_replication.md
@@ -21,7 +21,7 @@ MyStaticModelComponent.SetModelAssetId(ModelAssetId);
 Once the client has made their changes to the component properties they need to (They are free to make as many changes over any period of time, no replication will occur until they specify), they will queue up a patch message to be sent to cloud hosted services by invoking `QueueUpdate` on the space entity.
 
 ```c++
-void SpaceEntity::SendUpdate(CallbackHandler Callback)
+void SpaceEntity::SendUpdate(CallbackHandler Callback);
 ```
 
 This calls into the `SpaceEntitySystem` (which manages all entities and is responsible for multiplayer service communication) and the entity will be enqueued for patch message transmission.
@@ -95,7 +95,7 @@ switch (Value.GetReplicatedValueType())
 	case ReplicatedValueType::Boolean:
 		Value.GetBool() ? PropertyPacker.pack_true() : PropertyPacker.pack_false();
 		Break;
-…
+	...
 ```
 
 As you can see above, we first pack the `Id` for the property, so that we can apply to the correct property in the map on the receiving end. We then pack the type of the replicated value, so that we know what data we should expect when unpacking (This is important as we need to know how many bytes to read, especially for data like strings).

--- a/Library/docs/source/manual/documentation/programming_guidelines.md
+++ b/Library/docs/source/manual/documentation/programming_guidelines.md
@@ -1,0 +1,81 @@
+# Programming Guidelines
+We closely follow coding standards outlined in the [Epic C++ Coding Standard](https://docs.unrealengine.com/5.2/en-US/epic-cplusplus-coding-standard-for-unreal-engine/).
+
+All variable, field, parameter, class, and function names should be UpperCamelCase. We include a .clang-format file to help with code formatting which is run on a pre-commit hook.
+
+## API Markup Standards
+
+The source makes use of Macros to add additional functionality to the public interface when it is processed by the wrapper generator. Because of this, it's important to understand the correct usage of these Macros so that the library works correctly when being used with other languages.
+
+* Use `CSP_API` to mark your class or free function for export. This allows it to be accessed across the DLL boundary and be made visible by the wrapper generator.
+  ```c++
+  CSP_API void DoSomething();
+
+  class CSP_API MyClass { }
+  ```
+* Functions or fields that should not be wrapped should be marked with `CSP_NO_EXPORT`.
+  ```c++
+  // This function will still be exported in the DLL, but not wrapped by the wrapper generator.
+  CSP_API CSP_NO_EXPORT void DoSomethingFromUnreal();
+  ```
+
+* Entire files can also be ignored by placing `CSP_NO_EXPORT` at the top of the file after the header includes.
+* Blocks of code that should be ignored by the wrapper generator (in the case of syntax not being supported yet) should be surrounded by `CSP_START_IGNORE` and `CSP_END_IGNORE`.
+
+  ```c++
+  class CSP_API MyClass
+  {
+    CSP_START_IGNORE
+    // Friend template class declarations are not yet parsed correctly by the wrapper generator.
+    friend class csp::MyTemplateClass<int>;
+    CSP_END_IGNORE
+  }
+  ```
+
+* Reference-type parameters intended to store an output of a function should be marked with `CSP_OUT`.
+  ```c++
+  CSP_API void GetSomeIntValue(CSP_OUT int& OutValue)
+  {
+    OutValue = 5;
+  }
+  ```
+* Reference-type parameters intended to both provide an initial value and store an output of a function should be marked with `CSP_IN_OUT`.
+  ```c++
+  CSP_API void ReadSomeBytes(CSP_IN_OUT int& Count) 
+  {
+    // Reads at most Count bytes from the socket and stores the number of read bytes in Count
+    Count = socket.read(buffer, Count);
+  }
+  ```
+* Functions that take a callback should always have the callback as the last parameter.
+
+* Functions that take a callback that is intended to only be called once when the requested action has been completed should be marked with `CSP_ASYNC_RESULT`.
+  ```c++
+    // Log out of the current account asynchronously.
+    CSP_API CSP_ASYNC_RESULT void LogOut(LogOutCallback Callback);
+  ```
+* If the callback should also be called with progress updates for the requested action (as is the case with file downloads), it should instead use `CSP_ASYNC_RESULT_WITH_PROGRESS`.
+
+* Functions that take a callback that is intended to be called whenever an event occurs should be marked with `CSP_EVENT`.
+
+  ```c++
+    // Allow the user to set a callback to be notified when the client is disconnected.
+    CSP_API CSP_EVENT void SetDisconnectCallback(DisconnectCallback Callback);
+  ```
+
+* Classes that are meant to be used as interfaces should be marked with `CSP_INTERFACE`.
+
+  ```c++
+  class CSP_API CSP_INTERFACE IMyInterfaceClass 
+  {
+    public:
+      virtual void DoSomething() = 0;
+  }
+  ```
+
+* _**NOTE: Interface classes must only contain pure virtual functions and must also contain a virtual default destructor.**_
+* Classes that should never be disposed by the wrapper should be marked with `CSP_NO_DISPOSE`. This is useful for classes where only a single instance will ever be created and is owned by another class (as is the case for all of the *System classes and SystemsManager). Interfaces should also use the "I" prefix.
+
+```c++
+  class CSP_API CSP_NO_DISPOSE ClassWithSingleInstanceOwnedByManager { }
+```

--- a/Library/docs/source/manual/documentation/script_system.md
+++ b/Library/docs/source/manual/documentation/script_system.md
@@ -1,0 +1,123 @@
+# Script System
+
+The entity-component-based nature of the CSP multiplayer architecture comprises individual components, such as Images, Videos and Buttons, which can be combined together to create unique pieces of content.
+
+The Connected Spaces Platform's [Script Component](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/Library/include/CSP/Multiplayer/Components/ScriptSpaceComponent.h) and [Script System](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/Library/include/CSP/Systems/Script/ScriptSystem.h) are what enables content creators to author complex and engaging interactions with this content via CSP client applications.
+
+The Script Component is the glue that holds these components together. Using the Script Component, creators can define the causal relationships between different components and triggering events.
+
+## EntityScript
+The Script Component can be added to all Entities, including Avatars. Like the other components, it has replicated properties accessible from CSP clients via getters and setters. The Script Component's associated JavaScript code is stored as a replicated string property.
+
+The JavaScript code is compiled to bytecode and interpreted by [QuickJS Javascript Engine](https://bellard.org/quickjs/), which supports the ES2020 standard and features.
+
+To access the script on a CSP Entity we use the following:
+
+`EntityScript* Script = Entity->GetScript();`
+
+There are several useful things you can do with `EntityScript`, including updating the script, invoking it directly, checking for errors, and getting error messages back. For more information on the API, head over [here](https://builds.magnoboard.com/connected-spaces-platform/api/classcsp_1_1multiplayer_1_1_entity_script.html#class-documentation).
+
+## Actions
+Scripts can invoke events, known as actions, to which client applications can respond directly to. At the client level, each component is responsible for defining and managing its own component actions using the `RegisterActionHandler` and `UnregisterActionHandler` functions on [ComponentBase](https://github.com/magnopus-opensource/connected-spaces-platform/blob/develop/Library/include/CSP/Multiplayer/ComponentBase.h).
+
+So if a script invoked an action like this...
+```js
+processButtonClick()
+{
+    invokeAction('PlayVideo')
+}
+```
+Then an Unreal client could respond to it at the client level like this...
+
+```c++
+void MyUnrealCSPComponent::RegisterActionHandler(...)
+{
+    ...
+    // Initialise the action handler for a 'play video' action
+    const csp::multiplayer::ComponentBase::EntityActionHandler PlayVideoHandler =
+
+        [](csp::multiplayer::ComponentBase& Component,         
+        csp::common::String ActionId, csp::common::String ActionParams)
+        {
+            // my response to the action being fired from script
+        };
+
+    // Register the action handler
+    BoundCSPSpaceComponent->RegisterActionHandler("PlayVideo", PlayVideoHandler);
+}
+
+void MyUnrealCSPComponent::UnregisterActionHandler()
+{
+    ...
+    // Unregister the action handler for the play video action
+    BoundCSPSpaceComponent->UnregisterActionHandler("PlayVideo");
+}
+```
+
+## Messages
+Script messages are synonymous with events within the CSP scripting runtime environment. Any object with access to the Script Component of a specific SpaceEntity can post messages to it. The Script Component can then define how it responds to that message.
+
+### Sending Messages between Entity Scripts
+Using the script system, entities can send messages to other entities running scripts. Scripts can post messages to one another using the ‘PostMessage’ function.
+
+So when one entity posts a `HeyThere` message...
+
+```js
+PostAMessage()
+{
+    var spaceEntity = TheEntitySystem.getEntityByName("OLY-SPACEENTITY-2115");
+    spaceEntity.postMessage("HeyThere", "MyParameters");
+}
+
+```
+
+The other entity can respond to it.
+
+```js
+SomebodySaidHey(Params)
+{
+    // respond to the message
+}
+
+ThisEntity.subscribeToMessage("HeyThere", "SomebodySaidHey");
+```
+
+## Referencing other scripts as Modules
+Scripts can import and reference other scripts as Modules using the import keyword with the name of the entity to import the script from.
+
+`import {MyTriggers} from "CSP-SCRIPTENTITY-TRIGGERS-MODULE"`
+
+## Leader Election
+For coherence purposes, it is important that scripts are ticked by one and only one client application at any given time. The leader election system provides a method for CSP-based clients to agree on a single client to handle the execution of scripts.
+
+The current system is based on the [Bully Algorithm](https://en.wikipedia.org/wiki/Bully_algorithm#Algotithm), using the `ClientId` to determine the Leader.
+
+### Process Summary
+The algorithm uses the following message types:
+
+* Election Message: Sent to announce election.
+* Answer (Alive) Message: Responds to the Election message.
+* Coordinator (Victory) Message: Sent by winner of the election to announce victory.
+
+When a process P recovers from failure, or the failure detector indicates that the current coordinator has failed, P performs the following actions:
+
+> 1. If P has the highest process ID, it sends a Victory message to all other processes and becomes the new Coordinator. Otherwise, P broadcasts an Election message to all other processes with higher process IDs than itself.
+> 1. If P receives no Answer after sending an Election message, then it broadcasts a Victory message to all other processes and becomes the Coordinator.
+> 1. If P receives an Answer from a process with a higher ID, it sends no further messages for this election and waits for a Victory message. (If there is no Victory message after a period of time, it restarts the process at the beginning.)
+> 1. If P receives an Election message from another process with a lower ID it sends an Answer message back and if it has not already started an election, it starts the election process at the beginning, by sending an Election message to higher-numbered processes.
+> 1. If P receives a Coordinator message, it treats the sender as the coordinator.
+
+### Leader Heartbeat
+The purpose of the leader heartbeat is to allow the leader election system to respond to a connection error with the current leader. Without the heartbeat, if the leader’s connection drops, then all leader functionality (e.g. running scripts) will stop until the server notices that the leader is no longer there, which could currently take up to several minutes.
+
+When a client becomes a leader it will start sending periodic heartbeat messages to all other clients. The heartbeat period is configurable, but defaults to every 5 seconds.
+
+Clients expect to receive this heartbeat, and if they don’t receive it after some period of time (again configurable, but currently 3 heartbeat periods) then they will broadcast a ‘Leader Lost’ message to other clients.
+
+If enough ‘Leader Lost’ messages are received by any client then they will initiate a new leader election.
+
+The purpose of this approach is to try and avoid a re-election being caused by just one or two clients temporarily losing contact with the leader. Instead a majority must agree before the election is triggered.
+
+When some threshold (currently more than half) of the clients have lost contact with the leader then they will re-elect.
+
+Note it is possible that this re-election could re-elect the same leader again if their connection has returned.

--- a/Library/docs/source/manual/documentation/services_abstraction_layer.md
+++ b/Library/docs/source/manual/documentation/services_abstraction_layer.md
@@ -1,4 +1,4 @@
-# CSP Services Abstraction Layer
+# Services Abstraction Layer
 
 The Connected Spaces Platform communicates with the world via RESTful endpoints and WebSockets, and in order for CSP to meet its goals around interoperability, it depends on those RESTful endpoints following a spec.
 
@@ -12,6 +12,6 @@ What that means practically speaking, is that if you as a CSP contributor wish t
 
 Typically, you will be updating the CSP submodule to reference to the latest version of the services repo. To do that, follow the same process as with any other change, and in your branch invoke:
 
-`git submodule update --init --remote modules/olympus-foundation-chs`
+`git submodule update --init --remote modules/csp-services`
 
 Include the resultant change as part of your push to the remote branch, and include it as part of the PR you eventually create.

--- a/Library/docs/source/manual/documentation/services_abstraction_layer.md
+++ b/Library/docs/source/manual/documentation/services_abstraction_layer.md
@@ -1,0 +1,17 @@
+# CSP Services Abstraction Layer
+
+The Connected Spaces Platform communicates with the world via RESTful endpoints and WebSockets, and in order for CSP to meet its goals around interoperability, it depends on those RESTful endpoints following a spec.
+
+That spec comes in the form of an automatically generated C++ API that can be found in the [csp-services repo](https://github.com/magnopus-opensource/csp-services).
+
+Developers are able to build their own web services that implement this spec, and the implementation can then be validated by directing CSP to interface with those services.
+
+CSP consumes the C++ services API as a **git submodule** referencing a specific commit hash. This allows CSP to electively update which version of the services spec it uses over time.
+
+What that means practically speaking, is that if you as a CSP contributor wish to make use of new features introduced to the services spec, or need to respond to changes to the spec, you will need to update the version of the services repo that the CSP submodule references.
+
+Typically, you will be updating the CSP submodule to reference to the latest version of the services repo. To do that, follow the same process as with any other change, and in your branch invoke:
+
+`git submodule update --init --remote modules/olympus-foundation-chs`
+
+Include the resultant change as part of your push to the remote branch, and include it as part of the PR you eventually create.

--- a/Library/docs/source/manual/documentation/wrapper_generator/c_interface.md
+++ b/Library/docs/source/manual/documentation/wrapper_generator/c_interface.md
@@ -1,0 +1,248 @@
+# C Interface
+
+## General rules
+* All functions in the C interface should be marked with `CSP_C_API` instead of `CSP_API`. This is to accommodate Emscripten's requirements for exported functions in the WASM binary.
+
+## Classes
+* All public fields and functions should be wrapped.
+  * Fields are wrapped with a getter function and a setter function.
+* Private constructors/destructors should not be wrapped.
+
+## Template classes
+* Every template instance needs to be wrapped.
+* Template instances should be treated like regular classes.
+
+## Return types
+### Primitives
+
+* By-value return types should be kept as-is.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API int32_t GetPrimitiveByValue();
+  }
+
+  // C
+  CSP_C_API int32_t csp_GetPrimitiveByValue() {
+      return csp::GetPrimitiveByValue();
+  }
+  ```
+
+* Non-const pointer return types should be kept as-is.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API int32_t* GetPrimitiveByPointer();
+  }
+
+  // C
+  CSP_C_API int32_t* csp_GetPrimitiveByPointer() {
+      return csp::GetPrimitiveByPointer();
+  }
+  ```
+
+* Const pointer return types should be returned by value.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API const int32_t* GetPrimitiveByConstPointer();
+  }
+
+  // C
+  CSP_C_API int32_t csp_GetPrimitiveByConstPointer() {
+      return *csp::GetPrimitiveByConstPointer();
+  }
+  ```
+
+* Non-const reference return types should be returned as a pointer.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API int32_t& GetPrimitiveByReference();
+  }
+
+  // C
+  CSP_C_API int32_t* csp_GetPrimitiveByReference() {
+      return &csp::GetPrimitiveByReference();
+  }
+  ```
+
+* Const reference return types should be returned by value.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API const int32_t& GetPrimitiveByConstReference();
+  }
+
+  // C
+  CSP_C_API int32_t csp_GetPrimitiveByConstReference() {
+      return csp::GetPrimitiveByConstReference();
+  }
+  ```
+
+### Classes
+* Classes are always returned as `NativePointer`.
+* A copy should be made on the heap for classes returned by value, and `NativePointer.OwnsOwnData` should be `true`.
+  ```c++
+  // C++
+  namespace csp {
+      class ExampleClass;
+
+      CSP_API ExampleClass GetClassByValue();
+  }
+
+  // C
+  CSP_C_API NativePointer csp_GetClassByValue() {
+      return NativePointer {
+          CSP_NEW csp::ExampleClass(csp::GetClassByValue()),
+          true
+      };
+  }
+  ```
+
+* Non-const pointers should be returned with `NativePointer.OwnsOwnData` set to `false`.
+  ```c++
+  // C++
+  namespace csp {
+      class ExampleClass;
+
+      CSP_API ExampleClass* GetClassByPointer();
+  }
+
+  // C
+  CSP_C_API NativePointer csp_GetClassByPointer() {
+      return NativePointer {
+          csp::GetClassByPointer(),
+          false
+      };
+  }
+  ```
+
+* A copy should be made on the heap for classes returned by const pointer, and `NativePointer.OwnsOwnData` should be `true`.
+  ```c++
+  // C++
+  namespace csp {
+      class ExampleClass;
+
+      CSP_API const ExampleClass* GetClassByConstPointer();
+  }
+
+  // C
+  CSP_C_API NativePointer csp_GetClassByConstPointer() {
+      return NativePointer {
+          CSP_NEW csp::ExampleClass(*csp::GetClassByConstPointer()),
+          true
+      };
+  }
+  ```
+
+* Non-const references should be returned by pointer with `NativePointer.OwnsOwnData` set to `false`.
+  ```c++
+  // C++
+  namespace csp {
+      class ExampleClass;
+
+      CSP_API ExampleClass& GetClassByReference();
+  }
+
+  // C
+  CSP_C_API NativePointer csp_GetClassByReference() {
+      return NativePointer {
+          &csp::GetClassByReference(),
+          false
+      };
+  }
+  ```
+
+* A copy should be made on the heap for classes returned by const reference, and `NativePointer.OwnsOwnData` should be `true`.
+  ```c++
+  // C++
+  namespace csp {
+      class CSP_API ExampleClass {};
+
+      CSP_API const ExampleClass& GetClassByConstReference();
+  }
+
+  // C
+  CSP_C_API NativePointer csp_GetClassByConstReference() {
+      return NativePointer {
+          CSP_NEW csp::ExampleClass(csp::GetClassByConstReference()),
+          true
+      };
+  }
+  ```
+
+### `csp::common::String`
+* For Strings returned by value or by const-reference, a copy of the underlying C-string should be made on the heap and returned. The caller is responsible for freeing the memory allocated during the copy.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API csp::common::String GetStringByValue();
+      CSP_API const csp::common::String& GetStringByConstReference();
+  }
+
+  // C
+  CSP_C_API char* csp_GetStringByValue() {
+      auto Value = csp::GetStringByValue();
+      auto Buf = (char*)csp::memory::DllAlloc(Value.Length() + 1);
+      std::memcpy(Buf, Value.c_str(), Value.Length());
+      Buf[Value.Length()] = '\0';
+
+      return Buf;
+  }
+
+  CSP_C_API NativePointer csp_GetStringByConstReference() {
+      const auto& Value = csp::GetStringByConstReference();
+      auto Buf = (char*)csp::memory::DllAlloc(Value.Length() + 1);
+      std::memcpy(Buf, Value.c_str(), Value.Length());
+      Buf[Value.Length()] = '\0';
+
+      return Buf;
+  }
+  ```
+
+* Returning Strings by pointer or non-const reference is not supported.
+
+## Parameter types
+### Primitives
+
+* By-value parameter types should be kept as-is.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API void SetPrimitiveByValue(int32_t Value);
+  }
+
+  // C
+  CSP_C_API void csp_SetPrimitiveByValue(int32_t Value) {
+      csp::SetPrimitiveByValue(Value);
+  }
+  ```
+
+* Non-const reference parameter types marked with `CSP_OUT` should be passed by pointer.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API void GetPrimitiveByOut(CSP_OUT int32_t& OutValue);
+  }
+
+  // C
+  CSP_C_API void csp_GetPrimitiveByOut(int32_t* OutValue) {
+      csp::GetPrimitiveByOut(&OutValue);
+  }
+  ```
+
+* Non-const reference parameter types marked with `CSP_IN_OUT` should be passed by pointer.
+  ```c++
+  // C++
+  namespace csp {
+      CSP_API void SetPrimitiveByInGetByOut(CSP_IN_OUT int32_t& InOutValue);
+  }
+
+  // C
+  CSP_C_API void SetPrimitiveByInGetByOut(int32_t* InOutValue) {
+      csp::SetPrimitiveByInGetByOut(&InOutValue);
+  }
+  ```
+
+* Pointer primitive types, const reference primitive types, and non-const primitive reference types not marked with `CSP_OUT` or `CSP_IN_OUT` are not supported as parameters.

--- a/Library/docs/source/manual/documentation/wrapper_generator/csharp_wrapper.md
+++ b/Library/docs/source/manual/documentation/wrapper_generator/csharp_wrapper.md
@@ -1,0 +1,212 @@
+# C# Wrapper
+
+## General rules
+* The root namespace of the C# wrapper should be `Csp`.
+
+## Classes
+* All classes without a base type should inherit from `NativeClassWrapper`.
+  * The exception to this is classes marked with `CSP_INTERFACE`, which should have no base type.
+* All classes marked with `CSP_INTERFACE` should be wrapped as C# interfaces.
+
+## Template classes
+* Template classes should be wrapped as C# generic classes.
+
+## Return types
+### Primitives
+
+* Primitive C types should be translated to the equivalent C# type.
+  * `int8_t` -> `sbyte`
+  * `uint8_t` -> `byte`
+  * `short`, `signed short`, `short int`, `signed short int`, `int16_t` -> `short`
+  * `unsigned short`, `unsigned short int`, `uint16_t` -> `ushort`
+  * `int`, `signed int`, `long`, `signed long`, `long int`, `signed long int`, `int32_t` -> `int`
+  * `unsigned int`, `unsigned long`, `unsigned long int`, `uint32_t` -> `uint`
+  * `long long`, `signed long long`, `long long int`, `signed long long int`, `int64_t` -> `long`
+  * `unsigned long long`, `unsigned long long int`, `uint64_t` -> `ulong`
+  * `float` -> `float`
+  * `double` -> `double`
+
+* The P/Invoke signature for any C wrapper functions returning primitive pointers should use IntPtr to represent the pointer.
+
+* By-value return types should be kept as-is.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API int32_t GetPrimitiveByValue();
+  }
+  ```
+  ``` c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern int csp_GetPrimitiveByValue();
+
+      public int GetPrimitiveByValue() {
+        return csp_GetPrimitiveByValue();
+      }
+    }
+  }
+  ```
+
+* Non-const pointer and reference return types should be returned as `Ref<T>`.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API int32_t& GetPrimitiveByReference();
+  }
+  ```
+  ``` c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern IntPtr csp_GetPrimitiveByReference();
+
+      public Ref<int> GetPrimitiveByReference() {
+        return new Ref<int>(csp_GetPrimitiveByReference());
+      }
+    }
+  }
+  ```
+
+* Const pointer or reference return types should be passed by value.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API const int32_t* GetPrimitiveByConstPointer();
+  }
+  ```
+  ``` c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern int csp_GetPrimitiveByConstPointer();
+
+      public int GetPrimitiveByConstPointer() {
+        return csp_GetPrimitiveByConstPointer();
+      }
+    }
+  }
+  ```
+
+### Classes
+
+* Classes are always returned from the C interface as `NativePointer`.
+* The returned pointer should be passed to the class' `internal` constructor.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API MyClass& GetClassByReference();
+  }
+  ```
+  ```c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern NativePointer csp_GetClassByReference();
+
+      public Csp.MyClass GetClassByReference() {
+        return new Csp.MyClass(csp_GetClassByReference());
+      }
+    }
+  }
+  ```
+
+### `csp::common::String`
+
+* String returns should be converted to a C# string using `WrapperHelper.NativeUTF8ToString()`. The pointer returned from the C interface should then freed with `Global.Free()`.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API csp::common::String GetStringByValue();
+  }
+  ```
+  ```c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern IntPtr csp_GetStringByValue();
+
+      public string GetStringByValue() {
+        var result = csp_GetStringByValue();
+
+        var stringResult = WrapperHelper.NativeUTF8ToString(result);
+        Global.Free(result);
+
+        return stringResult;
+      }
+    }
+  }
+  ```
+
+## Parameter types
+* Parameter names should be converted from `UpperCamelCase` to `lowerCamelCase`.
+
+### Primitives
+
+* By-value parameter types should be kept as-is.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API void SetPrimitiveByValue(int32_t Value);
+  }
+  ```
+  ```c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern void csp_SetPrimitiveByValue(int value);
+
+      public void SetPrimitiveByValue(int value) {
+        csp_SetPrimitiveByValue(value);
+      }
+    }
+  }
+  ```
+
+* Non-const reference parameter types marked with `CSP_OUT` should be passed as out parameters.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API void GetPrimitiveByOut(CSP_OUT int32_t& OutValue);
+  }
+  ```
+  ```c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern void csp_GetPrimitiveByOut(out int outValue);
+
+      public void GetPrimitiveByOut(out int outValue) {
+        csp_SetPrimitiveByValue(out outValue);
+      }
+    }
+  }
+  ```
+
+* Non-const reference parameter types marked with `CSP_IN_OUT` should be passed as ref parameters.
+  ```c++
+  // C++
+  namespace csp {
+    CSP_API void SetPrimitiveByInGetByOut(CSP_IN_OUT int32_t& InOutValue);
+  }
+  ```
+  ```c#
+  // C#
+  namespace Csp {
+    public static class Global {
+      [DllImport("OlympusFoundation.dll")]
+      static extern void csp_SetPrimitiveByInGetByOut(ref int inOutValue);
+
+      public void SetPrimitiveByInGetByOut(ref int inOutValue) {
+        csp_SetPrimitiveByInGetByOut(ref inOutValue);
+      }
+    }
+  }
+  ```

--- a/Library/docs/source/manual/documentation/wrapper_generator/typescript_wrapper.md
+++ b/Library/docs/source/manual/documentation/wrapper_generator/typescript_wrapper.md
@@ -1,0 +1,193 @@
+# TypeScript Wrapper
+
+## General rules
+* The root C++ namespace `csp` should not appear in the wrapper generator. Child namespaces `systems`, `multiplayer`, etc. should, but should be translated to PascalCase.
+* Type names (classes, interfaces, structs, etc.) should be left as-is (ie. PascalCase).
+* Functions, class fields, and function parameters should be translated to camelCase to fit JavaScript naming conventions.
+
+## Classes
+* All public fields and functions should be wrapped.
+* Fields are wrapped with a getter function and a setter function.
+* Private constructors/destructors should not be wrapped.
+
+## Return types
+### Primitives
+
+* Primitive C types should be translated to the equivalent TypeScript type.
+  * Any integer type that is 32-bits or smaller in width -> `number`
+  * Any integer type that is 64-bits in width -> `bigint`
+  * Any floating-point type -> `number`
+  * `char*` -> `string`
+
+* By-value return types should be kept as-is.
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API int32_t GetPrimitiveByValue();
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function getPrimitiveByValue(): number {
+    // `Module.ccall()` is an Emscripten function that manages calling in to the C API.
+    // It takes a function name, the return type as a string, an array of parameter types as strings,
+    // and an array of arguments.
+    return Module.ccall("csp_GetPrimitiveByValue", "number", [], []);
+  }
+  ```
+
+* Non-const pointer or reference return types should be returned as `NativeRef`.
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API const int32_t* GetPrimitiveByPointer();
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function getPrimitiveByPointer(): NativeRef {
+    const _result = Module.ccall("csp_GetPrimitiveByPointer", "number", [], []);
+    
+    return new NativeRef(_result, NativeType.Int32);
+  }
+  ```
+
+* Const pointer or reference return types should be passed by value.
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API const int32_t* GetPrimitiveByConstPointer();
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function getPrimitiveByConstPointer(): number {
+    let _result = Module.ccall("csp_GetPrimitiveByConstPointer", "number", [], []);
+    
+    return _result;
+  }
+  ```
+
+**NOTE: Due to the nature of WebAssembly, _unsigned_ integer values need to be corrected to get the original value returned by CSP. For a 32-bit unsigned integer, the following snippet of code corrects the value by erasing the sign. Replace the `32` in `2 ** 32` with however many bits are in the type of the value you wish to correct.**
+``` typescript
+let _fixedValue = _unfixedValue < 0 ? _unfixedValue + 2 ** 32 : _unfixedValue;
+```
+
+### Classes
+* Classes are always returned from the C interface as `NativePointer`.
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API MyClass& GetClassByReference();
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function: getClassByReference(): MyClass {
+    // Emscripten/WebAssembly does not return struct types.
+    // Instead, we are required to allocate space to hold the resulting struct and pass a pointer
+    // to this new memory as the first argument in the function call.
+    var _ret = Module._malloc(8);
+    Module.ccall("csp_Global_GetClassByReference_MyClassP", "void", [], [_ret]);
+
+    // `getNativePointer` in our wrapper returns a NativePointer struct instance from a raw pointer
+    // by reading values from the address.
+    var _nPtr = new MyClass(getNativePointer(_ret));
+
+    // Care should be taken to ensure that the allocated space is always freed!
+    Module._free(_ret);
+
+    return _nPtr;
+  }
+  ```
+
+### `csp::common::String`
+* `csp::common::String` is returned as a pointer. You should convert this pointer to a Javascript string using `Module.UTF8ToString` and then free the original pointer using `free(pointer)`,
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API csp::common::String GetStringByValue();
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function getStringByValue(): string {
+    const _result = Module.ccall("csp_GetStringByValue", "number", [], []);
+    const _resultString = Module.UTF8ToString(_result);
+
+    // `free()` is a function we have declared in our C++ library and takes care of freeing memory
+    // allocated using our custom allocator.
+    free(_result);
+
+    return _resultString;
+  }
+  ```
+
+## Parameter types
+* Parameter names should be converted from `PascalCase` to `camelCase`.
+* Out parameters should be removed from the parameter list when generate the TypeScript function, and should instead be included in the return value. If the function has no return value and only a single out parameter, the type of the out parameter becomes the return type of the function. If there is a return value, or there are multiple out parameters, the function should instead return an anonymous object containing the original return value as `result` and any out parameters using their original name as the key.
+* In-out parameters should be treated the same way as out parameters, except they should not be removed from the list of parameters.
+
+### Primitives
+
+* By-value parameter types should be kept as-is.
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API void SetPrimitiveByValue(int32_t Value);
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function setPrimitiveByValue(value: number): void {
+    Module.ccall("csp_SetPrimitiveByValue", "void", ["number"], [value]);
+  }
+  ```
+
+* Non-const reference parameter types marked with CSP_OUT should be passed as out parameters.
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API void GetPrimitiveByOut(CSP_OUT int32_t& OutValue);
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function getPrimitveByOut(): number {
+    // Space must be allocated to hold the value of the out parameter.
+    const _pOutValue = Module._malloc(4);
+
+    Module.ccall("csp_GetPrimitiveByOut", "void", ["number"], [_pOutValue]);
+
+    // Read the value from the pointer as a 32-bit signed integer
+    let _outValue = Module.getValue(_pOutValue, "i32");
+    Module._free(_pOutValue);
+
+    return _outValue;
+  }
+  ```
+
+* Non-const reference parameter types marked with CSP_IN_OUT should be passed as ref parameters.
+  ``` c++
+  // C++
+  namespace csp {
+    CSP_API void SetPrimitiveByInGetByOut(CSP_IN_OUT int32_t& InOutValue);
+  }
+  ```
+  ``` typescript
+  // TypeScript
+  function setPrimitiveByInGetByOut(inOutValue: number): number {
+    const _pInOutValue = Module._malloc(4);
+
+    // We should first write the value passed to this function to the space we allocated.
+    Module.setValue(_pInOutValue, inOutValue, "i32");
+
+    Module.ccall("csp_SetPrimitiveByInGetByOut", "void", ["number"], [_pInOutValue]);
+
+    // Then, the resulting value needs to be read back from the pointer.
+    let _inOutValue = Module.getValue(_pInOutValue, "i32");
+    Module._free(_pInOutValue);
+
+    return _inOutValue;
+  }
+  ```

--- a/Library/docs/source/manual/documentation/wrapper_generator_specs.md
+++ b/Library/docs/source/manual/documentation/wrapper_generator_specs.md
@@ -19,7 +19,7 @@ To achieve this, it relies on API source files including some markup/generation-
    :maxdepth: 1
    :titlesonly:
 
-   wrapper_generator/C-interface
+   wrapper_generator/c_interface
    wrapper_generator/csharp_wrapper
    wrapper_generator/typescript_wrapper
 ```

--- a/Library/docs/source/manual/documentation/wrapper_generator_specs.md
+++ b/Library/docs/source/manual/documentation/wrapper_generator_specs.md
@@ -1,0 +1,25 @@
+# Wrapper Generator Specifications
+
+The CSP wrapper generator is responsible for automatically generating wrapper APIs for supported non-C++ languages and is run as part of the pipeline when generating new versions of Foundation.
+
+The wrapper generator allows CSP contributors to focus on building new features and APIs in one language, and it takes care of the work required to expose that to client applications built in other languages. In this way, it also guarantees API consistency and parity across all languages supported by Foundation.
+
+To achieve this, it relies on API source files including some markup/generation-time hints, to allow the wrapper generator to understand the intent behind the source, and render it to other languages appropriately. 
+
+## General rules
+* Only classes and functions marked with `CSP_API` are exported by the parser.
+* For classes, only public fields and functions are exported by the parser.
+  * The only exception to this is constructors/destructors. Metadata _is_ generated for private constructors/destructors and has its `is_private` field set to `True`. This is needed as the wrappers need to know that a class shouldn't be publicly constructible or destructible.
+* When mutating the CSP C++ API, ensure any functions that accept enums pass those by parameters by value, not by reference. The wrapper generator does not support passing enums by reference.
+
+## Wrapper-specific rules
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   wrapper_generator/C-interface
+   wrapper_generator/csharp_wrapper
+   wrapper_generator/typescript_wrapper
+```

--- a/Library/docs/source/manual/getting_started/cplusplus.md
+++ b/Library/docs/source/manual/getting_started/cplusplus.md
@@ -1,0 +1,9 @@
+# C++
+
+To get started with Connected Spaces Platform using C++, head on over to the [Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases) and grab the latest available version for your platform. We provide shared binaries for Windows, macOS, and Android, and static libraries for macOS and iOS.
+
+## Adding Connected Spaces Platform to your project
+
+1. Add the Connected Spaces Platform header files to your include paths.
+2. Link against `ConnectedSpacesPlatform` (release) or `ConnectedSpacesPlatform_D` (debug).
+3. If linking against a shared build of Connected Spaces Platform, define `USING_CSP_DLL` before including any CSP headers. A good place to do this is in your project settings.

--- a/Library/docs/source/manual/getting_started/csharp.md
+++ b/Library/docs/source/manual/getting_started/csharp.md
@@ -12,17 +12,17 @@
 
 4. Save the new scoped registry.
 
-![image info](./getting_started\npmjs_registry.png)
+![image info](../../_static/getting_started/npmjs_registry.png)
 
 5. Navigate to the Package Manager window via `Window->Package Manager`
 6. From the Packages dropdown, select the `My Registries` option.
 
-![image info](./getting_started\myregistry.png)
+![image info](../../_static/getting_started/myregistry.png)
 
 7. From the `Other` category, selected the `connected-spaces-platform.unity.core` package.
 8. Select `Install` to add the latest version of the package to your project.
 
-![image info](./getting_started\install_package.png)
+![image info](../../_static/getting_started/install_package.png)
 
 ## VisionOS
 

--- a/Library/docs/source/manual/getting_started/csharp.md
+++ b/Library/docs/source/manual/getting_started/csharp.md
@@ -1,0 +1,31 @@
+# C# (Unity)
+
+## Package Installation Steps
+
+1. Navigate to your project's `Project Settings`.
+2. Select the `Package Manager` option.
+3. Add a new Scoped Registry with the following details:
+
+> **Name** `npmjs`  
+> **URL** [https://registry.npmjs.org](https://registry.npmjs.org)  
+> **Scope(s)** `connected-spaces-platform`  
+
+4. Save the new scoped registry.
+
+![image info](./getting_started\npmjs_registry.png)
+
+5. Navigate to the Package Manager window via `Window->Package Manager`
+6. From the Packages dropdown, select the `My Registries` option.
+
+![image info](./getting_started\myregistry.png)
+
+7. From the `Other` category, selected the `connected-spaces-platform.unity.core` package.
+8. Select `Install` to add the latest version of the package to your project.
+
+![image info](./getting_started\install_package.png)
+
+## VisionOS
+
+The Vision Pro runs on Apple silicion and does not allow for applications built on Intel architectures to run on it. As a result, CSP binaries available in published packages are all built explicitly for Apple silicon.
+
+This means that the Unity CSP application developer must also be using a version of Unity Editor for Apple silicon.

--- a/Library/docs/source/manual/getting_started/javascript.md
+++ b/Library/docs/source/manual/getting_started/javascript.md
@@ -1,0 +1,18 @@
+# JavaScript
+
+1. Grab and install a version of the NPM package from [npmjs](https://www.npmjs.com/package/connected-spaces-platform.web).
+2. Import the Connected Spaces Platform (CSP) for Web module:
+    - `import * as Olympus from './node_modules/@magnopus-opensource/connected-spaces-platform-web/connectedspacesplatform.js';`
+3. Await `Olympus.ready()`, passing `true` to load the Debug build of CSP, and `false` or no value to load the Release build:
+    - `await Olympus.ready(true);`
+4. If needed, custom paths for the WASM files are supported. e.g.
+    - `var options = new FoundationOptions();`
+    - `options.wrapperUrl = "./Debug/ConnectedSpacesPlatform_WASM.js";`
+    - `options.wasmUrl = "./ConnectedSpacesPlatform_WASM.wasm";`
+    - `options.workerUrl = "./ConnectedSpacesPlatform_WASM.worker.js";`
+    - `await Olympus.ready(options);`
+5. That's all! You can now start calling CSP functions:
+    - `console.log(Olympus.OlympusFoundation.getVersion());`
+
+NOTE: You can also store the return value from the `ready()` promise and use it to access Emscripten functions directly:
+  * `var Module = await Olympus.ready(); var buf = Module._malloc(32);`

--- a/Library/docs/source/manual/manual.md
+++ b/Library/docs/source/manual/manual.md
@@ -1,0 +1,101 @@
+# MANUAL
+
+This manual serves as a central hub for documentation, guides, and resources related to the working with CSP.
+
+Whether you're a developer, contributor, or simply curious about the platform, this wiki is here to help you get started either using or contributing to CSP.
+
+## Getting Started
+
+Connected Spaces Platform currently provides APIs for 3 languages: C++, C#, and TypeScript/JavaScript.
+For a quick guide on getting started with Connected Spaces Platform, follow the link below that corresponds to the language you use:
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   getting_started/cplusplus
+   getting_started/csharp
+   getting_started/javascript
+```
+
+## Tutorials
+
+Use these tutorials to help you get yor CSP-enabled application running as fast as possible.
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   tutorials/cplusplus
+   tutorials/csharp
+   tutorials/javascript
+```
+
+## Processes, Principles and Tooling
+
+Documentation on processes and principles that the library adheres to.
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   documentation/programming_guidelines
+   documentation/adding_components
+   documentation/branching_strategy
+   documentation/wrapper_generator_specs
+   documentation/script_system
+   documentation/expected_application_flow
+   documentation/multiplayer_state_replication
+   documentation/external_tools
+```
+
+## Building CSP
+
+If you're forking CSP for your own purposes, or seeking to contribute back, you can find documentation on how to build CSP here.
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   building/web
+   building/cpp
+   building/csharp
+   building/android
+   building/macos
+   building/ios
+```
+
+## Tests
+
+CSP's functionality is validated via an ever-growing suite of tests, and any chance introducing new functionality is expected to also include test coverage.
+In this section, you can find out how the tests work, testing best practices, and how to run them.
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   tests/best_practices
+   tests/test_locations
+   tests/test_account_credentials
+```
+
+## Debugging
+
+Inevitably, at some point you will encounter unexpected behaviour in your application, and you'll break out the debugger to diagnose.
+
+CSP itself is also debuggable, and in this section you can learn how to dive inside the library at runtime.
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   debugging/debugging_unity
+   debugging/debugging_web
+   debugging/performance_profiling
+```

--- a/Library/docs/source/manual/manual.md
+++ b/Library/docs/source/manual/manual.md
@@ -49,6 +49,7 @@ Documentation on processes and principles that the library adheres to.
    documentation/script_system
    documentation/expected_application_flow
    documentation/multiplayer_state_replication
+   documentation/services_abstraction_layer
    documentation/external_tools
 ```
 

--- a/Library/docs/source/manual/tests/best_practices.md
+++ b/Library/docs/source/manual/tests/best_practices.md
@@ -1,0 +1,12 @@
+# Testing Best Practices
+
+Based on the philosophy that testable code is readable code, all code should be written in a way that makes testing trivial. Ideally this means small units that can be tested with unit testing that does not rely on making API calls. This obviously misses places that require calls to external APIs so code should be structured in such a way that as much code as possible is testable without relying on the API call and code that does call APIs simply makes those calls and delegates to other functions to handle preparation and results of requests.
+
+Functional tests should test the system end to end via the public API and ensure coverage of any and all external API calls. It is important that functional tests do not simply take the happy path but also test various different combinations of parameters, especially ensuring that invalid parameters are rejected.
+
+It is accepted that in some cases targeting small easily testable functions can be a contradictory goal to performance optimization. In those cases, it is up to the contributor to balance these goals. For example, an action like creating a space which is called infrequently does not need to take micro optimizations into account in the way that a deserialization that occurs on every tick might. In these cases an effort should still be made to have as much unit test coverage as possible but that additional functional tests may be needed to cover all areas. 
+
+This document mostly focuses on C++ code and tests as it is assumed that WrapperGenerator unit tests ensure consistency of the API in the Web/C#. However, in some cases macros are used to control code for different builds and it is important that when this occurs we ensure that functional tests exist targeting all code variants. An example could be the WebClient implementation used in web vs C++.
+
+# Pull requests
+When reviewing a pull request it should be clear from tests alone what has been introduced into the code base. If new functionality is added then tests should cover those use cases. If a bug is being fixed a test should be added that reproduces the issue and the new code should ensure that test passes. Sometimes it is not always possible to do this but a PR should not be approved without these in place or a reasonable explanation of why they are missing. 

--- a/Library/docs/source/manual/tests/best_practices.md
+++ b/Library/docs/source/manual/tests/best_practices.md
@@ -8,5 +8,5 @@ It is accepted that in some cases targeting small easily testable functions can 
 
 This document mostly focuses on C++ code and tests as it is assumed that WrapperGenerator unit tests ensure consistency of the API in the Web/C#. However, in some cases macros are used to control code for different builds and it is important that when this occurs we ensure that functional tests exist targeting all code variants. An example could be the WebClient implementation used in web vs C++.
 
-# Pull requests
+## Pull requests
 When reviewing a pull request it should be clear from tests alone what has been introduced into the code base. If new functionality is added then tests should cover those use cases. If a bug is being fixed a test should be added that reproduces the issue and the new code should ensure that test passes. Sometimes it is not always possible to do this but a PR should not be approved without these in place or a reasonable explanation of why they are missing. 

--- a/Library/docs/source/manual/tests/test_account_credentials.md
+++ b/Library/docs/source/manual/tests/test_account_credentials.md
@@ -1,0 +1,27 @@
+# Test Account Credentials
+
+## File Location
+
+If you want to run tests locally, you will need to create a `test_account_creds.txt` file in the following locations:
+
+C++
+- connected-spaces-platform\Tests\Binaries\x64\DebugDLL
+
+WASM
+ - connected-spaces-platform\Tests\Web\html\assets
+
+## File Format
+
+`test_account_creds.txt` should contain the following information:
+
+``` 
+<main test account email> <main test account password> 
+<alt test account email> <alt test account password> 
+<oko.tests account email> <oko.tests account password>
+```
+
+> **Accounts created for the OKO_TESTS tenant **do not** have to be verified upon account creation).
+
+## Test Account Requirements
+
+* In each instance, the main and alt test accounts must be different accounts. (Ensuring that both are registered and authenticated by the email you are sent post-account-creation. This applies to alias accounts also.)

--- a/Library/docs/source/manual/tests/test_locations.md
+++ b/Library/docs/source/manual/tests/test_locations.md
@@ -1,0 +1,10 @@
+# Test Locations
+
+The source for the Connected Spaces Platform includes automated tests for the main library and integration tests for wrapped languages. 
+
+One the CSP project/solution [has been generated](https://github.com/magnopus-opensource/connected-spaces-platform/wiki/Building-Foundation-for-CPP), these can be found as follows.
+
+* C++: `Tests/Tests.vcxproj`
+* C#: `Tests/CSharp/CSharpTests.csproj`
+* Unity C#: `Tests/Unity/`
+* JavaScript: `Tests/Web/html/`

--- a/Library/docs/source/manual/tutorials/cplusplus.md
+++ b/Library/docs/source/manual/tutorials/cplusplus.md
@@ -1,0 +1,279 @@
+# C++
+
+## Initializing
+Connected Spaces Platform needs to be initiali\ed before making any calls to other parts of its API. For this, you will need a valid CSP tenant. If you don't already have one, you'll need to [apply for one](https://www.magnopus.com/csp/for-developers#tenant-id).
+
+```c++
+#include "CSP/CSPFoundation.h"
+
+/* 
+ * The first parameter passed to Initialise is the CHS services root URL.
+ * "ogs-ostage" is the environment, and is currently the only environment publicly available for clients.
+ * The last parameter is your tenant ID.
+ */
+csp::CSPFoundation::Initialise("https://ogs-ostage.magnoboard.com", "<your tenant>");
+```
+
+After initialising, you should then set the user agent information that will be used for all requests made by CSP.
+
+```c++
+csp::ClientUserAgent userAgent;
+userAgent.CSPVersion        = csp::CSPFoundation::GetVersion();
+userAgent.ClientOS          = "<your current OS identifier>";
+userAgent.ClientSKU         = "<an identifier for your project>";
+userAgent.ClientVersion     = "<your project version identifier>";
+userAgent.ClientEnvironment = "<your project environment>";
+
+csp::CSPFoundation::SetClientUserAgentInfo(userAgent);
+```
+
+## Authenticating
+
+Authentication is done using the `UserSystem` singleton. System singleton instances are managed by the static `SystemsManager` class. The code snippet below shows how to retrieve the singleton instance for `UserSystem`.
+
+```c++
+#include "CSP/Systems/Users/UserSystem.h"
+#include "CSP/Systems/SystemsManager.h"
+
+csp::systems::SystemsManager& systemManager = csp::systems::SystemsManager::Get();
+csp::systems::UserSystem* userSystem = systemManager.GetUserSystem();
+```
+
+You can then proceed to log in using an account or as a guest user. Most endpoints in CSP are asynchronous and you will need to pass a callback to them. This callback will be called once for each progress update, and once more when the request has completed.
+
+```c++
+void OnLogin(const csp::systems::LoginStateResult& result) {
+  csp::services::EResultCode resCode = result.GetResultCode();
+
+  // Some endpoints (like AssetSystem::UploadAssetData()) report progress status.
+  // This endpoint does not, so it can be ignored.
+  if (resCode == csp::services::EResultCode::InProgress)
+    return;
+
+  // If the request fails, ResultCode will be set to EResultCode::Failed
+  if (resCode == csp::services::EResultCode::Failed) {
+    // ResultBase::FailureReason will be set if the request failed and should
+    // be used to determine the cause of the failure.
+    auto reason = static_cast<csp::systems::ELoginStateFailureReason>(result.GetFailureReason());
+
+    switch (reason) {
+      case csp::systems::ELoginStateFailureReason::EmailNotConfirmed:
+        std::cout << "User email not verified! Please follow the link in the verification email sent to you after registering an account." << std::endl;
+        break;
+      case csp::systems::ELoginStateFailureReason::AgeNotVerified:
+        std::cout << "User has not confirmed they are over 18! Either you are too young or should re-enter your DoB on the sign in page." << std::endl;
+        break;
+      case csp::systems::ELoginStateFailureReason::Unknown:
+        // If FailureReason is unknown, check the HTTP response code.
+        // If it is 403, the provided account credentials were incorrect.
+        std::cout << "Request failed with HTTP response code " << result.GetHttpResultCode() << std::endl;
+        break;
+    }
+  }
+}
+
+// Log in using a registered account
+// The 4th parameter is a boolean indicating whether the user has verified their age or not,
+// and can be null to use the value supplied during a previous call to Login() or CreateUser()
+userSystem->Login("<username - leave empty>", "<account email>", "<account password>", true, OnLogin);
+
+// Log in as a guest user
+// The 1st parameter is the same boolean as above
+userSystem->LoginAsGuest(true, OnLogin);
+```
+
+## Querying Spaces
+
+Space Querying is done using the SpaceSystem singleton.
+
+The code snippet below, shows how to retrieve the singleton instance for SpaceSystem.
+```
+#include "CSP/Systems/SystemsManager.h"
+#include “CSP/Systems/Spaces/SpaceSystem.h
+
+
+csp::systems::SystemsManager& systemManager = csp::systems::SystemsManager::Get();
+csp::systems::SpaceSystem* spaceSystem = SystemsManager.GetSpaceSystem();
+```
+
+You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled “Authenticating”.
+
+### Retrieving all spaces associated with the currently logged in user
+
+First, a callback is defined to handle the result of the query call.
+```
+auto resultHandler = [](const SpacesResult& result)
+{
+    // Example code responding to a successful query
+    if(result.GetResultCode() == csp::systems::EResultCode::Success)
+    {
+        std::cout<<”SUCCESS: ”<<std::endl;
+
+        for (int i = 0; i < result.GetSpaces().Size(); i++)
+        {
+            std::cout<<”Space found: ”<<result.GetSpaces()[i].Id<<std::endl;
+        } 
+        return true;
+    }
+    else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
+    {
+        // Example progress reporting code
+        std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+        return true;
+    }
+    else
+    {
+        // Example failure logging
+        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        return false;
+    }
+};
+spaceSystem->GetSpaces(resultHandler);
+```
+
+Where the space ids are alphanumeric strings.
+
+### Retrieving a single space, associated with a particular space id
+```
+auto resultHandler = [](const SpaceResult& result)
+{
+    if(result.GetResultCode() == csp::systems::EResultCode::Success)
+    {
+        std::cout<<”SUCCESS: ”<<std::endl;
+
+        // Example code responding to a successful query
+        std::cout<<”Space found: ”<<result.GetSpace().Id<<std::endl;
+
+        return true;
+    }
+    else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
+    {
+        // Example progress reporting code
+        std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+        return true;
+    }
+    else
+    {
+        // Example failure logging
+        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        return false;
+    }
+};
+
+SpaceSystem->GetSpace(“ah34hgt25prv”, resultHandler);
+```
+
+Where the space id is an alphanumeric string.
+
+### Retrieving all spaces associated with a particular user id
+```
+auto resultHandler = [](const SpacesResult& result)
+{
+    // Example code responding to a successful query
+    if(result.GetResultCode() == csp::systems::EResultCode::Success)
+    {
+        std::cout<<”SUCCESS: ”<<std::endl;
+
+        for (int i = 0; i < result.GetSpaces().Size(); i++)
+        {
+	    std::cout<<”Space found: ”<<result.GetSpaces()[i].Id<<std::endl;
+        } 
+
+        return true;
+    }
+    else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
+    {
+        // Example progress reporting code
+	std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+	return true;
+    }
+    else
+    {
+	// Example failure logging
+        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        return false;
+    }
+};
+
+SpaceSystem->GetSpacesForUserId(
+    “bc649hnt21h”, 
+    resultHandler
+);
+```
+Where the user id is an alphanumeric string. 
+It should be noted that this can only be performed by users with elevated privileges. Calling this function without elevated privileges will fail.
+
+### Retrieving spaces by specifying a number of space identifiers associated with the currently logged in user
+
+```
+auto resultHandler = [](const SpacesResult& result)
+{
+    // Example code responding to a successful query
+    if(result.GetResultCode() == csp::systems::EResultCode::Success)
+    {
+        std::cout<<”SUCCESS: ”<<std::endl;
+
+        for (int i = 0; i < result.GetSpaces().Size(); i++)
+        {
+            std::cout<<”Space found: ”<<result.GetSpaces()[i].Id<<std::endl;
+        } 
+        return true;
+    }
+    else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
+    {
+        // Example progress reporting code
+        std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+        return true;
+    }
+    else
+    {
+        // Example failure logging
+        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        return false;
+    }
+};
+
+spaceSystem->GetSpacesByAttributes(
+    true, 	// isDiscoverable
+    false, 	// isArchived
+    true, 	// requiresInvite
+    0, 		// results skip (in this case start the first result)
+    4, 		// results max ( in this case stop at 4)
+    resultHandler	
+);
+
+
+```
+
+Each of the attribute arguments are optional.
+* `isDiscoverable` is set to true if we are searching for spaces which are publicly listed.
+* `isArchived` is set to true if we are searching for archived spaces.
+* `requiresInvite` is set to true if we are searching for spaces which require an invite to enter.
+* The next two arguments are to enable paginating results.
+* `resultsSkip` sets which result to start at (in the above case, the first result)
+* `resultsMax` sets which result to stop the current search (in the above example, result 4)
+
+You could then fetch the next 5 spaces in the following way:
+```
+spaceSystem->GetSpacesByAttributes(
+    true,    // isDiscoverable
+    false,   // isArchivable
+    true,    // requiresInvite
+    5, 	     // results skip (in this case start at space result 5)
+    9, 	     // results max ( in this case stop at 9)
+    resultHandler
+);
+```
+
+You can disable pagination, by changing the last two arguments to zero values:
+
+```
+spaceSystem->GetSpacesByAttributes(
+    true,    // isDiscoverable
+    false,   // isArchivable
+    true,    // requiresInvite
+    0, 	     // resultsSkip
+    0, 	     // resultsMax
+    resultHandler
+);
+```

--- a/Library/docs/source/manual/tutorials/cplusplus.md
+++ b/Library/docs/source/manual/tutorials/cplusplus.md
@@ -89,42 +89,43 @@ Space Querying is done using the SpaceSystem singleton.
 The code snippet below, shows how to retrieve the singleton instance for SpaceSystem.
 ```
 #include "CSP/Systems/SystemsManager.h"
-#include “CSP/Systems/Spaces/SpaceSystem.h
+#include "CSP/Systems/Spaces/SpaceSystem.h
 
 
 csp::systems::SystemsManager& systemManager = csp::systems::SystemsManager::Get();
 csp::systems::SpaceSystem* spaceSystem = SystemsManager.GetSpaceSystem();
 ```
 
-You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled “Authenticating”.
+You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled "Authenticating".
 
 ### Retrieving all spaces associated with the currently logged in user
 
 First, a callback is defined to handle the result of the query call.
+
 ```
 auto resultHandler = [](const SpacesResult& result)
 {
     // Example code responding to a successful query
     if(result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        std::cout<<”SUCCESS: ”<<std::endl;
+        std::cout << "SUCCESS: " << std::endl;
 
         for (int i = 0; i < result.GetSpaces().Size(); i++)
         {
-            std::cout<<”Space found: ”<<result.GetSpaces()[i].Id<<std::endl;
+            std::cout << "Space found: " << result.GetSpaces()[i].Id << std::endl;
         } 
         return true;
     }
     else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
     {
         // Example progress reporting code
-        std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+        std::cout << "Progress: " << result.GetRequestProgress() << std::endl;
         return true;
     }
     else
     {
         // Example failure logging
-        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        std::cout << "Error: " << ToString(result.GetFailureReason()) << std::endl;
         return false;
     }
 };
@@ -134,33 +135,34 @@ spaceSystem->GetSpaces(resultHandler);
 Where the space ids are alphanumeric strings.
 
 ### Retrieving a single space, associated with a particular space id
+
 ```
 auto resultHandler = [](const SpaceResult& result)
 {
     if(result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        std::cout<<”SUCCESS: ”<<std::endl;
+        std::cout << "SUCCESS: " << std::endl;
 
         // Example code responding to a successful query
-        std::cout<<”Space found: ”<<result.GetSpace().Id<<std::endl;
+        std::cout << "Space found: " << result.GetSpace().Id << std::endl;
 
         return true;
     }
     else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
     {
         // Example progress reporting code
-        std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+        std::cout << "Progress: " << result.GetRequestProgress() << std::endl;
         return true;
     }
     else
     {
         // Example failure logging
-        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        std::cout << "Error: " << ToString(result.GetFailureReason()) << std::endl;
         return false;
     }
 };
 
-SpaceSystem->GetSpace(“ah34hgt25prv”, resultHandler);
+SpaceSystem->GetSpace("ah34hgt25prv", resultHandler);
 ```
 
 Where the space id is an alphanumeric string.
@@ -172,11 +174,11 @@ auto resultHandler = [](const SpacesResult& result)
     // Example code responding to a successful query
     if(result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        std::cout<<”SUCCESS: ”<<std::endl;
+        std::cout << "SUCCESS: " << std::endl;
 
         for (int i = 0; i < result.GetSpaces().Size(); i++)
         {
-	    std::cout<<”Space found: ”<<result.GetSpaces()[i].Id<<std::endl;
+	    std::cout << "Space found: " << result.GetSpaces()[i].Id << std::endl;
         } 
 
         return true;
@@ -184,19 +186,19 @@ auto resultHandler = [](const SpacesResult& result)
     else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
     {
         // Example progress reporting code
-	std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+	std::cout << "Progress: " << result.GetRequestProgress() << std::endl;
 	return true;
     }
     else
     {
 	// Example failure logging
-        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        std::cout << "Error: " << ToString(result.GetFailureReason()) << std::endl;
         return false;
     }
 };
 
 SpaceSystem->GetSpacesForUserId(
-    “bc649hnt21h”, 
+    "bc649hnt21h", 
     resultHandler
 );
 ```
@@ -211,24 +213,24 @@ auto resultHandler = [](const SpacesResult& result)
     // Example code responding to a successful query
     if(result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        std::cout<<”SUCCESS: ”<<std::endl;
+        std::cout << "SUCCESS: " << std::endl;
 
         for (int i = 0; i < result.GetSpaces().Size(); i++)
         {
-            std::cout<<”Space found: ”<<result.GetSpaces()[i].Id<<std::endl;
+            std::cout << "Space found: " << result.GetSpaces()[i].Id << std::endl;
         } 
         return true;
     }
     else if(result.GetResultCode() == csp::systems::EResultCode::InProgress)
     {
         // Example progress reporting code
-        std::cout<<”Progress: ”<<result.GetRequestProgress()<<std::endl;
+        std::cout << "Progress: " << result.GetRequestProgress() << std::endl;
         return true;
     }
     else
     {
         // Example failure logging
-        std::cout<<”Error:<< ToString(result.GetFailureReason())<<std::endl;
+        std::cout << "Error: " << ToString(result.GetFailureReason()) << std::endl;
         return false;
     }
 };

--- a/Library/docs/source/manual/tutorials/csharp.md
+++ b/Library/docs/source/manual/tutorials/csharp.md
@@ -1,0 +1,239 @@
+# C#
+
+## Initializing
+
+Connected Spaces Platform needs to be initialized before making any calls to other parts of its API. For this, you will need a valid CSP tenant. If you don't already have one, you'll need to [apply for one](https://www.magnopus.com/csp/for-developers#tenant-id).
+
+```c#
+using Csp;
+
+/* 
+ * The first parameter passed to Initialise is the CHS services root URL.
+ * "ogs-ostage" is the environment, and is currently the only environment publicly available for clients.
+ * The last parameter is your tenant ID.
+ */
+CSPFoundation.Initialise("https://ogs-ostage.magnoboard.com", "<your tenant>");
+```
+
+After initialising, you should then set the user agent information that will be used for all requests made by CSP.
+
+```c#
+using var userAgent = new ClientUserAgent()
+{
+  CSPVersion        = CSPFoundation.GetVersion(),
+  ClientOS          = "<your current OS identifier>",
+  ClientSKU         = "<an identifier for your project>",
+  ClientVersion     = "<your project version identifier>",
+  ClientEnvironment = "<your project environment>"
+};
+
+CSPFoundation.SetClientUserAgentInfo(userAgent);
+```
+
+## Authenticating
+
+Authentication is done using the `UserSystem` singleton. System singleton instances are managed by the static `SystemsManager` class. The code snippet below shows how to retrieve the singleton instance for `UserSystem`.
+
+```c#
+using Csp;
+using Csp.Services;
+using Csp.Systems;
+
+SystemsManager systemManager = SystemsManager.Get();
+UserSystem userSystem = systemManager.GetUserSystem();
+```
+
+You can then proceed to log in using an account or as a guest user. Most endpoints in CSP are asynchronous and will need to be awaited.
+
+```c#
+void OnLogin(LoginStateResult result) {
+  EResultCode resCode = result.GetResultCode();
+
+  // If the request fails, ResultCode will be set to EResultCode.Failed
+  if (resCode == EResultCode.Failed) {
+    // ResultBase.FailureReason will be set if the request failed and should
+    // be used to determine the cause of the failure.
+    var reason = (ELoginStateFailureReason)result.GetFailureReason();
+
+    switch (reason) {
+      case ELoginStateFailureReason.EmailNotConfirmed:
+        Console.WriteLine("User email not verified! Please follow the link in the verification email sent to you after registering an account.");
+        break;
+      case ELoginStateFailureReason.AgeNotVerified:
+        Console.WriteLine("User has not confirmed they are over 18! Either you are too young or should re-enter your DoB on the sign in page.");
+        break;
+      case ELoginStateFailureReason.Unknown:
+        // If FailureReason is unknown, check the HTTP response code.
+        // If it is 403, the provided account credentials were incorrect.
+        Console.WriteLine($"Request failed with HTTP response code {result.GetHttpResultCode()}");
+        break;
+    }
+  }
+}
+
+// Log in using a registered account
+// The 4th parameter is a boolean indicating whether the user has verified their age or not,
+// and can be null to use the value supplied during a previous call to Login() or CreateUser()
+using LoginStateResult result = await userSystem.Login("<username - leave empty>", "<account email>", "<account password>", true);
+OnLogin(result);
+
+// Log in using a guest account
+// The 1st parameter is the same boolean as above
+using LoginStateResult result = await userSystem.LoginAsGuest(true);
+OnLogin(result);
+```
+
+## Querying Spaces
+
+Space Querying is done using the `SpaceSystem` singleton.
+
+The code snippet below, shows how to retrieve the singleton instance for `SpaceSystem`.
+```
+using Csp;
+using Csp.Services;
+using Csp.Systems;
+
+var spaceSystem = Csp.Systems.SystemsManager.Get().GetSpaceSystem();
+```
+
+You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled “Authenticating”.
+
+### Retrieving all spaces associated with the currently logged in user
+```
+using CspSystems.SpacesResult spaceResult = await spaceSystem.GetSpaces();
+
+if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
+{
+    using var spaces = spaceResult.GetSpaces();
+    await EnterSpace(spaces[0]);
+}
+else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
+{
+    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+}
+else
+{
+    // Example failure logging
+    Debug.LogError($"Failed to get space". Unable to enter.");
+    Debug.LogError($"ToString(result.GetFailureReason())");
+}
+```
+
+### Retrieving a single space, associated with a particular space id
+```
+using Csp.Systems.SpaceResult spaceResult = await spaceSystem.GetSpace(“ah34hgt25prv”);
+
+
+if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
+{
+    using var space = spaceResult.GetSpace();
+    await EnterSpaceAsync(space);
+}
+else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
+{
+    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+}
+else
+{
+    // Example failure logging
+    Debug.LogError($"Failed to get space". Unable to enter.");
+    Debug.LogError($"ToString(result.GetFailureReason())");
+}
+```
+Where the id is an alphanumeric string.
+
+
+### Retrieving spaces associated with a particular user id
+```
+using CspSystems.SpaceResult spaceResult = await spaceSystem.GetSpacesForUserId(“bc649hnt21h”);
+
+if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
+{
+    using var spaces = spaceResult.GetSpaces();
+    await EnterSpace(spaces[0]);
+}
+else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
+{
+    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+}
+else
+{
+    // Example failure logging
+    Debug.LogError($"Failed to get space". Unable to enter.");
+    Debug.LogError($"ToString(result.GetFailureReason())");
+}
+```
+Where the user id is an alphanumeric string. 
+It should be noted that this can only be performed by users with elevated privileges. Calling this function without elevated privileges will fail.
+
+### Retrieving spaces by specifying a number of space identifiers associated with the currently logged in user
+```
+using idArray = new Csp.Common.Array<string>(3);
+idArray[0] = “ah34hgt25prv”;
+idArray[1] = “ev936bym27c”; 
+idArray[2] = “jt94nrp74k”;
+
+using CspSystems.SpacesResult spaceResult = await spaceSystem.GetSpacesByIds(idArray);
+
+if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
+{
+    using var spaces = spaceResult.GetSpaces();
+    await EnterSpace(spaces[0]);
+}
+else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
+{
+    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+}
+else
+{
+    // Example failure logging
+    Debug.LogError($"Failed to get space". Unable to enter.");
+    Debug.LogError($"ToString(result.GetFailureReason())");
+}
+```
+Where the space ids are alphanumeric strings.
+
+### Retrieving spaces with the given set of attributes available to the logged in user
+```
+using CspSystems.SpacesResult spaceResult = await spaceSystem.GetSpacesByAttributes(
+    true, 		// isDiscoverable
+    false,    	        // isArchivable
+    true, 		// requiresInvite
+    0, 		        // results skip (in this case start the first result)
+    4 		        // results max ( in this case stop at 4)
+);
+```
+Each of the attribute arguments are optional. 
+* `isDiscoverable` is set to true if we are searching for spaces which are publicly listed.
+* `isArchived` is set to true if we are searching for archived spaces.
+* `requiresInvite` is set to true if we are searching for spaces which require an invite to enter.
+* The next two arguments are to enable paginating results.
+* results skip sets which result to start at (in the above example, the first result)
+* results max sets which result to stop the current search (in the above example, result 4)
+
+In the case of the C# wrapper, you can disable pagination, by changing the last two arguments to null values:
+```
+using CspSystems.SpacesResult spaceResult = await spaceSystem.GetSpacesByAttributes(
+    true, 		// isDiscoverable
+    false, 	        // isArchivable
+    true, 		// requiresInvite
+    null,
+    null 		// Two null arguments mean all spaces will be retrieved
+);
+
+if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
+{
+    using var spaces = spaceResult.GetSpaces();
+    await EnterSpace(spaces[0]);
+}
+else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
+{
+    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+}
+else
+{
+    // Example failure logging
+    Debug.LogError($"Failed to get space". Unable to enter.");
+    Debug.LogError($"ToString(result.GetFailureReason())");
+}
+```

--- a/Library/docs/source/manual/tutorials/csharp.md
+++ b/Library/docs/source/manual/tutorials/csharp.md
@@ -96,7 +96,7 @@ using Csp.Systems;
 var spaceSystem = Csp.Systems.SystemsManager.Get().GetSpaceSystem();
 ```
 
-You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled “Authenticating”.
+You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled "Authenticating”.
 
 ### Retrieving all spaces associated with the currently logged in user
 ```
@@ -109,7 +109,7 @@ if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
 }
 else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
 {
-    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+    Console.WriteLine("Progress: ” + result.GetRequestProgress());
 }
 else
 {
@@ -121,7 +121,7 @@ else
 
 ### Retrieving a single space, associated with a particular space id
 ```
-using Csp.Systems.SpaceResult spaceResult = await spaceSystem.GetSpace(“ah34hgt25prv”);
+using Csp.Systems.SpaceResult spaceResult = await spaceSystem.GetSpace("ah34hgt25prv”);
 
 
 if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
@@ -131,7 +131,7 @@ if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
 }
 else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
 {
-    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+    Console.WriteLine("Progress: ” + result.GetRequestProgress());
 }
 else
 {
@@ -145,7 +145,7 @@ Where the id is an alphanumeric string.
 
 ### Retrieving spaces associated with a particular user id
 ```
-using CspSystems.SpaceResult spaceResult = await spaceSystem.GetSpacesForUserId(“bc649hnt21h”);
+using CspSystems.SpaceResult spaceResult = await spaceSystem.GetSpacesForUserId("bc649hnt21h”);
 
 if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
 {
@@ -154,7 +154,7 @@ if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
 }
 else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
 {
-    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+    Console.WriteLine("Progress: ” + result.GetRequestProgress());
 }
 else
 {
@@ -169,9 +169,9 @@ It should be noted that this can only be performed by users with elevated privil
 ### Retrieving spaces by specifying a number of space identifiers associated with the currently logged in user
 ```
 using idArray = new Csp.Common.Array<string>(3);
-idArray[0] = “ah34hgt25prv”;
-idArray[1] = “ev936bym27c”; 
-idArray[2] = “jt94nrp74k”;
+idArray[0] = "ah34hgt25prv”;
+idArray[1] = "ev936bym27c”; 
+idArray[2] = "jt94nrp74k”;
 
 using CspSystems.SpacesResult spaceResult = await spaceSystem.GetSpacesByIds(idArray);
 
@@ -182,7 +182,7 @@ if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
 }
 else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
 {
-    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+    Console.WriteLine("Progress: ” + result.GetRequestProgress());
 }
 else
 {
@@ -228,7 +228,7 @@ if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.Success)
 }
 else if (spaceResult.GetResultCode() == Csp.Systems.EResultCode.InProgress)
 {
-    Console.WriteLine(“Progress: ” + result.GetRequestProgress());
+    Console.WriteLine("Progress: ” + result.GetRequestProgress());
 }
 else
 {

--- a/Library/docs/source/manual/tutorials/javascript.md
+++ b/Library/docs/source/manual/tutorials/javascript.md
@@ -95,7 +95,7 @@ The code snippet below, shows how to retrieve the singleton instance for `SpaceS
 
 `const spaceSystem = systemsManager.getSpaceSystem();`
 
-You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled “Authenticating”.
+You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled "Authenticating”.
 
 
 ### Retrieving all spaces associated with the currently logged in user
@@ -113,7 +113,7 @@ if (spaceResult.getResultCode() === Systems.EResultCode.Success)
 }
 else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
 {
-    console.log(“In progress: “, result.GetRequestProgress());
+    console.log("In progress: ", result.GetRequestProgress());
     enterSpaceResult.delete();
 }
 else
@@ -126,7 +126,7 @@ else
 
 ### Retrieving a single space, associated with a particular id
 ```
-let spaceId = “ah34hgt25prv”;
+let spaceId = "ah34hgt25prv”;
 
 const spaceResult = await spaceSystem.getSpace(spaceId);
 
@@ -141,7 +141,7 @@ if (spaceResult.getResultCode() === Systems.EResultCode.Success)
 }
 else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
 {
-    console.log(“In progress: “, result.GetRequestProgress());
+    console.log("In progress: ", result.GetRequestProgress());
     enterSpaceResult.delete();
 }
 else
@@ -154,7 +154,7 @@ else
 
 ### Retrieving spaces associated with a particular user id
 ```
-let user_id = “bc649hnt21h”;
+let user_id = "bc649hnt21h”;
 
 const spacesResult = await spaceSystem.getSpacesForUserId(user_id);
 
@@ -169,7 +169,7 @@ if (spaceResult.getResultCode() === Systems.EResultCode.Success)
 }
 else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
 {
-    console.log(“In progress: “, result.GetRequestProgress());
+    console.log("In progress: ", result.GetRequestProgress());
     enterSpaceResult.delete();
 }
 else
@@ -183,9 +183,9 @@ It should be noted that this can only be performed by users with elevated privil
 
 ### Retrieving spaces, by specifying a number of space identifiers associated with the currently logged in user
 ```
-let space_ids = [ “ah34hgt25prv”, 
-“ev936bym27c”, 
-“jt94nrp74k” ];
+let space_ids = [ "ah34hgt25prv”, 
+"ev936bym27c”, 
+"jt94nrp74k” ];
 
 const spacesResult = await spaceSystem.getSpacesByIds(space_ids);
 
@@ -200,7 +200,7 @@ if (spaceResult.getResultCode() === Systems.EResultCode.Success)
 }
 else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
 {
-    console.log(“In progress: “, result.GetRequestProgress());
+    console.log("In progress: ", result.GetRequestProgress());
     enterSpaceResult.delete();
 }
 else
@@ -231,7 +231,7 @@ if (spaceResult.getResultCode() === Systems.EResultCode.Success)
 }
 else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
 {
-    console.log(“In progress: “, result.GetRequestProgress());
+    console.log("In progress: ", result.GetRequestProgress());
     enterSpaceResult.delete();
 }
 else
@@ -270,7 +270,7 @@ if (spaceResult.getResultCode() === Systems.EResultCode.Success)
 }
 else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
 {
-    console.log(“In progress: “, result.GetRequestProgress());
+    console.log("In progress: ", result.GetRequestProgress());
     enterSpaceResult.delete();
 }
 else

--- a/Library/docs/source/manual/tutorials/javascript.md
+++ b/Library/docs/source/manual/tutorials/javascript.md
@@ -1,0 +1,281 @@
+# JavaScript
+
+## Initializing
+
+Connected Spaces Platform needs to be initialized before making any calls to other parts of its API. For this, you will need a valid CSP tenant. If you don't already have one, you'll need to [apply for one](https://www.magnopus.com/csp/for-developers#tenant-id).
+
+```javascript
+import { ready, CSPFoundation } from 'connected-spaces-platform.web';
+
+// We first need to load the CSP WASM module by calling `ready`
+await ready();
+
+/* 
+ * The first parameter passed to Initialise is the CHS services root URL.
+ * "ogs-ostage" is the environment, and is currently the only environment publicly available for clients.
+ * The last parameter is your tenant ID.
+ */
+CSPFoundation.initialise('https://ogs-ostage.magnoboard.com', '<your tenant>');
+```
+
+After initialising, you should then set the user agent information that will be used for all requests made by CSP.
+
+```javascript
+import { ClientUserAgent } from 'connected-spaces-platform.web';
+
+const userAgent = ClientUserAgent.create();
+userAgent.cSPVersion        = CSPFoundation.getVersion();
+userAgent.clientOS          = '<your current OS identifier>';
+userAgent.clientSKU         = '<an identifier for your project>';
+userAgent.clientVersion     = '<your project version identifier>';
+userAgent.clientEnvironment = '<your project environment>';
+
+CSPFoundation.setClientUserAgentInfo(userAgent);
+userAgent.delete();
+```
+
+## Authenticating
+
+Authentication is done using the `UserSystem` singleton. System singleton instances are managed by the static `SystemsManager` class. The code snippet below shows how to retrieve the singleton instance for `UserSystem`.
+
+```javascript
+import { Services, Systems } from 'connected-spaces-platform.web';
+
+const systemManager = Systems.SystemsManager.get();
+const userSystem = systemManager.getUserSystem();
+```
+
+You can then proceed to log in using an account or as a guest user. Most endpoints in CSP are asynchronous and should be awaited.
+
+```javascript
+function onLogin(result) {
+  const resCode = result.getResultCode();
+
+  // If the request fails, ResultCode will be set to EResultCode.Failed
+  if (resCode == Services.EResultCode.Failed) {
+    // ResultBase.FailureReason will be set if the request failed and should
+    // be used to determine the cause of the failure.
+    const reason = result.getFailureReason();
+
+    switch (reason) {
+      case Systems.ELoginStateFailureReason.EmailNotConfirmed:
+        console.log('User email not verified! Please follow the link in the verification email sent to you after registering an account.');
+        break;
+      case Systems.ELoginStateFailureReason.AgeNotVerified:
+        console.log('User has not confirmed they are over 18! Either you are too young or should re-enter your DoB on the sign in page.');
+        break;
+      case Systems.ELoginStateFailureReason.Unknown:
+        // If FailureReason is unknown, check the HTTP response code.
+        // If it is 403, the provided account credentials were incorrect.
+        console.log('Request failed with HTTP response code ', result.GetHttpResultCode());
+        break;
+    }
+  }
+}
+
+// Log in using a registered account
+// The 4th parameter is a boolean indicating whether the user has verified their age or not,
+// and can be null to use the value supplied during a previous call to login() or createUser()
+const result = await userSystem.login('<username - leave empty>', '<account email>', '<account password>', true);
+onLogin(result);
+result.delete();
+
+// Log in using a guest account
+// The 1st parameter is the same boolean as above
+const result = await userSystem.loginAsGuest(true);
+onLogin(result);
+result.delete();
+```
+
+## Querying Spaces
+
+Space Querying is done using the `SpaceSystem `singleton.
+
+The code snippet below, shows how to retrieve the singleton instance for `SpaceSystem`.
+
+`const spaceSystem = systemsManager.getSpaceSystem();`
+
+You can then proceed to log in using an account or as a guest user, as described in the previous tutorial, entitled “Authenticating”.
+
+
+### Retrieving all spaces associated with the currently logged in user
+```
+const spacesResult = await spaceSystem.getSpaces();
+
+if (spaceResult.getResultCode() === Systems.EResultCode.Success)
+{
+    let spaces = spacesResult.GetSpaces();
+    // Enter space
+    const enterSpaceResult = await spaceSystem.enterSpace(spaces[0].id, false);
+    console.log("Enter Space", resultStatus(enterSpaceResult));
+    enterSpaceResult.delete();
+    spaces.delete();
+}
+else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
+{
+    console.log(“In progress: “, result.GetRequestProgress());
+    enterSpaceResult.delete();
+}
+else
+{
+    console.log("Failed to get spaces", resultStatus(spacesResult));
+    enterSpaceResult.delete();
+}
+```
+
+
+### Retrieving a single space, associated with a particular id
+```
+let spaceId = “ah34hgt25prv”;
+
+const spaceResult = await spaceSystem.getSpace(spaceId);
+
+if (spaceResult.getResultCode() === Systems.EResultCode.Success)
+{
+    let space = spacesResult.GetSpace();
+    // Enter space
+    const enterSpaceResult = await spaceSystem.enterSpace(space.id, false);
+    console.log("Enter Space", resultStatus(enterSpaceResult));
+    enterSpaceResult.delete();
+    spaces.delete();
+}
+else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
+{
+    console.log(“In progress: “, result.GetRequestProgress());
+    enterSpaceResult.delete();
+}
+else
+{
+    console.log("Failed to get spaces", resultStatus(spacesResult));
+    enterSpaceResult.delete();
+}
+```
+
+
+### Retrieving spaces associated with a particular user id
+```
+let user_id = “bc649hnt21h”;
+
+const spacesResult = await spaceSystem.getSpacesForUserId(user_id);
+
+if (spaceResult.getResultCode() === Systems.EResultCode.Success)
+{
+    let spaces = spacesResult.GetSpaces();
+    // Enter space
+    const enterSpaceResult = await spaceSystem.enterSpace(spaces[0].id, false);
+    console.log("Enter Space", resultStatus(enterSpaceResult));
+    enterSpaceResult.delete();
+    spaces.delete();
+}
+else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
+{
+    console.log(“In progress: “, result.GetRequestProgress());
+    enterSpaceResult.delete();
+}
+else
+{
+    console.log("Failed to get spaces", resultStatus(spacesResult));
+    enterSpaceResult.delete();
+}
+```
+It should be noted that this can only be performed by users with elevated privileges. Calling this function without elevated privileges will fail.
+
+
+### Retrieving spaces, by specifying a number of space identifiers associated with the currently logged in user
+```
+let space_ids = [ “ah34hgt25prv”, 
+“ev936bym27c”, 
+“jt94nrp74k” ];
+
+const spacesResult = await spaceSystem.getSpacesByIds(space_ids);
+
+if (spaceResult.getResultCode() === Systems.EResultCode.Success)
+{
+    let spaces = spacesResult.GetSpaces();
+    // Enter space
+    const enterSpaceResult = await spaceSystem.enterSpace(spaces[0].id, false);
+    console.log("Enter Space", resultStatus(enterSpaceResult));
+    enterSpaceResult.delete();
+    spaces.delete();
+}
+else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
+{
+    console.log(“In progress: “, result.GetRequestProgress());
+    enterSpaceResult.delete();
+}
+else
+{
+    console.log("Failed to get spaces", resultStatus(spacesResult));
+    enterSpaceResult.delete();
+}
+```
+
+### Retrieving spaces with the given set of attributes available to the logged in user
+```
+const spacesResult = await spaceSystem.getSpacesByAttributes(
+    true, 		// isDiscoverable
+    false, 	        // isArchivable
+    true, 		// requiresInvite
+    0, 		        // results skip (in this case start the first result)
+    4 		        // results max ( in this case stop at 4)
+);
+
+if (spaceResult.getResultCode() === Systems.EResultCode.Success)
+{
+    let spaces = spacesResult.GetSpaces();
+    // Enter space
+    const enterSpaceResult = await spaceSystem.enterSpace(spaces[0].id, false);
+    console.log("Enter Space", resultStatus(enterSpaceResult));
+    enterSpaceResult.delete();
+    spaces.delete();
+}
+else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
+{
+    console.log(“In progress: “, result.GetRequestProgress());
+    enterSpaceResult.delete();
+}
+else
+{
+    console.log("Failed to get spaces", resultStatus(spacesResult));
+    enterSpaceResult.delete();
+}
+```
+
+Each of the attribute arguments are optional. 
+* `isDiscoverable `is set to true if we are searching for spaces which are publicly listed.
+* `isArchived `is set to true if we are searching for archived spaces.
+* `requiresInvite `is set to true if we are searching for spaces which require an invite to enter.
+* The next two arguments are to enable paginating results.
+* `resultsSkip `sets which result to start at (in the above case, the first result)
+* `resultsMax `sets which result to stop the current search (in the above example, result 4)
+
+You can disable pagination, by changing the last two arguments to null values:
+```
+const spacesResult = await spaceSystem.getSpacesByAttributes(
+    true, 		// isDiscoverable
+    false, 	        // isArchivable
+    true, 		// requiresInvite
+    null, 		
+    null 		// Two null arguments mean all spaces will be retrieved
+);
+
+if (spaceResult.getResultCode() === Systems.EResultCode.Success)
+{
+    let spaces = spacesResult.GetSpaces();
+    // Enter space
+    const enterSpaceResult = await spaceSystem.enterSpace(spaces[0].id, false);
+    console.log("Enter Space", resultStatus(enterSpaceResult));
+    enterSpaceResult.delete();
+    spaces.delete();
+}
+else if (spaceResult.getResultCode() === Systems.EResultCode.InProgress)
+{
+    console.log(“In progress: “, result.GetRequestProgress());
+    enterSpaceResult.delete();
+}
+else
+{
+    console.log("Failed to get spaces", resultStatus(spacesResult));
+    enterSpaceResult.delete();
+}
+```


### PR DESCRIPTION
# Summary
This change does several things:

* Improves the look and feel of the automatically generated CSP documentation site.
* Migrates all documentation currently hosted on the GitHub wiki to the site (under a 'Manual' section at the root).
* Adds the first module in a new curriculum designed to help users learn CSP (under a 'Learn' section at the root).

# What to Pay Attention To
* Part of the visual upgrade involved upgrading the pipeline's dependencies, plus adding several more. The dependencies had not been upgraded in several years, and had reached a point where they would not run at all on new machines.
 * These can be found in `requirements.txt` and `conf.py`
* All GitHub wiki content has been added to the site. Please do verify everything there is present and correct.

# What I'm Less Concerned About
* The documentation structure in the `Learn` section could use more thought if I'm honest. It's reasonably coherent, but certain topics like `Logging` don't feel like they belong in an Overview module. I'm not overly concerned about this with this PR, as I would prefer to integrate the change and establish the new basic structure, rather than seek perfection first-try.
* The documentation in the `Learn` section has also been pre-reviewed and approved by @MAG-AdamThorn and myself, so whilst I am very keen on nitpicks, I'm not keen on rewriting large swathes as part of this change.