### PR TITLE
[OF-1494] Enable warnings as errors (Pure Refactor)

### DIFF
--- a/Library/CSharpWrapper/premake5.lua
+++ b/Library/CSharpWrapper/premake5.lua
@@ -25,6 +25,8 @@ if not WrapperGenerator then
         dotnetframework "4.7.1"
         csversion "8.0"
         clr "unsafe"
+		disablewarnings { "CS0109" } -- Error CS0109: The member 'HotspotSequenceSystem.Dispose()' does not hide an accessible member. The new keyword is not required.
+									 -- Suppressing during the warnings-as-errors effort, don't want to modify the generators.
         
         -- We only include this project for the C# build configs as it is not needed by the pure-C++ variants
         filter "configurations:not *CSharp*"

--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -122,7 +122,7 @@ if not Project then
         
         -- Needed for dynamic_cast
         rtti("On")
-        
+		
         -- Config for platforms
         filter "platforms:x64"
             defines { 
@@ -199,6 +199,12 @@ if not Project then
             libdirs {
                 "%{wks.location}/ThirdParty/OpenSSL/1.1.1k/lib/Mac"
             }
+			
+			-- Could not manage to get xcode to co-operate in any other less specific manner of setting the flags.
+			-- These disables are to do with warnings in generated code that we should get around to dealing with.
+			xcodebuildsettings {
+				["WARNING_CFLAGS"] = "-Wno-error=deprecated-declarations -Wno-braced-scalar-init"
+			}
 
             links { 
                 "ssl",
@@ -214,6 +220,12 @@ if not Project then
             externalincludedirs {
                 "%{wks.location}/ThirdParty/OpenSSL/1.1.1k/include/platform/ios"
             }
+			
+			-- Could not manage to get xcode to co-operate in any other less specific manner of setting the flags.
+			-- These disables are to do with warnings in generated code that we should get around to dealing with.
+			xcodebuildsettings {
+				["WARNING_CFLAGS"] = "-Wno-error=deprecated-declarations -Wno-braced-scalar-init"
+			}
 
             links {
                 "ssl",            
@@ -226,11 +238,13 @@ if not Project then
                 "CSP_WASM",
                 "USE_STD_MALLOC=1"
             }
-
+			
             buildoptions {
                 "--no-entry",           -- remove default library entry point
                 "-pthread",             -- enable threading
-                "-fwasm-exceptions"     -- enable native wasm exceptions
+                "-fwasm-exceptions",     -- enable native wasm exceptions
+				"-Wno-error=deprecated-declarations", --Don't error on deprecation warnings, this is because we use Uri a lot in our services generated code, which has deprecation warnings for some unused but still generated endpoints.
+				"-Wno-braced-scalar-init" -- Don't warn against doing stuff like `return {0}`, which we do in the interop output.
             }
 
             linkoptions { 

--- a/Library/src/AssetHash.cpp
+++ b/Library/src/AssetHash.cpp
@@ -54,11 +54,6 @@
 namespace
 {
 
-// Some primes between 2^63 and 2^64 for various uses.
-constexpr uint64_t k0 = 0xc3a5c85c97cb3127ULL;
-constexpr uint64_t k1 = 0xb492b66fbe98f273ULL;
-constexpr uint64_t k2 = 0x9ae16a3b2f90404fULL;
-
 // Magic numbers for 32-bit hashing.  Copied from Murmur3.
 constexpr uint32_t c1 = 0xcc9e2d51;
 constexpr uint32_t c2 = 0x1b873593;

--- a/Library/src/Common/DateTime.cpp
+++ b/Library/src/Common/DateTime.cpp
@@ -81,10 +81,10 @@ DateTime::DateTime(const csp::common::String& DateString)
     int Year, Day, Month, Hour, Minute, Second, Fraction, OffsetHours, OffsetMinutes;
     char OffsetModifier;
 #ifdef _MSC_VER
-    int _ = sscanf_s(DateString.c_str(), "%d-%d-%dT%d:%d:%d.%d%c%d:%d", &Year, &Month, &Day, &Hour, &Minute, &Second, &Fraction, &OffsetModifier, 1,
+    sscanf_s(DateString.c_str(), "%d-%d-%dT%d:%d:%d.%d%c%d:%d", &Year, &Month, &Day, &Hour, &Minute, &Second, &Fraction, &OffsetModifier, 1,
         &OffsetHours, &OffsetMinutes);
 #else
-    int _ = std::sscanf(DateString.c_str(), "%d-%d-%dT%d:%d:%d.%d%c%d:%d", &Year, &Month, &Day, &Hour, &Minute, &Second, &Fraction, &OffsetModifier,
+    std::sscanf(DateString.c_str(), "%d-%d-%dT%d:%d:%d.%d%c%d:%d", &Year, &Month, &Day, &Hour, &Minute, &Second, &Fraction, &OffsetModifier,
         &OffsetHours, &OffsetMinutes);
 #endif
 

--- a/Library/src/Common/MimeTypeHelper.cpp
+++ b/Library/src/Common/MimeTypeHelper.cpp
@@ -40,7 +40,7 @@ String& MimeTypeHelper::GetMimeType(const String& FilePath)
 
     for (auto i = 0; i < Length; ++i)
     {
-        LowerChars[i] = std::tolower(Chars[i]);
+        LowerChars[i] = static_cast<char>(std::tolower(Chars[i]));
     }
 
     String LowerExtension(LowerChars.get(), Length);

--- a/Library/src/Common/String.cpp
+++ b/Library/src/Common/String.cpp
@@ -360,7 +360,7 @@ String String::ToLower() const
 
     for (int i = 0; i < Length; ++i)
     {
-        Text[i] = std::tolower(Text[i]);
+        Text[i] = static_cast<char>(std::tolower(Text[i]));
     }
 
     return Copy;

--- a/Library/src/Common/UUIDGenerator.h
+++ b/Library/src/Common/UUIDGenerator.h
@@ -41,7 +41,7 @@ inline std::string GenerateUUID()
     CurrentTime = std::chrono::high_resolution_clock::now();
     CurrentNanoseconds = std::chrono::time_point_cast<std::chrono::nanoseconds>(CurrentTime);
     Rand.seed(CurrentNanoseconds.time_since_epoch().count());
-    auto SkippedVal = Rand(); // Skip one pseudo-random number
+    [[maybe_unused]] auto SkippedVal = Rand(); // Skip one pseudo-random number
     *reinterpret_cast<uint64_t*>(&Uuid[8]) = Rand();
 
     // Convert to hex string

--- a/Library/src/Memory/MemoryManager.cpp
+++ b/Library/src/Memory/MemoryManager.cpp
@@ -23,6 +23,9 @@ namespace csp::memory
 {
 
 #if defined(CSP_WINDOWS)
+// (initializers put in library initialization area) Not at all sure why this is here, hopefully we can delete the custom memory management because no
+// one really understands it.
+#pragma warning(disable : 4073)
 #pragma init_seg(lib)
 #else
 __attribute__((init_priority(101)))

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -210,7 +210,7 @@ void VideoPlayerSpaceComponent::SetVideoPlayerSourceType(VideoPlayerSourceType V
 
 uint16_t VideoPlayerSpaceComponent::GetMeshComponentId() const
 {
-    return GetIntegerProperty(static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId));
+	return static_cast<uint16_t>(GetIntegerProperty(static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId)));
 }
 
 void VideoPlayerSpaceComponent::SetMeshComponentId(uint16_t Value)

--- a/Library/src/Multiplayer/Election/ClientProxy.cpp
+++ b/Library/src/Multiplayer/Election/ClientProxy.cpp
@@ -195,7 +195,6 @@ void ClientProxy::SendElectionLeaderEvent(int64_t TargetClientId)
 void ClientProxy::SendEvent(int64_t TargetClientId, int64_t EventType, int64_t ClientId)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
-    MultiplayerConnection* Connection = SystemsManager.GetMultiplayerConnection();
     EventBus* EventBus = SystemsManager.GetEventBus();
 
     const int64_t MessageId = Eid++;
@@ -217,7 +216,6 @@ void ClientProxy::SendEvent(int64_t TargetClientId, int64_t EventType, int64_t C
 void ClientProxy::SendRemoteRunScriptEvent(int64_t TargetClientId, int64_t ContextId, const csp::common::String& ScriptText)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
-    MultiplayerConnection* Connection = SystemsManager.GetMultiplayerConnection();
     EventBus* EventBus = SystemsManager.GetEventBus();
 
     const MultiplayerConnection::ErrorCodeCallbackHandler SignalRCallback = [](ErrorCode Error)

--- a/Library/src/Multiplayer/Election/ClientProxy.cpp
+++ b/Library/src/Multiplayer/Election/ClientProxy.cpp
@@ -136,6 +136,10 @@ void ClientProxy::HandleEvent(int64_t EventType, int64_t ClientId)
         break;
     case ClientElectionMessageType::ElectionNotifyLeader:
         HandleElectionNotifyLeaderEvent(ClientId);
+        break;
+    case ClientElectionMessageType::NumElectionMessages:
+        // Do nothing
+        break;
     }
 }
 

--- a/Library/src/Multiplayer/EventBus.cpp
+++ b/Library/src/Multiplayer/EventBus.cpp
@@ -22,13 +22,14 @@
 #include "Multiplayer/EventSerialisation.h"
 #include "Multiplayer/SignalR/SignalRConnection.h"
 #include "NetworkEventManagerImpl.h"
+#include <limits>
 
 namespace csp::multiplayer
 {
 
 extern ErrorCode ParseError(std::exception_ptr Exception);
 
-constexpr const uint64_t ALL_CLIENTS_ID = -1;
+constexpr const uint64_t ALL_CLIENTS_ID = std::numeric_limits<uint64_t>::max();
 
 EventBus::~EventBus() { }
 

--- a/Library/src/Multiplayer/EventSerialisation.cpp
+++ b/Library/src/Multiplayer/EventSerialisation.cpp
@@ -85,7 +85,7 @@ csp::common::String csp::multiplayer::GetSequenceKeyIndex(const csp::common::Str
     const std::string SequenceKeyString(SequenceKey.c_str());
     // Match item after second ':' to get our parent Id.
     // See CreateKey in HotSpotSequenceSystem for more info on the pattern.
-    const std::regex Expression("^(?:[^:]*\:){" + std::to_string(Index) + "}([^:]*)");
+    const std::regex Expression(R"(^(?:[^:]*\:){)" + std::to_string(Index) + R"(}([^:]*))");
     std::smatch Match;
     const bool Found = std::regex_search(std::begin(SequenceKeyString), std::end(SequenceKeyString), Match, Expression);
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -45,6 +45,7 @@
 #include <exception>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <thread>
 
@@ -107,7 +108,7 @@ ErrorCode ParseError(std::exception_ptr Exception)
     return ErrorCode::Unknown;
 }
 
-constexpr const uint64_t ALL_ENTITIES_ID = -1;
+constexpr const uint64_t ALL_ENTITIES_ID = std::numeric_limits<uint64_t>::max();
 constexpr const uint32_t KEEP_ALIVE_INTERVAL = 15;
 
 /// @brief MultiplayerConnection

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -24,13 +24,14 @@
 #include "Multiplayer/SignalR/SignalRConnection.h"
 
 #include <iostream>
+#include <limits>
 
 namespace csp::multiplayer
 {
 
 extern ErrorCode ParseError(std::exception_ptr Exception);
 
-constexpr const uint64_t ALL_CLIENTS_ID = -1;
+constexpr const uint64_t ALL_CLIENTS_ID = std::numeric_limits<uint64_t>::max();
 
 NetworkEventManagerImpl::NetworkEventManagerImpl(MultiplayerConnection* InMultiplayerConnection)
     : MultiplayerConnectionInst(InMultiplayerConnection)

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
@@ -40,8 +40,8 @@ DEFINE_SCRIPT_PROPERTY_VEC3(TextSpaceComponent, BackgroundColor);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsBackgroundVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, BillboardMode, int64_t, BillboardMode);
-DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, uint32_t, uint32_t, Width);
-DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, uint32_t, uint32_t, Height);
+DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Width);
+DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Height);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsARVisible);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
@@ -29,7 +29,7 @@ VideoPlayerSpaceComponentScriptInterface::VideoPlayerSpaceComponentScriptInterfa
 {
 }
 
-DEFINE_SCRIPT_PROPERTY_STRING(VideoPlayerSpaceComponent, Name);
+DEFINE_SCRIPT_PROPERTY_STRING_ADAPTNAME(VideoPlayerSpaceComponent, Name, ComponentName);
 
 DEFINE_SCRIPT_PROPERTY_VEC3(VideoPlayerSpaceComponent, Scale);
 DEFINE_SCRIPT_PROPERTY_VEC3(VideoPlayerSpaceComponent, Position);

--- a/Library/src/Multiplayer/Script/ComponentScriptMacros.h
+++ b/Library/src/Multiplayer/Script/ComponentScriptMacros.h
@@ -37,29 +37,41 @@
                                                                                                                                                      \
     std::string COMP##ScriptInterface::Get##NAME() const { return (std::string)((COMP*)Component)->Get##NAME().c_str(); }
 
-#define DEFINE_SCRIPT_PROPERTY_VEC2(COMP, NAME)                                                                                                      \
-    ComponentScriptInterface::Vector2 COMP##ScriptInterface::Get##NAME() const                                                                       \
-    {                                                                                                                                                \
-        ComponentScriptInterface::Vector2 Vec = { 0, 0 };                                                                                            \
-                                                                                                                                                     \
-        if (Component)                                                                                                                               \
-        {                                                                                                                                            \
-            csp::common::Vector2 Value = ((COMP*)Component)->Get##NAME();                                                                            \
-                                                                                                                                                     \
-            Vec[0] = Value.X;                                                                                                                        \
-            Vec[1] = Value.Y;                                                                                                                        \
-        }                                                                                                                                            \
-                                                                                                                                                     \
-        return Vec;                                                                                                                                  \
-    }                                                                                                                                                \
-                                                                                                                                                     \
-    void COMP##ScriptInterface::Set##NAME(ComponentScriptInterface::Vector2 Vec)                                                                     \
-    {                                                                                                                                                \
-        csp::common::Vector2 Value(Vec[0], Vec[1]);                                                                                                  \
-        ((COMP*)Component)->Set##NAME(Value);                                                                                                        \
-                                                                                                                                                     \
-        SendPropertyUpdate();                                                                                                                        \
-    }
+#define DEFINE_SCRIPT_PROPERTY_STRING_ADAPTNAME(COMP, SCRIPTFUNCNAME, UNDERLYINGNAME)  \
+	void COMP##ScriptInterface::Set##SCRIPTFUNCNAME(std::string Value)                 \
+	{                                                                                  \
+		((COMP*) Component)->Set##UNDERLYINGNAME((csp::common::String) Value.c_str()); \
+		SendPropertyUpdate();                                                          \
+	}                                                                                  \
+                                                                                       \
+	std::string COMP##ScriptInterface::Get##SCRIPTFUNCNAME() const                     \
+	{                                                                                  \
+		return (std::string)((COMP*) Component)->Get##UNDERLYINGNAME().c_str();        \
+	}
+
+#define DEFINE_SCRIPT_PROPERTY_VEC2(COMP, NAME)                                  \
+	ComponentScriptInterface::Vector2 COMP##ScriptInterface::Get##NAME() const   \
+	{                                                                            \
+		ComponentScriptInterface::Vector2 Vec = {0, 0};                          \
+                                                                                 \
+		if (Component)                                                           \
+		{                                                                        \
+			csp::common::Vector2 Value = ((COMP*) Component)->Get##NAME();       \
+                                                                                 \
+			Vec[0] = Value.X;                                                    \
+			Vec[1] = Value.Y;                                                    \
+		}                                                                        \
+                                                                                 \
+		return Vec;                                                              \
+	}                                                                            \
+                                                                                 \
+	void COMP##ScriptInterface::Set##NAME(ComponentScriptInterface::Vector2 Vec) \
+	{                                                                            \
+		csp::common::Vector2 Value(Vec[0], Vec[1]);                              \
+		((COMP*) Component)->Set##NAME(Value);                                   \
+                                                                                 \
+		SendPropertyUpdate();                                                    \
+	}
 
 #define DEFINE_SCRIPT_PROPERTY_VEC3(COMP, NAME)                                                                                                      \
     ComponentScriptInterface::Vector3 COMP##ScriptInterface::Get##NAME() const                                                                       \

--- a/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
+++ b/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
@@ -98,6 +98,9 @@ namespace
 
             break;
         }
