### PR TITLE
[NT-0] doc: Update example tenant from FOUNDATION_HELLO_WORLD to CSP_HELLO_WORLD

### DIFF
--- a/Examples/Basic Framework/Web/index.js
+++ b/Examples/Basic Framework/Web/index.js
@@ -21,7 +21,7 @@ import {
 const ENDPOINT = "https://ogs.magnopus-stg.cloud";
 
 // Tenant defines the application scope.
-const TENANT = "FOUNDATION_HELLO_WORLD";
+const TENANT = "CSP_HELLO_WORLD";
 
 // Desired email / password combination to run the tests.
 const EMAIL = "";

--- a/Examples/Initialising Foundation/CPlusPlus/InitialisingFoundation/InitialisingFoundation/InitialisingFoundation.cpp
+++ b/Examples/Initialising Foundation/CPlusPlus/InitialisingFoundation/InitialisingFoundation/InitialisingFoundation.cpp
@@ -11,7 +11,7 @@
 using namespace std;
 
 
-const oly_common::String Tenant = "FOUNDATION_HELLO_WORLD";
+const oly_common::String Tenant = "CSP_HELLO_WORLD";
 
 
 int main()

--- a/Examples/Initialising Foundation/Web/index.js
+++ b/Examples/Initialising Foundation/Web/index.js
@@ -7,7 +7,7 @@ import {
 const ENDPOINT = "https://ogs.magnopus-stg.cloud";
 
 // Tenant defines the application scope.
-const TENANT = "FOUNDATION_HELLO_WORLD";
+const TENANT = "CSP_HELLO_WORLD";
 
 const runInitialisingCSPExample = () => {
   // If we should use debug version of Connected Spaces Platform (CSP).


### PR DESCRIPTION
CHS got in touch asking us to stop using the FOUNDATION_HELLO_WORLD tenant.
I'd been using it to repro a bug, having started from the web example.

The foundation tenant only appears in a few of our examples.

Update to CSP_HELLO_WORLD, which CHS recommends instead now. We shouldn't have the term "Foundation" in our docs anyhow.