### PR TITLE
Asset: make ThirdParty properties public, remove methods

### DIFF
--- a/Library/include/CSP/Systems/Assets/Asset.h
+++ b/Library/include/CSP/Systems/Assets/Asset.h
@@ -101,27 +101,8 @@ public:
 	int Version;
 	csp::common::String MimeType;
 	csp::common::String ExternalMimeType;
-
-
-	/// @brief Gets the third party packaged asset identifier of this asset
-	/// @return returns a string representing the party packaged asset identifier set for this asset.
-	const csp::common::String& GetThirdPartyPackagedAssetIdentifier() const;
-
-	/// @brief Sets the party packaged asset identifier for this asset
-	/// @param InThirdPartyPackagedAssetIdentifier The third party packaged asset identifier to set.
-	void SetThirdPartyPackagedAssetIdentifier(const csp::common::String& InThirdPartyPackagedAssetIdentifier);
-
-	/// @brief Gets the third party platform type of this asset
-	/// @return returns a string representing third party platform type set for this asset.
-	const EThirdPartyPlatform GetThirdPartyPlatformType() const;
-
-	/// @brief Sets third party platform type for this asset
-	/// @param InThirdPartyPlatformType The third party platform type to set.
-	void SetThirdPartyPlatformType(const EThirdPartyPlatform InThirdPartyPlatformType);
-
-private:
 	csp::common::String ThirdPartyPackagedAssetIdentifier;
-	EThirdPartyPlatform ThirdPartyPlatform;
+	EThirdPartyPlatform ThirdPartyPlatformType;
 };
 
 /// @brief Defines a base data source for an Asset, attributing a mime type and providing functionality for uploading the data.

--- a/Library/src/Systems/Assets/Asset.cpp
+++ b/Library/src/Systems/Assets/Asset.cpp
@@ -139,19 +139,19 @@ void AssetDetailDtoToAsset(const chs::AssetDetailDto& Dto, csp::systems::Asset& 
 		const auto& InAddressableId = Dto.GetAddressableId().Split('|');
 		if (InAddressableId.Size() == 2)
 		{
-			Asset.SetThirdPartyPlatformType(static_cast<EThirdPartyPlatform>(std::stoi(InAddressableId[1].c_str())));
-			Asset.SetThirdPartyPackagedAssetIdentifier(InAddressableId[0]);
+			Asset.ThirdPartyPlatformType = static_cast<EThirdPartyPlatform>(std::stoi(InAddressableId[1].c_str()));
+			Asset.ThirdPartyPackagedAssetIdentifier = InAddressableId[0];
 		}
 		else
 		{
-			Asset.SetThirdPartyPackagedAssetIdentifier(Dto.GetAddressableId());
-			Asset.SetThirdPartyPlatformType(EThirdPartyPlatform::NONE);
+			Asset.ThirdPartyPackagedAssetIdentifier = Dto.GetAddressableId();
+			Asset.ThirdPartyPlatformType = EThirdPartyPlatform::NONE;
 		}
 	}
 	else
 	{
-		Asset.SetThirdPartyPackagedAssetIdentifier("");
-		Asset.SetThirdPartyPlatformType(EThirdPartyPlatform::NONE);
+		Asset.ThirdPartyPackagedAssetIdentifier = "";
+		Asset.ThirdPartyPlatformType = EThirdPartyPlatform::NONE;
 	}
 
 	if (Dto.HasUri())
