### PR TITLE
[OF-1499] doc: Add PR guidelines

### DIFF
--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -26,12 +26,6 @@ When leaving review comments, mark your comment with a tag demonstrating what th
 - **[Nit]** is for nitpicks, stylistic or otherwise. Authors may choose to address these, or close the conversation with no action.
 - **[Comment]** is similar to a nit, but does not even imply a desired change. These will almost always just be resolved by the PR author.
 
-### Link Commits to Conversations
-After having made a change in response to a suggestion by a reviewer, this change should be linked to the relevant conversation, so that the reviewer may evaluate the change.
-This prevents reviewers from having to search through large changesets in order to validate whether or not particular comments have been addressed.
-
-![image](https://github.com/user-attachments/assets/749326a2-7f21-4836-b635-4de2dd36898f)
-
 ### Clean Commit History
 Keep a clean, noise-free commit history when making a pull request. The following in particular are highly frowned upon when appearing in a changeset.
 - Merge commits
@@ -43,6 +37,16 @@ Remember, you are walking the reviewer through the changeset, try to tell them a
 > [!TIP]
 > A simple, albeit crude way of curating your history is to perform `git reset SHA_OF_INITIAL_BRANCH_COMMIT --soft`, which will reset your branch to before you made any changes, whilst keeping all your changes locally.
 > You may then stage them in a way that best tells the story of the change. Remember to take a backup/stash first, just to play it safe.
+
+### Link Commits to Conversations
+After having made a change in response to a suggestion by a reviewer, this change should be linked to the relevant conversation, so that the reviewer may evaluate the change.
+This prevents reviewers from having to search through large changesets in order to validate whether or not particular comments have been addressed.
+
+![image](https://github.com/user-attachments/assets/749326a2-7f21-4836-b635-4de2dd36898f)
+
+> [!WARNING]  
+> Once people have started reviewing a PR, the author should try to avoid force-pushing, as this breaks conversation links.
+> Be sure to do all your history rewriting before marking the PR as ready to review.
 
 ### Merge via Squash
 To keep things simple, all PRs are merged into main via squash. GitHub should only give you this option, so no need to think about it!

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -3,7 +3,7 @@
 When making, or engaging with a new pull request against main, please attempt to follow these guidelines.
 
 > [!NOTE]
-> All of these policys are general guidelines, and we acknowledge that exceptions to every rule exists. Use your best judgement, always.
+> All of these policies are general guidelines, and we acknowledge that exceptions to every rule exist. Use your best judgement, always.
 
 
 ### Comment Ladder

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -22,7 +22,7 @@ When leaving review comments, mark your comment with a tag demonstrating what th
 
 - **[Fix]** comments must be addressed, either by a change, or by the author convincing the reviewer that the change is not necessary. Once the change is made, the reviewer should evaluate the change, and resolve the conversation if it is acceptable.
 - **[Consider]** comments are meaningful suggestions. They may be ignored, but the author should respond with justification as to why. This justification need not be accepted by the commenter, the reviewer is free to resolve the conversation.
-- **[Questions]** mandate a response, and the reviewer should either follow up, or resolve the conversation with a satisfactory answer.
+- **[Question]** mandates a response, and the reviewer should either follow up, or resolve the conversation with a satisfactory answer.
 - **[Nit]** is for nitpicks, stylistic or otherwise. Authors may choose to address these, or close the conversation with no action.
 - **[Comment]** is similar to a nit, but does not even imply a desired change. These will almost always just be resolved by the PR author.
 

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -48,7 +48,7 @@ Remember, you are walking the reviewer through the changeset, try to tell them a
 To keep things simple, all PRs are merged into main via squash. GitHub should only give you this option, so no need to think about it!
 
 ### Reviewer Assignment
-When making a pull-request, GitHub should automatically assign two reviewers from the connected-spaces-platform team.
+When making a pull request, GitHub should automatically assign two reviewers from the connected-spaces-platform team.
 If, as a pull-request author, you are aware of a particular reviewer who really should be involved in this particular change, you are free to remove one of the auto-assigned reviewers and manually assign the necessary specialist.
 
 ### Review Timeframe

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -45,10 +45,10 @@ Remember, you are walking the reviewer through the changeset, try to tell them a
 > You may then stage them in a way that best tells the story of the change. Remember to take a backup/stash first, just to play it safe.
 
 ### Merge via Squash
-To keep things simple, all PR's are merged into main via squash. Github should only give you this option, so no need to think about it!
+To keep things simple, all PRs are merged into main via squash. GitHub should only give you this option, so no need to think about it!
 
 ### Reviewer Assignment
-When making a pull-request, github should automatically assign two reviewers from the connected-spaces-platform team.
+When making a pull-request, GitHub should automatically assign two reviewers from the connected-spaces-platform team.
 If, as a pull-request author, you are aware of a particular reviewer who really should be involved in this particular change, you are free to remove one of the auto-assigned reviewers and manually assign the necessary specialist.
 
 ### Review Timeframe

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -28,7 +28,7 @@ When leaving review comments, mark your comment with a tag demonstrating what th
 
 ### Link Commits to Conversations
 After having made a change in response to a suggestion by a reviewer, this change should be linked to the relevant conversation, so that the reviewer may evaluate the change.
-This prevents reviewers having to search through large changesets in order to validate whether or not particular comments have been addressed.
+This prevents reviewers from having to search through large changesets in order to validate whether or not particular comments have been addressed.
 
 ![image](https://github.com/user-attachments/assets/749326a2-7f21-4836-b635-4de2dd36898f)
 

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -20,7 +20,7 @@ When leaving review comments, mark your comment with a tag demonstrating what th
 | [Nit]  | ❌  | ❌  | ✔️  |
 | [Comment]  | ❌  | ❌  | ✔️  |
 
-- **[Fix]** comments must be addressed, either by a change, or by the author convincing the reviewer that the change is not neccesary. Once the change is made, the reviewer should evaluate the change, and resolve the conversation if it is acceptable.
+- **[Fix]** comments must be addressed, either by a change, or by the author convincing the reviewer that the change is not necessary. Once the change is made, the reviewer should evaluate the change, and resolve the conversation if it is acceptable.
 - **[Consider]** comments are meaningful suggestions. They may be ignored, but the author should respond with justification as to why. This justification need not be accepted by the commenter, the reviewer is free to resolve the conversation.
 - **[Questions]** mandate a response, and the reviewer should either follow up, or resolve the conversation with a satisfactory answer.
 - **[Nit]** is for nitpicks, stylistic or otherwise. Authors may choose to address these, or close the conversation with no action.
@@ -49,7 +49,7 @@ To keep things simple, all PR's are merged into main via squash. Github should o
 
 ### Reviewer Assignment
 When making a pull-request, github should automatically assign two reviewers from the connected-spaces-platform team.
-If, as a pull-request author, you are aware of a particular reviewer who really should be involved in this particular change, you are free to remove one of the auto-assigned reviewers and manually assign the neccesary specialist.
+If, as a pull-request author, you are aware of a particular reviewer who really should be involved in this particular change, you are free to remove one of the auto-assigned reviewers and manually assign the necessary specialist.
 
 ### Review Timeframe
 Maintainers should attempt to look at any PR assigned to them within a 24 hour working period. If they are unable to do so, they should contact the PR author informing them that they will not be able to provide a review in a timely manner.

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -33,7 +33,7 @@ This prevents reviewers from having to search through large changesets in order 
 ![image](https://github.com/user-attachments/assets/749326a2-7f21-4836-b635-4de2dd36898f)
 
 ### Clean Commit History
-Keep a clean, noise free commit history when making a pull request. The following in particular are highly frowned upon when appearing in a changeset.
+Keep a clean, noise-free commit history when making a pull request. The following in particular are highly frowned upon when appearing in a changeset.
 - Merge commits
 - "Undo" commits. (Ie, commits that undo changes made earlier in the changeset)
 - Changes that are already in main

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -1,0 +1,55 @@
+# Pull Request Guidelines
+
+When making, or engaging with a new pull request against main, please attempt to follow these guidelines.
+
+> [!NOTE]
+> All of these policys are general guidelines, and we acknowledge that exceptions to every rule exists. Use your best judgement, always.
+
+
+### Comment Ladder
+When leaving review comments, mark your comment with a tag demonstrating what the expected reaction to your comment is, in order to avoid text-comms based ambiguity.
+
+![image](https://github.com/user-attachments/assets/9fd015c4-815a-4bd0-82b1-e27a6ab99717)
+
+
+| Tag  | Is a response required? | Is a change required?  | May the PR author resolve |
+| ------------- | ------------- | ------------- | ------------- |
+| [Fix]  | ✔️  | ✔️ | ❌  |
+| [Consider]  |✔️  | ❌  | ✔️  |
+| [Question]  | ✔️  | ❌  | ❌  |
+| [Nit]  | ❌  | ❌  | ✔️  |
+| [Comment]  | ❌  | ❌  | ✔️  |
+
+- **[Fix]** comments must be addressed, either by a change, or by the author convincing the reviewer that the change is not neccesary. Once the change is made, the reviewer should evaluate the change, and resolve the conversation if it is acceptable.
+- **[Consider]** comments are meaningful suggestions. They may be ignored, but the author should respond with justification as to why. This justification need not be accepted by the commenter, the reviewer is free to resolve the conversation.
+- **[Questions]** mandate a response, and the reviewer should either follow up, or resolve the conversation with a satisfactory answer.
+- **[Nit]** is for nitpicks, stylistic or otherwise. Authors may choose to address these, or close the conversation with no action.
+- **[Comment]** is similar to a nit, but does not even imply a desired change. These will almost always just be resolved by the PR author.
+
+### Link Commits to Conversations
+After having made a change in response to a suggestion by a reviewer, this change should be linked to the relevant conversation, so that the reviewer may evaluate the change.
+This prevents reviewers having to search through large changesets in order to validate whether or not particular comments have been addressed.
+
+![image](https://github.com/user-attachments/assets/749326a2-7f21-4836-b635-4de2dd36898f)
+
+### Clean Commit History
+Keep a clean, noise free commit history when making a pull request. The following in particular are highly frowned upon when appearing in a changeset.
+- Merge commits
+- "Undo" commits. (Ie, commits that undo changes made earlier in the changeset)
+- Changes that are already in main
+
+Remember, you are walking the reviewer through the changeset, try to tell them a story. The fact that you changed your mind and undid a lot of work is not important, only the final result is.
+
+> [!TIP]
+> A simple, albeit crude way of curating your history is to perform `git reset SHA_OF_INITIAL_BRANCH_COMMIT --soft`, which will reset your branch to before you made any changes, whilst keeping all your changes locally.
+> You may then stage them in a way that best tells the story of the change. Remember to take a backup/stash first, just to play it safe.
+
+### Merge via Squash
+To keep things simple, all PR's are merged into main via squash. Github should only give you this option, so no need to think about it!
+
+### Reviewer Assignment
+When making a pull-request, github should automatically assign two reviewers from the connected-spaces-platform team.
+If, as a pull-request author, you are aware of a particular reviewer who really should be involved in this particular change, you are free to remove one of the auto-assigned reviewers and manually assign the neccesary specialist.
+
+### Review Timeframe
+Maintainers should attempt to look at any PR assigned to them within a 24 hour working period. If they are unable to do so, they should contact the PR author informing them that they will not be able to provide a review in a timely manner.

--- a/PR_GUIDELINES.md
+++ b/PR_GUIDELINES.md
@@ -1,6 +1,6 @@
 # Pull Request Guidelines
 
-When making, or engaging with a new pull request against main, please attempt to follow these guidelines.
+When making, or engaging with, a new pull request against main, please attempt to follow these guidelines.
 
 > [!NOTE]
 > All of these policies are general guidelines, and we acknowledge that exceptions to every rule exist. Use your best judgement, always.


### PR DESCRIPTION
Add PR guidelines document capturing the decisions made in the recent team meeting.

For best effect, click "Display the rich diff" for this review.

I decided to place this at the root of the repo, as there is no "contributing" directory as yet. I'm tempted to make one, although until we have more than one document it doesn't feel worth it.

I know we have website docs, this doesn't feel like it belongs there though, this is extremely repo-specific. Open to suggestions on location.