+        case ReplicatedValueType::InvalidType:
+            CSP_LOG_ERROR_MSG("Recieved Invalid Type as SignalR Replicated Value");
+            return std::make_pair(ValueType, signalr::value {});
         }
 
         return std::make_pair(ValueType, NewValue);

--- a/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
+++ b/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
@@ -99,7 +99,7 @@ namespace
             break;
         }
         case ReplicatedValueType::InvalidType:
-            CSP_LOG_ERROR_MSG("Recieved Invalid Type as SignalR Replicated Value");
+            CSP_LOG_ERROR_MSG("Received Invalid Type as SignalR Replicated Value");
             return std::make_pair(ValueType, signalr::value {});
         }
 

--- a/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
+++ b/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
@@ -251,24 +251,24 @@ void SignalRMsgPackEntitySerialiser::WriteVector2(const csp::common::Vector2& Va
 {
     assert(CurrentState == SerialiserState::InEntity && "WriteVector2() function not supported in current state!");
 
-    double ArrayValue[] = { Value.X, Value.Y };
-    Fields.push_back(signalr::value(ArrayValue));
+    std::vector<signalr::value> ArrayValue { Value.X, Value.Y };
+    Fields.push_back(std::move(ArrayValue));
 }
 
 void SignalRMsgPackEntitySerialiser::WriteVector3(const csp::common::Vector3& Value)
 {
     assert(CurrentState == SerialiserState::InEntity && "WriteVector3() function not supported in current state!");
 
-    double ArrayValue[] = { Value.X, Value.Y, Value.Z };
-    Fields.push_back(signalr::value(ArrayValue));
+    std::vector<signalr::value> ArrayValue { Value.X, Value.Y, Value.Z };
+    Fields.push_back(std::move(ArrayValue));
 }
 
 void SignalRMsgPackEntitySerialiser::WriteVector4(const csp::common::Vector4& Value)
 {
     assert(CurrentState == SerialiserState::InEntity && "WriteVector4() function not supported in current state!");
 
-    double ArrayValue[] = { Value.X, Value.Y, Value.Z, Value.W };
-    Fields.push_back(signalr::value(ArrayValue));
+    std::vector<signalr::value> ArrayValue { Value.X, Value.Y, Value.Z, Value.W };
+    Fields.push_back(std::move(ArrayValue));
 }
 
 void SignalRMsgPackEntitySerialiser::WriteNull()

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -620,7 +620,7 @@ void SpaceEntity::Deserialise(IEntityDeserialiser& Deserialiser)
 
         Deserialiser.EnterComponents();
         {
-            auto ComponentCount = Deserialiser.GetNumComponents();
+            [[maybe_unused]] auto ComponentCount = Deserialiser.GetNumComponents();
             auto RealComponentCount = Deserialiser.GetNumRealComponents();
 
             assert(ComponentCount >= 3 && "SpaceObject should have at least 4 components!");
@@ -1208,7 +1208,6 @@ void SpaceEntity::DestroyComponent(uint16_t Key)
 
 ComponentBase* SpaceEntity::FindFirstComponentOfType(ComponentType Type, bool SearchDirtyComponents) const
 {
-    auto& CheckComponents = *GetComponents();
     const csp::common::Array<uint16_t>* ComponentKeys = Components.Keys();
     ComponentBase* LocatedComponent = nullptr;
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -176,8 +176,6 @@ std::map<uint64_t, signalr::value> GetEntityTransformComponents(const SpaceEntit
 
 class DirtyComponent;
 
-static constexpr uint64_t ALL_ENTITIES_ID = -1;
-
 using namespace std::chrono;
 
 SpaceEntitySystem::SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection)

--- a/Library/src/Multiplayer/SpaceTransform.cpp
+++ b/Library/src/Multiplayer/SpaceTransform.cpp
@@ -43,7 +43,8 @@ csp::multiplayer::SpaceTransform csp::multiplayer::SpaceTransform::operator*(con
     glm::quat Orientation { Rotation.X, Rotation.Y, Rotation.Z, Rotation.W };
     glm::quat OtherOrientation { Transform.Rotation.X, Transform.Rotation.Y, Transform.Rotation.Z, Transform.Rotation.W };
     glm::quat FinalOrientation = OtherOrientation * Orientation;
-    glm::normalize(FinalOrientation);
+    // Temporarily supress the unused variable warning
+    [[maybe_unused]] auto temporary = glm::normalize(FinalOrientation);
     return SpaceTransform(
         Position + Transform.Position, { FinalOrientation.x, FinalOrientation.y, FinalOrientation.z, FinalOrientation.w }, Scale * Transform.Scale);
 }

--- a/Library/src/Systems/Assets/Asset.cpp
+++ b/Library/src/Systems/Assets/Asset.cpp
@@ -286,7 +286,6 @@ void UriResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
     ResultBase::OnResponse(ApiResponse);
 
     const auto* Response = ApiResponse->GetResponse();
-    const auto& Headers = Response->GetPayload().GetHeaders();
 
     if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
     {

--- a/Library/src/Systems/ECommerce/ECommerce.cpp
+++ b/Library/src/Systems/ECommerce/ECommerce.cpp
@@ -673,8 +673,8 @@ void ProductInfoCollectionResult::OnResponse(const csp::services::ApiResponseBas
         std::vector<chs_aggregation::ShopifyProductDto>& ProductsArray = ProductCollectionResponse->GetArray();
 
         // Loop through products to count the variants, we want 1 output product per variant
-        int VariantCount = 0;
-        for (int DtoCount = 0; DtoCount < ProductsArray.size(); DtoCount++)
+        size_t VariantCount = 0;
+        for (size_t DtoCount = 0; DtoCount < ProductsArray.size(); DtoCount++)
         {
             VariantCount += ProductsArray[DtoCount].GetVariants().size();
         }

--- a/Library/src/Systems/Script/ScriptSystem.cpp
+++ b/Library/src/Systems/Script/ScriptSystem.cpp
@@ -34,9 +34,6 @@
 #include <map>
 #include <sstream>
 
-// For safer printfs
-constexpr int MAX_SCRIPT_FUNCTION_LEN = 256;
-
 // Template specializations for some custom csp types we want to use
 template <> struct qjs::js_property_traits<csp::common::String>
 {

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -182,7 +182,7 @@ void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys,
         Regex = csp::common::Encode::URI(*InKeyRegex);
     }
 
-    if (InReferenceType.HasValue() && InReferenceIds.IsEmpty() || !InReferenceIds.IsEmpty() && !InReferenceType.HasValue())
+    if ((InReferenceType.HasValue() && InReferenceIds.IsEmpty()) || (!InReferenceIds.IsEmpty() && !InReferenceType.HasValue()))
     {
         CSP_LOG_ERROR_MSG("InReferenceType and InReferenceIds need to be used together");
         INVOKE_IF_NOT_NULL(Callback, MakeInvalid<SequencesResult>(csp::systems::ERequestFailureReason::InvalidSequenceKey));

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -829,7 +829,8 @@ void SettingsSystem::SetAvatarInfo(AvatarType InType, const String& InIdentifier
     rapidjson::Document Json;
     Json.SetObject();
     Json.AddMember("type", static_cast<int>(InType), Json.GetAllocator());
-    Json.AddMember("identifier", rapidjson::Value(InIdentifier.c_str(), InIdentifier.Length()), Json.GetAllocator());
+    Json.AddMember(
+        "identifier", rapidjson::Value(InIdentifier.c_str(), static_cast<rapidjson::SizeType>(InIdentifier.Length())), Json.GetAllocator());
     rapidjson::StringBuffer Buffer;
     rapidjson::Writer<rapidjson::StringBuffer> Writer(Buffer);
     Json.Accept(Writer);

--- a/MultiplayerTestRunner/premake5.lua
+++ b/MultiplayerTestRunner/premake5.lua
@@ -39,6 +39,9 @@ if not MultiplayerTestRunner then
         libdirs {"%{wks.location}/Library/Binaries/%{cfg.platform}/%{cfg.buildcfg}"}
 		links {"ConnectedSpacesPlatform"}
 		defines {"USING_CSP_DLL"}
+		
+		filter "platforms:x64"
+            linkoptions { "/ignore:4099"} --Complains about no PDB for googletest, don't care.
 			   
 		 -- Conditionally link google test, not the standard _d stuff so we need to do it per config
 	   filter "configurations:*Debug*"

--- a/MultiplayerTestRunner/src/InternalUnitTests/Test_CLI.cpp
+++ b/MultiplayerTestRunner/src/InternalUnitTests/Test_CLI.cpp
@@ -22,11 +22,22 @@
 
 TEST(CLITest, AllArgsBasic)
 {
-    using namespace MultiplayerTestRunner::TestIdentifiers;
-    std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
-    std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com", "--password", "password123",
-        "--space", "space-id-123", "--timeout", "60", "--endpoint", "https://example.com" };
-    CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(args.size(), args.data());
+	using namespace MultiplayerTestRunner::TestIdentifiers;
+	std::string TestID				 = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
+	std::vector<char*> args			 = {"MultiplayerTestRunner",
+										"--test",
+										TestID.data(),
+										"--email",
+										"test@example.com",
+										"--password",
+										"password123",
+										"--space",
+										"space-id-123",
+										"--timeout",
+										"60",
+										"--endpoint",
+										"https://example.com"};
+	CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
 
     EXPECT_EQ(Settings.LoginEmailAndPassword.first, "test@example.com");
     EXPECT_EQ(Settings.LoginEmailAndPassword.second, "password123");
@@ -41,19 +52,19 @@ TEST(CLITest, TestIdentifierRequired)
     std::vector<char*> args = { "MultiplayerTestRunner", "--email", "test@example.com", "--password", "password123", "--space", "space-id-123",
         "--timeout", "60", "--endpoint", "https://example.com" };
 
-    try
-    {
-        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(args.size(), args.data());
-    }
-    catch (const Utils::ExceptionWithCode& Exception)
-    {
-        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
-        EXPECT_EQ(std::string(Exception.what()), std::string("--test is required"));
-    }
-    catch (...)
-    {
-        FAIL() << "Unexpected exception type thrown";
-    }
+	try
+	{
+		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+	}
+	catch (const Utils::ExceptionWithCode& Exception)
+	{
+		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
+		EXPECT_EQ(std::string(Exception.what()), std::string("--test is required"));
+	}
+	catch (...)
+	{
+		FAIL() << "Unexpected exception type thrown";
+	}
 }
 
 TEST(CLITest, WhenInvalidTestIdentiferThenExceptionThrow)
@@ -61,27 +72,27 @@ TEST(CLITest, WhenInvalidTestIdentiferThenExceptionThrow)
     std::vector<char*> args
         = { "MultiplayerTestRunner", "--test", "NotARealTestIdentifier", "--email", "test@example.com", "--password", "password123" };
 
-    try
-    {
-        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(args.size(), args.data());
-    }
-    catch (const Utils::ExceptionWithCode& Exception)
-    {
-        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::INVALID_TEST_SPECIFIER);
-        EXPECT_EQ(std::string(Exception.what()), std::string("String `NotARealTestIdentifier` does not match any TestIdentifier"));
-    }
-    catch (...)
-    {
-        FAIL() << "Unexpected exception type thrown";
-    }
+	try
+	{
+		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+	}
+	catch (const Utils::ExceptionWithCode& Exception)
+	{
+		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::INVALID_TEST_SPECIFIER);
+		EXPECT_EQ(std::string(Exception.what()), std::string("String `NotARealTestIdentifier` does not match any TestIdentifier"));
+	}
+	catch (...)
+	{
+		FAIL() << "Unexpected exception type thrown";
+	}
 }
 
 TEST(CLITest, DefaultsSet)
 {
-    using namespace MultiplayerTestRunner::TestIdentifiers;
-    std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
-    std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com", "--password", "password123" };
-    CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(args.size(), args.data());
+	using namespace MultiplayerTestRunner::TestIdentifiers;
+	std::string TestID				 = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
+	std::vector<char*> args			 = {"MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com", "--password", "password123"};
+	CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
 
     // We don't want to go to the credentials file for the defaults, so we provide a user/password
     EXPECT_EQ(Settings.LoginEmailAndPassword.first, "test@example.com");
@@ -99,22 +110,22 @@ TEST(CLITest, WhenNoEmailThenError)
     std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
     std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--password", "password123" };
 
-    try
-    {
-        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(args.size(), args.data());
-    }
-    catch (const Utils::ExceptionWithCode& Exception)
-    {
-        // If there's no credentials file, we'll throw an error.
-        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
-        EXPECT_EQ(std::string(Exception.what()),
-            std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
-                        "wish to use the credentials file."));
-    }
-    catch (...)
-    {
-        FAIL() << "Unexpected exception type thrown";
-    }
+	try
+	{
+		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+	}
+	catch (const Utils::ExceptionWithCode& Exception)
+	{
+		// If there's no credentials file, we'll throw an error.
+		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
+		EXPECT_EQ(std::string(Exception.what()),
+				  std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
+							  "wish to use the credentials file."));
+	}
+	catch (...)
+	{
+		FAIL() << "Unexpected exception type thrown";
+	}
 }
 
 /* This test tests different paths depending on if there's a credentials file or not */
@@ -124,21 +135,21 @@ TEST(CLITest, WhenNoPasswordThenError)
     std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
     std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com" };
 
-    try
-    {
-        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(args.size(), args.data());
-    }
-    catch (const Utils::ExceptionWithCode& Exception)
-    {
-        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
-        EXPECT_EQ(std::string(Exception.what()),
-            std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
-                        "wish to use the credentials file."));
-    }
-    catch (...)
-    {
-        FAIL() << "Unexpected exception type thrown";
-    }
+	try
+	{
+		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+	}
+	catch (const Utils::ExceptionWithCode& Exception)
+	{
+		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
+		EXPECT_EQ(std::string(Exception.what()),
+				  std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
+							  "wish to use the credentials file."));
+	}
+	catch (...)
+	{
+		FAIL() << "Unexpected exception type thrown";
+	}
 }
 
 /* This test tests different paths depending on if there's a credentials file or not */