@@ -180,7 +180,7 @@ void AssetDetailDtoToAsset(const chs::AssetDetailDto& Dto, csp::systems::Asset& 
 namespace csp::systems
 {
 
-Asset::Asset() : Type(EAssetType::MODEL), Version(0), ThirdPartyPackagedAssetIdentifier(""), ThirdPartyPlatform(EThirdPartyPlatform::NONE)
+Asset::Asset() : Type(EAssetType::MODEL), Version(0), ThirdPartyPackagedAssetIdentifier(""), ThirdPartyPlatformType(EThirdPartyPlatform::NONE)
 {
 }
 
@@ -360,23 +360,4 @@ void AssetDataResult::OnResponse(const csp::services::ApiResponseBase* ApiRespon
 	ResultBase::OnResponse(ApiResponse);
 }
 
-const csp::common::String& Asset::GetThirdPartyPackagedAssetIdentifier() const
-{
-	return ThirdPartyPackagedAssetIdentifier;
-}
-
-void Asset::SetThirdPartyPackagedAssetIdentifier(const csp::common::String& InThirdPartyPackagedAssetIdentifier)
-{
-	ThirdPartyPackagedAssetIdentifier = InThirdPartyPackagedAssetIdentifier;
-}
-
-void Asset::SetThirdPartyPlatformType(const EThirdPartyPlatform InThirdPartyPlatformType)
-{
-	ThirdPartyPlatform = InThirdPartyPlatformType;
-}
-
-const EThirdPartyPlatform Asset::GetThirdPartyPlatformType() const
-{
-	return ThirdPartyPlatform;
-}
 } // namespace csp::systems

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -519,7 +519,7 @@ void AssetSystem::UpdateAsset(const Asset& Asset, AssetResultCallback Callback)
 	}
 
 	AssetInfo->SetAddressableId(
-		StringFormat("%s|%d", Asset.GetThirdPartyPackagedAssetIdentifier().c_str(), static_cast<int>(Asset.GetThirdPartyPlatformType())));
+		StringFormat("%s|%d", Asset.ThirdPartyPackagedAssetIdentifier.c_str(), static_cast<int>(Asset.ThirdPartyPlatformType)));
 
 	AssetInfo->SetAssetType(ConvertAssetTypeToString(Asset.Type));
 	services::ResponseHandlerPtr ResponseHandler

--- a/Tests/CSharp/src/Tests/AssetSystemTests.cs
+++ b/Tests/CSharp/src/Tests/AssetSystemTests.cs
@@ -374,19 +374,19 @@ namespace CSPEngine
 
             Assert.AreEqual(assets.Size(), 1UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
-            Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), thirdPartyPackagedAssetIdentifier);
+            Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifier);
 
             var inboundAsset = assets[0];
             inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
-            Assert.AreEqual(inboundAsset.GetThirdPartyPackagedAssetIdentifier(), "Test");
+            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
             inboundAsset.SetThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL);
-            Assert.AreEqual(inboundAsset.GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
+            Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
 
             var updatedAsset = assetSystem.UpdateAsset(inboundAsset).Result;
             Assert.AreEqual(updatedAsset.GetResultCode(), Systems.EResultCode.Success);
 
-            Assert.AreEqual(updatedAsset.GetAsset().GetThirdPartyPackagedAssetIdentifier(), "Test");
-            Assert.AreEqual(updatedAsset.GetAsset().GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
+            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPackagedAssetIdentifier, "Test");
+            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             updatedAsset.Dispose();
             inboundAsset.Dispose();
 
@@ -419,19 +419,19 @@ namespace CSPEngine
 
             Assert.AreEqual(assets.Size(), 1UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
-            Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), thirdPartyPackagedAssetIdentifier);
+            Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifier);
 
             var inboundAsset = assets[0];
             inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
-            Assert.AreEqual(inboundAsset.GetThirdPartyPackagedAssetIdentifier(), "Test");
+            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
             inboundAsset.SetThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL);
-            Assert.AreEqual(inboundAsset.GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
+            Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
 
             var updatedAsset = assetSystem.UpdateAsset(inboundAsset).Result;
             Assert.AreEqual(updatedAsset.GetResultCode(), Systems.EResultCode.Success);
 
-            Assert.AreEqual(updatedAsset.GetAsset().GetThirdPartyPackagedAssetIdentifier(), "Test");
-            Assert.AreEqual(updatedAsset.GetAsset().GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
+            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPackagedAssetIdentifier, "Test");
+            Assert.AreEqual(updatedAsset.GetAsset().GeThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             updatedAsset.Dispose();
             inboundAsset.Dispose();
 
@@ -1412,14 +1412,14 @@ namespace CSPEngine
             GetAssetsInCollection(assetSystem, assetCollection, out var assets);
             Assert.AreEqual(assets.Size(), 1UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
-            Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), "");
-            Assert.AreEqual(assets[0].GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.NONE);
+            Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, "");
+            Assert.AreEqual(assets[0].ThirdPartyPlatformType, Systems.EThirdPartyPlatform.NONE);
 
             var inboundAsset = assets[0];
             inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
