### PR TITLE
[OB-3643] fix: update callbacks

### DIFF
--- a/Library/src/Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.cpp
@@ -63,7 +63,7 @@ EM_BOOL onSocketError(int EventType, const EmscriptenWebSocketErrorEvent *Websoc
 
 	auto WebSocketClient = static_cast<CSPWebSocketClientEmscripten *>(UserData);
 
-	if (WebSocketClient->getReceiveCallback())
+	if (WebSocketClient->getReceiveCallback() && *WebSocketClient->getReceiveCallback())
 	{
 		(*WebSocketClient->getReceiveCallback())("", false);
 	}
@@ -77,7 +77,7 @@ EM_BOOL onSocketClosed(int EventType, const EmscriptenWebSocketCloseEvent *Webso
 
 	auto WebSocketClient = static_cast<CSPWebSocketClientEmscripten *>(UserData);
 
-	if (WebSocketClient->getReceiveCallback())
+	if (WebSocketClient->getReceiveCallback() && *WebSocketClient->getReceiveCallback())
 	{
 		(*WebSocketClient->getReceiveCallback())("", false);
 	}


### PR DESCRIPTION
This PR is created as a reference and isn't intended to be the final fix for this issue.

When the multiplayer connection fails, the callback is returned on a separate thread, which is unsupported in wasm builds. This PR ensures that the callbacks are called on the main thread.

It also fixes issues with unbound std::functions being called.