### PR TITLE
[OF-1494] fix: Fix SpaceTransform multiplication

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceTransform.h
+++ b/Library/include/CSP/Multiplayer/SpaceTransform.h
@@ -30,7 +30,7 @@ public:
 
     /// @brief Custom constructor for the SpaceTransform.
     /// @param Position csp::common::Vector3 : The position value for the transform.
-    /// @param Rotation csp::common::Vector4 : The rotation value for the transform.
+    /// @param Rotation csp::common::Vector4 : The rotation value for the transform, will be normalized during multiplication operations.
     /// @param Scale csp::common::Vector3 : The scale value for the transform.
     SpaceTransform(const csp::common::Vector3& Position, const csp::common::Vector4& Rotation, const csp::common::Vector3& Scale);
 
@@ -38,9 +38,13 @@ public:
     /// @param SpaceTransform Transform
     bool operator==(const SpaceTransform& Transform) const;
 
+    /// @brief Inequality operator
+    /// @param SpaceTransform Transform
+    bool operator!=(const SpaceTransform& Transform) const;
+
     /// @brief Multiplication operator
     /// @param SpaceTransform Transform
-    /// @note This mimics the operations of a matrix transform multiplication, but converts the back into a recognisable form.
+    /// @note This performs TRS matrix composition, then decomposes back to Pos, Rot, Scale.
     SpaceTransform operator*(const SpaceTransform& Transform) const;
     /// @brief The position value for the transform.
     csp::common::Vector3 Position;

--- a/Library/src/Multiplayer/SpaceTransform.cpp
+++ b/Library/src/Multiplayer/SpaceTransform.cpp
@@ -17,7 +17,6 @@
 #include "CSP/Multiplayer/SpaceTransform.h"
 
 #define GLM_ENABLE_EXPERIMENTAL // glm::decompose is still technically an experimental feature, but better than a hand-rolled solution in my opinion.
-#include "glm/gtx/string_cast.hpp"
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/matrix_decompose.hpp>
 #include <glm/gtx/quaternion.hpp>

--- a/Library/src/Multiplayer/SpaceTransform.cpp
+++ b/Library/src/Multiplayer/SpaceTransform.cpp
@@ -16,7 +16,12 @@
 
 #include "CSP/Multiplayer/SpaceTransform.h"
 
+#define GLM_ENABLE_EXPERIMENTAL // glm::decompose is still technically an experimental feature, but better than a hand-rolled solution in my opinion.
+#include "glm/gtx/string_cast.hpp"
 #include <glm/gtc/quaternion.hpp>
+#include <glm/gtx/matrix_decompose.hpp>
+#include <glm/gtx/quaternion.hpp>
+#include <tuple>
 
 csp::multiplayer::SpaceTransform::SpaceTransform()
     : Position(0.0f, 0.0f, 0.0f)
@@ -38,13 +43,53 @@ bool csp::multiplayer::SpaceTransform::operator==(const SpaceTransform& Transfor
     return Position == Transform.Position && Rotation == Transform.Rotation && Scale == Transform.Scale;
 }
 
