### PR TITLE
[OSB-12] fix: Init order AvatarInfoResult

### DIFF
--- a/Library/include/CSP/Systems/Settings/SettingsCollection.h
+++ b/Library/include/CSP/Systems/Settings/SettingsCollection.h
@@ -102,7 +102,7 @@ public:
 	[[nodiscard]] const csp::common::Variant& GetAvatarIdentifier() const;
 
 	CSP_NO_EXPORT AvatarInfoResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
-		: Type(AvatarType::None), csp::systems::ResultBase(ResCode, HttpResCode) {};
+		: csp::systems::ResultBase(ResCode, HttpResCode), Type(AvatarType::None) {};
 
 private:
 	AvatarInfoResult() : Type(AvatarType::None) {};


### PR DESCRIPTION
Fix initializer list ordering for GetAvatarIdentifier. This was surfacing on mac builds. The CI should be enough to prove this is fine.

It's odd that only this warning was surfacing, as there's lots of warnings of the same nature if you enable
all the warnings. What's odder is that I couldn't get _this specific_ warning to trigger on Windows, despite being able
to see loads of other bad ordering.

Although, this is perhaps a little different in that it's in a header, and external warnings are treated differently to internal ones, and I know GCC/Apple-clang defaults around this are different to MSVC. Could be what caused this to be seen and not others