### PR TITLE
[OF-1408] Replace Variant pattern for Avatar Info settings

### DIFF
--- a/Library/include/CSP/Systems/Settings/SettingsSystem.h
+++ b/Library/include/CSP/Systems/Settings/SettingsSystem.h
@@ -130,7 +130,7 @@ public:
 	/// @brief Retrieves the Avatar Portrait information associated with the space
 	/// If the user of the Avatar portrait associated with it the result callback will be successful, the HTTP res code will be ResponseNotFound
 	/// and the Uri field inside the UriResult will be empty
-    /// @param InUserID const csp::common::String : The id of the user we are seelomg to retrieve the portrait for
+	/// @param InUserID const csp::common::String : The id of the user we are seelomg to retrieve the portrait for
 	/// @param Callback UriResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void GetAvatarPortrait(const csp::common::String InUserID, UriResultCallback Callback);
 
@@ -141,9 +141,9 @@ public:
 
 	/// @brief Sets the avatar type and identifier for a user.
 	/// @param InType csp::systems::AvatarType : The type of avatar (predefined, Ready Player Me, or custom).
-	/// @param InIdentifier csp::common::Variant : A value used to identify or locate the avatar. Differs depending on the value of InType.
+	/// @param InIdentifier csp::common::String : A string used to identify or locate the avatar.
 	/// @param Callback NullResultCallback : Callback to call when task finishes.
-	CSP_ASYNC_RESULT void SetAvatarInfo(AvatarType InType, const csp::common::Variant& InIdentifier, NullResultCallback Callback);
+	CSP_ASYNC_RESULT void SetAvatarInfo(AvatarType InType, const csp::common::String& InIdentifier, NullResultCallback Callback);
 
 	/// @brief Retrieves the avatar type and identifier for a user.
 	/// @param Callback NullResultCallback : Callback to call when task finishes.

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -873,7 +873,6 @@ void SettingsSystem::SetAvatarInfo(AvatarType InType, const String& InIdentifier
 	rapidjson::Document Json;
 	Json.SetObject();
 	Json.AddMember("type", static_cast<int>(InType), Json.GetAllocator());
-	Json.AddMember("identifierType", static_cast<int>(VariantType::String), Json.GetAllocator());
 
 	Json.AddMember("identifier", rapidjson::Value(InIdentifier.c_str(), InIdentifier.Length()), Json.GetAllocator());
 
@@ -927,10 +926,9 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
 			return;
 		}
 
-		const auto& type		   = Json["type"];
-		const auto& identifierType = Json["identifierType"];
+		const auto& type = Json["type"];
 
-		if (!type.IsInt() || !identifierType.IsInt())
+		if (!type.IsInt())
 		{
 			CSP_LOG_ERROR_MSG("Invalid avatar info!");
 

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -429,8 +429,8 @@ void SettingsSystem::UpdateAvatarPortrait(const FileAssetDataSource& NewAvatarPo
 		}
 	};
 
-    auto* UserSystem     = SystemsManager::Get().GetUserSystem();
-    const auto& UserId = UserSystem->GetLoginState().UserId;
+	auto* UserSystem   = SystemsManager::Get().GetUserSystem();
+	const auto& UserId = UserSystem->GetLoginState().UserId;
 	GetAvatarPortraitAssetCollection(UserId, AvatarPortraitAssetCollCallback);
 }
 
@@ -552,8 +552,8 @@ void SettingsSystem::UpdateAvatarPortraitWithBuffer(const BufferAssetDataSource&
 		}
 	};
 
-    auto* UserSystem     = SystemsManager::Get().GetUserSystem();
-    const auto& UserId = UserSystem->GetLoginState().UserId;
+	auto* UserSystem   = SystemsManager::Get().GetUserSystem();
+	const auto& UserId = UserSystem->GetLoginState().UserId;
 	GetAvatarPortraitAssetCollection(UserId, ThumbnailAssetCollCallback);
 }
 
@@ -863,35 +863,19 @@ void SettingsSystem::RemoveAvatarPortrait(NullResultCallback Callback)
 		}
 	};
 
-    auto* UserSystem     = SystemsManager::Get().GetUserSystem();
-    const auto& UserId = UserSystem->GetLoginState().UserId;
+	auto* UserSystem   = SystemsManager::Get().GetUserSystem();
+	const auto& UserId = UserSystem->GetLoginState().UserId;
 	GetAvatarPortraitAssetCollection(UserId, PortraitAvatarAssetCollCallback);
 }
 
-void SettingsSystem::SetAvatarInfo(AvatarType InType, const Variant& InIdentifier, NullResultCallback Callback)
+void SettingsSystem::SetAvatarInfo(AvatarType InType, const String& InIdentifier, NullResultCallback Callback)
 {
 	rapidjson::Document Json;
 	Json.SetObject();
 	Json.AddMember("type", static_cast<int>(InType), Json.GetAllocator());
-	Json.AddMember("identifierType", static_cast<int>(InIdentifier.GetValueType()), Json.GetAllocator());
+	Json.AddMember("identifierType", static_cast<int>(VariantType::String), Json.GetAllocator());
 
-	switch (InIdentifier.GetValueType())
-	{
-		case VariantType::Integer:
-			Json.AddMember("identifier", InIdentifier.GetInt(), Json.GetAllocator());
-			break;
-		case VariantType::String:
-			Json.AddMember("identifier", rapidjson::Value(InIdentifier.GetString().c_str(), InIdentifier.GetString().Length()), Json.GetAllocator());
-			break;
-		default:
-		{
-			CSP_LOG_ERROR_MSG("Unsupported Avatar Identifier type.");
-
-			INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
-
-			return;
-		}
-	}
+	Json.AddMember("identifier", rapidjson::Value(InIdentifier.c_str(), InIdentifier.Length()), Json.GetAllocator());
 
 	rapidjson::StringBuffer Buffer;
 	rapidjson::Writer<rapidjson::StringBuffer> Writer(Buffer);
@@ -957,25 +941,7 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
 
 		InternalResult.SetAvatarType(static_cast<AvatarType>(type.GetInt()));
 
-		auto IdentifierType = static_cast<VariantType>(identifierType.GetInt());
-
-		switch (IdentifierType)
-		{
-			case VariantType::Integer:
-				InternalResult.SetAvatarIdentifier(static_cast<int64_t>(Json["identifier"].GetInt()));
-				break;
-			case VariantType::String:
-				InternalResult.SetAvatarIdentifier(Json["identifier"].GetString());
-				break;
-			default:
-			{
-				CSP_LOG_ERROR_MSG("Unsupported Avatar Identifier type.");
-
-				Callback(MakeInvalid<AvatarInfoResult>());
-
-				return;
-			}
-		}
+		InternalResult.SetAvatarIdentifier(Json["identifier"].GetString());
 
 		Callback(InternalResult);
 	};


### PR DESCRIPTION
Remove the ability to set the Identifier Type to string or int using a Variant, so that the Identifier Type is now always a string.
