### PR TITLE
[NT-0] doc: updated stack graphic

### DIFF
--- a/Library/docs/source/_static/stack.png
+++ b/Library/docs/source/_static/stack.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c45ca97ab4ee75d757c3257624a98235a74a4aed5ac7e9e8348ba7a86782bbf4
-size 98440
+oid sha256:f3ff3b151e575039b5a9f6fc490287df9f910e1a62511f76285409cd972eebee
+size 320508


### PR DESCRIPTION
Updating the apps/CSP/services stack graphic with a new visual treatment.

I'd like to replace this png with the svg equivalent, but the svg uses the proxima nova font, which the site doesn't currently support. I didn't want to go down the yak shaving route for updating just this graphic, so for now I have elected for a simple update of the png.