+bool csp::multiplayer::SpaceTransform::operator!=(const SpaceTransform& Transform) const { return !(*this == Transform); }
+
+namespace
+{
+/*
+ * Return the TRS components derived from the position, quaternion and scale values set in this transform.
+ * First is T(Translation), Second is R(Rotation), Third is S(Scale)
+ * All Mat4s for uniform application, despite slight space redundancy in T and S matrices.
+ */
+std::tuple<glm::mat4, glm::mat4, glm::mat4> GetTRSComponents(const csp::multiplayer::SpaceTransform& Transform)
+{
+    glm::mat4 TMatrix = glm::mat4(1.0f); // mat4(1.0f) gives an identity matrix
+    TMatrix = glm::translate(TMatrix, glm::vec3 { Transform.Position.X, Transform.Position.Y, Transform.Position.Z });
+
+    // Quaternions must be normalized in order to not introduce crazy chaos.
+    glm::quat NormalQ = glm::normalize(glm::quat(Transform.Rotation.W, Transform.Rotation.X, Transform.Rotation.Y, Transform.Rotation.Z));
+    glm::mat4 RMatrix = glm::toMat4(std::move(NormalQ));
+
+    glm::mat4 SMatrix = glm::mat4(1.0f);
+    SMatrix = glm::scale(SMatrix, glm::vec3(Transform.Scale.X, Transform.Scale.Y, Transform.Scale.Z));
+
+    return { std::move(TMatrix), std::move(RMatrix), std::move(SMatrix) };
+}
+}
+
 csp::multiplayer::SpaceTransform csp::multiplayer::SpaceTransform::operator*(const SpaceTransform& Transform) const
 {
-    glm::quat Orientation { Rotation.X, Rotation.Y, Rotation.Z, Rotation.W };
-    glm::quat OtherOrientation { Transform.Rotation.X, Transform.Rotation.Y, Transform.Rotation.Z, Transform.Rotation.W };
-    glm::quat FinalOrientation = OtherOrientation * Orientation;
-    // Temporarily supress the unused variable warning
-    [[maybe_unused]] auto temporary = glm::normalize(FinalOrientation);
+    // Transformation order is important when applying TRS matrices. Scale first, then Rotation, then Translation.
+    // Otherwise, non-uniform scaling is effected by previous rotation, introducing skew, which is not normally desired.
+    const auto [T1, R1, S1] = GetTRSComponents(*this);
+    const auto [T2, R2, S2] = GetTRSComponents(Transform);
+
+    const auto TRS1 = T1 * R1 * S1; // Remember, "First" in matrix composition means the last element listed in the multiplication
+    const auto TRS2 = T2 * R2 * S2;
+    const auto ComposedTRS = TRS1 * TRS2;
+
+    glm::vec3 Scale;
+    glm::quat Rotation;
+    glm::vec3 Translation;
+    glm::vec3 Skew;
+    glm::vec4 Perspective;
+    glm::decompose(ComposedTRS, Scale, Rotation, Translation, Skew, Perspective);
+    // We're ignoring skew and perspective, as TRS composition should not have introduced any,
+    // provided inputs are normalized.
+    // Note, if you're getting confusing outputs for rotation when you have negative scales, you're
+    // probably flipping the rotation, which is _fine_, but hard to understand without visualization.
+
     return SpaceTransform(
-        Position + Transform.Position, { FinalOrientation.x, FinalOrientation.y, FinalOrientation.z, FinalOrientation.w }, Scale * Transform.Scale);
+        { Translation.x, Translation.y, Translation.z }, { Rotation.x, Rotation.y, Rotation.z, Rotation.w }, { Scale.x, Scale.y, Scale.z });
 }

--- a/Tests/src/PublicAPITests/SpaceTransformTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceTransformTests.cpp
@@ -95,7 +95,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityTransformT
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTest)
 {
     const csp::multiplayer::SpaceTransform Identity;
-    // An angle-axis rotation equivilent to a 90 degree rotation along the (1,1,0) axis.
+    // An angle-axis rotation equivalent to a 90 degree rotation along the (1,1,0) axis.
     // This should produce a final (euler) rotation of approx 90, 45, 45
     const csp::common::Vector4 NinetyDegAroundXYAxisNormalizedQuat { 0.5f, 0.5f, 0.0f, 0.7071055f };
 

--- a/Tests/src/PublicAPITests/SpaceTransformTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceTransformTests.cpp
@@ -67,7 +67,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityAxiomTest)
 {
     // Two identity matrices should be identity
     const csp::multiplayer::SpaceTransform Identity;
-    const auto result = Identity * Identity;
     EXPECT_EQ((Identity * Identity), Identity);
 }
 #endif