-            Assert.AreEqual(inboundAsset.GetThirdPartyPackagedAssetIdentifier(), "Test");
+            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
             inboundAsset.SetThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL);
-            Assert.AreEqual(inboundAsset.GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
+            Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             inboundAsset.Dispose();
 
             // Create asset
@@ -1430,8 +1430,8 @@ namespace CSPEngine
 
             Assert.AreEqual(assets.Size(), 2UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
-            Assert.AreEqual(assets[0].GetThirdPartyPackagedAssetIdentifier(), thirdPartyPackagedAssetIdentifierAlphanumeric);
-            Assert.AreEqual(assets[0].GetThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNITY);
+            Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifierAlphanumeric);
+            Assert.AreEqual(assets[0].ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNITY);
 
         }
 #endif

--- a/Tests/CSharp/src/Tests/AssetSystemTests.cs
+++ b/Tests/CSharp/src/Tests/AssetSystemTests.cs
@@ -377,9 +377,9 @@ namespace CSPEngine
             Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifier);
 
             var inboundAsset = assets[0];
-            inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
+            inboundAsset.ThirdPartyPackagedAssetIdentifier = "Test";
             Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
-            inboundAsset.SetThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL);
+            inboundAsset.ThirdPartyPlatformType = Systems.EThirdPartyPlatform.UNREAL;
             Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
 
             var updatedAsset = assetSystem.UpdateAsset(inboundAsset).Result;
@@ -422,9 +422,9 @@ namespace CSPEngine
             Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifier);
 
             var inboundAsset = assets[0];
-            inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
+            inboundAsset.ThirdPartyPackagedAssetIdentifier = "Test";
             Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
-            inboundAsset.SetThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL);
+            inboundAsset.ThirdPartyPlatformType = Systems.EThirdPartyPlatform.UNREAL;
             Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
 
             var updatedAsset = assetSystem.UpdateAsset(inboundAsset).Result;
@@ -1416,9 +1416,9 @@ namespace CSPEngine
             Assert.AreEqual(assets[0].ThirdPartyPlatformType, Systems.EThirdPartyPlatform.NONE);
 
             var inboundAsset = assets[0];
-            inboundAsset.SetThirdPartyPackagedAssetIdentifier("Test");
+            inboundAsset.ThirdPartyPackagedAssetIdentifier = "Test";
             Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
-            inboundAsset.SetThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL);
+            inboundAsset.ThirdPartyPlatformType = Systems.EThirdPartyPlatform.UNREAL;
             Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             inboundAsset.Dispose();
 

--- a/Tests/CSharp/src/Tests/AssetSystemTests.cs
+++ b/Tests/CSharp/src/Tests/AssetSystemTests.cs
@@ -356,6 +356,7 @@ namespace CSPEngine
             string testAssetCollectionName = GenerateUniqueString("OLY-UNITTEST-ASSETCOLLECTION-REWIND");
             string testAssetName = GenerateUniqueString("OLY-UNITTEST-ASSET-REWIND");
             string thirdPartyPackagedAssetIdentifier = "OKO interoperable assets Test";
+            string thirdPartyPackagedAssetIdentifierTest = "Test";
 
             // Log in
             _ = UserSystemTests.LogIn(userSystem);
@@ -377,15 +378,15 @@ namespace CSPEngine
             Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifier);
 
             var inboundAsset = assets[0];
