### PR TITLE
[NT-0] refac: replacing foundation term

### DIFF
--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -388,7 +388,7 @@ void CSPFoundation::SetClientUserAgentInfo(const csp::ClientUserAgent& ClientUse
 	ClientUserAgentInfo->ClientVersion		= CSP_TEXT(ClientUserAgentHeader.ClientVersion);
 	ClientUserAgentInfo->ClientEnvironment	= CSP_TEXT(ClientUserAgentHeader.ClientEnvironment);
 	ClientUserAgentInfo->CHSEnvironment		= CSP_TEXT(ClientUserAgentHeader.CHSEnvironment);
-	const char* ClientUserAgentHeaderFormat = "%s/%s(%s) Foundation/%s(%s) CHS(%s) CSP/%s(%s)";
+	const char* ClientUserAgentHeaderFormat = "%s/%s(%s) CSP/%s(%s) CHS(%s) CSP/%s(%s)";
 
 	*ClientUserAgentString = csp::common::StringFormat(ClientUserAgentHeaderFormat,
 													   GetClientUserAgentInfo().ClientSKU.c_str(),


### PR DESCRIPTION
Replacing an instance of the term 'foundation' that is emitted to client logs with the term 'CSP'.