### PR TITLE
[NT-0] refac: Including documentation in Library project

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -49,6 +49,7 @@ if not Project then
         files {
             "%{wks.location}/Library/**.h",
             "%{wks.location}/Library/**.cpp",
+			"%{wks.location}/Library/docs/source/**.md",
             "%{wks.location}/modules/csp-services/generated/**.h",
             "%{wks.location}/modules/csp-services/generated/**.cpp"
         }


### PR DESCRIPTION
With this change, the CSP Library project pulls in all markdown files in `Library\docs\source`, listing them in a `docs` directory alongside CSP source files.

This is intended to make it easier for developers to make changes to the documentation as an atomic operation, along with the corresponding code changes being made to the library itself. One powerful example is having all references to particular method show up across both the codebase itself _and_ documentation when searching for a term in the IDE.

![image](https://github.com/user-attachments/assets/569b8ed9-315c-40de-8c72-328e4cd38bd7)