-            inboundAsset.ThirdPartyPackagedAssetIdentifier = "Test";
-            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
+            inboundAsset.ThirdPartyPackagedAssetIdentifier = thirdPartyPackagedAssetIdentifierTest;
+            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifierTest);
             inboundAsset.ThirdPartyPlatformType = Systems.EThirdPartyPlatform.UNREAL;
             Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
 
             var updatedAsset = assetSystem.UpdateAsset(inboundAsset).Result;
             Assert.AreEqual(updatedAsset.GetResultCode(), Systems.EResultCode.Success);
 
-            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPackagedAssetIdentifier, "Test");
+            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifierTest);
             Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             updatedAsset.Dispose();
             inboundAsset.Dispose();
@@ -404,6 +405,7 @@ namespace CSPEngine
             string testAssetCollectionName = GenerateUniqueString("OLY-UNITTEST-ASSETCOLLECTION-REWIND");
             string testAssetName = GenerateUniqueString("OLY-UNITTEST-ASSET-REWIND");
             string thirdPartyPackagedAssetIdentifier = "OKO interoperable assets Test";
+            string thirdPartyPackagedAssetIdentifierTest = "Test";
 
             // Log in
             _ = UserSystemTests.LogIn(userSystem);
@@ -422,15 +424,15 @@ namespace CSPEngine
             Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifier);
 
             var inboundAsset = assets[0];
-            inboundAsset.ThirdPartyPackagedAssetIdentifier = "Test";
-            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
+            inboundAsset.ThirdPartyPackagedAssetIdentifier = thirdPartyPackagedAssetIdentifierTest;
+            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifierTest);
             inboundAsset.ThirdPartyPlatformType = Systems.EThirdPartyPlatform.UNREAL;
             Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
 
             var updatedAsset = assetSystem.UpdateAsset(inboundAsset).Result;
             Assert.AreEqual(updatedAsset.GetResultCode(), Systems.EResultCode.Success);
 
-            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPackagedAssetIdentifier, "Test");
+            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifierTest);
             Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             updatedAsset.Dispose();
             inboundAsset.Dispose();
@@ -1395,6 +1397,8 @@ namespace CSPEngine
             string testAssetCollectionName = GenerateUniqueString("OLY-UNITTEST-ASSETCOLLECTION-REWIND");
             string testAssetName = GenerateUniqueString("OLY-UNITTEST-ASSET-REWIND");
             string thirdPartyPackagedAssetIdentifierAlphanumeric = "^[a-zA-Z0-9][a-zA-Z0-9/\\s]/*^\\s]*";
+            string thirdPartyPackagedAssetIdentifierTest = "Test";
+            string thirdPartyPackagedAssetIdentifierBlank = "";
 
             // Log in
             _ = UserSystemTests.LogIn(userSystem);
@@ -1412,12 +1416,12 @@ namespace CSPEngine
             GetAssetsInCollection(assetSystem, assetCollection, out var assets);
             Assert.AreEqual(assets.Size(), 1UL);
             Assert.AreEqual(assets[0].Name, testAssetName);
-            Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, "");
+            Assert.AreEqual(assets[0].ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifierBlank);
             Assert.AreEqual(assets[0].ThirdPartyPlatformType, Systems.EThirdPartyPlatform.NONE);
 
             var inboundAsset = assets[0];
-            inboundAsset.ThirdPartyPackagedAssetIdentifier = "Test";
-            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, "Test");
+            inboundAsset.ThirdPartyPackagedAssetIdentifier = thirdPartyPackagedAssetIdentifierTest;
+            Assert.AreEqual(inboundAsset.ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifierTest);
             inboundAsset.ThirdPartyPlatformType = Systems.EThirdPartyPlatform.UNREAL;
             Assert.AreEqual(inboundAsset.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             inboundAsset.Dispose();

--- a/Tests/CSharp/src/Tests/AssetSystemTests.cs
+++ b/Tests/CSharp/src/Tests/AssetSystemTests.cs
@@ -431,7 +431,7 @@ namespace CSPEngine
             Assert.AreEqual(updatedAsset.GetResultCode(), Systems.EResultCode.Success);
 
             Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPackagedAssetIdentifier, "Test");