@@ -148,24 +159,24 @@ TEST(CLITest, WhenNoCredentialsOnCLIThenCredentialsFileIsQueried)
     std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
     std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data() };
 
-    try
-    {
-        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(args.size(), args.data());
-        // If there is a credentials file, we'll now have a username and a password
-        EXPECT_TRUE(Settings.LoginEmailAndPassword.first.length() > 0);
-        EXPECT_TRUE(Settings.LoginEmailAndPassword.second.length() > 0);
-    }
-    catch (const Utils::ExceptionWithCode& Exception)
-    {
-        // If there's no credentials file, we'll throw an error.
-        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::COULD_NOT_FIND_CREDENTIALS_FILE);
-        EXPECT_EQ(std::string(Exception.what()),
-            std::string(
-                "test_account_creds.txt not found! This file must exist and must contain the following information:\n<DefaultLoginEmail> "
-                "<DefaultLoginPassword>\n<AlternativeLoginEmail> <AlternativeLoginPassword>\n<SuperUserLoginEmail> <SuperUserLoginPassword>"));
-    }
-    catch (...)
-    {
-        FAIL() << "Unexpected exception type thrown";
-    }
+	try
+	{
+		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+		// If there is a credentials file, we'll now have a username and a password
+		EXPECT_TRUE(Settings.LoginEmailAndPassword.first.length() > 0);
+		EXPECT_TRUE(Settings.LoginEmailAndPassword.second.length() > 0);
+	}
+	catch (const Utils::ExceptionWithCode& Exception)
+	{
+		// If there's no credentials file, we'll throw an error.
+		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::COULD_NOT_FIND_CREDENTIALS_FILE);
+		EXPECT_EQ(std::string(Exception.what()),
+				  std::string(
+					  "test_account_creds.txt not found! This file must exist and must contain the following information:\n<DefaultLoginEmail> "
+					  "<DefaultLoginPassword>\n<AlternativeLoginEmail> <AlternativeLoginPassword>\n<SuperUserLoginEmail> <SuperUserLoginPassword>"));
+	}
+	catch (...)
+	{
+		FAIL() << "Unexpected exception type thrown";
+	}
 }

