### PR TITLE
[OF-1471] test: Integrate multiplayer test runner with Tests project

### DIFF
--- a/MultiplayerTestRunner/include/ProcessDescriptors.h
+++ b/MultiplayerTestRunner/include/ProcessDescriptors.h
@@ -24,50 +24,54 @@ namespace MultiplayerTestRunner::ProcessDescriptors
  * Process descriptors are emitted in stdout. The string will be emitted followed by a newline.
  * These are intended to be used by invoking processes to manage when they conduct their test assertions.
  * These may be disabled by setting the `--descriptors` flag in the CLI.
+ * It's important that you don't output these strings to the stream except in the correct places, and
+ * definitely not more than once per process. Be careful with debug logging.
  */
 
 /*
  * Emitted when the test has completed its setup and is ready for any controlling process to run tests
  * assertions. This is the main one you'll want to use.
  */
-constexpr const char* READY_FOR_ASSERTIONS_DESCRIPTOR = "READY_FOR_ASSERTIONS";
+constexpr const char* READY_FOR_ASSERTIONS_DESCRIPTOR = "READY_FOR_ASSERTIONS_DESCRIPTOR";
 
 /*
  *  Emitted when the test has logged in.
  */
-constexpr const char* LOGGED_IN_DESCRIPTOR = "LOGGED_IN";
+constexpr const char* LOGGED_IN_DESCRIPTOR = "LOGGED_IN_DESCRIPTOR";
 
 /*
  * Emitted when the test has logged out. Logout may not be emitted if process is terminated.
  */
-constexpr const char* LOGGED_OUT_DESCRIPTOR = "LOGGED_OUT";
+constexpr const char* LOGGED_OUT_DESCRIPTOR = "LOGGED_OUT_DESCRIPTOR";
 
 /*
  * Emitted when a new space is created. Not always emitted as existing space may be
  * specified for use via the `--space` CLI param.
  */
-constexpr const char* CREATED_SPACE_DESCRIPTOR = "CREATED_SPACE";
+constexpr const char* CREATED_SPACE_DESCRIPTOR = "CREATED_SPACE_DESCRIPTOR";
 
 /*
  * Emitted during cleanup when a space is deleted. Will not be emitted if the `--space` CLI param was used to
- * specify a custom space, as cleanup is not performed in that instance. Room cleanup may not be emitted if
+ * specify a custom space, as cleanup is not performed in that instance. Space cleanup may not be emitted if
  * process is terminated.
  */
-constexpr const char* DESTROYED_SPACE_DESCRIPTOR = "DESTROYED_SPACE";
+constexpr const char* DESTROYED_SPACE_DESCRIPTOR = "DESTROYED_SPACE_DESCRIPTOR";
 
 /*
  * Emitted when a logged in user joins a space
  */
-constexpr const char* JOINED_SPACE_DESCRIPTOR = "JOINED_SPACE";
+constexpr const char* JOINED_SPACE_DESCRIPTOR = "JOINED_SPACE_DESCRIPTOR";
 
 /*
  * Emitted when a user leaves a space
  */
-constexpr const char* EXIT_SPACE_DESCRIPTOR = "LEFT_SPACE";
+constexpr const char* EXIT_SPACE_DESCRIPTOR = "EXIT_SPACE_DESCRIPTOR";
 
-// This method exists just to encode the decision about there always being a newline.
+// This method exists to encode the decision about there always being a newline,
+// as well as to make sure we flush, which we need to do when using stdout as
+// an async channel of communication.
 inline void PrintProcessDescriptor(const char* Descriptor)
 {
-	std::cout << Descriptor << "\n";
+	std::cout << Descriptor << "\n" << std::flush;
 }
 } // namespace MultiplayerTestRunner::ProcessDescriptors

--- a/MultiplayerTestRunner/include/TestIdentifiers.h
+++ b/MultiplayerTestRunner/include/TestIdentifiers.h
@@ -15,9 +15,31 @@
  */
 
 #pragma once
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+
+namespace
+{
+
+/*
+ * Construct a new string from the input that is lower cased (via std::tolower)
+ */
+std::string ToLowerCaseString(const std::string& input)
+{
+	std::string output = input;
+	std::transform(input.cbegin(),
+				   input.cend(),
+				   output.begin(),
+				   [](const unsigned char c)
+				   {
+					   return std::tolower(c);
+				   });
+	return output;
+}
+
+} // namespace
 
 namespace MultiplayerTestRunner::TestIdentifiers
 {
@@ -61,7 +83,7 @@ inline TestIdentifier StringToTestIdentifier(std::string identifier)
 						   TestIdentifierStringMap.end(),
 						   [&identifier](const auto& pair)
 						   {
-							   return Utils::ToLowerCaseString(pair.second) == Utils::ToLowerCaseString(identifier);
+							   return ToLowerCaseString(pair.second) == ToLowerCaseString(identifier);
 						   });
 
 	if (it != TestIdentifierStringMap.end())

--- a/MultiplayerTestRunner/premake5.lua
+++ b/MultiplayerTestRunner/premake5.lua
@@ -42,7 +42,6 @@ if not MultiplayerTestRunner then
 			   
 		 -- Conditionally link google test, not the standard _d stuff so we need to do it per config
 	   filter "configurations:*Debug*"
-		  defines { "RUN_MULTIPLAYER_RUNNER_TESTS" } -- Run tests by default in debug configs
 		  links { "gtestd_md" } -- Debug versions
 		  libdirs {"%{wks.location}/ThirdParty/googletest/lib/%{cfg.platform}/Debug"}
 		  staticruntime "off"

--- a/MultiplayerTestRunner/src/Utils.cpp
+++ b/MultiplayerTestRunner/src/Utils.cpp
@@ -84,17 +84,4 @@ void InitialiseCSPWithUserAgentInfo(const csp::common::String& EndpointRootURI)
 	csp::CSPFoundation::SetClientUserAgentInfo(ClientHeaderInfo);
 }
 
-std::string ToLowerCaseString(const std::string& input)
-{
-	std::string output = input;
-	std::transform(input.cbegin(),
-				   input.cend(),
-				   output.begin(),
-				   [](const unsigned char c)
-				   {
-					   return std::tolower(c);
-				   });
-	return output;
-}
-
 } // namespace Utils

--- a/MultiplayerTestRunner/src/Utils.h
+++ b/MultiplayerTestRunner/src/Utils.h
@@ -78,11 +78,6 @@ TestAccountCredentials LoadTestAccountCredentials();
  */
 void InitialiseCSPWithUserAgentInfo(const csp::common::String& EndpointRootURI);
 
-/*
- * Construct a new string from the input that is lower cased (via std::tolower)
- */
-std::string ToLowerCaseString(const std::string& input);
-
 constexpr char* DEFAULT_TEST_ENDPOINT			= "https://ogs-internal.magnopus-dev.cloud";
 constexpr int DEFAULT_TIMEOUT_IN_SECONDS		= 30;
 constexpr bool DEFAULT_EMIT_PROCESS_DESCRIPTORS = true;

--- a/Tests/premake5.lua
+++ b/Tests/premake5.lua
@@ -25,6 +25,8 @@ if not Tests then
             "%{prj.location}/src",
             "%{wks.location}/ThirdParty/googletest/include",
             "%{wks.location}/ThirdParty/uuid-v4",
+			"%{wks.location}/ThirdParty/tiny-process-library/install/include",
+			"%{wks.location}/MultiplayerTestRunner/include"
         }   
         
         debugdir "%{prj.location}\\Binaries\\%{cfg.platform}\\%{cfg.buildcfg}"
@@ -133,6 +135,7 @@ if not Tests then
             }
         filter {}
 
