### PR TITLE
[NT-0] feat!: Add metadata and tag parameters to material creation

### DIFF
--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -244,8 +244,12 @@ public:
     /// @brief Creates a new material backed by an AssetCollection/Asset.
     /// @param Name const csp::common::String& : The name of the new material.
     /// @param SpaceId const csp::common::String& : The space id this material is associated with.
+    /// @param Metadata csp::common::Map<csp::common::String, csp::common::String>& : The metadata to be associated with the created asset colection.
+    /// @param AssetTags csp::common::Array<csp::common::String>& : Tags to be associated with the created asset collection.
     /// @param Callback GLTFMaterialResultCallback : Callback when asynchronous task finishes.
-    CSP_ASYNC_RESULT void CreateMaterial(const csp::common::String& Name, const csp::common::String& SpaceId, GLTFMaterialResultCallback Callback);
+    CSP_ASYNC_RESULT void CreateMaterial(const csp::common::String& Name, const csp::common::String& SpaceId,
+        csp::common::Map<csp::common::String, csp::common::String> Metadata, const csp::common::Array<csp::common::String> AssetTags,
+        GLTFMaterialResultCallback Callback);
 
     /// @brief Updates an existing material's properties.
     /// The material should be retrieved through GetMaterials or GetMaterial.

--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -244,8 +244,8 @@ public:
     /// @brief Creates a new material backed by an AssetCollection/Asset.
     /// @param Name const csp::common::String& : The name of the new material.
     /// @param SpaceId const csp::common::String& : The space id this material is associated with.
-    /// @param Metadata csp::common::Map<csp::common::String, csp::common::String>& : The metadata to be associated with the created asset colection.
-    /// @param AssetTags csp::common::Array<csp::common::String>& : Tags to be associated with the created asset collection.
+    /// @param Metadata csp::common::Map<csp::common::String, csp::common::String>& : The metadata to be associated with the created material.
+    /// @param AssetTags csp::common::Array<csp::common::String>& : Tags to be associated with the created material.
     /// @param Callback GLTFMaterialResultCallback : Callback when asynchronous task finishes.
     CSP_ASYNC_RESULT void CreateMaterial(const csp::common::String& Name, const csp::common::String& SpaceId,
         csp::common::Map<csp::common::String, csp::common::String> Metadata, const csp::common::Array<csp::common::String> AssetTags,

--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -248,7 +248,8 @@ public:
     /// @param AssetTags csp::common::Array<csp::common::String>& : Tags to be associated with the created material.
     /// @param Callback GLTFMaterialResultCallback : Callback when asynchronous task finishes.
     CSP_ASYNC_RESULT void CreateMaterial(const csp::common::String& Name, const csp::common::String& SpaceId,
-        csp::common::Map<csp::common::String, csp::common::String> Metadata, const csp::common::Array<csp::common::String> AssetTags,
+        const csp::common::Map<csp::common::String, csp::common::String>& Metadata, const csp::
+        common::Array<csp::common::String>& AssetTags,
         GLTFMaterialResultCallback Callback);
 
     /// @brief Updates an existing material's properties.

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -896,7 +896,7 @@ void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::com
     };
 
     const csp::common::String MaterialCollectionName = CreateUniqueMaterialAssetCollectionName(Name, SpaceId);
-    const Array<String> AssetTag = { "material" };
+    static const Array<String> AssetTag = { "material" };
     csp::common::Map<csp::common::String, csp::common::String> Metadata = { { "AssetType", "Material" } };
 
     CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, Metadata, EAssetCollectionType::DEFAULT, AssetTag, CreateAssetCollectionCB);

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -897,8 +897,9 @@ void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::com
 
     const csp::common::String MaterialCollectionName = CreateUniqueMaterialAssetCollectionName(Name, SpaceId);
     Array<String> AssetTag = { "material" };
+    csp::common::Map<csp::common::String, csp::common::String> Metadata = { { "AssetType", "Material" } };
 
-    CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, nullptr, EAssetCollectionType::DEFAULT, AssetTag, CreateAssetCollectionCB);
+    CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, Metadata, EAssetCollectionType::DEFAULT, AssetTag, CreateAssetCollectionCB);
 }
 
 void AssetSystem::UpdateMaterial(const GLTFMaterial& Material, NullResultCallback Callback)

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -896,7 +896,7 @@ void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::com
     };
 
     const csp::common::String MaterialCollectionName = CreateUniqueMaterialAssetCollectionName(Name, SpaceId);
-    Array<String> AssetTag = { "Material" };
+    Array<String> AssetTag = { "material" };
 
     CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, nullptr, EAssetCollectionType::DEFAULT, AssetTag, CreateAssetCollectionCB);
 }

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -896,7 +896,7 @@ void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::com
     };
 
     const csp::common::String MaterialCollectionName = CreateUniqueMaterialAssetCollectionName(Name, SpaceId);