--- a/MultiplayerTestRunner/src/InternalUnitTests/Test_CLI.cpp
+++ b/MultiplayerTestRunner/src/InternalUnitTests/Test_CLI.cpp
@@ -22,22 +22,11 @@
 
 TEST(CLITest, AllArgsBasic)
 {
-	using namespace MultiplayerTestRunner::TestIdentifiers;
-	std::string TestID				 = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
-	std::vector<char*> args			 = {"MultiplayerTestRunner",
-										"--test",
-										TestID.data(),
-										"--email",
-										"test@example.com",
-										"--password",
-										"password123",
-										"--space",
-										"space-id-123",
-										"--timeout",
-										"60",
-										"--endpoint",
-										"https://example.com"};
-	CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+    using namespace MultiplayerTestRunner::TestIdentifiers;
+    std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
+    std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com", "--password", "password123",
+        "--space", "space-id-123", "--timeout", "60", "--endpoint", "https://example.com" };
+    CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
 
     EXPECT_EQ(Settings.LoginEmailAndPassword.first, "test@example.com");
     EXPECT_EQ(Settings.LoginEmailAndPassword.second, "password123");
@@ -52,19 +41,19 @@ TEST(CLITest, TestIdentifierRequired)
     std::vector<char*> args = { "MultiplayerTestRunner", "--email", "test@example.com", "--password", "password123", "--space", "space-id-123",
         "--timeout", "60", "--endpoint", "https://example.com" };
 