--- a/Tests/src/PublicAPITests/SpaceTransformTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceTransformTests.cpp
@@ -75,7 +75,9 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityAxiomTest)
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityTransformTest)
 {
     const csp::multiplayer::SpaceTransform Identity;
-    const csp::common::Vector4 NinetyDegAroundXNormalizedQuat { 0.7071068f, 0.0f, 0.0f, 0.7071068f };
+    // For mathy trig reasons, this is quaternion languge for "ninety degrees" (not really ... sort of)
+    const float SqrtTwoOverTwo = std::sqrt(2.0f) / 2.0f;
+    const csp::common::Vector4 NinetyDegAroundXNormalizedQuat { SqrtTwoOverTwo, 0.0f, 0.0f, SqrtTwoOverTwo };
 
     // An identity matrix multiplied into another matrix (in either order) should just be the other matrix
     const csp::multiplayer::SpaceTransform Translated { { 1.0f, 2.0f, 3.0f }, { 0.0f, 0.0f, 0.0f, 1.0f }, { 1.0f, 1.0f, 1.0f } };
@@ -95,9 +97,12 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityTransformT
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTest)
 {
     const csp::multiplayer::SpaceTransform Identity;
+    // For mathy trig reasons, this is quaternion languge for "ninety degrees" (not really ... sort of)
+    const float SqrtTwoOverTwo = std::sqrt(2.0f) / 2.0f;
+
     // An angle-axis rotation equivalent to a 90 degree rotation along the (1,1,0) axis.
     // This should produce a final (euler) rotation of approx 90, 45, 45
-    const csp::common::Vector4 NinetyDegAroundXYAxisNormalizedQuat { 0.5f, 0.5f, 0.0f, 0.7071055f };
+    const csp::common::Vector4 NinetyDegAroundXYAxisNormalizedQuat { 0.5f, 0.5f, 0.0f, SqrtTwoOverTwo };
 
     // Apply a complicated transform to the identity.
     const csp::multiplayer::SpaceTransform Transformation { { 1.0f, 0.0f, 1.0f }, NinetyDegAroundXYAxisNormalizedQuat, { 2.0f, 1.0f, 4.0f } };
@@ -120,10 +125,13 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTest)
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTestNonNormalQuat)
 {
     const csp::multiplayer::SpaceTransform Identity;
+    // For mathy trig reasons, this is quaternion languge for "ninety degrees" (not really ... sort of)
+    const float SqrtTwoOverTwo = std::sqrt(2.0f) / 2.0f;
+
     // An angle-axis rotation equivilent to a 90 degree rotation along the (1,1,0) axis.
     // This should produce a final (euler) rotation of approx 90, 45, 45
     // Scale by an arbitrary factor to make this non-normal, to test that the transformation code can handle that.
-    const csp::common::Vector4 NinetyDegAroundXYAxisNonNormalizedQuat { 0.5f * 2.5f, 0.5f * 2.5f, 0.0f * 2.5f, 0.7071055f * 2.5f };
+    const csp::common::Vector4 NinetyDegAroundXYAxisNonNormalizedQuat { 0.5f * 2.5f, 0.5f * 2.5f, 0.0f * 2.5f, SqrtTwoOverTwo * 2.5f };
 
     // Apply a complicated transform to the identity.
     const csp::multiplayer::SpaceTransform Transformation { { 1.0f, 0.0f, 1.0f }, NinetyDegAroundXYAxisNonNormalizedQuat, { 2.0f, 1.0f, 4.0f } };

--- a/Tests/src/PublicAPITests/SpaceTransformTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceTransformTests.cpp
@@ -22,8 +22,6 @@
 
 #include "gtest/gtest.h"
 
-using namespace csp::common;
-
 #if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_DEFAULT_CONSTRUCT_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, DefaultConstructTest)
 {

--- a/Tests/src/PublicAPITests/SpaceTransformTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceTransformTests.cpp
@@ -108,9 +108,9 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTest)
     glm::vec3 Euler = glm::eulerAngles(glm::normalize(glm::quat { Output.Rotation.W, Output.Rotation.X, Output.Rotation.Y, Output.Rotation.Z }));
 
     const float epsilon = 1e-5f; // Matrix operations involving euler conversions arn't terribly stable at the floating point level cross platform.
-    EXPECT_NEAR(Euler.x, 1.57080138f, epsilon); // 90 degrees
-    EXPECT_NEAR(Euler.y, 0.785398126f, epsilon); // 45 degrees
-    EXPECT_NEAR(Euler.z, 0.785398126f, epsilon); // 45 degrees
+    EXPECT_NEAR(Euler.x, glm::radians(90.0f), epsilon); // 90 degrees
+    EXPECT_NEAR(Euler.y, glm::radians(45.0f), epsilon); // 45 degrees
+    EXPECT_NEAR(Euler.z, glm::radians(45.0f), epsilon); // 45 degrees
 
     EXPECT_EQ(Output.Scale, (csp::common::Vector3 { 2.0f, 1.0f, 4.0f }));
 }
@@ -134,9 +134,9 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTestNonNormalQu
     glm::vec3 Euler = glm::eulerAngles(glm::normalize(glm::quat { Output.Rotation.W, Output.Rotation.X, Output.Rotation.Y, Output.Rotation.Z }));
 
     const float epsilon = 1e-5f; // Matrix operations involving euler conversions arn't terribly stable at the floating point level cross platform.