+		links { "%{wks.location}/ThirdParty/tiny-process-library/install/lib/tiny-process-library" }
             
         filter "configurations:*DLL*"
             links {
@@ -161,12 +164,16 @@ if not Tests then
         -- The tests project depend on ConnectedSpacesPlatform first finishing in order to be able to guarantee the DLLs exist before we copy them
         -- NOTE: This will slow builds down as it effectively means we need to build ConnectedSpacesPlatform twice in a linear fashion, so we need to address this in a better manner long-term.
         dependson {"ConnectedSpacesPlatform"}
-            
+		-- We call the multiplayer test runner in our tests
+		dependson {"MultiplayerTestRunner"}
+
         filter "platforms:x64"
             postbuildcommands {
-                "{COPY} %{wks.location}\\Library\\Binaries\\%{cfg.platform}\\%{cfg.buildcfg}\\ %{cfg.buildtarget.directory}"
+                "{COPY} %{wks.location}\\Library\\Binaries\\%{cfg.platform}\\%{cfg.buildcfg}\\ %{cfg.buildtarget.directory}", -- CSP
+				"{COPY} %{wks.location}\\MultiplayerTestRunner\\Binaries\\%{cfg.platform}\\%{cfg.buildcfg}\\ %{cfg.buildtarget.directory}" --MultiplayerTestRunner
             }
         filter {}
+
     end
 end
 

--- a/Tests/src/InternalTests/MultiplayerTestRunnerProcessTests.cpp
+++ b/Tests/src/InternalTests/MultiplayerTestRunnerProcessTests.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SKIP_INTERNAL_TESTS
+
+	#include "MultiplayerTestRunnerProcess.h"
+	#include "TestHelpers.h"
+
+	#include "gtest/gtest.h"
+
+	#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_ARG_TEST
+CSP_INTERNAL_TEST(CSPEngine, MultiplayerTestRunnerProcessTests, ArgTest)
+{
+	MultiplayerTestRunnerProcess Process(MultiplayerTestRunner::TestIdentifiers::TestIdentifier::CREATE_AVATAR);
+	EXPECT_EQ(Process.GetTestToRun(), MultiplayerTestRunner::TestIdentifiers::TestIdentifier::CREATE_AVATAR);
+	EXPECT_EQ(Process.GetInvocationArgs(), (std::vector<std::string> {"MultiplayerTestRunner", "--test", "CreateAvatar"}));
+
+	// Optional arguments have no value initially
+	EXPECT_FALSE(Process.GetLoginEmail().has_value());
+	EXPECT_FALSE(Process.GetPassword().has_value());
+	EXPECT_FALSE(Process.GetSpaceId().has_value());
+	EXPECT_FALSE(Process.GetTimeoutInSeconds().has_value());
+	EXPECT_FALSE(Process.GetEndpoint().has_value());
+
+	Process.SetLoginEmail("FakeEmail@MrMoustacheMan.com");
+	EXPECT_EQ(Process.GetLoginEmail(), std::optional<std::string> {"FakeEmail@MrMoustacheMan.com"});
+	EXPECT_EQ(Process.GetInvocationArgs(),
+			  (std::vector<std::string> {"MultiplayerTestRunner", "--test", "CreateAvatar", "--email", "FakeEmail@MrMoustacheMan.com"}));
+
+	Process.SetPassword("Hunter2");
+	EXPECT_EQ(Process.GetPassword(), std::optional<std::string> {"Hunter2"});
+	EXPECT_EQ(
+		Process.GetInvocationArgs(),
+		(std::vector<
+			std::string> {"MultiplayerTestRunner", "--test", "CreateAvatar", "--email", "FakeEmail@MrMoustacheMan.com", "--password", "Hunter2"}));
+
+	Process.SetSpaceId("MyFakeSpaceId");
+	EXPECT_EQ(Process.GetSpaceId(), std::optional<std::string> {"MyFakeSpaceId"});
+	EXPECT_EQ(Process.GetInvocationArgs(),
+			  (std::vector<std::string> {"MultiplayerTestRunner",
+										 "--test",
+										 "CreateAvatar",
+										 "--email",
+										 "FakeEmail@MrMoustacheMan.com",
+										 "--password",
+										 "Hunter2",
+										 "--space",
+										 "MyFakeSpaceId"}));
+
+	Process.SetTimeoutInSeconds(5);
+	EXPECT_EQ(Process.GetTimeoutInSeconds(), std::optional<int> {5});
+	EXPECT_EQ(Process.GetInvocationArgs(),
+			  (std::vector<std::string> {"MultiplayerTestRunner",
+										 "--test",
+										 "CreateAvatar",
+										 "--email",
+										 "FakeEmail@MrMoustacheMan.com",
+										 "--password",
+										 "Hunter2",
+										 "--space",
+										 "MyFakeSpaceId",
+										 "--timeout",
+										 "5"}));
+
+	Process.SetEndpoint("https://www.website.com");
+	EXPECT_EQ(Process.GetEndpoint(), std::optional<std::string> {"https://www.website.com"});
+	EXPECT_EQ(Process.GetInvocationArgs(),
+			  (std::vector<std::string> {"MultiplayerTestRunner",
+										 "--test",
+										 "CreateAvatar",
+										 "--email",
+										 "FakeEmail@MrMoustacheMan.com",
+										 "--password",
+										 "Hunter2",
+										 "--space",
+										 "MyFakeSpaceId",
+										 "--timeout",
+										 "5",
+										 "--endpoint",
+										 "https://www.website.com"}));
+}
+	#endif
+
+	#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_FUTURE_TEST
+CSP_INTERNAL_TEST(CSPEngine, MultiplayerTestRunnerProcessTests, FutureTest)
+{
+	// Actually invoke the runner and make sure the future's are all set
+	MultiplayerTestRunnerProcess Process(MultiplayerTestRunner::TestIdentifiers::TestIdentifier::CREATE_AVATAR);
+	Process.SetTimeoutInSeconds(0); // So we don't sit at ready for assertions for any real time.
+
+	Process.StartProcess();
+
+	// We need to spin up a process, login, create a space, join it, ... so we're a bit permissive with the timeouts to try and prevent flakiness.
+	auto LoggedInFutureStatus = Process.LoggedInFuture().wait_for(std::chrono::seconds(20));
+	EXPECT_EQ(LoggedInFutureStatus, std::future_status::ready);
+
+	auto JoinedSpaceFutureStatus = Process.JoinedSpaceFuture().wait_for(std::chrono::seconds(20));
+	EXPECT_EQ(JoinedSpaceFutureStatus, std::future_status::ready);
+
+	auto ReadForAssertionsFutureStatus = Process.ReadyForAssertionsFuture().wait_for(std::chrono::seconds(20));
+	EXPECT_EQ(ReadForAssertionsFutureStatus, std::future_status::ready);
+
+	auto ExitSpaceFutureStatus = Process.ExitSpaceFuture().wait_for(std::chrono::seconds(20));
+	EXPECT_EQ(ExitSpaceFutureStatus, std::future_status::ready);
+
+	auto LoggedOutFutureStatus = Process.LoggedOutFuture().wait_for(std::chrono::seconds(20));
+	EXPECT_EQ(LoggedOutFutureStatus, std::future_status::ready);
+}
+	#endif
+
+#endif

--- a/Tests/src/MultiplayerTestRunnerProcess.cpp
+++ b/Tests/src/MultiplayerTestRunnerProcess.cpp
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MultiplayerTestRunnerProcess.h"
+
+#include "ProcessDescriptors.h"
+#include "process.hpp"
+
+MultiplayerTestRunnerProcess::MultiplayerTestRunnerProcess(MultiplayerTestRunner::TestIdentifiers::TestIdentifier _TestToRun) : TestToRun(_TestToRun)
+{
+}
+
+MultiplayerTestRunnerProcess ::~MultiplayerTestRunnerProcess()
+{
+	/* (EM) I'm still a little worried about windows nonsenses with this testing approach.
+	 * You cannot simply force kill a process on Windows, there's umpteen things that can lock it.
+	 * TinyProcessLib makes a good attempt to handle edge cases, but I'm still nervous.
+	 * With our (currently, 2025) sketchy CI configuration, we should keep an eye on this.
+	 * I'd be much less concerned if our CI runners were built from the ground up each time, then
+	 * zombie processes couldn't accumulate even if windows gets huffy sometimes. */
+	TerminateProcess();
+}
+
+MultiplayerTestRunnerProcess::MultiplayerTestRunnerProcess(const MultiplayerTestRunnerProcess& other)
+	: TestToRun(other.TestToRun)
+	, LoginEmail(other.LoginEmail)
+	, Password(other.Password)
+	, SpaceId(other.SpaceId)
+	, TimeoutInSeconds(other.TimeoutInSeconds)
+	, Endpoint(other.Endpoint)
+{
+}
+
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::operator=(const MultiplayerTestRunnerProcess& other)
+{
+	if (this != &other)
+	{
+		MultiplayerTestRunnerProcess swapping(other);
+		std::swap(*this, swapping);
+	}
+	return *this;
+}
+
+MultiplayerTestRunnerProcess::MultiplayerTestRunnerProcess(MultiplayerTestRunnerProcess&& other)
+	: LoggedInPromise(std::exchange(other.LoggedInPromise, std::promise<void>()))
+	, JoinedSpacePromise(std::exchange(other.JoinedSpacePromise, std::promise<void>()))
+	, ReadyForAssertionsPromise(std::exchange(other.ReadyForAssertionsPromise, std::promise<void>()))
+	, ExitSpacePromise(std::exchange(other.ExitSpacePromise, std::promise<void>()))
+	, LoggedOutPromise(std::exchange(other.LoggedOutPromise, std::promise<void>()))
+	, TestToRun(other.TestToRun)
+	, LoginEmail(std::exchange(other.LoginEmail, std::optional<std::string>()))
+	, Password(std::exchange(other.Password, std::optional<std::string>()))
+	, SpaceId(std::exchange(other.SpaceId, std::optional<std::string>()))
+	, TimeoutInSeconds(std::exchange(other.TimeoutInSeconds, std::optional<int>()))
+	, Endpoint(std::exchange(other.Endpoint, std::optional<std::string>()))
+	, ProcessHandle(std::exchange(other.ProcessHandle, nullptr))
+{
+}
+
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::operator=(MultiplayerTestRunnerProcess&& other)
+{
+	if (this != &other)
+	{
+		// Steal the juicy internals, whilst being nice and resetting the moved-from object to a sensible state.
+		this->LoggedInPromise			= std::exchange(other.LoggedInPromise, std::promise<void>());
+		this->JoinedSpacePromise		= std::exchange(other.JoinedSpacePromise, std::promise<void>());
+		this->ReadyForAssertionsPromise = std::exchange(other.ReadyForAssertionsPromise, std::promise<void>());
+		this->ExitSpacePromise			= std::exchange(other.ExitSpacePromise, std::promise<void>());
+		this->LoggedOutPromise			= std::exchange(other.LoggedOutPromise, std::promise<void>());
+
+		this->TestToRun = other.TestToRun;
+
+		this->LoginEmail	   = std::exchange(other.LoginEmail, std::optional<std::string>());
+		this->Password		   = std::exchange(other.Password, std::optional<std::string>());
+		this->SpaceId		   = std::exchange(other.SpaceId, std::optional<std::string>());
+		this->TimeoutInSeconds = std::exchange(other.TimeoutInSeconds, std::optional<int>());
+		this->Endpoint		   = std::exchange(other.Endpoint, std::optional<std::string>());
+
+		this->ProcessHandle = std::exchange(other.ProcessHandle, nullptr);
+	}
+	return *this;
+}
+
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetLoginEmail(std::string LoginEmail)
+{
+	this->LoginEmail = std::move(LoginEmail);
+	return *this;
+}
+
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetPassword(std::string Password)
+{
+	this->Password = std::move(Password);
+	return *this;
+}
+
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetSpaceId(std::string SpaceId)
+{
+	this->SpaceId = std::move(SpaceId);
+	return *this;
+}
+
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetTimeoutInSeconds(int TimeoutInSeconds)
+{
+	this->TimeoutInSeconds = TimeoutInSeconds;
+	return *this;
+}
+
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetEndpoint(std::string Endpoint)
+{
+	this->Endpoint = std::move(Endpoint);
+	return *this;
+}
+
+namespace
+{
+/* Construct the CLI arguments to pass to MultiplayerTestRunner with spawning a TinyProcessLib::Process*/
+std::vector<std::string> BuildProcessArgList(MultiplayerTestRunner::TestIdentifiers::TestIdentifier TestToRun,
+											 std::optional<std::string> LoginEmail,
+											 std::optional<std::string> Password,
+											 std::optional<std::string> SpaceId,
+											 std::optional<int> TimeoutInSeconds,
+											 std::optional<std::string> Endpoint)
+{
+	std::vector<std::string> CLIArgs;
+
+	/* The multiplayer test runner application is copied to the active directory
+	as a post build command, so we just call it directly*/
+	CLIArgs.push_back("MultiplayerTestRunner");
+	CLIArgs.push_back("--test");
+	CLIArgs.push_back(MultiplayerTestRunner::TestIdentifiers::TestIdentifierToString(TestToRun));
+
+	if (LoginEmail.has_value())
+	{
+		CLIArgs.push_back("--email");
+		CLIArgs.push_back(LoginEmail.value());
+	}
+
+	if (Password.has_value())
+	{
+		CLIArgs.push_back("--password");
+		CLIArgs.push_back(Password.value());
+	}
+
+	if (SpaceId.has_value())
+	{
+		CLIArgs.push_back("--space");
+		CLIArgs.push_back(SpaceId.value());
+	}
+
+	if (TimeoutInSeconds.has_value())
+	{
+		CLIArgs.push_back("--timeout");
+		CLIArgs.push_back(std::to_string(TimeoutInSeconds.value()));
+	}
+
+	if (Endpoint.has_value())
+	{
+		CLIArgs.push_back("--endpoint");
+		CLIArgs.push_back(Endpoint.value());
+	}
+
+	return CLIArgs;
+}
+
+bool ContainsStr(const std::string& ContainingString, const std::string& ContainedString)
+{
+	auto findR = ContainingString.find(ContainedString);
+	return findR != std::string::npos;
+}
+
+} // namespace
+
+MultiplayerTestRunner::TestIdentifiers::TestIdentifier MultiplayerTestRunnerProcess::GetTestToRun() const
+{
+	return TestToRun;
+}
+
+std::optional<std::string> MultiplayerTestRunnerProcess::GetLoginEmail() const
+{
+	return LoginEmail;
+}
+
+std::optional<std::string> MultiplayerTestRunnerProcess::GetPassword() const
+{
+	return Password;
+}
+
+std::optional<std::string> MultiplayerTestRunnerProcess::GetSpaceId() const
+{
+	return SpaceId;
+}
+
+std::optional<int> MultiplayerTestRunnerProcess::GetTimeoutInSeconds() const
+{
+	return TimeoutInSeconds;
+}
+
+std::optional<std::string> MultiplayerTestRunnerProcess::GetEndpoint() const
+{
+	return Endpoint;
+}
+
+std::vector<std::string> MultiplayerTestRunnerProcess::GetInvocationArgs() const
+{
+	return BuildProcessArgList(TestToRun, LoginEmail, Password, SpaceId, TimeoutInSeconds, Endpoint);
+}
+
+void MultiplayerTestRunnerProcess::StartProcess()
+{
+	std::vector<std::string> InvocationArgs = BuildProcessArgList(TestToRun, LoginEmail, Password, SpaceId, TimeoutInSeconds, Endpoint);
+
+	// Be a bit loud in the output, I think this warrants special mention when test output is being displayed.
+	std::cout << "Launching Multiplayer Test Runner Process with Test: " << MultiplayerTestRunner::TestIdentifiers::TestIdentifierToString(TestToRun)
+			  << std::endl;
+
+	/* Start the MultiplayerTestRunner process with provided CLI args
+	   The way this works is by registering callbacks for stdout and stderr streams.
+	   In the stdout stream, we check for the existence of the process descriptors, and
+	   toggle the appropriate promises. The callbacks are async, so beware!
+	   Don't assume that one cout in the MultiplayerTestRunner translates to one call
+	   of the callback, I've observed they can be batched, probably an OS thing. */
+	ProcessHandle = std::make_unique<TinyProcessLib::Process>(
+		std::move(InvocationArgs),
+		"",
+		[this](const char* bytes, size_t n)
+		{
+			// STDOUT
+			std::string StdOutStr = std::string(bytes, n);
+			// You might want to put std::cout << StdOutStr << std::endl; here when debugging.
+
+			if (ContainsStr(StdOutStr, MultiplayerTestRunner::ProcessDescriptors::LOGGED_IN_DESCRIPTOR))
+			{
+				LoggedInPromise.set_value();
+			}
+
+			if (ContainsStr(StdOutStr, MultiplayerTestRunner::ProcessDescriptors::JOINED_SPACE_DESCRIPTOR))
+			{
+				JoinedSpacePromise.set_value();
+			}
+
+			if (ContainsStr(StdOutStr, MultiplayerTestRunner::ProcessDescriptors::READY_FOR_ASSERTIONS_DESCRIPTOR))
+			{
+				ReadyForAssertionsPromise.set_value();
+			}
+
+			if (ContainsStr(StdOutStr, MultiplayerTestRunner::ProcessDescriptors::EXIT_SPACE_DESCRIPTOR))
+			{
+				ExitSpacePromise.set_value();
+			}
+
+			if (ContainsStr(StdOutStr, MultiplayerTestRunner::ProcessDescriptors::LOGGED_OUT_DESCRIPTOR))
+			{
+				LoggedOutPromise.set_value();
+			}
+		},
+		[](const char* bytes, size_t n)
+		{
+			// STDERR
+			std::string StdErrStr = std::string(bytes, n);
+			std::cout << StdErrStr << "\n";
+			throw std::runtime_error(StdErrStr);
+		});
+}
+
+void MultiplayerTestRunnerProcess::TerminateProcess()
+{
+	if (ProcessHandle != nullptr)
+	{
+		std::cout << "Terminating Multiplayer Test Runner Process." << std::endl;
+		ProcessHandle->kill();
+		ProcessHandle = nullptr;
+	}
+}
+
+std::future<void> MultiplayerTestRunnerProcess::LoggedInFuture()
+{
+	return LoggedInPromise.get_future();
+}
+std::future<void> MultiplayerTestRunnerProcess::JoinedSpaceFuture()
+{
+	return JoinedSpacePromise.get_future();
+}
+std::future<void> MultiplayerTestRunnerProcess::ReadyForAssertionsFuture()
+{
+	return ReadyForAssertionsPromise.get_future();
+}
+std::future<void> MultiplayerTestRunnerProcess::ExitSpaceFuture()
+{
+	return ExitSpacePromise.get_future();
+}
+std::future<void> MultiplayerTestRunnerProcess::LoggedOutFuture()
+{
+	return LoggedOutPromise.get_future();
+}

--- a/Tests/src/MultiplayerTestRunnerProcess.h
+++ b/Tests/src/MultiplayerTestRunnerProcess.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+
+#include "TestIdentifiers.h"
+
+#include <future>
+#include <memory>
+#include <optional>
+
+namespace TinyProcessLib
+{
+class Process;
+}
+
+/*
+ * Invokes the MultiplayerTestRunner, built as a prerequisite to the tests project
+ * as a process (CLI invocation) via tiny-process-library.
+ * Parses the stdout of MultiplayerTestClient, and provides a future async
+ * interface to allow users to know when the off-process test has reached
+ * certain points, as specified by the process descriptors.
+ *
+ * WARNING: Using this will necessarily add a lot of realtime overhead to your
+ * test functions, it takes a good 5-10 seconds for processes to spin up and
+ * become ready. Use this sparingly, and account for runtime fluctuations to
+ * prevent undue flakiness.
+ */
+class MultiplayerTestRunnerProcess
+{
+public:
+	MultiplayerTestRunnerProcess(MultiplayerTestRunner::TestIdentifiers::TestIdentifier _TestToRun);
+	~MultiplayerTestRunnerProcess();
+
+	/* Copying this object copies all the configuration data, but does nothing
+	   about the process. You still need to call `StartProcess` to start
+	   a new process, even if you copied from an already running process. */
+	MultiplayerTestRunnerProcess(const MultiplayerTestRunnerProcess& other);
+	MultiplayerTestRunnerProcess& operator=(const MultiplayerTestRunnerProcess& other);
+
+	/* Moving steals all the internals, so any already running process stays running. */
+	MultiplayerTestRunnerProcess(MultiplayerTestRunnerProcess&& other);
+	MultiplayerTestRunnerProcess& operator=(MultiplayerTestRunnerProcess&& other);
+
+	/* Chained methods (fluent interface pattern) to set the parameters.
+	   All of these are optional.
+	   Reminder that if either login or password is not found, then the
+	   MultiplayerTestRunner will attempt to look for a credentials file.
+	   If a space is not specified, the MultiplayerTestRunner makes a
+	   temporary one. You'll almost certainly want to specify a spaceID
+	   when doing multi-client tests, or you'll get lots of clients in
+	   isolated spaces.
+	   */
+	MultiplayerTestRunnerProcess& SetLoginEmail(std::string Email);
+	MultiplayerTestRunnerProcess& SetPassword(std::string Password);
+	MultiplayerTestRunnerProcess& SetSpaceId(std::string SpaceId);
+	MultiplayerTestRunnerProcess& SetTimeoutInSeconds(int TimeoutInSeconds);
+	MultiplayerTestRunnerProcess& SetEndpoint(std::string Endpoint);
+
+	/* Getters. Mostly for testing, but handy.
+	   Return null optionals if values have not been set. */
+	MultiplayerTestRunner::TestIdentifiers::TestIdentifier GetTestToRun() const;
+	std::optional<std::string> GetLoginEmail() const;
+	std::optional<std::string> GetPassword() const;
+	std::optional<std::string> GetSpaceId() const;
+	std::optional<int> GetTimeoutInSeconds() const;
+	std::optional<std::string> GetEndpoint() const;
+
+	/* Return the vector of strings that will be used to invoke the multiplayer test runner.
+	   Depending on what values you've set, will look something like :
+	   {"MultiplayerTestRunner", "--test", "CreateAvatar", "--timeout", "10"} */
+	std::vector<std::string> GetInvocationArgs() const;
+
+	/* Invoke the process with the provided parameters */
+	void StartProcess();
+
+	/* Hard terminate the process. This happens in destruction anyway,
+	   but this method provided to support alternate styles. */
+	void TerminateProcess();
+
+	/* You can acquire the future that the process desriptor
+	   promises via these methods.
+	   We set the promise when we parse the appropriate
+	   process descriptor when it is recieved through stdout. */
+	std::future<void> LoggedInFuture();
+	std::future<void> JoinedSpaceFuture();
+	std::future<void> ReadyForAssertionsFuture();
+	std::future<void> ExitSpaceFuture();
+	std::future<void> LoggedOutFuture();
+
+private:
+	// These promises set via parsing stdout for process descriptors.
+	std::promise<void> LoggedInPromise;
+	std::promise<void> JoinedSpacePromise;
+	std::promise<void> ReadyForAssertionsPromise;
+	std::promise<void> ExitSpacePromise;
+	std::promise<void> LoggedOutPromise;
+
+	// The test we are telling the multiplayer test runner to invoke. Set on construction. Non-optional.
+	MultiplayerTestRunner::TestIdentifiers::TestIdentifier TestToRun;
+
+	// Optional parameters, MultiplayerTestRunner has default behaviour if not set
+	std::optional<std::string> LoginEmail;
+	std::optional<std::string> Password;
+	std::optional<std::string> SpaceId;
+	std::optional<int> TimeoutInSeconds;
+	std::optional<std::string> Endpoint;
+
+	// Created in StartProcess
+	std::unique_ptr<TinyProcessLib::Process> ProcessHandle = nullptr;
+};

--- a/ThirdParty/tiny-process-library/.clang-format
+++ b/ThirdParty/tiny-process-library/.clang-format
@@ -1,0 +1,9 @@
+IndentWidth: 2
+AccessModifierOffset: -2
+UseTab: Never
+ColumnLimit: 0
+MaxEmptyLinesToKeep: 2
+SpaceBeforeParens: Never
+BreakBeforeBraces: Custom
+BraceWrapping: {BeforeElse: true, BeforeCatch: true}
+NamespaceIndentation: None

--- a/ThirdParty/tiny-process-library/.gitignore
+++ b/ThirdParty/tiny-process-library/.gitignore
@@ -1,0 +1,51 @@
+# https://github.com/github/gitignore/blob/master/CMake.gitignore
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Makefile
+cmake_install.cmake
+install_manifest.txt
+*.cmake
+#Additions to https://github.com/github/gitignore/blob/master/CMake.gitignore
+Testing
+compile_commands.json
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+examples
+tpl_io_test
+tpl_multithread_test
+tpl_open_close_test
+io_test
+
+# Commonly used build directory
+build
+install
+
+io_test_stdout.txt

--- a/ThirdParty/tiny-process-library/.gitlab-ci.yml
+++ b/ThirdParty/tiny-process-library/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+image: eidheim/testing
+
+before_script:
+  - mkdir build && cd build
+  - export CXXFLAGS=-Werror
+  - export CTEST_OUTPUT_ON_FAILURE=1
+
+test:
+  script:
+    - scan-build-6.0 cmake .. && scan-build-6.0 --status-bugs make
+    - rm -r *
+    - CXX=clang++-6.0 cmake .. && make
+    - rm -r *
+    - CXX=g++ cmake .. && make && make test

--- a/ThirdParty/tiny-process-library/CMakeLists.txt
+++ b/ThirdParty/tiny-process-library/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(tiny-process-library)
+
+if(CMAKE_SOURCE_DIR STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  option(BUILD_TESTING "set ON to build library tests" ON)
+else()
+  option(BUILD_TESTING "set ON to build library tests" OFF)
+endif()
+
+add_library(tiny-process-library process.cpp)
+add_library(tiny-process-library::tiny-process-library ALIAS tiny-process-library)
+
+if(MSVC)
+  target_compile_definitions(tiny-process-library PRIVATE /D_CRT_SECURE_NO_WARNINGS)
+else()
+  target_compile_options(tiny-process-library PRIVATE -std=c++11 -Wall -Wextra)
+endif()
+
+if(WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  target_sources(tiny-process-library PRIVATE process_win.cpp)
+  #If compiled using MSYS2, use sh to run commands
+  if(MSYS)
+    target_compile_definitions(tiny-process-library PUBLIC MSYS_PROCESS_USE_SH)
+  endif()
+else()
+  target_sources(tiny-process-library PRIVATE process_unix.cpp)
+endif()
+
+find_package(Threads REQUIRED)
+
+target_link_libraries(tiny-process-library Threads::Threads)
+target_include_directories(tiny-process-library PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                                                       $<INSTALL_INTERFACE:include>)
+
+# if tiny-process-library is not a sub-project:
+if(CMAKE_SOURCE_DIR STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  if(MSVC)
+    add_definitions(/D_CRT_SECURE_NO_WARNINGS)
+  else()
+    add_compile_options(-std=c++11 -Wall -Wextra)
+  endif()
+
+  add_executable(examples examples.cpp)
+  target_link_libraries(examples tiny-process-library)
+
+  install(TARGETS tiny-process-library
+    EXPORT ${PROJECT_NAME}-config
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
+
+  install(EXPORT ${PROJECT_NAME}-config
+    FILE ${PROJECT_NAME}-config.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION lib/cmake/${PROJECT_NAME}
+  )
+
+  install(FILES process.hpp DESTINATION include)
+endif()
+
+if(BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/ThirdParty/tiny-process-library/LICENSE
+++ b/ThirdParty/tiny-process-library/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2020 Ole Christian Eidheim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/ThirdParty/tiny-process-library/README.md
+++ b/ThirdParty/tiny-process-library/README.md
@@ -1,0 +1,42 @@
+# tiny-process-library
+A small platform independent library making it simple to create and stop new processes in C++, as well as writing to stdin and reading from stdout and stderr of a new process.
+
+This library was created for, and is used by the C++ IDE project [juCi++](https://gitlab.com/cppit/jucipp).
+
+### Features
+* No external dependencies
+* Simple to use
+* Platform independent
+  * Creating processes using executables is supported on all platforms
+  * Creating processes using functions is only possible on Unix-like systems
+* Read separately from stdout and stderr using anonymous functions
+* Write to stdin
+* Kill a running process (SIGTERM is supported on Unix-like systems)
+* Correctly closes file descriptors/handles
+
+### Usage
+See [examples.cpp](examples.cpp).
+
+### Get, compile and run
+
+#### Unix-like systems
+```sh
+git clone http://gitlab.com/eidheim/tiny-process-library
+cd tiny-process-library
+mkdir build
+cd build
+cmake ..
+make
+./examples
+```
+
+#### Windows with MSYS2 (https://msys2.github.io/)
+```sh
+git clone http://gitlab.com/eidheim/tiny-process-library
+cd tiny-process-library
+mkdir build
+cd build
+cmake -G"MSYS Makefiles" ..
+make
+./examples
+```

--- a/ThirdParty/tiny-process-library/examples.cpp
+++ b/ThirdParty/tiny-process-library/examples.cpp
@@ -1,0 +1,234 @@
+#include "process.hpp"
+#include <iostream>
+
+using namespace std;
+using namespace TinyProcessLib;
+
+int main() {
+#if !defined(_WIN32) || defined(MSYS_PROCESS_USE_SH)
+  // The following examples are for Unix-like systems and Windows through MSYS2
+
+
+  cout << "Example 1a - the mandatory Hello World through a command" << endl;
+  Process process1a("echo Hello World", "", [](const char *bytes, size_t n) {
+    cout << "Output from stdout: " << string(bytes, n);
+  });
+  auto exit_status = process1a.get_exit_status();
+  cout << "Example 1a process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 1b - Hello World using arguments" << endl;
+  Process process1b(vector<string>{"/bin/echo", "Hello", "World"}, "", [](const char *bytes, size_t n) {
+    cout << "Output from stdout: " << string(bytes, n);
+  });
+  exit_status = process1b.get_exit_status();
+  cout << "Example 1b process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+#ifndef _WIN32
+  cout << endl
+       << "Example 1c - Hello World through a function on Unix-like systems" << endl;
+  Process process1c(
+      [] {
+        cout << "Hello World" << endl;
+        exit(0);
+      },
+      [](const char *bytes, size_t n) {
+        cout << "Output from stdout: " << string(bytes, n);
+      });
+  exit_status = process1c.get_exit_status();
+  cout << "Example 1c process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+#endif
+
+
+  cout << endl
+       << "Example 2 - cd into a nonexistent directory" << endl;
+  Process process2(
+      "cd a_nonexistent_directory", "",
+      [](const char *bytes, size_t n) {
+        cout << "Output from stdout: " << string(bytes, n);
+      },
+      [](const char *bytes, size_t n) {
+        cout << "Output from stderr: " << string(bytes, n);
+        // Add a newline for prettier output on some platforms:
+        if(bytes[n - 1] != '\n')
+          cout << endl;
+      });
+  exit_status = process2.get_exit_status();
+  cout << "Example 2 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 3 - async sleep process" << endl;
+  thread thread3([]() {
+    Process process3("sleep 2");
+    auto exit_status = process3.get_exit_status();
+    cout << "Example 3 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  });
+  thread3.detach();
+  this_thread::sleep_for(chrono::seconds(4));
+
+
+  cout << endl
+       << "Example 4 - killing async sleep process after 2 seconds" << endl;
+  auto process4 = make_shared<Process>("sleep 4");
+  thread thread4([process4]() {
+    auto exit_status = process4->get_exit_status();
+    cout << "Example 4 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  });
+  thread4.detach();
+  this_thread::sleep_for(chrono::seconds(2));
+  process4->kill();
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 5 - multiple commands, stdout and stderr" << endl;
+  Process process5(
+      "echo Hello && ls an_incorrect_path", "",
+      [](const char *bytes, size_t n) {
+        cout << "Output from stdout: " << string(bytes, n);
+      },
+      [](const char *bytes, size_t n) {
+        cout << "Output from stderr: " << string(bytes, n);
+        // Add a newline for prettier output on some platforms:
+        if(bytes[n - 1] != '\n')
+          cout << endl;
+      });
+  exit_status = process5.get_exit_status();
+  cout << "Example 5 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 6 - run bash with input from stdin" << endl;
+  Process process6(
+      "bash", "",
+      [](const char *bytes, size_t n) {
+        cout << "Output from stdout: " << string(bytes, n);
+      },
+      nullptr, true);
+  process6.write("echo Hello from bash\n");
+  process6.write("exit\n");
+  exit_status = process6.get_exit_status();
+  cout << "Example 6 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 7 - send data to cat through stdin" << endl;
+  Process process7(
+      "cat", "",
+      [](const char *bytes, size_t n) {
+        cout << "Output from stdout: " << string(bytes, n);
+      },
+      nullptr, true);
+  process7.write("Hello cat\n");
+  process7.close_stdin();
+  exit_status = process7.get_exit_status();
+  cout << "Example 7 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 8 - demonstrates Process::try_get_exit_status" << endl;
+  Process process8("sleep 3");
+  while(!process8.try_get_exit_status(exit_status)) {
+    cout << "Example 8 process is running" << endl;
+    this_thread::sleep_for(chrono::seconds(1));
+  }
+  cout << "Example 8 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 9 - launch with different environment" << endl;
+  Process process9("printenv", "", {{"VAR1", "value1"}, {"VAR2", "second value"}}, [](const char *bytes, size_t n) {
+    std::cout << std::string{bytes, n};
+  });
+  exit_status = process9.get_exit_status();
+  cout << "Example 9 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 10 - launch with normal environment" << endl;
+  Process process10("printenv", "", [](const char *bytes, size_t n) {
+    std::cout << std::string{bytes, n};
+  });
+  exit_status = process10.get_exit_status();
+  cout << "Example 10 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+
+
+#else
+  // Examples for Windows without MSYS2
+
+
+  cout << "Example 1 - the mandatory Hello World" << endl;
+  Process process1("cmd /C echo Hello World", "", [](const char *bytes, size_t n) {
+    cout << "Output from stdout: " << string(bytes, n);
+  });
+  auto exit_status = process1.get_exit_status();
+  cout << "Example 1 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 2 - cd into a nonexistent directory" << endl;
+  Process process2(
+      "cmd /C cd a_nonexistent_directory", "",
+      [](const char *bytes, size_t n) {
+        cout << "Output from stdout: " << string(bytes, n);
+      },
+      [](const char *bytes, size_t n) {
+        cout << "Output from stderr: " << string(bytes, n);
+        // Add a newline for prettier output on some platforms:
+        if(bytes[n - 1] != '\n')
+          cout << endl;
+      });
+  exit_status = process2.get_exit_status();
+  cout << "Example 2 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 3 - async sleep process" << endl;
+  thread thread3([]() {
+    Process process3("timeout 2");
+    auto exit_status = process3.get_exit_status();
+    cout << "Example 3 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  });
+  thread3.detach();
+  this_thread::sleep_for(chrono::seconds(4));
+
+
+  cout << endl
+       << "Example 4 - killing async sleep process after 2 seconds" << endl;
+  auto process4 = make_shared<Process>("timeout 4");
+  thread thread4([process4]() {
+    auto exit_status = process4->get_exit_status();
+    cout << "Example 4 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+  });
+  thread4.detach();
+  this_thread::sleep_for(chrono::seconds(2));
+  process4->kill();
+  this_thread::sleep_for(chrono::seconds(2));
+
+
+  cout << endl
+       << "Example 5 - demonstrates Process::try_get_exit_status" << endl;
+  Process process5("timeout 3");
+  while(!process5.try_get_exit_status(exit_status)) {
+    cout << "Example 5 process is running" << endl;
+    this_thread::sleep_for(chrono::seconds(1));
+  }
+  cout << "Example 5 process returned: " << exit_status << " (" << (exit_status == 0 ? "success" : "failure") << ")" << endl;
+
+
+#endif
+}

--- a/ThirdParty/tiny-process-library/process.cpp
+++ b/ThirdParty/tiny-process-library/process.cpp
@@ -1,0 +1,55 @@
+#include "process.hpp"
+
+namespace TinyProcessLib {
+
+Process::Process(const std::vector<string_type> &arguments, const string_type &path,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(arguments, path);
+  async_read();
+}
+
+Process::Process(const string_type &command, const string_type &path,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(command, path);
+  async_read();
+}
+
+Process::Process(const std::vector<string_type> &arguments, const string_type &path,
+                 const environment_type &environment,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(arguments, path, &environment);
+  async_read();
+}
+
+Process::Process(const string_type &command, const string_type &path,
+                 const environment_type &environment,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(command, path, &environment);
+  async_read();
+}
+
+Process::~Process() noexcept {
+  close_fds();
+}
+
+Process::id_type Process::get_id() const noexcept {
+  return data.id;
+}
+
+bool Process::write(const std::string &str) {
+  return write(str.c_str(), str.size());
+}
+
+} // namespace TinyProcessLib

--- a/ThirdParty/tiny-process-library/process.hpp
+++ b/ThirdParty/tiny-process-library/process.hpp
@@ -1,0 +1,184 @@
+#ifndef TINY_PROCESS_LIBRARY_HPP_
+#define TINY_PROCESS_LIBRARY_HPP_
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
+namespace TinyProcessLib {
+/// Additional parameters to Process constructors.
+struct Config {
+  /// Buffer size for reading stdout and stderr. Default is 131072 (128 kB).
+  std::size_t buffer_size = 131072;
+  /// Set to true to inherit file descriptors from parent process. Default is false.
+  /// On Windows: has no effect unless read_stdout==nullptr, read_stderr==nullptr and open_stdin==false.
+  bool inherit_file_descriptors = false;
+
+  /// If set, invoked when process stdout is closed.
+  /// This call goes after last call to read_stdout().
+  std::function<void()> on_stdout_close = nullptr;
+  /// If set, invoked when process stderr is closed.
+  /// This call goes after last call to read_stderr().
+  std::function<void()> on_stderr_close = nullptr;
+
+  /// On Windows only: controls how the process is started, mimics STARTUPINFO's wShowWindow.
+  /// See: https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+  /// and https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-showwindow
+  enum class ShowWindow {
+    hide = 0,
+    show_normal = 1,
+    show_minimized = 2,
+    maximize = 3,
+    show_maximized = 3,
+    show_no_activate = 4,
+    show = 5,
+    minimize = 6,
+    show_min_no_active = 7,
+    show_na = 8,
+    restore = 9,
+    show_default = 10,
+    force_minimize = 11
+  };
+  /// On Windows only: controls how the window is shown.
+  ShowWindow show_window{ShowWindow::show_default};
+
+  /// Set to true to break out of flatpak sandbox by prepending all commands with `/usr/bin/flatpak-spawn --host`
+  /// which will execute the command line on the host system.
+  /// Requires the flatpak `org.freedesktop.Flatpak` portal to be opened for the current sandbox.
+  /// See https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn.
+  bool flatpak_spawn_host = false;
+};
+
+/// Platform independent class for creating processes.
+/// Note on Windows: it seems not possible to specify which pipes to redirect.
+/// Thus, at the moment, if read_stdout==nullptr, read_stderr==nullptr and open_stdin==false,
+/// the stdout, stderr and stdin are sent to the parent process instead.
+class Process {
+public:
+#ifdef _WIN32
+  typedef unsigned long id_type; // Process id type
+  typedef void *fd_type;         // File descriptor type
+#ifdef UNICODE
+  typedef std::wstring string_type;
+#else
+  typedef std::string string_type;
+#endif
+#else
+  typedef pid_t id_type;
+  typedef int fd_type;
+  typedef std::string string_type;
+#endif
+  typedef std::unordered_map<string_type, string_type> environment_type;
+
+private:
+  class Data {
+  public:
+    Data() noexcept;
+    id_type id;
+#ifdef _WIN32
+    void *handle{nullptr};
+#endif
+    int exit_status{-1};
+  };
+
+public:
+  /// Starts a process with the environment of the calling process.
+  Process(const std::vector<string_type> &arguments, const string_type &path = string_type(),
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+  /// Starts a process with the environment of the calling process.
+  Process(const string_type &command, const string_type &path = string_type(),
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+
+  /// Starts a process with specified environment.
+  Process(const std::vector<string_type> &arguments,
+          const string_type &path,
+          const environment_type &environment,
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+  /// Starts a process with specified environment.
+  Process(const string_type &command,
+          const string_type &path,
+          const environment_type &environment,
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+#ifndef _WIN32
+  /// Starts a process with the environment of the calling process.
+  /// Supported on Unix-like systems only.
+  /// Since the command line is not known to the Process object itself,
+  /// this overload does not support the flatpak_spawn_host configuration.
+  Process(const std::function<void()> &function,
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {});
+#endif
+  ~Process() noexcept;
+
+  /// Get the process id of the started process.
+  id_type get_id() const noexcept;
+  /// Wait until process is finished, and return exit status.
+  int get_exit_status() noexcept;
+  /// If process is finished, returns true and sets the exit status. Returns false otherwise.
+  bool try_get_exit_status(int &exit_status) noexcept;
+  /// Write to stdin.
+  bool write(const char *bytes, size_t n);
+  /// Write to stdin. Convenience function using write(const char *, size_t).
+  bool write(const std::string &str);
+  /// Close stdin. If the process takes parameters from stdin, use this to notify that all parameters have been sent.
+  void close_stdin() noexcept;
+
+  /// Kill the process. force=true is only supported on Unix-like systems.
+  void kill(bool force = false) noexcept;
+  /// Kill a given process id. Use kill(bool force) instead if possible. force=true is only supported on Unix-like systems.
+  static void kill(id_type id, bool force = false) noexcept;
+#ifndef _WIN32
+  /// Send the signal signum to the process.
+  void signal(int signum) noexcept;
+#endif
+
+private:
+  Data data;
+  bool closed;
+  std::mutex close_mutex;
+  std::function<void(const char *bytes, size_t n)> read_stdout;
+  std::function<void(const char *bytes, size_t n)> read_stderr;
+#ifndef _WIN32
+  std::thread stdout_stderr_thread;
+#else
+  std::thread stdout_thread, stderr_thread;
+#endif
+  bool open_stdin;
+  std::mutex stdin_mutex;
+
+  Config config;
+
+  std::unique_ptr<fd_type> stdout_fd, stderr_fd, stdin_fd;
+
+  id_type open(const std::vector<string_type> &arguments, const string_type &path, const environment_type *environment = nullptr) noexcept;
+  id_type open(const string_type &command, const string_type &path, const environment_type *environment = nullptr) noexcept;
+#ifndef _WIN32
+  id_type open(const std::function<void()> &function) noexcept;
+#endif
+  void async_read() noexcept;
+  void close_fds() noexcept;
+};
+
+} // namespace TinyProcessLib
+
+#endif // TINY_PROCESS_LIBRARY_HPP_

--- a/ThirdParty/tiny-process-library/process_unix.cpp
+++ b/ThirdParty/tiny-process-library/process_unix.cpp
@@ -1,0 +1,521 @@
+#include "process.hpp"
+#include <algorithm>
+#include <bitset>
+#include <cstdlib>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <set>
+#include <signal.h>
+#include <stdexcept>
+#include <string.h>
+#include <unistd.h>
+
+namespace TinyProcessLib {
+
+static int portable_execvpe(const char *file, char *const argv[], char *const envp[]) {
+#ifdef __GLIBC__
+  // Prefer native implementation.
+  return execvpe(file, argv, envp);
+#else
+  if(!file || !*file) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  if(strchr(file, '/') != nullptr) {
+    // If file contains a slash, no search is needed.
+    return execve(file, argv, envp);
+  }
+
+  const char *path = getenv("PATH");
+  char cspath[PATH_MAX + 1] = {};
+  if(!path) {
+    // If env variable is not set, use static path string.
+    confstr(_CS_PATH, cspath, sizeof(cspath));
+    path = cspath;
+  }
+
+  const size_t path_len = strlen(path);
+  const size_t file_len = strlen(file);
+
+  if(file_len > NAME_MAX) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+
+  // Indicates whether we encountered EACCESS at least once.
+  bool eacces = false;
+
+  const char *curr = nullptr;
+  const char *next = nullptr;
+
+  for(curr = path; *curr; curr = *next ? next + 1 : next) {
+    next = strchr(curr, ':');
+    if(!next) {
+      next = path + path_len;
+    }
+
+    const size_t sz = (next - curr);
+    if(sz > PATH_MAX) {
+      // Path is too long. Proceed to next path in list.
+      continue;
+    }
+
+    char exe_path[PATH_MAX + 1 + NAME_MAX + 1]; // 1 byte for slash + 1 byte for \0
+    memcpy(exe_path, curr, sz);
+    exe_path[sz] = '/';
+    memcpy(exe_path + sz + 1, file, file_len);
+    exe_path[sz + 1 + file_len] = '\0';
+
+    execve(exe_path, argv, envp);
+
+    switch(errno) {
+    case EACCES:
+      eacces = true;
+    case ENOENT:
+    case ESTALE:
+    case ENOTDIR:
+    case ENODEV:
+    case ETIMEDOUT:
+      // The errors above indicate that the executable was not found.
+      // The list of errors replicates one from glibc.
+      // In this case we proceed to next path in list.
+      break;
+
+    default:
+      // Other errors indicate that executable was found but failed
+      // to execute. In this case we return error.
+      return -1;
+    }
+  }
+
+  if(eacces) {
+    // If search failed, and at least one iteration reported EACCESS, it means
+    // that the needed executable exists but does not have suitable permissions.
+    // In this case we report EACEESS for user.
+    errno = EACCES;
+  }
+  // Otherwise we just keep last encountered errno.
+  return -1;
+#endif
+}
+
+Process::Data::Data() noexcept : id(-1) {
+}
+
+Process::Process(const std::function<void()> &function,
+                 std::function<void(const char *, size_t)> read_stdout,
+                 std::function<void(const char *, size_t)> read_stderr,
+                 bool open_stdin, const Config &config)
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  if(config.flatpak_spawn_host)
+    throw std::invalid_argument("Cannot break out of a flatpak sandbox with this overload.");
+  open(function);
+  async_read();
+}
+
+Process::id_type Process::open(const std::function<void()> &function) noexcept {
+  if(open_stdin)
+    stdin_fd = std::unique_ptr<fd_type>(new fd_type);
+  if(read_stdout)
+    stdout_fd = std::unique_ptr<fd_type>(new fd_type);
+  if(read_stderr)
+    stderr_fd = std::unique_ptr<fd_type>(new fd_type);
+
+  int stdin_p[2], stdout_p[2], stderr_p[2];
+
+  if(stdin_fd && pipe(stdin_p) != 0)
+    return -1;
+  if(stdout_fd && pipe(stdout_p) != 0) {
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    return -1;
+  }
+  if(stderr_fd && pipe(stderr_p) != 0) {
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    if(stdout_fd) {
+      close(stdout_p[0]);
+      close(stdout_p[1]);
+    }
+    return -1;
+  }
+
+  id_type pid = fork();
+
+  if(pid < 0) {
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    if(stdout_fd) {
+      close(stdout_p[0]);
+      close(stdout_p[1]);
+    }
+    if(stderr_fd) {
+      close(stderr_p[0]);
+      close(stderr_p[1]);
+    }
+    return pid;
+  }
+  else if(pid == 0) {
+    if(stdin_fd)
+      dup2(stdin_p[0], 0);
+    if(stdout_fd)
+      dup2(stdout_p[1], 1);
+    if(stderr_fd)
+      dup2(stderr_p[1], 2);
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    if(stdout_fd) {
+      close(stdout_p[0]);
+      close(stdout_p[1]);
+    }
+    if(stderr_fd) {
+      close(stderr_p[0]);
+      close(stderr_p[1]);
+    }
+
+    if(!config.inherit_file_descriptors) {
+      // Optimization on some systems: using 8 * 1024 (Debian's default _SC_OPEN_MAX) as fd_max limit
+      int fd_max = std::min(8192, static_cast<int>(sysconf(_SC_OPEN_MAX))); // Truncation is safe
+      if(fd_max < 0)
+        fd_max = 8192;
+      for(int fd = 3; fd < fd_max; fd++)
+        close(fd);
+    }
+
+    setpgid(0, 0);
+    // TODO: See here on how to emulate tty for colors: http://stackoverflow.com/questions/1401002/trick-an-application-into-thinking-its-stdin-is-interactive-not-a-pipe
+    // TODO: One solution is: echo "command;exit"|script -q /dev/null
+
+    if(function)
+      function();
+
+    _exit(EXIT_FAILURE);
+  }
+
+  if(stdin_fd)
+    close(stdin_p[0]);
+  if(stdout_fd)
+    close(stdout_p[1]);
+  if(stderr_fd)
+    close(stderr_p[1]);
+
+  if(stdin_fd)
+    *stdin_fd = stdin_p[1];
+  if(stdout_fd)
+    *stdout_fd = stdout_p[0];
+  if(stderr_fd)
+    *stderr_fd = stderr_p[0];
+
+  closed = false;
+  data.id = pid;
+  return pid;
+}
+
+Process::id_type Process::open(const std::vector<string_type> &arguments, const string_type &path, const environment_type *environment) noexcept {
+  return open([this, &arguments, &path, &environment] {
+    if(arguments.empty())
+      exit(127);
+
+    std::vector<const char *> argv_ptrs;
+
+    if(config.flatpak_spawn_host) {
+      // break out of sandbox, execute on host
+      argv_ptrs.reserve(arguments.size() + 3);
+      argv_ptrs.emplace_back("/usr/bin/flatpak-spawn");
+      argv_ptrs.emplace_back("--host");
+    }
+    else
+      argv_ptrs.reserve(arguments.size() + 1);
+
+    for(auto &argument : arguments)
+      argv_ptrs.emplace_back(argument.c_str());
+    argv_ptrs.emplace_back(nullptr);
+
+    if(!path.empty()) {
+      if(chdir(path.c_str()) != 0)
+        exit(1);
+    }
+
+    if(!environment)
+      execvp(argv_ptrs[0], const_cast<char *const *>(argv_ptrs.data()));
+    else {
+      std::vector<std::string> env_strs;
+      std::vector<const char *> env_ptrs;
+      env_strs.reserve(environment->size());
+      env_ptrs.reserve(environment->size() + 1);
+      for(const auto &e : *environment) {
+        env_strs.emplace_back(e.first + '=' + e.second);
+        env_ptrs.emplace_back(env_strs.back().c_str());
+      }
+      env_ptrs.emplace_back(nullptr);
+
+      portable_execvpe(argv_ptrs[0], const_cast<char *const *>(argv_ptrs.data()), const_cast<char *const *>(env_ptrs.data()));
+    }
+  });
+}
+
+Process::id_type Process::open(const std::string &command, const std::string &path, const environment_type *environment) noexcept {
+  return open([this, &command, &path, &environment] {
+    auto command_c_str = command.c_str();
+    std::string cd_path_and_command;
+    if(!path.empty()) {
+      auto path_escaped = path;
+      size_t pos = 0;
+      // Based on https://www.reddit.com/r/cpp/comments/3vpjqg/a_new_platform_independent_process_library_for_c11/cxsxyb7
+      while((pos = path_escaped.find('\'', pos)) != std::string::npos) {
+        path_escaped.replace(pos, 1, "'\\''");
+        pos += 4;
+      }
+      cd_path_and_command = "cd '" + path_escaped + "' && " + command; // To avoid resolving symbolic links
+      command_c_str = cd_path_and_command.c_str();
+    }
+
+    if(!environment) {
+      if(config.flatpak_spawn_host)
+        // break out of sandbox, execute on host
+        execl("/usr/bin/flatpak-spawn", "/usr/bin/flatpak-spawn", "--host", "/bin/sh", "-c", command_c_str, nullptr);
+      else
+        execl("/bin/sh", "/bin/sh", "-c", command_c_str, nullptr);
+    }
+    else {
+      std::vector<std::string> env_strs;
+      std::vector<const char *> env_ptrs;
+      env_strs.reserve(environment->size());
+      env_ptrs.reserve(environment->size() + 1);
+      for(const auto &e : *environment) {
+        env_strs.emplace_back(e.first + '=' + e.second);
+        env_ptrs.emplace_back(env_strs.back().c_str());
+      }
+      env_ptrs.emplace_back(nullptr);
+      if(config.flatpak_spawn_host)
+        // break out of sandbox, execute on host
+        execle("/usr/bin/flatpak-spawn", "/usr/bin/flatpak-spawn", "--host", "/bin/sh", "-c", command_c_str, nullptr, env_ptrs.data());
+      else
+        execle("/bin/sh", "/bin/sh", "-c", command_c_str, nullptr, env_ptrs.data());
+    }
+  });
+}
+
+void Process::async_read() noexcept {
+  if(data.id <= 0 || (!stdout_fd && !stderr_fd))
+    return;
+
+  stdout_stderr_thread = std::thread([this] {
+    std::vector<pollfd> pollfds;
+    std::bitset<2> fd_is_stdout;
+    if(stdout_fd) {
+      fd_is_stdout.set(pollfds.size());
+      pollfds.emplace_back();
+      pollfds.back().fd = fcntl(*stdout_fd, F_SETFL, fcntl(*stdout_fd, F_GETFL) | O_NONBLOCK) == 0 ? *stdout_fd : -1;
+      pollfds.back().events = POLLIN;
+    }
+    if(stderr_fd) {
+      pollfds.emplace_back();
+      pollfds.back().fd = fcntl(*stderr_fd, F_SETFL, fcntl(*stderr_fd, F_GETFL) | O_NONBLOCK) == 0 ? *stderr_fd : -1;
+      pollfds.back().events = POLLIN;
+    }
+    auto buffer = std::unique_ptr<char[]>(new char[config.buffer_size]);
+    bool any_open = !pollfds.empty();
+    while(any_open && (poll(pollfds.data(), static_cast<nfds_t>(pollfds.size()), -1) > 0 || errno == EINTR)) {
+      any_open = false;
+      for(size_t i = 0; i < pollfds.size(); ++i) {
+        if(pollfds[i].fd >= 0) {
+          if(pollfds[i].revents & POLLIN) {
+            const ssize_t n = read(pollfds[i].fd, buffer.get(), config.buffer_size);
+            if(n > 0) {
+              if(fd_is_stdout[i])
+                read_stdout(buffer.get(), static_cast<size_t>(n));
+              else
+                read_stderr(buffer.get(), static_cast<size_t>(n));
+            }
+            else if(n == 0 || (n < 0 && errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK)) {
+              if(fd_is_stdout[i]) {
+                if(config.on_stdout_close)
+                  config.on_stdout_close();
+              }
+              else {
+                if(config.on_stderr_close)
+                  config.on_stderr_close();
+              }
+              pollfds[i].fd = -1;
+              continue;
+            }
+          }
+          else if(pollfds[i].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            if(fd_is_stdout[i]) {
+              if(config.on_stdout_close)
+                config.on_stdout_close();
+            }
+            else {
+              if(config.on_stderr_close)
+                config.on_stderr_close();
+            }
+            pollfds[i].fd = -1;
+            continue;
+          }
+          any_open = true;
+        }
+      }
+    }
+  });
+}
+
+int Process::get_exit_status() noexcept {
+  if(data.id <= 0)
+    return -1;
+
+  int exit_status;
+  id_type pid;
+  do {
+    pid = waitpid(data.id, &exit_status, 0);
+  } while(pid < 0 && errno == EINTR);
+
+  if(pid < 0 && errno == ECHILD) {
+    // PID doesn't exist anymore, return previously sampled exit status (or -1)
+    return data.exit_status;
+  }
+  else {
+    // Store exit status for future calls
+    if(exit_status >= 256)
+      exit_status = exit_status >> 8;
+    data.exit_status = exit_status;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    closed = true;
+  }
+  close_fds();
+
+  return exit_status;
+}
+
+bool Process::try_get_exit_status(int &exit_status) noexcept {
+  if(data.id <= 0) {
+    exit_status = -1;
+    return true;
+  }
+
+  const id_type pid = waitpid(data.id, &exit_status, WNOHANG);
+  if(pid < 0 && errno == ECHILD) {
+    // PID doesn't exist anymore, set previously sampled exit status (or -1)
+    exit_status = data.exit_status;
+    return true;
+  }
+  else if(pid <= 0) {
+    // Process still running (p==0) or error
+    return false;
+  }
+  else {
+    // store exit status for future calls
+    if(exit_status >= 256)
+      exit_status = exit_status >> 8;
+    data.exit_status = exit_status;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    closed = true;
+  }
+  close_fds();
+
+  return true;
+}
+
+void Process::close_fds() noexcept {
+  if(stdout_stderr_thread.joinable())
+    stdout_stderr_thread.join();
+
+  if(stdin_fd)
+    close_stdin();
+  if(stdout_fd) {
+    if(data.id > 0)
+      close(*stdout_fd);
+    stdout_fd.reset();
+  }
+  if(stderr_fd) {
+    if(data.id > 0)
+      close(*stderr_fd);
+    stderr_fd.reset();
+  }
+}
+
+bool Process::write(const char *bytes, size_t n) {
+  if(!open_stdin)
+    throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
+
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    while(n != 0) {
+      const ssize_t ret = ::write(*stdin_fd, bytes, n);
+      if(ret < 0) {
+        if(errno == EINTR)
+          continue;
+        else
+          return false;
+      }
+      bytes += static_cast<size_t>(ret);
+      n -= static_cast<size_t>(ret);
+    }
+    return true;
+  }
+  return false;
+}
+
+void Process::close_stdin() noexcept {
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    if(data.id > 0)
+      close(*stdin_fd);
+    stdin_fd.reset();
+  }
+}
+
+void Process::kill(bool force) noexcept {
+  std::lock_guard<std::mutex> lock(close_mutex);
+  if(data.id > 0 && !closed) {
+    if(force) {
+      ::kill(-data.id, SIGTERM);
+      ::kill(data.id, SIGTERM); // Based on comment in https://gitlab.com/eidheim/tiny-process-library/-/merge_requests/29#note_1146144166
+    }
+    else {
+      ::kill(-data.id, SIGINT);
+      ::kill(data.id, SIGINT);
+    }
+  }
+}
+
+void Process::kill(id_type id, bool force) noexcept {
+  if(id <= 0)
+    return;
+
+  if(force) {
+    ::kill(-id, SIGTERM);
+    ::kill(id, SIGTERM);
+  }
+  else {
+    ::kill(-id, SIGINT);
+    ::kill(id, SIGINT);
+  }
+}
+
+void Process::signal(int signum) noexcept {
+  std::lock_guard<std::mutex> lock(close_mutex);
+  if(data.id > 0 && !closed) {
+    ::kill(-data.id, signum);
+    ::kill(data.id, signum);
+  }
+}
+
+} // namespace TinyProcessLib

--- a/ThirdParty/tiny-process-library/process_win.cpp
+++ b/ThirdParty/tiny-process-library/process_win.cpp
@@ -1,0 +1,424 @@
+#include "process.hpp"
+// clang-format off
+#include <windows.h>
+// clang-format on
+#include <cstring>
+#include <stdexcept>
+#include <tlhelp32.h>
+
+namespace TinyProcessLib {
+
+Process::Data::Data() noexcept : id(0) {}
+
+// Simple HANDLE wrapper to close it automatically from the destructor.
+class Handle {
+public:
+  Handle() noexcept : handle(INVALID_HANDLE_VALUE) {}
+  ~Handle() noexcept {
+    close();
+  }
+  void close() noexcept {
+    if(handle != INVALID_HANDLE_VALUE)
+      CloseHandle(handle);
+  }
+  HANDLE detach() noexcept {
+    HANDLE old_handle = handle;
+    handle = INVALID_HANDLE_VALUE;
+    return old_handle;
+  }
+  operator HANDLE() const noexcept { return handle; }
+  HANDLE *operator&() noexcept { return &handle; }
+
+private:
+  HANDLE handle;
+};
+
+template <class Char>
+struct CharSet;
+
+template <>
+struct CharSet<char> {
+  static constexpr const char *whitespace = " \t\n\v\"";
+  static constexpr char space = ' ';
+  static constexpr char doublequote = '"';
+  static constexpr char backslash = '\\';
+};
+
+template <>
+struct CharSet<wchar_t> {
+  static constexpr const wchar_t *whitespace = L" \t\n\v\"";
+  static constexpr wchar_t space = L' ';
+  static constexpr wchar_t doublequote = L'"';
+  static constexpr wchar_t backslash = L'\\';
+};
+
+// Based on blog post https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
+template <class Char>
+static std::basic_string<Char> join_arguments(const std::vector<std::basic_string<Char>> &args) {
+  using charset = CharSet<Char>;
+
+  std::basic_string<Char> ret;
+
+  for(const auto &arg : args) {
+    if(!ret.empty())
+      ret.push_back(charset::space);
+
+    if(!arg.empty() && arg.find_first_of(charset::whitespace) == arg.npos) {
+      ret.append(arg);
+      continue;
+    }
+
+    ret.push_back(charset::doublequote);
+
+    for(auto it = arg.begin();; ++it) {
+      size_t n_backslashes = 0;
+
+      while(it != arg.end() && *it == charset::backslash) {
+        ++it;
+        ++n_backslashes;
+      }
+
+      if(it == arg.end()) {
+        // Escape all backslashes, but let the terminating double quotation mark
+        // we add below be interpreted  as a metacharacter.
+        ret.append(n_backslashes * 2, charset::backslash);
+        break;
+      }
+      else if(*it == charset::doublequote) {
+        // Escape all backslashes and the following double quotation mark.
+        ret.append(n_backslashes * 2 + 1, charset::backslash);
+        ret.push_back(*it);
+      }
+      else {
+        // Backslashes aren't special here.
+        ret.append(n_backslashes, charset::backslash);
+        ret.push_back(*it);
+      }
+    }
+
+    ret.push_back(charset::doublequote);
+  }
+
+  return ret;
+}
+
+// Based on the discussion thread: https://www.reddit.com/r/cpp/comments/3vpjqg/a_new_platform_independent_process_library_for_c11/cxq1wsj
+std::mutex create_process_mutex;
+
+Process::id_type Process::open(const std::vector<string_type> &arguments, const string_type &path, const environment_type *environment) noexcept {
+  return open(join_arguments(arguments), path, environment);
+}
+
+// Based on the example at https://msdn.microsoft.com/en-us/library/windows/desktop/ms682499(v=vs.85).aspx.
+Process::id_type Process::open(const string_type &command, const string_type &path, const environment_type *environment) noexcept {
+  if(open_stdin)
+    stdin_fd = std::unique_ptr<fd_type>(new fd_type(nullptr));
+  if(read_stdout)
+    stdout_fd = std::unique_ptr<fd_type>(new fd_type(nullptr));
+  if(read_stderr)
+    stderr_fd = std::unique_ptr<fd_type>(new fd_type(nullptr));
+
+  Handle stdin_rd_p;
+  Handle stdin_wr_p;
+  Handle stdout_rd_p;
+  Handle stdout_wr_p;
+  Handle stderr_rd_p;
+  Handle stderr_wr_p;
+
+  SECURITY_ATTRIBUTES security_attributes;
+
+  security_attributes.nLength = sizeof(SECURITY_ATTRIBUTES);
+  security_attributes.bInheritHandle = TRUE;
+  security_attributes.lpSecurityDescriptor = nullptr;
+
+  std::lock_guard<std::mutex> lock(create_process_mutex);
+  if(stdin_fd) {
+    if(!CreatePipe(&stdin_rd_p, &stdin_wr_p, &security_attributes, 0) ||
+       !SetHandleInformation(stdin_wr_p, HANDLE_FLAG_INHERIT, 0))
+      return 0;
+  }
+  if(stdout_fd) {
+    if(!CreatePipe(&stdout_rd_p, &stdout_wr_p, &security_attributes, 0) ||
+       !SetHandleInformation(stdout_rd_p, HANDLE_FLAG_INHERIT, 0)) {
+      return 0;
+    }
+  }
+  if(stderr_fd) {
+    if(!CreatePipe(&stderr_rd_p, &stderr_wr_p, &security_attributes, 0) ||
+       !SetHandleInformation(stderr_rd_p, HANDLE_FLAG_INHERIT, 0)) {
+      return 0;
+    }
+  }
+
+  PROCESS_INFORMATION process_info;
+  STARTUPINFO startup_info;
+
+  ZeroMemory(&process_info, sizeof(PROCESS_INFORMATION));
+
+  ZeroMemory(&startup_info, sizeof(STARTUPINFO));
+  startup_info.cb = sizeof(STARTUPINFO);
+  startup_info.hStdInput = stdin_rd_p;
+  startup_info.hStdOutput = stdout_wr_p;
+  startup_info.hStdError = stderr_wr_p;
+  if(stdin_fd || stdout_fd || stderr_fd)
+    startup_info.dwFlags |= STARTF_USESTDHANDLES;
+
+  if(config.show_window != Config::ShowWindow::show_default) {
+    startup_info.dwFlags |= STARTF_USESHOWWINDOW;
+    startup_info.wShowWindow = static_cast<WORD>(config.show_window);
+  }
+
+  auto process_command = command;
+#ifdef MSYS_PROCESS_USE_SH
+  size_t pos = 0;
+  while((pos = process_command.find('\\', pos)) != string_type::npos) {
+    process_command.replace(pos, 1, "\\\\\\\\");
+    pos += 4;
+  }
+  pos = 0;
+  while((pos = process_command.find('\"', pos)) != string_type::npos) {
+    process_command.replace(pos, 1, "\\\"");
+    pos += 2;
+  }
+  process_command.insert(0, "sh -c \"");
+  process_command += "\"";
+#endif
+
+  DWORD creation_flags = stdin_fd || stdout_fd || stderr_fd ? CREATE_NO_WINDOW : 0; // CREATE_NO_WINDOW cannot be used when stdout or stderr is redirected to parent process
+  string_type environment_str;
+  if(environment) {
+#ifdef UNICODE
+    for(const auto &e : *environment)
+      environment_str += e.first + L'=' + e.second + L'\0';
+    if(!environment_str.empty())
+      environment_str += L'\0';
+    creation_flags |= CREATE_UNICODE_ENVIRONMENT;
+#else
+    for(const auto &e : *environment)
+      environment_str += e.first + '=' + e.second + '\0';
+    if(!environment_str.empty())
+      environment_str += '\0';
+#endif
+  }
+  BOOL bSuccess = CreateProcess(nullptr, process_command.empty() ? nullptr : &process_command[0], nullptr, nullptr,
+                                stdin_fd || stdout_fd || stderr_fd || config.inherit_file_descriptors, // Cannot be false when stdout, stderr or stdin is used
+                                creation_flags,
+                                environment_str.empty() ? nullptr : &environment_str[0],
+                                path.empty() ? nullptr : path.c_str(),
+                                &startup_info, &process_info);
+
+  if(!bSuccess)
+    return 0;
+  else
+    CloseHandle(process_info.hThread);
+
+  if(stdin_fd)
+    *stdin_fd = stdin_wr_p.detach();
+  if(stdout_fd)
+    *stdout_fd = stdout_rd_p.detach();
+  if(stderr_fd)
+    *stderr_fd = stderr_rd_p.detach();
+
+  closed = false;
+  data.id = process_info.dwProcessId;
+  data.handle = process_info.hProcess;
+  return process_info.dwProcessId;
+}
+
+void Process::async_read() noexcept {
+  if(data.id == 0)
+    return;
+
+  if(stdout_fd) {
+    stdout_thread = std::thread([this]() {
+      DWORD n;
+      std::unique_ptr<char[]> buffer(new char[config.buffer_size]);
+      for(;;) {
+        BOOL bSuccess = ReadFile(*stdout_fd, static_cast<CHAR *>(buffer.get()), static_cast<DWORD>(config.buffer_size), &n, nullptr);
+        if(!bSuccess || n == 0) {
+          if(config.on_stdout_close)
+            config.on_stdout_close();
+          break;
+        }
+        read_stdout(buffer.get(), static_cast<size_t>(n));
+      }
+    });
+  }
+  if(stderr_fd) {
+    stderr_thread = std::thread([this]() {
+      DWORD n;
+      std::unique_ptr<char[]> buffer(new char[config.buffer_size]);
+      for(;;) {
+        BOOL bSuccess = ReadFile(*stderr_fd, static_cast<CHAR *>(buffer.get()), static_cast<DWORD>(config.buffer_size), &n, nullptr);
+        if(!bSuccess || n == 0) {
+          if(config.on_stderr_close)
+            config.on_stderr_close();
+          break;
+        }
+        read_stderr(buffer.get(), static_cast<size_t>(n));
+      }
+    });
+  }
+}
+
+int Process::get_exit_status() noexcept {
+  if(data.id == 0)
+    return -1;
+
+  if(!data.handle)
+    return data.exit_status;
+
+  WaitForSingleObject(data.handle, INFINITE);
+
+  DWORD exit_status;
+  if(!GetExitCodeProcess(data.handle, &exit_status))
+    data.exit_status = -1; // Store exit status for future calls
+  else
+    data.exit_status = static_cast<int>(exit_status); // Store exit status for future calls
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    CloseHandle(data.handle);
+    data.handle = nullptr;
+    closed = true;
+  }
+  close_fds();
+
+  return data.exit_status;
+}
+
+bool Process::try_get_exit_status(int &exit_status) noexcept {
+  if(data.id == 0) {
+    exit_status = -1;
+    return true;
+  }
+
+  if(!data.handle) {
+    exit_status = data.exit_status;
+    return true;
+  }
+
+  DWORD wait_status = WaitForSingleObject(data.handle, 0);
+  if(wait_status == WAIT_TIMEOUT)
+    return false;
+
+  DWORD exit_status_tmp;
+  if(!GetExitCodeProcess(data.handle, &exit_status_tmp))
+    exit_status = -1;
+  else
+    exit_status = static_cast<int>(exit_status_tmp);
+  data.exit_status = exit_status; // Store exit status for future calls
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    CloseHandle(data.handle);
+    data.handle = nullptr;
+    closed = true;
+  }
+  close_fds();
+
+  return true;
+}
+
+void Process::close_fds() noexcept {
+  if(stdout_thread.joinable())
+    stdout_thread.join();
+  if(stderr_thread.joinable())
+    stderr_thread.join();
+
+  if(stdin_fd)
+    close_stdin();
+  if(stdout_fd) {
+    if(*stdout_fd != nullptr)
+      CloseHandle(*stdout_fd);
+    stdout_fd.reset();
+  }
+  if(stderr_fd) {
+    if(*stderr_fd != nullptr)
+      CloseHandle(*stderr_fd);
+    stderr_fd.reset();
+  }
+}
+
+bool Process::write(const char *bytes, size_t n) {
+  if(!open_stdin)
+    throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
+
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    DWORD written;
+    BOOL bSuccess = WriteFile(*stdin_fd, bytes, static_cast<DWORD>(n), &written, nullptr);
+    if(!bSuccess || written == 0) {
+      return false;
+    }
+    else {
+      return true;
+    }
+  }
+  return false;
+}
+
+void Process::close_stdin() noexcept {
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    if(*stdin_fd != nullptr)
+      CloseHandle(*stdin_fd);
+    stdin_fd.reset();
+  }
+}
+
+// Based on http://stackoverflow.com/a/1173396
+void Process::kill(bool /*force*/) noexcept {
+  std::lock_guard<std::mutex> lock(close_mutex);
+  if(data.id > 0 && !closed) {
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if(snapshot) {
+      PROCESSENTRY32 process;
+      ZeroMemory(&process, sizeof(process));
+      process.dwSize = sizeof(process);
+      if(Process32First(snapshot, &process)) {
+        do {
+          if(process.th32ParentProcessID == data.id) {
+            HANDLE process_handle = OpenProcess(PROCESS_TERMINATE, FALSE, process.th32ProcessID);
+            if(process_handle) {
+              TerminateProcess(process_handle, 2);
+              CloseHandle(process_handle);
+            }
+          }
+        } while(Process32Next(snapshot, &process));
+      }
+      CloseHandle(snapshot);
+    }
+    TerminateProcess(data.handle, 2);
+  }
+}
+
+// Based on http://stackoverflow.com/a/1173396
+void Process::kill(id_type id, bool /*force*/) noexcept {
+  if(id == 0)
+    return;
+
+  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if(snapshot) {
+    PROCESSENTRY32 process;
+    ZeroMemory(&process, sizeof(process));
+    process.dwSize = sizeof(process);
+    if(Process32First(snapshot, &process)) {
+      do {
+        if(process.th32ParentProcessID == id) {
+          HANDLE process_handle = OpenProcess(PROCESS_TERMINATE, FALSE, process.th32ProcessID);
+          if(process_handle) {
+            TerminateProcess(process_handle, 2);
+            CloseHandle(process_handle);
+          }
+        }
+      } while(Process32Next(snapshot, &process));
+    }
+    CloseHandle(snapshot);
+  }
+  HANDLE process_handle = OpenProcess(PROCESS_TERMINATE, FALSE, id);
+  if(process_handle)
+    TerminateProcess(process_handle, 2);
+}
+
+} // namespace TinyProcessLib

--- a/ThirdParty/tiny-process-library/tests/CMakeLists.txt
+++ b/ThirdParty/tiny-process-library/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+include_directories(..)
+
+add_executable(tpl_io_test io_test.cpp)
+target_link_libraries(tpl_io_test tiny-process-library)
+add_test(tpl_io_test tpl_io_test)
+
+add_executable(tpl_open_close_test open_close_test.cpp)
+target_link_libraries(tpl_open_close_test tiny-process-library)
+add_test(tpl_open_close_test tpl_open_close_test)
+
+add_executable(tpl_multithread_test multithread_test.cpp)
+target_link_libraries(tpl_multithread_test tiny-process-library)
+add_test(tpl_multithread_test tpl_multithread_test)
+
+add_executable(tpl_path_test path_test.cpp)
+target_link_libraries(tpl_path_test tiny-process-library)
+add_test(tpl_path_test tpl_path_test)

--- a/ThirdParty/tiny-process-library/tests/io_test.cpp
+++ b/ThirdParty/tiny-process-library/tests/io_test.cpp
@@ -1,0 +1,274 @@
+#include "process.hpp"
+#include <atomic>
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+using namespace std;
+using namespace TinyProcessLib;
+
+int main() {
+  auto output = make_shared<string>();
+  auto error = make_shared<string>();
+  auto eof = make_shared<std::atomic<int>>(0);
+  {
+    Process process("echo Test", "", [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    output->clear();
+  }
+
+  {
+    freopen("io_test_stdout.txt", "w", stdout);
+    Process process("echo Test");
+    assert(process.get_exit_status() == 0);
+    stringstream ss;
+    ifstream ifs("io_test_stdout.txt");
+    ss << ifs.rdbuf();
+    assert(ss.str().substr(0, 4) == "Test");
+  }
+
+  {
+    Process process(std::vector<string>{"/bin/echo", "Test"}, "", [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    output->clear();
+  }
+
+  {
+    Process process(std::vector<string>{"/bin/echo", "Test"}, "", {{"VAR1", "value1"}, {"VAR2", "value2"}}, [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    output->clear();
+  }
+
+  {
+    Config config;
+    Process process(
+        std::vector<string>{"echo", "Test"}, "", [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        },
+        nullptr, false, config);
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    output->clear();
+  }
+
+#ifndef _WIN32
+  {
+    Process process("pwd", "/usr", [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "/usr");
+    output->clear();
+  }
+
+  {
+    Process process(std::vector<string>{"/bin/pwd"}, "/usr", [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "/usr");
+    output->clear();
+  }
+
+  {
+    Process process(std::vector<string>{"/bin/sh", "-c", "echo $VAR1 $VAR2"}, "", {{"VAR1", "value1"}, {"VAR2", "value2"}}, [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 13) == "value1 value2");
+    output->clear();
+  }
+
+  {
+    Process process("while true; do sleep 10000; done");
+    int exit_status;
+    assert(!process.try_get_exit_status(exit_status));
+    process.kill();
+    assert(process.get_exit_status() != 0);
+  }
+
+  {
+    Process process(
+        [] {
+          cout << "Test" << endl;
+          exit(0);
+        },
+        [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    output->clear();
+  }
+  {
+    Config config;
+    config.buffer_size = 4;
+    Process process(
+        std::vector<string>{"printf", "Hello, world!\nHi, there!"}, {}, [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        },
+        nullptr, false, config);
+    assert(process.get_exit_status() == 0);
+    assert(*output == "Hello, world!\nHi, there!");
+    output->clear();
+  }
+#endif
+
+  {
+    Process process("ls an_incorrect_path", "", nullptr, [error](const char *bytes, size_t n) {
+      *error += string(bytes, n);
+    });
+    assert(process.get_exit_status() > 0);
+    assert(!error->empty());
+    error->clear();
+  }
+
+  {
+    Process process(
+        "echo Test && ls an_incorrect_path", "",
+        [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        },
+        [error](const char *bytes, size_t n) {
+          *error += string(bytes, n);
+        });
+    assert(process.get_exit_status() > 0);
+    assert(output->substr(0, 4) == "Test");
+    assert(!error->empty());
+    output->clear();
+    error->clear();
+  }
+
+  {
+    Config config;
+    config.on_stdout_close = [eof]() {
+      ++*eof;
+    };
+    Process process(
+        std::vector<string>{"/bin/echo", "Test"}, "", [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        },
+        nullptr, false, config);
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    assert(*eof == 1);
+    output->clear();
+    *eof = 0;
+  }
+
+  {
+    Config config;
+    config.on_stderr_close = [eof]() {
+      ++*eof;
+    };
+    Process process(
+        "ls an_incorrect_path", "", nullptr, [error](const char *bytes, size_t n) {
+          *error += string(bytes, n);
+        },
+        false, config);
+    assert(process.get_exit_status() > 0);
+    assert(!error->empty());
+    assert(*eof == 1);
+    error->clear();
+    *eof = 0;
+  }
+
+  {
+    Config config;
+    config.on_stdout_close = [eof]() {
+      ++*eof;
+    };
+    config.on_stderr_close = [eof]() {
+      ++*eof;
+    };
+    Process process(
+        "echo Test && ls an_incorrect_path", "",
+        [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        },
+        [error](const char *bytes, size_t n) {
+          *error += string(bytes, n);
+        },
+        false, config);
+    assert(process.get_exit_status() > 0);
+    assert(output->substr(0, 4) == "Test");
+    assert(!error->empty());
+    assert(*eof == 2);
+    output->clear();
+    error->clear();
+    *eof = 0;
+  }
+
+  {
+    Process process(
+        "bash", "",
+        [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        },
+        nullptr, true);
+    process.write("echo Test\n");
+    process.write("exit\n");
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    output->clear();
+  }
+
+  {
+    Process process(
+        "cat", "",
+        [output](const char *bytes, size_t n) {
+          *output += string(bytes, n);
+        },
+        nullptr, true);
+    process.write("Test\n");
+    process.close_stdin();
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 4) == "Test");
+    output->clear();
+  }
+
+  {
+    Process process("sleep 5");
+    int exit_status = -2;
+    assert(!process.try_get_exit_status(exit_status));
+    assert(exit_status == -2);
+    this_thread::sleep_for(chrono::seconds(3));
+    assert(!process.try_get_exit_status(exit_status));
+    assert(exit_status == -2);
+    this_thread::sleep_for(chrono::seconds(5));
+    assert(process.try_get_exit_status(exit_status));
+    assert(exit_status == 0);
+    assert(process.try_get_exit_status(exit_status));
+    assert(exit_status == 0);
+  }
+
+  {
+    Process process("echo $VAR1 $VAR2", "", {{"VAR1", "value1"}, {"VAR2", "value2"}}, [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 13) == "value1 value2");
+    output->clear();
+  }
+
+  {
+    Process process("echo $VAR1 $VAR2", "", {{"VAR1", "value1 value2"}, {"VAR2", "\"value3 value 4\""}}, [output](const char *bytes, size_t n) {
+      *output += string(bytes, n);
+    });
+    assert(process.get_exit_status() == 0);
+    assert(output->substr(0, 30) == "value1 value2 \"value3 value 4\"");
+    output->clear();
+  }
+}

--- a/ThirdParty/tiny-process-library/tests/multithread_test.cpp
+++ b/ThirdParty/tiny-process-library/tests/multithread_test.cpp
@@ -1,0 +1,48 @@
+#include "process.hpp"
+#include <atomic>
+#include <iostream>
+#include <vector>
+
+using namespace std;
+using namespace TinyProcessLib;
+
+int main() {
+  atomic<bool> stdout_error(false);
+  atomic<bool> exit_status_error(false);
+  vector<thread> threads;
+  for(size_t ct = 0; ct < 4; ct++) {
+    threads.emplace_back([&stdout_error, &exit_status_error, ct]() {
+      for(size_t c = 0; c < 1000; c++) {
+        Process process(
+            "echo Hello World " + to_string(c) + " " + to_string(ct), "",
+            [&stdout_error, ct, c](const char *bytes, size_t n) {
+              if(string(bytes, n) != "Hello World " + to_string(c) + " " + to_string(ct) + "\n")
+                stdout_error = true;
+            },
+            [](const char *, size_t) {},
+            true);
+        auto exit_status = process.get_exit_status();
+        if(exit_status != 0)
+          exit_status_error = true;
+        if(exit_status_error)
+          return;
+        if(stdout_error)
+          return;
+      }
+    });
+  }
+
+  for(auto &thread : threads)
+    thread.join();
+
+  if(stdout_error) {
+    cerr << "Wrong output to stdout." << endl;
+    return 1;
+  }
+  if(exit_status_error) {
+    cerr << "Process returned failure." << endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/ThirdParty/tiny-process-library/tests/open_close_test.cpp
+++ b/ThirdParty/tiny-process-library/tests/open_close_test.cpp
@@ -1,0 +1,30 @@
+#include "process.hpp"
+#include <iostream>
+
+using namespace std;
+using namespace TinyProcessLib;
+
+int main() {
+  bool stdout_error = false;
+  for(size_t c = 0; c < 4000; c++) {
+    Process process(
+        "echo Hello World " + to_string(c), "",
+        [&stdout_error, c](const char *bytes, size_t n) {
+          if(string(bytes, n) != "Hello World " + to_string(c) + "\n")
+            stdout_error = true;
+        },
+        [](const char *, size_t) {},
+        true);
+    auto exit_status = process.get_exit_status();
+    if(exit_status != 0) {
+      cerr << "Process returned failure." << endl;
+      return 1;
+    }
+    if(stdout_error) {
+      cerr << "Wrong output to stdout." << endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/ThirdParty/tiny-process-library/tests/path_test.cpp
+++ b/ThirdParty/tiny-process-library/tests/path_test.cpp
@@ -1,0 +1,119 @@
+#include "process.hpp"
+#include <cassert>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+
+using namespace std;
+using namespace TinyProcessLib;
+
+static void check(std::vector<std::string> cmd, bool ok) {
+  {
+    Process process(cmd);
+    if(ok)
+      assert(process.get_exit_status() == 0);
+    else
+      assert(process.get_exit_status() != 0);
+  }
+
+  {
+    Process process(cmd, "", Process::environment_type{});
+    if(ok)
+      assert(process.get_exit_status() == 0);
+    else
+      assert(process.get_exit_status() != 0);
+  }
+}
+
+int main() {
+#ifndef _WIN32
+  {
+    // default PATH
+    check({"echo"}, true);
+  }
+
+  {
+    // custom PATH
+    setenv("PATH", "/bin:/usr/bin", 1);
+    check({"echo"}, true);
+  }
+
+  {
+    // empty dirs in PATH
+    setenv("PATH", ":::/bin::::/usr/bin:::", 1);
+    check({"echo"}, true);
+  }
+
+  {
+    // one dir in PATH is longer than PATH_MAX
+    static char path[PATH_MAX * 3] = {};
+    for(int i = 0; i < PATH_MAX * 2; i++) {
+      strcat(path, "x");
+    }
+    strcat(path, ":/bin:/usr/bin");
+    setenv("PATH", path, 1);
+    check({"echo"}, true);
+  }
+
+  {
+    // each dir is short, but PATH in total is longer than PATH_MAX
+    static char path[PATH_MAX * 3] = {};
+    for(int i = 0; i < PATH_MAX; i++) {
+      strcat(path, "x:");
+    }
+    strcat(path, "/bin:/usr/bin");
+    setenv("PATH", path, 1);
+    check({"echo"}, true);
+  }
+
+  {
+    // PATH is not set (_CS_PATH should be used)
+    unsetenv("PATH");
+    check({"echo"}, true);
+  }
+
+  {
+    // PATH is set to ""
+    setenv("PATH", "", 1);
+    check({"echo"}, false); // ERROR
+  }
+
+  {
+    // PATH is set to empty dirs only
+    setenv("PATH", "::::", 1);
+    check({"echo"}, false); // ERROR
+  }
+
+  {
+    // PATH is set to "", but search in PATH is not needed
+    setenv("PATH", "", 1);
+    check({"/bin/echo"}, true);
+  }
+
+  {
+    // exe name is longer than NAME_MAX
+    setenv("PATH", "/bin:/usr/bin", 1);
+    std::string name;
+    for(int i = 0; i < NAME_MAX + 1; i++) {
+      name += "x";
+    }
+    check({name}, false); // ERROR
+  }
+
+  {
+    // exe name is longer than PATH_MAX
+    setenv("PATH", "/bin:/usr/bin", 1);
+    std::string name;
+    for(int i = 0; i < PATH_MAX + 1; i++) {
+      name += "x";
+    }
+    check({name}, false); // ERROR
+  }
+
+  {
+    // exe name is empty
+    setenv("PATH", "/bin:/usr/bin", 1);
+    check({""}, false); // ERROR
+  }
+#endif
+}

--- a/generate_solution.bat
+++ b/generate_solution.bat
@@ -31,9 +31,19 @@ IF NOT EXIST "modules/googletest/build/ALL_BUILD.vcxproj" (
 	cd ../../..
 )
 
+REM Tiny process library used in tests project (statically linked) to invoke multiplayer test runner.
+REM We install to thirdparty, i'm not sure this is the best idea, but i'm not sure why modules and thirdparty are split.
+IF NOT EXIST "ThirdParty/tiny-process-library/install/lib/tiny-process-library.lib" (
+	cd Thirdparty/tiny-process-library
+	mkdir build
+	call cmake -S . -B build -G "Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=install
+	call cmake --build build --config Release
+	call cmake --install build --config Release
+	cd ../..
+)
+
 cd tools/wrappergenerator
 call npm install
-
 cd ../..
 
 "modules/premake/bin/release/premake5.exe" vs2022 %*


### PR DESCRIPTION
Integrates the previously written multiplayer test runner with the tests project. An example integration test is provided not so much to test the actual functionality, but to provide a template for additional tests going forward.

> [!TIP]
> Some reviewers may have missed the standup where I noted this implementation was pivoting from making a separate `MultiplayerTestManager` project towards direct integrations with the `Tests` library. This rethink was caused by the undue complexity of integrating just a subset of boost, and the need to find an alternate process library, which was much easier to integrate, and made a direct tests integration make sense. The `MultiplayerTestRunner` remains as it had before, a useful tool for direct running of CSP functionality. Due to the holidays, this change in direction may not have been percolated among the entire team as it should have, apologies.

### Tiny-Process-Library
This PR integrates [tiny process library](https://gitlab.com/eidheim/tiny-process-library) (MIT) in order to invoke the `MultiplayerTestRunner` as a process. 

It is a cmake project, and is built in the same way that we build googletest, in fact, better, because we use the proper install steps rather than just invoking the build directly. I had a fair amount of discussion with @MAG-mv about this, and we are deviating from the pattern intentionally, as wrapping thirdparty dependencies in premake projects is too high a cost to pay, and not a good idea in general.

Where we _do_ try to follow a pattern is that we checkout the entire lib to `Thirdparty`, rather than using a submodule. We are currently quite inconsistent in what we do here, see [this issue](https://magnopus.atlassian.net/browse/OF-1526) for further discussion.

> [!IMPORTANT]
> Do not review the code for tiny-process-library. as it's just moving the lib into thirdparty. It's isolated to one commit.

### MultiplayerTestRunner
In order to invoke the test runner, we now copy it into the working directory, similar to what we do with CSP itself.

### Process monitoring
Managing the process is achieved with a promise/future interfaces, that listens to `stdout` of the invoked test runner, listening for the previously implement process descriptors. This should be pretty clear from the examples.
The wrapping RAII object terminates the process on destruction, although my windows suspicion remains here, refer to the comment in that section of the codebase. Has been completely fine so far though.

### Unique Users
~~As we're logging in simultaneously, we need unique users. I took code from an existing PR to do that. Once that's merged, i'll drop that commit and use the real function.~~
PR was merged, so this commit has been dropped.

### WASM Tests
~~This PR introduces a change that cannot function on WASM, the usage of tiny-process-library. Up until now our tests build for WASM, but they are never run. We discussed just not building the tests for WASM, and this PR includes that change.~~
That change was introduced in a different PR, so I dropped it from here.