-	try
-	{
-		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
-	}
-	catch (const Utils::ExceptionWithCode& Exception)
-	{
-		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
-		EXPECT_EQ(std::string(Exception.what()), std::string("--test is required"));
-	}
-	catch (...)
-	{
-		FAIL() << "Unexpected exception type thrown";
-	}
+    try
+    {
+        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+    }
+    catch (const Utils::ExceptionWithCode& Exception)
+    {
+        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
+        EXPECT_EQ(std::string(Exception.what()), std::string("--test is required"));
+    }
+    catch (...)
+    {
+        FAIL() << "Unexpected exception type thrown";
+    }
 }
 
 TEST(CLITest, WhenInvalidTestIdentiferThenExceptionThrow)
@@ -72,27 +61,27 @@ TEST(CLITest, WhenInvalidTestIdentiferThenExceptionThrow)
     std::vector<char*> args
         = { "MultiplayerTestRunner", "--test", "NotARealTestIdentifier", "--email", "test@example.com", "--password", "password123" };
 
-	try
-	{
-		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
-	}
-	catch (const Utils::ExceptionWithCode& Exception)
-	{
-		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::INVALID_TEST_SPECIFIER);
-		EXPECT_EQ(std::string(Exception.what()), std::string("String `NotARealTestIdentifier` does not match any TestIdentifier"));
-	}
-	catch (...)
-	{
-		FAIL() << "Unexpected exception type thrown";
-	}
+    try
+    {
+        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+    }
+    catch (const Utils::ExceptionWithCode& Exception)
+    {
+        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::INVALID_TEST_SPECIFIER);
+        EXPECT_EQ(std::string(Exception.what()), std::string("String `NotARealTestIdentifier` does not match any TestIdentifier"));
+    }
+    catch (...)
+    {
+        FAIL() << "Unexpected exception type thrown";
+    }
 }
 
 TEST(CLITest, DefaultsSet)
 {
-	using namespace MultiplayerTestRunner::TestIdentifiers;
-	std::string TestID				 = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
-	std::vector<char*> args			 = {"MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com", "--password", "password123"};
-	CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+    using namespace MultiplayerTestRunner::TestIdentifiers;
+    std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
+    std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com", "--password", "password123" };
+    CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
 
     // We don't want to go to the credentials file for the defaults, so we provide a user/password
     EXPECT_EQ(Settings.LoginEmailAndPassword.first, "test@example.com");
@@ -110,22 +99,22 @@ TEST(CLITest, WhenNoEmailThenError)
     std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
     std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--password", "password123" };
 
-	try
-	{
-		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
-	}
-	catch (const Utils::ExceptionWithCode& Exception)
-	{
-		// If there's no credentials file, we'll throw an error.
-		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
-		EXPECT_EQ(std::string(Exception.what()),
-				  std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
-							  "wish to use the credentials file."));
-	}
-	catch (...)
-	{
-		FAIL() << "Unexpected exception type thrown";
-	}
+    try
+    {
+        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+    }
+    catch (const Utils::ExceptionWithCode& Exception)
+    {
+        // If there's no credentials file, we'll throw an error.
+        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
+        EXPECT_EQ(std::string(Exception.what()),
+            std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
+                        "wish to use the credentials file."));
+    }
+    catch (...)
+    {
+        FAIL() << "Unexpected exception type thrown";
+    }
 }
 
 /* This test tests different paths depending on if there's a credentials file or not */
