### PR TITLE
[OF-1441] fix: wasm crash

### DIFF
--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -57,6 +57,12 @@ CSP_END_IGNORE
 namespace csp::systems
 {
 
+struct DownloadMaterialsJob
+{
+	int AssetsDownloaded = 0;
+	csp::common::Array<GLTFMaterial> Materials;
+};
+
 /// @ingroup Asset System
 /// @brief Public facing system that allows uploading/downloading and creation of assets.
 class CSP_API AssetSystem : public SystemBase
@@ -299,6 +305,8 @@ private:
 	csp::services::ApiBase* AssetDetailAPI;
 
 	csp::web::RemoteFileManager* FileManager;
+
+	csp::common::Map<csp::common::String, DownloadMaterialsJob> DownloadMaterialsJobs;
 };
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -57,12 +57,6 @@ CSP_END_IGNORE
 namespace csp::systems
 {
 
-struct DownloadMaterialsJob
-{
-	int AssetsDownloaded = 0;
-	csp::common::Array<GLTFMaterial> Materials;
-};
-
 /// @ingroup Asset System
 /// @brief Public facing system that allows uploading/downloading and creation of assets.
 class CSP_API AssetSystem : public SystemBase
@@ -305,8 +299,6 @@ private:
 	csp::services::ApiBase* AssetDetailAPI;
 
 	csp::web::RemoteFileManager* FileManager;
-
-	csp::common::Map<csp::common::String, DownloadMaterialsJob> DownloadMaterialsJobs;
 };
 
 } // namespace csp::systems

--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -246,7 +246,6 @@ if not Project then
                 "-sALLOW_MEMORY_GROWTH=1",                                      -- we don't know how much memory we'll need, so allow WASM to dynamically allocate more memory
                 "-sINITIAL_MEMORY=33554432",
                 "-sMAXIMUM_MEMORY=1073741824",                                  -- set an upper memory allocation bound to prevent Emscripten from trying to allocate too much memory
-                "-sPROXY_TO_PTHREAD",
                 "-sEXPORTED_RUNTIME_METHODS=[" ..
                     "'ccall'," ..
                     "'setValue'," ..

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -225,20 +225,52 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMultipleMaterialsTest)
 
 	// Ensure we found the right materials
 	std::vector<csp::common::String> MaterialNames {TestMaterialName1, TestMaterialName2, TestMaterialName3};
+	std::vector<csp::common::String> MaterialCollectionIds {
+		CreatedMaterial1.GetMaterialCollectionId(),
+		CreatedMaterial2.GetMaterialCollectionId(),
+		CreatedMaterial3.GetMaterialCollectionId(),
+	};
+	std::vector<csp::common::String> MaterialIds {
+		CreatedMaterial1.GetMaterialId(),
+		CreatedMaterial2.GetMaterialId(),
+		CreatedMaterial3.GetMaterialId(),
+	};
 
 	for (int i = 0; i < FoundMaterials.Size(); ++i)
 	{
-		const csp::common::String& SearchName = FoundMaterials[i].GetName();
+		const csp::common::String& SearchName		  = FoundMaterials[i].GetName();
+		const csp::common::String& SearchCollectionId = FoundMaterials[i].GetMaterialCollectionId();
+		const csp::common::String& SearchId			  = FoundMaterials[i].GetMaterialId();
 
-		auto Found = std::find_if(std::begin(MaterialNames),
-								  std::end(MaterialNames),
-								  [&SearchName](const csp::common::String& Name)
-								  {
-									  return Name == SearchName;
-								  });
+		auto FoundName = std::find_if(std::begin(MaterialNames),
+									  std::end(MaterialNames),
+									  [&SearchName](const csp::common::String& Name)
+									  {
+										  return Name == SearchName;
+									  });
 
 
-		EXPECT_TRUE(Found != MaterialNames.end());
+		EXPECT_TRUE(FoundName != MaterialNames.end());
+
+		auto FoundCollectionId = std::find_if(std::begin(MaterialCollectionIds),
+											  std::end(MaterialCollectionIds),
+											  [&SearchCollectionId](const csp::common::String& CollectionId)
+											  {
+												  return CollectionId == SearchCollectionId;
+											  });
+
+
+		EXPECT_TRUE(FoundCollectionId != MaterialCollectionIds.end());
+
+		auto FoundId = std::find_if(std::begin(MaterialIds),
+									std::end(MaterialIds),
+									[&SearchId](const csp::common::String& Id)
+									{
+										return Id == SearchId;
+									});
+
+
+		EXPECT_TRUE(FoundId != MaterialIds.end());
 	}
 
 	// Cleanup
@@ -279,6 +311,8 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMaterialTest)
 	GetMaterial(AssetSystem, CreatedMaterial.GetMaterialCollectionId(), CreatedMaterial.GetMaterialId(), FoundMaterial);
 
 	EXPECT_EQ(FoundMaterial.GetName(), CreatedMaterial.GetName());
+	EXPECT_EQ(FoundMaterial.GetMaterialCollectionId(), CreatedMaterial.GetMaterialCollectionId());
+	EXPECT_EQ(FoundMaterial.GetMaterialId(), CreatedMaterial.GetMaterialId());
 
 	// Cleanup
 	DeleteMaterial(AssetSystem, CreatedMaterial);


### PR DESCRIPTION
* Fixed wasm crash with blocking the main thread by replacing promise/future with a container of jobs which exists on the asset system to prevent data going out of scope
* Fixed issue with material ids not being set