-            Assert.AreEqual(updatedAsset.GetAsset().GeThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
+            Assert.AreEqual(updatedAsset.GetAsset().ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
             updatedAsset.Dispose();
             inboundAsset.Dispose();
 

--- a/Tests/Web/html/tests/assetsystem_tests.js
+++ b/Tests/Web/html/tests/assetsystem_tests.js
@@ -270,11 +270,11 @@ test('AssetSystemTests', 'ThirdPartyPackagedAssetIdentifierTest', async function
     assert.areEqual(asset.ThirdPartyPackagedAssetIdentifier, "");
     assert.areEqual(asset.getThirdPartyPlatformType(), Systems.EThirdPartyPlatform.NONE);
 
-    asset.setThirdPartyPackagedAssetIdentifier("Test");
+    asset.ThirdPartyPackagedAssetIdentifier = "Test";
     assert.areEqual(asset.ThirdPartyPackagedAssetIdentifier, "Test");
 
-    asset.setThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL)
-    asset.setThirdPartyPackagedAssetIdentifier("")
+    asset.ThirdPartyPlatformType = Systems.EThirdPartyPlatform.UNREAL;
+    asset.ThirdPartyPackagedAssetIdentifier = "";
     const Assetupdated = await assetSystem.updateAsset(asset);
     assert.areEqual(Assetupdated.getAsset().ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
     assert.areEqual(Assetupdated.getAsset().ThirdPartyPackagedAssetIdentifier, "");

--- a/Tests/Web/html/tests/assetsystem_tests.js
+++ b/Tests/Web/html/tests/assetsystem_tests.js
@@ -267,22 +267,22 @@ test('AssetSystemTests', 'ThirdPartyPackagedAssetIdentifierTest', async function
     // Create asset
     var asset = await createAsset(assetSystem, assetCollection, assetName);
 
-    assert.areEqual(asset.getThirdPartyPackagedAssetIdentifier(), "");
+    assert.areEqual(asset.ThirdPartyPackagedAssetIdentifier, "");
     assert.areEqual(asset.getThirdPartyPlatformType(), Systems.EThirdPartyPlatform.NONE);
 
     asset.setThirdPartyPackagedAssetIdentifier("Test");
-    assert.areEqual(asset.getThirdPartyPackagedAssetIdentifier(), "Test");
+    assert.areEqual(asset.ThirdPartyPackagedAssetIdentifier, "Test");
 
     asset.setThirdPartyPlatformType(Systems.EThirdPartyPlatform.UNREAL)
     asset.setThirdPartyPackagedAssetIdentifier("")
     const Assetupdated = await assetSystem.updateAsset(asset);
-    assert.areEqual(Assetupdated.getAsset().getThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNREAL);
-    assert.areEqual(Assetupdated.getAsset().getThirdPartyPackagedAssetIdentifier(), "");
+    assert.areEqual(Assetupdated.getAsset().ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNREAL);
+    assert.areEqual(Assetupdated.getAsset().ThirdPartyPackagedAssetIdentifier, "");
 
     // Create asset
     const asset2 = await createAsset(assetSystem, assetCollection, assetName,thirdPartyPackagedAssetIdentifier, Systems.EThirdPartyPlatform.UNITY);
 
-    assert.areEqual(asset2.getThirdPartyPackagedAssetIdentifier(), thirdPartyPackagedAssetIdentifier);
-    assert.areEqual(asset2.getThirdPartyPlatformType(), Systems.EThirdPartyPlatform.UNITY);
+    assert.areEqual(asset2.ThirdPartyPackagedAssetIdentifier, thirdPartyPackagedAssetIdentifier);
+    assert.areEqual(asset2.ThirdPartyPlatformType, Systems.EThirdPartyPlatform.UNITY);
 
 });

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -537,7 +537,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetTest)
 
 	EXPECT_EQ(Assets.Size(), 1);
 	EXPECT_EQ(Assets[0].Name, UniqueAssetName);
-	EXPECT_EQ(Assets[0].GetThirdPartyPackagedAssetIdentifier(), ThirdPartyPackagedAssetIdentifier);
+	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifier);
 
 	// Delete asset
 	DeleteAsset(AssetSystem, AssetCollection, Asset);