@@ -135,21 +124,21 @@ TEST(CLITest, WhenNoPasswordThenError)
     std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
     std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data(), "--email", "test@example.com" };
 
-	try
-	{
-		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
-	}
-	catch (const Utils::ExceptionWithCode& Exception)
-	{
-		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
-		EXPECT_EQ(std::string(Exception.what()),
-				  std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
-							  "wish to use the credentials file."));
-	}
-	catch (...)
-	{
-		FAIL() << "Unexpected exception type thrown";
-	}
+    try
+    {
+        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+    }
+    catch (const Utils::ExceptionWithCode& Exception)
+    {
+        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::CLI_PARSE_ERROR);
+        EXPECT_EQ(std::string(Exception.what()),
+            std::string("Both email and password must be provided together. Missing one likely indicates a mistake. Omit both if you "
+                        "wish to use the credentials file."));
+    }
+    catch (...)
+    {
+        FAIL() << "Unexpected exception type thrown";
+    }
 }
 
 /* This test tests different paths depending on if there's a credentials file or not */
@@ -159,24 +148,24 @@ TEST(CLITest, WhenNoCredentialsOnCLIThenCredentialsFileIsQueried)
     std::string TestID = TestIdentifierToString(TestIdentifier::CREATE_AVATAR);
     std::vector<char*> args = { "MultiplayerTestRunner", "--test", TestID.data() };
 
