### PR TITLE
[NT-0] fix: Emscripten release mode build warning

### DIFF
--- a/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
+++ b/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
@@ -120,7 +120,11 @@ EmscriptenWebClient::EmscriptenWebClient(const Port InPort, const ETransferProto
     std::srand(std::time(nullptr));
 }
 
-std::string EmscriptenWebClient::MD5Hash(const void* Data, const size_t Size) { assert(false && "Not implemented!"); }
+std::string EmscriptenWebClient::MD5Hash(const void* Data, const size_t Size)
+{
+    assert(false && "Not implemented!");
+    return "MD5Hash Not Implemented";
+}
 
 void EmscriptenWebClient::SetFileUploadContentFromFile(
     HttpPayload* Payload, const char* FilePath, const char* Version, const csp::common::String& MediaType)


### PR DESCRIPTION
Fix a silly warning for a not implemented function for emscripten builds. Only manifests in release builds, which is why it wasn't caught.

Yet another reason why unfinished functions and untested functions should not hit main.