-    EXPECT_NEAR(Euler.x, 1.57080138f, epsilon); // 90 degrees
-    EXPECT_NEAR(Euler.y, 0.785398126f, epsilon); // 45 degrees
-    EXPECT_NEAR(Euler.z, 0.785398126f, epsilon); // 45 degrees
+    EXPECT_NEAR(Euler.x, glm::radians(90.0f), epsilon); // 90 degrees
+    EXPECT_NEAR(Euler.y, glm::radians(45.0f), epsilon); // 45 degrees
+    EXPECT_NEAR(Euler.z, glm::radians(45.0f), epsilon); // 45 degrees
 
     EXPECT_EQ(Output.Scale, (csp::common::Vector3 { 2.0f, 1.0f, 4.0f }));
 }

--- a/Tests/src/PublicAPITests/SpaceTransformTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceTransformTests.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/Multiplayer/SpaceTransform.h"
+#include "TestHelpers.h"
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include "gtest/gtest.h"
+
+using namespace csp::common;
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_DEFAULT_CONSTRUCT_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, DefaultConstructTest)
+{
+    const csp::multiplayer::SpaceTransform SpaceTransform;
+    EXPECT_EQ(SpaceTransform.Position, csp::common::Vector3::Zero());
+    EXPECT_EQ(SpaceTransform.Rotation, csp::common::Vector4::Identity());
+    EXPECT_EQ(SpaceTransform.Scale, csp::common::Vector3::One());
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_CONSTRUCT_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, ConstructTest)
+{
+    const csp::common::Vector3 Pos { 1.0f, 2.0f, 3.0f };
+    const csp::common::Vector4 Rot { 15.0f, 35.0f, -10.0f, 1.0f };
+    const csp::common::Vector3 Scale { 3.0f, 2.0f, 1.0f };
+
+    const csp::multiplayer::SpaceTransform SpaceTransform(Pos, Rot, Scale);
+    EXPECT_EQ(SpaceTransform.Position, Pos);
+    EXPECT_EQ(SpaceTransform.Rotation, Rot);
+    EXPECT_EQ(SpaceTransform.Scale, Scale);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_EQUALITY_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, EqualityTest)
+{
+    const csp::common::Vector3 Pos { 1.0f, 2.0f, 3.0f };
+    const csp::common::Vector4 Rot { 15.0f, 35.0f, -10.0f, 1.0f };
+    const csp::common::Vector3 Scale { 3.0f, 2.0f, 1.0f };
+
+    const csp::multiplayer::SpaceTransform SpaceTransform1(Pos, Rot, Scale);
+    const csp::multiplayer::SpaceTransform SpaceTransform2(Pos, Rot, Scale);
+    const csp::multiplayer::SpaceTransform SpaceTransformIdentity;
+
+    EXPECT_EQ(SpaceTransform1, SpaceTransform2);
+    EXPECT_NE(SpaceTransform1, SpaceTransformIdentity);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_IDENTITY_AXIOM_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityAxiomTest)
+{
+    // Two identity matrices should be identity
+    const csp::multiplayer::SpaceTransform Identity;
+    const auto result = Identity * Identity;
+    EXPECT_EQ((Identity * Identity), Identity);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_IDENTITY_TRANSFORM_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityTransformTest)
+{
+    const csp::multiplayer::SpaceTransform Identity;
+    const csp::common::Vector4 NinetyDegAroundXNormalizedQuat { 0.7071068f, 0.0f, 0.0f, 0.7071068f };
+
+    // An identity matrix multiplied into another matrix (in either order) should just be the other matrix
+    const csp::multiplayer::SpaceTransform Translated { { 1.0f, 2.0f, 3.0f }, { 0.0f, 0.0f, 0.0f, 1.0f }, { 1.0f, 1.0f, 1.0f } };
+    const csp::multiplayer::SpaceTransform Rotated { { 0.0f, 0.0f, 0.0f }, NinetyDegAroundXNormalizedQuat, { 1.0f, 1.0f, 1.0f } };
+    const csp::multiplayer::SpaceTransform Scaled { { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 0.0f, 1.0f }, { 2.0f, 3.0f, 4.0f } };
+
+    EXPECT_EQ((Identity * Translated), Translated);
+    EXPECT_EQ((Translated * Identity), Translated);
+    EXPECT_EQ((Identity * Rotated), Rotated);
+    EXPECT_EQ((Rotated * Identity), Rotated);
+    EXPECT_EQ((Identity * Scaled), Scaled);
+    EXPECT_EQ((Scaled * Identity), Scaled);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_TRS_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTest)
+{
+    const csp::multiplayer::SpaceTransform Identity;
+    // An angle-axis rotation equivilent to a 90 degree rotation along the (1,1,0) axis.
+    // This should produce a final (euler) rotation of approx 90, 45, 45
+    const csp::common::Vector4 NinetyDegAroundXYAxisNormalizedQuat { 0.5f, 0.5f, 0.0f, 0.7071055f };
+
+    // Apply a complicated transform to the identity.
+    const csp::multiplayer::SpaceTransform Transformation { { 1.0f, 0.0f, 1.0f }, NinetyDegAroundXYAxisNormalizedQuat, { 2.0f, 1.0f, 4.0f } };
+
+    const auto Output = Identity * Transformation;
+    EXPECT_EQ(Output.Position, (csp::common::Vector3 { 1.0f, 0.0f, 1.0f }));
+
+    glm::vec3 Euler = glm::eulerAngles(glm::normalize(glm::quat { Output.Rotation.W, Output.Rotation.X, Output.Rotation.Y, Output.Rotation.Z }));
+
+    const float epsilon = 1e-5f; // Matrix operations involving euler conversions arn't terribly stable at the floating point level cross platform.
+    EXPECT_NEAR(Euler.x, 1.57080138f, epsilon); // 90 degrees
+    EXPECT_NEAR(Euler.y, 0.785398126f, epsilon); // 45 degrees
+    EXPECT_NEAR(Euler.z, 0.785398126f, epsilon); // 45 degrees
+
+    EXPECT_EQ(Output.Scale, (csp::common::Vector3 { 2.0f, 1.0f, 4.0f }));
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_NON_NORMAL_QUAT_TRS_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTestNonNormalQuat)
+{
+    const csp::multiplayer::SpaceTransform Identity;
+    // An angle-axis rotation equivilent to a 90 degree rotation along the (1,1,0) axis.
+    // This should produce a final (euler) rotation of approx 90, 45, 45
+    // Scale by an arbitrary factor to make this non-normal, to test that the transformation code can handle that.
+    const csp::common::Vector4 NinetyDegAroundXYAxisNonNormalizedQuat { 0.5f * 2.5f, 0.5f * 2.5f, 0.0f * 2.5f, 0.7071055f * 2.5f };
+
+    // Apply a complicated transform to the identity.
+    const csp::multiplayer::SpaceTransform Transformation { { 1.0f, 0.0f, 1.0f }, NinetyDegAroundXYAxisNonNormalizedQuat, { 2.0f, 1.0f, 4.0f } };
+
+    const auto Output = Identity * Transformation;
+    EXPECT_EQ(Output.Position, (csp::common::Vector3 { 1.0f, 0.0f, 1.0f }));
+
+    glm::vec3 Euler = glm::eulerAngles(glm::normalize(glm::quat { Output.Rotation.W, Output.Rotation.X, Output.Rotation.Y, Output.Rotation.Z }));
+
+    const float epsilon = 1e-5f; // Matrix operations involving euler conversions arn't terribly stable at the floating point level cross platform.
+    EXPECT_NEAR(Euler.x, 1.57080138f, epsilon); // 90 degrees
+    EXPECT_NEAR(Euler.y, 0.785398126f, epsilon); // 45 degrees
+    EXPECT_NEAR(Euler.z, 0.785398126f, epsilon); // 45 degrees
+
+    EXPECT_EQ(Output.Scale, (csp::common::Vector3 { 2.0f, 1.0f, 4.0f }));
+}
+#endif


