### PR TITLE
[OB-3939] fix: Passing tags as nullptr no longer resets tags

### DIFF
--- a/Library/include/CSP/Systems/Spaces/Space.h
+++ b/Library/include/CSP/Systems/Spaces/Space.h
@@ -299,6 +299,7 @@ class CSP_API SpaceMetadataResult : public csp::systems::ResultBase
 
 public:
 	const csp::common::Map<csp::common::String, csp::common::String>& GetMetadata() const;
+	const csp::common::Array<csp::common::String>& GetTags() const;
 
 	CSP_NO_EXPORT
 	SpaceMetadataResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode) : csp::systems::ResultBase(ResCode, HttpResCode) {};
@@ -309,8 +310,10 @@ private:
 	SpaceMetadataResult() {};
 
 	void SetMetadata(const csp::common::Map<csp::common::String, csp::common::String>& MetadataAssetCollection);
+	void SetTags(const csp::common::Array<csp::common::String>& TagsAssetCollection);
 
 	csp::common::Map<csp::common::String, csp::common::String> Metadata;
+	csp::common::Array<csp::common::String> Tags;
 };
 
 
@@ -328,6 +331,7 @@ class CSP_API SpacesMetadataResult : public csp::systems::ResultBase
 
 public:
 	const csp::common::Map<csp::common::String, csp::common::Map<csp::common::String, csp::common::String>>& GetMetadata() const;
+	const csp::common::Map<csp::common::String, csp::common::Array<csp::common::String>>& GetTags() const;
 
 private:
 	SpacesMetadataResult(void*) {};
@@ -335,8 +339,10 @@ private:
 	SpacesMetadataResult() {};
 
 	void SetMetadata(const csp::common::Map<csp::common::String, csp::common::Map<csp::common::String, csp::common::String>>& InMetadata);
+	void SetTags(const csp::common::Map<csp::common::String, csp::common::Array<csp::common::String>>& InTags);
 
 	csp::common::Map<csp::common::String, csp::common::Map<csp::common::String, csp::common::String>> Metadata;
+	csp::common::Map<csp::common::String, csp::common::Array<csp::common::String>> Tags;
 };
 
 

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -264,7 +264,8 @@ public:
 	/// @brief Updates the Space metadata information with the new one provided
 	/// @param SpaceId csp::common::String : ID of Space for which the metadata will be updated
 	/// @param NewMetadata csp::common::String : New metadata information that will replace the previous one
-	/// @param Tags csp::common::Array<csp::common::String : optional array of strings to replace the tags in the metadata
+	/// @param Tags csp::common::Array<csp::common::String> : Array of strings that will replace the tags on the space. If unset, the existing tags on
+	/// the AssetCollection will be unmodified.
 	/// @param Callback NullResultCallback : callback when asynchronous task finishes
 	CSP_ASYNC_RESULT void UpdateSpaceMetadata(const csp::common::String& SpaceId,
 											  const csp::common::Map<csp::common::String, csp::common::String>& NewMetadata,

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -438,8 +438,12 @@ void AssetSystem::UpdateAssetCollectionMetadata(const AssetCollection& AssetColl
 												const Optional<Array<String>>& Tags,
 												AssetCollectionResultCallback Callback)
 {
-	auto PrototypeInfo
-		= CreatePrototypeDto(AssetCollection.SpaceId, AssetCollection.ParentId, AssetCollection.Name, NewMetadata, AssetCollection.Type, Tags);
+	auto PrototypeInfo = CreatePrototypeDto(AssetCollection.SpaceId,
+											AssetCollection.ParentId,
+											AssetCollection.Name,
+											NewMetadata,
+											AssetCollection.Type,
+											Tags.HasValue() ? Tags : AssetCollection.Tags);
 
 	services::ResponseHandlerPtr ResponseHandler
 		= PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);

--- a/Library/src/Systems/Spaces/Space.cpp
+++ b/Library/src/Systems/Spaces/Space.cpp
@@ -290,9 +290,19 @@ const Map<String, String>& SpaceMetadataResult::GetMetadata() const
 	return Metadata;
 }
 
+const Array<String>& SpaceMetadataResult::GetTags() const
+{
+	return Tags;
+}
+
 void SpaceMetadataResult::SetMetadata(const Map<String, String>& InMetadata)
 {
 	Metadata = InMetadata;
+}
+
+void SpaceMetadataResult::SetTags(const Array<String>& InTags)
+{
+	Tags = InTags;
 }
 
 Array<String>& PendingInvitesResult::GetPendingInvitesEmails()
@@ -333,9 +343,19 @@ const Map<String, Map<String, String>>& SpacesMetadataResult::GetMetadata() cons
 	return Metadata;
 }
 
+const Map<String, Array<String>>& SpacesMetadataResult::GetTags() const
+{
+	return Tags;
+}
+
 void SpacesMetadataResult::SetMetadata(const Map<String, Map<String, String>>& InMetadata)
 {
 	Metadata = InMetadata;
+}
+
+void SpacesMetadataResult::SetTags(const Map<String, Array<String>>& InTags)
+{
+	Tags = InTags;
 }
 
 const bool SpaceGeoLocationResult::HasSpaceGeoLocation() const

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -1044,6 +1044,7 @@ void SpaceSystem::GetSpacesMetadata(const Array<String>& SpaceIds, SpacesMetadat
 		if (Result.GetResultCode() == EResultCode::Success)
 		{
 			Map<String, Map<String, String>> SpacesMetadata;
+			Map<String, Array<String>> SpacesTags;
 			const auto& AssetCollections = Result.GetAssetCollections();
 
 			for (int i = 0; i < AssetCollections.Size(); ++i)
@@ -1053,9 +1054,11 @@ void SpaceSystem::GetSpacesMetadata(const Array<String>& SpaceIds, SpacesMetadat
 				auto SpaceId = SpaceSystemHelpers::GetSpaceIdFromMetadataAssetCollectionName(AssetCollection.Name);
 
 				SpacesMetadata[SpaceId] = systems::SpaceSystemHelpers::LegacyAssetConversion(AssetCollection);
+				SpacesTags[SpaceId]		= AssetCollection.Tags;
 			}
 
 			InternalResult.SetMetadata(SpacesMetadata);
+			InternalResult.SetTags(SpacesTags);
 		}
 
 		INVOKE_IF_NOT_NULL(Callback, InternalResult);
@@ -1084,6 +1087,7 @@ void SpaceSystem::GetSpaceMetadata(const String& SpaceId, SpaceMetadataResultCal
 			const auto& AssetCollection = Result.GetAssetCollection();
 
 			InternalResult.SetMetadata(systems::SpaceSystemHelpers::LegacyAssetConversion(AssetCollection));
+			InternalResult.SetTags(AssetCollection.Tags);
 		}
 
 		INVOKE_IF_NOT_NULL(Callback, InternalResult);


### PR DESCRIPTION
- Passing the optional tags parameter as nullptr to UpdateSpaceMetadata now leaves the tags unchanged instead of resetting them.
- Add a getter/setter for tags in SpaceMetadataResult[s]Callback
- Add test cases to ensure non-regression