@@ -597,7 +597,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetNoSpaceTest)
 
 	EXPECT_EQ(Assets.Size(), 1);
 	EXPECT_EQ(Assets[0].Name, UniqueAssetName);
-	EXPECT_EQ(Assets[0].GetThirdPartyPackagedAssetIdentifier(), ThirdPartyPackagedAssetIdentifier);
+	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifier);
 
 	// Delete asset
 	DeleteAsset(AssetSystem, AssetCollection, Asset);
@@ -672,7 +672,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateExternalUriAssetTest)
 
 	EXPECT_EQ(Assets.Size(), 1);
 	EXPECT_EQ(Assets[0].Name, UniqueAssetName);
-	EXPECT_EQ(Assets[0].GetThirdPartyPackagedAssetIdentifier(), ThirdPartyPackagedAssetIdentifier);
+	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifier);
 	EXPECT_EQ(Assets[0].Uri, "");
 
 	Assets[0].ExternalUri	   = TestExternalUri;
@@ -2155,8 +2155,8 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, ThirdPartyPackagedAssetIdentifierTe
 
 	EXPECT_EQ(Assets.Size(), 1);
 	EXPECT_EQ(Assets[0].Name, UniqueAssetName);
-	EXPECT_EQ(Assets[0].GetThirdPartyPackagedAssetIdentifier(), "");
-	EXPECT_EQ(Assets[0].GetThirdPartyPlatformType(), csp::systems::EThirdPartyPlatform::NONE);
+	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, "");
+	EXPECT_EQ(Assets[0].ThirdPartyPlatformType, csp::systems::EThirdPartyPlatform::NONE);
 	// Delete asset
 	DeleteAsset(AssetSystem, assetCollection, Asset);
 
@@ -2167,11 +2167,11 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, ThirdPartyPackagedAssetIdentifierTe
 
 	EXPECT_EQ(Assets.Size(), 1);
 	EXPECT_EQ(Assets[0].Name, UniqueAssetName);
-	EXPECT_EQ(Assets[0].GetThirdPartyPackagedAssetIdentifier(), ThirdPartyPackagedAssetIdentifier);
-	EXPECT_EQ(Assets[0].GetThirdPartyPlatformType(), csp::systems::EThirdPartyPlatform::UNITY);
+	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifier);
+	EXPECT_EQ(Assets[0].ThirdPartyPlatformType, csp::systems::EThirdPartyPlatform::UNITY);
 
 	Assets[0].SetThirdPartyPackagedAssetIdentifier(ThirdPartyPackagedAssetIdentifierLocal);
-	EXPECT_EQ(Assets[0].GetThirdPartyPackagedAssetIdentifier(), ThirdPartyPackagedAssetIdentifierLocal);
+	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifierLocal);
 	// Delete asset
 	DeleteAsset(AssetSystem, assetCollection, Asset);
 

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -2170,7 +2170,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, ThirdPartyPackagedAssetIdentifierTe
 	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifier);
 	EXPECT_EQ(Assets[0].ThirdPartyPlatformType, csp::systems::EThirdPartyPlatform::UNITY);
 
-	Assets[0].SetThirdPartyPackagedAssetIdentifier(ThirdPartyPackagedAssetIdentifierLocal);
+	Assets[0].ThirdPartyPackagedAssetIdentifier = ThirdPartyPackagedAssetIdentifierLocal;
 	EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifierLocal);
 	// Delete asset
 	DeleteAsset(AssetSystem, assetCollection, Asset);


### PR DESCRIPTION
To make the Asset class a full DTO, change the methods to properties. This will help simplify the C# Foundation layer & memory management wrapping.