-	try
-	{
-		CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
-		// If there is a credentials file, we'll now have a username and a password
-		EXPECT_TRUE(Settings.LoginEmailAndPassword.first.length() > 0);
-		EXPECT_TRUE(Settings.LoginEmailAndPassword.second.length() > 0);
-	}
-	catch (const Utils::ExceptionWithCode& Exception)
-	{
-		// If there's no credentials file, we'll throw an error.
-		EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::COULD_NOT_FIND_CREDENTIALS_FILE);
-		EXPECT_EQ(std::string(Exception.what()),
-				  std::string(
-					  "test_account_creds.txt not found! This file must exist and must contain the following information:\n<DefaultLoginEmail> "
-					  "<DefaultLoginPassword>\n<AlternativeLoginEmail> <AlternativeLoginPassword>\n<SuperUserLoginEmail> <SuperUserLoginPassword>"));
-	}
-	catch (...)
-	{
-		FAIL() << "Unexpected exception type thrown";
-	}
+    try
+    {
+        CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(static_cast<int>(args.size()), args.data());
+        // If there is a credentials file, we'll now have a username and a password
+        EXPECT_TRUE(Settings.LoginEmailAndPassword.first.length() > 0);
+        EXPECT_TRUE(Settings.LoginEmailAndPassword.second.length() > 0);
+    }
+    catch (const Utils::ExceptionWithCode& Exception)
+    {
+        // If there's no credentials file, we'll throw an error.
+        EXPECT_EQ(Exception.ErrorCode, MultiplayerTestRunner::ErrorCodes::COULD_NOT_FIND_CREDENTIALS_FILE);
+        EXPECT_EQ(std::string(Exception.what()),
+            std::string(
+                "test_account_creds.txt not found! This file must exist and must contain the following information:\n<DefaultLoginEmail> "
+                "<DefaultLoginPassword>\n<AlternativeLoginEmail> <AlternativeLoginPassword>\n<SuperUserLoginEmail> <SuperUserLoginPassword>"));
+    }
+    catch (...)
+    {
+        FAIL() << "Unexpected exception type thrown";
+    }
 }

--- a/Tests/src/InternalTests/CommonTypeTests/Array.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Array.cpp
@@ -248,7 +248,7 @@ CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayOutOfBoundsTest)
     try
     {
         Array<Optional<int>> Instance(ARRAY_SIZE);
-        auto& Element = Instance[ARRAY_SIZE];
+        [[maybe_unused]] auto& Element = Instance[ARRAY_SIZE];
     }
     catch (const std::out_of_range&)
     {

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -55,7 +55,6 @@ void CreateAvatarForLeaderElection(csp::multiplayer::SpaceEntitySystem* EntitySy
     AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
-    LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
 
     auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -186,7 +186,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
     CinematicCamera->SetAspectRatio(16.0f / 9.0f);
     CinematicCamera->SetFocalLength(0.150f);
     CinematicCamera->SetSensorSize(csp::common::Vector2(0.02703f, 0.01425f));
-    EXPECT_FLOAT_EQ(CinematicCamera->GetFov(), 0.16848914); // ~9 degrees
+    EXPECT_FLOAT_EQ(CinematicCamera->GetFov(), 0.16848914f); // ~9 degrees
 
     CinematicCamera->SetAspectRatio(21.0f / 9.0f);
     CinematicCamera->SetFocalLength(0.018f);

--- a/Tests/src/PublicAPITests/LogSystemTests.cpp
+++ b/Tests/src/PublicAPITests/LogSystemTests.cpp
@@ -695,7 +695,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, FailureMessageTest)
 
     auto Start = std::chrono::steady_clock::now();
     auto Current = std::chrono::steady_clock::now();
-    float TestTime = 0;
+    long long TestTime = 0;
 
     while (!LogConfirmed && TestTime < 20)
     {

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -838,7 +838,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
 
         if (Status == std::future_status::timeout)
         {
-            FAIL("CreateAvatar process timed out before it was ready for assertions.");
+            FAIL() << "CreateAvatar process timed out before it was ready for assertions.";
         }
     }
 
@@ -2038,10 +2038,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
     csp::common::String ChildEntityName = "ChildEntity";
     // Parent has a position [0,0,0], and 1.507 radian (90 degree) rotation around the y axis
     SpaceTransform ObjectTransformParent
-        = { csp::common::Vector3 { 0, 0, 0 }, csp::common::Vector4 { 0, -0.7071081, 0, 0.7071055 }, csp::common::Vector3 { 1, 1, 1 } };
+        = { csp::common::Vector3 { 0, 0, 0 }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f }, csp::common::Vector3 { 1, 1, 1 } };
     SpaceTransform ObjectTransformChild = { csp::common::Vector3 { 1, 0, 0 }, csp::common::Vector4 { 0, 0, 0, 1 }, csp::common::Vector3 { 1, 1, 1 } };
     SpaceTransform ObjectTransformExpected
-        = { csp::common::Vector3 { 0, 0, 1 }, csp::common::Vector4 { 0, -0.7071081, 0, 0.7071055 }, csp::common::Vector3 { 1, 1, 1 } };
+        = { csp::common::Vector3 { 0, 0, 1 }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f }, csp::common::Vector3 { 1, 1, 1 } };
 
     EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
 
@@ -2139,11 +2139,11 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
     // Create a parent, positioned at the origin, rotated 90 degrees, with a scale of -0.5 on x axis and 0.5 on Y/Z axes
     // child created at a position of [1,0,0], no rotation, and scale of 1
     SpaceTransform ObjectTransformParent
-        = { csp::common::Vector3 { 0, 0, 0 }, csp::common::Vector4 { 0, -0.7071081, 0, 0.7071055 }, csp::common::Vector3 { -0.5f, 0.5f, 0.5f } };
+        = { csp::common::Vector3 { 0, 0, 0 }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f }, csp::common::Vector3 { -0.5f, 0.5f, 0.5f } };
     SpaceTransform ObjectTransformChild = { csp::common::Vector3 { 1, 0, 0 }, csp::common::Vector4 { 0, 0, 0, 1 }, csp::common::Vector3 { 1, 1, 1 } };
 