### PR DESCRIPTION
(This issue found during the warnings as errors sweep, i'm fixing it now, it's the final fix)

The existing implementation had several things wrong with it, one has to imagine it was never called anywhere, because this would be so apparent. Unfortunately, it was untested since the beginning.

Issues :
- [[nodiscard]] warning on normalize ignored, although post-rotation normalization is only needed to prevent cascading floating point errors
- The W component for glm::quat is the first argument, but for our vectors it is the last, all our quaternions were being constructed with nonsense values. (Strong typing please! Vector4 is inappropriate to store quaternions for precisely this reason)
- I don't think you can do complex compositions in this manner, separating the translation, scale and rotation components like that, but I could be wrong there.
- Untested

The prior code, even with the code issues fixed, failed to pass even the identity assumptions in the new test suite that has been written. For that reason, and due to the face that matrix compositions are more comprehensible, (at least to me, I grant that they're somewhat verbose) I've replaced the implementation with a matrix based one. It's probably slightly slower than direct quaternion work, but at least it has a chance of being correct.

In a perfect world, one would have gone further here, fixing the `Vector4` `Quaternion` mismatch issue, and establishing normalization/negative scale preconditions, but changes like that would have been breaking, which I didn't want to do. (Note, the data members of this type are public, making type-level invariants impossible, alas)

