### PR TITLE
[OF-1494] refac!: Remove unused serialization vector methods

### DIFF
--- a/Library/include/CSP/Multiplayer/IEntitySerialiser.h
+++ b/Library/include/CSP/Multiplayer/IEntitySerialiser.h
@@ -63,18 +63,6 @@ public:
     /// @param Value csp::common::String : The value to write.
     virtual void WriteString(const csp::common::String& Value) = 0;
 
-    /// @brief Write a vector2 field of the entity.
-    /// @param Value Vector2 : The value to write.
-    virtual void WriteVector2(const csp::common::Vector2& Value) = 0;
-
-    /// @brief Write a vector3 field of the entity.
-    /// @param Value Vector3 : The value to write.
-    virtual void WriteVector3(const csp::common::Vector3& Value) = 0;
-
-    /// @brief Write a vector4 field of the entity.
-    /// @param Value Vector4 : The value to write.
-    virtual void WriteVector4(const csp::common::Vector4& Value) = 0;
-
     /// @brief Write a null field of the entity.
     virtual void WriteNull() = 0;
 

--- a/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
+++ b/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.cpp
@@ -247,30 +247,6 @@ void SignalRMsgPackEntitySerialiser::WriteString(const csp::common::String& Valu
     Fields.push_back(signalr::value(Value));
 }
 
-void SignalRMsgPackEntitySerialiser::WriteVector2(const csp::common::Vector2& Value)
-{
-    assert(CurrentState == SerialiserState::InEntity && "WriteVector2() function not supported in current state!");
-
-    std::vector<signalr::value> ArrayValue { Value.X, Value.Y };
-    Fields.push_back(std::move(ArrayValue));
-}
-
-void SignalRMsgPackEntitySerialiser::WriteVector3(const csp::common::Vector3& Value)
-{
-    assert(CurrentState == SerialiserState::InEntity && "WriteVector3() function not supported in current state!");
-
-    std::vector<signalr::value> ArrayValue { Value.X, Value.Y, Value.Z };
-    Fields.push_back(std::move(ArrayValue));
-}
-
-void SignalRMsgPackEntitySerialiser::WriteVector4(const csp::common::Vector4& Value)
-{
-    assert(CurrentState == SerialiserState::InEntity && "WriteVector4() function not supported in current state!");
-
-    std::vector<signalr::value> ArrayValue { Value.X, Value.Y, Value.Z, Value.W };
-    Fields.push_back(std::move(ArrayValue));
-}
-
 void SignalRMsgPackEntitySerialiser::WriteNull()
 {
     switch (CurrentState)

--- a/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.h
+++ b/Library/src/Multiplayer/SignalRMsgPackEntitySerialiser.h
@@ -59,9 +59,6 @@ public:
     void WriteInt64(int64_t Value) override;
     void WriteUInt64(uint64_t Value) override;
     void WriteString(const csp::common::String& Value) override;
-    void WriteVector2(const csp::common::Vector2& Value) override;
-    void WriteVector3(const csp::common::Vector3& Value) override;
-    void WriteVector4(const csp::common::Vector4& Value) override;
     void WriteNull() override;
     void BeginComponents() override;
     void EndComponents() override;


### PR DESCRIPTION
These methods are not at all called internally or in tests, and we confirmed with clients that they're not used downstream :

https://magnopus.slack.com/archives/C037VC209QT/p1737118085667259

Prior to the most recent change, these wern't even calling the correct overload to store vector data, so I'm pretty confident these can be ripped out.