-    Array<String> AssetTag = { "material" };
+    const Array<String> AssetTag = { "material" };
     csp::common::Map<csp::common::String, csp::common::String> Metadata = { { "AssetType", "Material" } };
 
     CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, Metadata, EAssetCollectionType::DEFAULT, AssetTag, CreateAssetCollectionCB);

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -835,7 +835,7 @@ CSP_ASYNC_RESULT_WITH_PROGRESS void AssetSystem::RegisterAssetToLODChain(
 }
 
 void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::common::String& SpaceId,
-    csp::common::Map<csp::common::String, csp::common::String> Metadata, const csp::common::Array<csp::common::String> AssetTags,
+    const csp::common::Map<csp::common::String, csp::common::String>& Metadata, const csp::common::Array<csp::common::String>& AssetTags,
     GLTFMaterialResultCallback Callback)
 {
     // 1. Create asset collection

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -834,7 +834,9 @@ CSP_ASYNC_RESULT_WITH_PROGRESS void AssetSystem::RegisterAssetToLODChain(
     GetAssetsByCriteria({ InAsset.AssetCollectionId }, nullptr, nullptr, Array<EAssetType> { EAssetType::MODEL }, GetAssetsCallback);
 }
 
-void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::common::String& SpaceId, GLTFMaterialResultCallback Callback)
+void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::common::String& SpaceId,
+    csp::common::Map<csp::common::String, csp::common::String> Metadata, const csp::common::Array<csp::common::String> AssetTags,
+    GLTFMaterialResultCallback Callback)
 {
     // 1. Create asset collection
     auto CreateAssetCollectionCB = [this, Callback, Name, SpaceId](const AssetCollectionResult& CreateAssetCollectionResult)
@@ -896,10 +898,8 @@ void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::com
     };
 
     const csp::common::String MaterialCollectionName = CreateUniqueMaterialAssetCollectionName(Name, SpaceId);
-    static const Array<String> AssetTag = { "material" };
-    csp::common::Map<csp::common::String, csp::common::String> Metadata = { { "AssetType", "Material" } };
 
-    CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, Metadata, EAssetCollectionType::DEFAULT, AssetTag, CreateAssetCollectionCB);
+    CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, Metadata, EAssetCollectionType::DEFAULT, AssetTags, CreateAssetCollectionCB);
 }
 
 void AssetSystem::UpdateMaterial(const GLTFMaterial& Material, NullResultCallback Callback)

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -896,8 +896,9 @@ void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::com
     };
 
     const csp::common::String MaterialCollectionName = CreateUniqueMaterialAssetCollectionName(Name, SpaceId);
+    Array<String> AssetTag = { "Material" };
 
-    CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, nullptr, EAssetCollectionType::DEFAULT, nullptr, CreateAssetCollectionCB);
+    CreateAssetCollection(SpaceId, nullptr, MaterialCollectionName, nullptr, EAssetCollectionType::DEFAULT, AssetTag, CreateAssetCollectionCB);
 }
 
 void AssetSystem::UpdateMaterial(const GLTFMaterial& Material, NullResultCallback Callback)

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -35,9 +35,11 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 
 } // namespace
 
-void CreateMaterial(AssetSystem* AssetSystem, const csp::common::String& Name, const csp::common::String& SpaceId, GLTFMaterial& OutMaterial)
+void CreateMaterial(AssetSystem* AssetSystem, const csp::common::String& Name, const csp::common::String& SpaceId,
+    csp::common::Map<csp::common::String, csp::common::String> Metadata, const csp::common::Array<csp::common::String> AssetTags,
+    GLTFMaterial& OutMaterial)
 {
-    auto [Result] = AWAIT_PRE(AssetSystem, CreateMaterial, RequestPredicate, Name, SpaceId);
+    auto [Result] = AWAIT_PRE(AssetSystem, CreateMaterial, RequestPredicate, Name, SpaceId, Metadata, AssetTags);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     const GLTFMaterial& Material = Result.GetGLTFMaterial();
@@ -96,7 +98,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, CreateMaterialTest)
     CreateDefaultTestSpace(SpaceSystem, Space);
 
     GLTFMaterial CreatedMaterial;
-    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, CreatedMaterial);
+    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, {}, {}, CreatedMaterial);
 
     // Cleanup
     DeleteMaterial(AssetSystem, CreatedMaterial);
@@ -127,7 +129,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, UpdateMaterialTest)
 
     // Create a material associated with the space
     GLTFMaterial CreatedMaterial;