-    SpaceTransform ObjectTransformExpected
-        = { csp::common::Vector3 { 0, 0, -0.5 }, csp::common::Vector4 { 0, -0.7071081, 0, 0.7071055 }, csp::common::Vector3 { -0.5f, 0.5f, 0.5f } };
+    SpaceTransform ObjectTransformExpected = { csp::common::Vector3 { 0, 0, -0.5f }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f },
+        csp::common::Vector3 { -0.5f, 0.5f, 0.5f } };
 
     EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
 
@@ -2238,11 +2238,11 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     csp::common::String ParentEntityName = "ParentEntity";
     csp::common::String ChildEntityName = "ChildEntity";
     SpaceTransform ObjectTransformParent
-        = { csp::common::Vector3 { 0, 0, 0 }, csp::common::Vector4 { 0, -0.7071081, 0, 0.7071055 }, csp::common::Vector3 { 1, 1, 1 } };
+        = { csp::common::Vector3 { 0, 0, 0 }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f }, csp::common::Vector3 { 1, 1, 1 } };
     SpaceTransform ObjectTransformChild
         = { csp::common::Vector3 { 1, 0, 0 }, csp::common::Vector4 { 0, 0, 0, 1 }, csp::common::Vector3 { 0.5f, 0.5f, 0.5f } };
     SpaceTransform ObjectTransformExpected
-        = { csp::common::Vector3 { 0, 0, 1 }, csp::common::Vector4 { 0, -0.7071081, 0, 0.7071055 }, csp::common::Vector3 { 0.5f, 0.5f, 0.5f } };
+        = { csp::common::Vector3 { 0, 0, 1 }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f }, csp::common::Vector3 { 0.5f, 0.5f, 0.5f } };
 
     EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -1253,7 +1253,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
 
     auto Start = std::chrono::steady_clock::now();
     auto Current = std::chrono::steady_clock::now();
-    float TestTime = 0;
+    long long TestTime = 0;
 
     // Interrupt connection here
     while (!Interrupted && TestTime < 60)

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -1676,7 +1676,6 @@ void RunParentEntityReplicationTest(bool Local)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
@@ -2432,7 +2431,6 @@ void RunParentChildDeletionTest(bool Local)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
@@ -2672,7 +2670,6 @@ void RunParentDeletionTest(bool Local)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 

--- a/ThirdParty/poco/Crypto/premake5.lua
+++ b/ThirdParty/poco/Crypto/premake5.lua
@@ -13,6 +13,7 @@ if not POCO.Crypto then
         kind "StaticLib"
         language "C++"
         cppdialect "C++17"
+		warnings "Off"
 
         files {
             "%{prj.location}/**.h",

--- a/ThirdParty/poco/Foundation/premake5.lua
+++ b/ThirdParty/poco/Foundation/premake5.lua
@@ -13,6 +13,7 @@ if not POCO.Foundation then
         kind "StaticLib"
         language "C++"
         cppdialect "C++17"
+		warnings "Off"
 
         files {
             "%{prj.location}/**.h",

--- a/ThirdParty/poco/NETSSL_OpenSSL/premake5.lua
+++ b/ThirdParty/poco/NETSSL_OpenSSL/premake5.lua
@@ -13,6 +13,7 @@ if not POCO.NETSSL_OpenSSL then
         kind "StaticLib"
         language "C++"
         cppdialect "C++17"
+		warnings "Off"
 
         files {
             "%{prj.location}/**.h",

--- a/ThirdParty/poco/Net/premake5.lua
+++ b/ThirdParty/poco/Net/premake5.lua
@@ -13,6 +13,7 @@ if not POCO.Net then
         kind "StaticLib"
         language "C++"
         cppdialect "C++17"
+		warnings "Off"
 
         files {
             "%{prj.location}/**.h",

--- a/ThirdParty/poco/Util/premake5.lua
+++ b/ThirdParty/poco/Util/premake5.lua
@@ -13,6 +13,7 @@ if not POCO.Util then
         kind "StaticLib"
         language "C++"
         cppdialect "C++17"
+		warnings "Off"
 
         files {
             "%{prj.location}/**.h",

--- a/ThirdParty/signalrclient/premake5.lua
+++ b/ThirdParty/signalrclient/premake5.lua
@@ -10,6 +10,7 @@ function SignalRClient.AddProject()
     kind "StaticLib"
     language "C++"
     cppdialect "C++11"
+	warnings "Off"
 
     files {
         "%{prj.location}/**.h",

--- a/UnitTesting/premake5.lua
+++ b/UnitTesting/premake5.lua
@@ -59,7 +59,7 @@ project "UnitTestingBinary"
         "%{prj.location}/../Library/include",
         "%{prj.location}/../Library/src"
     }
-    
+
     filter "platforms:x64"
         targetname "ConnectedSpacesPlatform_D"
         kind "SharedLib"
@@ -80,6 +80,10 @@ project "UnitTestingBinary"
         links {
             "mimalloc"
         }
+		
+		disablewarnings { "4251" } -- C4251 is a warning about not having a dll interface for a declspec export class.
+		                           -- Docs state "You can ignore C4251 if your class is derived from a type in the C++ Standard Library", which we are (std::optional)
+		
     filter "platforms:wasm"
         targetname "ConnectedSpacesPlatform_WASM.js"
         kind "None"

--- a/premake5_helpers.lua
+++ b/premake5_helpers.lua
@@ -82,7 +82,10 @@ if not CSP then
         -- C++
         language "C++"
         cppdialect "C++17"
-        
+		
+		flags {"FatalWarnings"}
+		externalwarnings "Off"
+			
         -- Standard debug/release config settings
         filter "configurations:*Debug*"
             defines { "DEBUG" }


### PR DESCRIPTION
Enable warnings as errors across all our projects, at default warning level.
Update the codebase to pass these new checks.

All warnings related to generated code have been suppressed, as has all external/thirdparty warnings. This surfaces a conceptual mistake in making some of our thirdparty libraries premake projects rather than using their packaging, as now we're unable to easily distinguish them as thirdparty, leading to manual maintenance as has been done here.

Deprecation warnings (on platforms that treat them as errors on w3 or equivalent) are suppressed as errors, but will still output. 

> [!IMPORTANT]  
> This PR excludes certain warning fixes that have a _very small_ chance of causing regressions. ([One](https://github.com/magnopus-opensource/connected-spaces-platform/pull/584/commits/1713652cd041daadfe0ff35b01956e6fe6787ba7), [Two](https://github.com/magnopus-opensource/connected-spaces-platform/pull/584/commits/8301d1eb2745b848a8210076c34e196547842faa)) They will come immediately in a subsequent PR, in order to better isolate integration risk. The warnings have been locally suppressed in this PR.