### PR TITLE
[OB-3785] fix: only log to console and file if there is no log callback

### DIFF
--- a/Library/include/CSP/Systems/Log/LogSystem.h
+++ b/Library/include/CSP/Systems/Log/LogSystem.h
@@ -70,7 +70,7 @@ public:
     CSP_EVENT void SetLogCallback(LogCallbackHandler InLogCallback);
 
     /// @brief Set a callback for handling an event log. Can be used to debug Connected Spaces Platform within a client application.
-    /// @param InEventCallback The callback to execute when an evvent log occurs.
+    /// @param InEventCallback The callback to execute when an event log occurs.
     CSP_EVENT void SetEventCallback(EventCallbackHandler InEventCallback);
 
     /// @brief Set a callback for handling a begin marker event. Can be used to debug Connected Spaces Platform within a client application.

--- a/Library/src/Systems/Log/LogSystem.cpp
+++ b/Library/src/Systems/Log/LogSystem.cpp
@@ -70,21 +70,23 @@ void LogSystem::LogMsg(const csp::systems::LogLevel Level, const csp::common::St
         return;
     }
 
-#if defined(CSP_WASM)
-    printf("%s\n", InMessage.c_str());
-#endif
-
-#if defined(CSP_ANDROID)
-    __android_log_print(ANDROID_LOG_VERBOSE, "CSP", InMessage.c_str());
-#endif
-
-    // Log to our Connected Spaces Platform file system.
-    LogToFile(InMessage);
-
     if (Callbacks->LogCallback != nullptr)
     {
         // Send message to clients to display the log on the client side.
         Callbacks->LogCallback(InMessage);
+    }
+    else
+    {
+#if defined(CSP_WASM)
+        printf("%s\n", InMessage.c_str());
+#endif
+
+#if defined(CSP_ANDROID)
+        __android_log_print(ANDROID_LOG_VERBOSE, "CSP", InMessage.c_str());
+#endif
+
+        // Log to our Connected Spaces Platform file system.
+        LogToFile(InMessage);
     }
 }
 

--- a/Library/src/Systems/Log/LogSystem.cpp
+++ b/Library/src/Systems/Log/LogSystem.cpp
@@ -70,6 +70,9 @@ void LogSystem::LogMsg(const csp::systems::LogLevel Level, const csp::common::St
         return;
     }
 
+    // Log to our Connected Spaces Platform file system.
+    LogToFile(InMessage);
+
     if (Callbacks->LogCallback != nullptr)
     {
         // Send message to clients to display the log on the client side.
@@ -84,9 +87,6 @@ void LogSystem::LogMsg(const csp::systems::LogLevel Level, const csp::common::St
 #if defined(CSP_ANDROID)
         __android_log_print(ANDROID_LOG_VERBOSE, "CSP", InMessage.c_str());
 #endif
-
-        // Log to our Connected Spaces Platform file system.
-        LogToFile(InMessage);
     }
 }
 


### PR DESCRIPTION
Only log to the console and the log file if there is no log callback set by a client.