-    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, CreatedMaterial);
+    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, {}, {}, CreatedMaterial);
 
     // Ensure the material can be updated
     EXPECT_NE(CreatedMaterial.GetAlphaCutoff(), 1);
@@ -204,15 +206,15 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMultipleMaterialsTest)
     // Create 3 materials
     constexpr const char* TestMaterialName1 = "TestMaterial1";
     GLTFMaterial CreatedMaterial1;
-    CreateMaterial(AssetSystem, TestMaterialName1, Space.Id, CreatedMaterial1);
+    CreateMaterial(AssetSystem, TestMaterialName1, Space.Id, {}, {}, CreatedMaterial1);
 
     constexpr const char* TestMaterialName2 = "TestMaterial2";
     GLTFMaterial CreatedMaterial2;
-    CreateMaterial(AssetSystem, TestMaterialName2, Space.Id, CreatedMaterial2);
+    CreateMaterial(AssetSystem, TestMaterialName2, Space.Id, {}, {}, CreatedMaterial2);
 
     constexpr const char* TestMaterialName3 = "TestMaterial3";
     GLTFMaterial CreatedMaterial3;
-    CreateMaterial(AssetSystem, TestMaterialName3, Space.Id, CreatedMaterial3);
+    CreateMaterial(AssetSystem, TestMaterialName3, Space.Id, {}, {}, CreatedMaterial3);
 
     // Attempt to find the 3 materials that have been created
     csp::common::Array<GLTFMaterial> FoundMaterials;
@@ -286,7 +288,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMaterialTest)
 
     // Create a material associated with the space
     GLTFMaterial CreatedMaterial;
-    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, CreatedMaterial);
+    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, {}, {}, CreatedMaterial);
 
     // Get the material to ensure it can be found
     GLTFMaterial FoundMaterial;
@@ -325,7 +327,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetInvalidMaterialTest)
 
     // Create a material so we have one in this space
     GLTFMaterial CreatedMaterial;
-    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, CreatedMaterial);
+    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, {}, {}, CreatedMaterial);
 
     // Attempt to get an invalid material
     GLTFMaterial FoundMaterial;
@@ -361,11 +363,11 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, DeleteMaterialTest)
     // Create 2 materials
     constexpr const char* TestMaterialName1 = "TestMaterial1";
     GLTFMaterial CreatedMaterial1;
-    CreateMaterial(AssetSystem, TestMaterialName1, Space.Id, CreatedMaterial1);
+    CreateMaterial(AssetSystem, TestMaterialName1, Space.Id, {}, {}, CreatedMaterial1);
 
     constexpr const char* TestMaterialName2 = "TestMaterial2";
     GLTFMaterial CreatedMaterial2;
-    CreateMaterial(AssetSystem, TestMaterialName2, Space.Id, CreatedMaterial2);
+    CreateMaterial(AssetSystem, TestMaterialName2, Space.Id, {}, {}, CreatedMaterial2);
 
     // Delete first material
     DeleteMaterial(AssetSystem, CreatedMaterial1);
@@ -433,7 +435,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
         AssetSystem->SetMaterialChangedCallback(CB);
 
         // Create a material associated with the space
-        CreateMaterial(AssetSystem, "TestMaterial", Space.Id, CreatedMaterial);
+        CreateMaterial(AssetSystem, "TestMaterial", Space.Id, {}, {}, CreatedMaterial);
         WaitForCallback(CallbackCalled);
 
         EXPECT_TRUE(CallbackCalled);
@@ -584,7 +586,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
     EXPECT_EQ(CallbackAssetId, Asset.Id);
 
     // Create a material associated with the space
-    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, CreatedMaterial);
+    CreateMaterial(AssetSystem, "TestMaterial", Space.Id, {}, {}, CreatedMaterial);
     WaitForCallback(CallbackCalled);
 
     EXPECT_TRUE(CallbackCalled);

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -36,7 +36,7 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 } // namespace
 
 void CreateMaterial(AssetSystem* AssetSystem, const csp::common::String& Name, const csp::common::String& SpaceId,
-    csp::common::Map<csp::common::String, csp::common::String> Metadata, const csp::common::Array<csp::common::String> AssetTags,
+    const csp::common::Map<csp::common::String, csp::common::String>& Metadata, const csp::common::Array<csp::common::String>& AssetTags,
     GLTFMaterial& OutMaterial)
 {
     auto [Result] = AWAIT_PRE(AssetSystem, CreateMaterial, RequestPredicate, Name, SpaceId, Metadata, AssetTags);


### PR DESCRIPTION
- Add parameters for metadata and tags to the create material method to support being able to filter them out from other types of assets
- Update the relevant tests