### PR TITLE
[OF-1523] feat: Add getter for ids of users who accepted invites

### DIFF
--- a/Library/include/CSP/Systems/Spaces/Space.h
+++ b/Library/include/CSP/Systems/Spaces/Space.h
@@ -369,6 +369,33 @@ private:
 };
 
 /// @ingroup Space System
+/// @brief Data class used to contain the ids of the users that have accepted the space invites
+class CSP_API AcceptedInvitesResult : public csp::systems::ResultBase
+{
+    /** @cond DO_NOT_DOCUMENT */
+    CSP_START_IGNORE
+    template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
+    CSP_END_IGNORE
+    /** @endcond */
+
+public:
+    /// @brief Retrieves the stored user ids
+    /// @return csp::common::Array<csp::common::String> : reference to the user ids array
+    csp::common::Array<csp::common::String>& GetAcceptedInvitesUserIds();
+
+    /// @brief Retrieves the stored user ids
+    /// @return csp::common::Array<csp::common::String> : reference to the user ids array
+    const csp::common::Array<csp::common::String>& GetAcceptedInvitesUserIds() const;
+
+private:
+    AcceptedInvitesResult(void*) {};
+
+    void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+
+    csp::common::Array<csp::common::String> AcceptedInvitesUserIds;
+};
+
+/// @ingroup Space System
 /// @brief Data class used to contain the outcome of space geo location operations.
 /// The result can be successful and still return no geo location if one does not exist.
 class CSP_API SpaceGeoLocationResult : public csp::systems::ResultBase
@@ -435,6 +462,7 @@ typedef std::function<void(const SpaceMetadataResult& Result)> SpaceMetadataResu
 typedef std::function<void(const SpacesMetadataResult& Result)> SpacesMetadataResultCallback;
 
 typedef std::function<void(const PendingInvitesResult& Result)> PendingInvitesResultCallback;
+typedef std::function<void(const AcceptedInvitesResult& Result)> AcceptedInvitesResultCallback;
 
 typedef std::function<void(const SpaceGeoLocationResult& Result)> SpaceGeoLocationResultCallback;
 typedef std::function<void(const SpaceGeoLocationCollectionResult& Result)> SpaceGeoLocationCollectionResultCallback;

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -212,6 +212,11 @@ public:
     /// @param Callback PendingInvitesResultCallback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void GetPendingUserInvites(const csp::common::String& SpaceId, PendingInvitesResultCallback Callback);
 
+    /// @brief Returns an array of ids of users that accepted the space invite
+    /// @param Space Space : Space for which the invites where sent
+    /// @param Callback AcceptedInvitesResultCallback : callback when asynchronous task finishes
+    CSP_ASYNC_RESULT void GetAcceptedUserInvites(const csp::common::String& SpaceId, AcceptedInvitesResultCallback Callback);
+
     /// @brief Removes a user from a space by the user's unique ID.
     /// @param Space Space : space to remove user from
     /// @param UserId csp::common::String : unique ID of user

--- a/Library/src/Systems/Spaces/Space.cpp
+++ b/Library/src/Systems/Spaces/Space.cpp
@@ -293,6 +293,36 @@ void PendingInvitesResult::OnResponse(const csp::services::ApiResponseBase* ApiR
     }
 }
 
+Array<String>& AcceptedInvitesResult::GetAcceptedInvitesUserIds() { return AcceptedInvitesUserIds; }
+
+const Array<String>& AcceptedInvitesResult::GetAcceptedInvitesUserIds() const { return AcceptedInvitesUserIds; }
+
+void AcceptedInvitesResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
+{
+    ResultBase::OnResponse(ApiResponse);
+
+    auto* AcceptedInvitesResponse = static_cast<csp::services::DtoArray<chs_users::GroupInviteDto>*>(ApiResponse->GetDto());
+    const csp::web::HttpResponse* Response = ApiResponse->GetResponse();
+
+    if (ApiResponse->GetResponseCode() == csp::services::EResponseCode::ResponseSuccess)
+    {
+        // Build the Dto from the response Json
+        AcceptedInvitesResponse->FromJson(Response->GetPayload().GetContent());
+
+        // Extract data from response in our accepted invites array
+        std::vector<chs_users::GroupInviteDto>& AcceptedInvitesArray = AcceptedInvitesResponse->GetArray();
+        AcceptedInvitesUserIds = Array<String>(AcceptedInvitesArray.size());
+
+        for (auto idx = 0; idx < AcceptedInvitesArray.size(); ++idx)
+        {
+            if (AcceptedInvitesArray[idx].HasId())
+            {
+                AcceptedInvitesUserIds[idx] = AcceptedInvitesArray[idx].GetId();
+            }
+        }
+    }
+}
+
 const Map<String, Map<String, String>>& SpacesMetadataResult::GetMetadata() const { return Metadata; }
 
 const Map<String, Array<String>>& SpacesMetadataResult::GetTags() const { return Tags; }

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -759,6 +759,15 @@ void SpaceSystem::GetPendingUserInvites(const String& SpaceId, PendingInvitesRes
     static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdEmailInvitesGet(SpaceId, ResponseHandler);
 }
 
+void SpaceSystem::GetAcceptedUserInvites(const String& SpaceId, AcceptedInvitesResultCallback Callback)
+{
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = GroupAPI->CreateHandler<AcceptedInvitesResultCallback, AcceptedInvitesResult, void, csp::services::DtoArray<chs::GroupInviteDto>>(
+            Callback, nullptr);
+
+    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdEmailInvitesAcceptedGet(SpaceId, ResponseHandler);
+}
+
 void SpaceSystem::AddUserToSpace(const csp::common::String& SpaceId, const String& UserId, SpaceResultCallback Callback)
 {
     // This function right here is the only place in the whole of CSP that needs to use group code.

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1849,7 +1849,15 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPendingUserInvitesTest)
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
-    const char* TestUserEmail = "testnopus.pokemon@magnopus.com";
+    // It is not possible to record pending invites and see them decrement as they are accepted,
+    // because the invites are sent by email and have to be accepted by clicking a link in them.
+    // The test suite does not have the capability to open emails and click links in them.
+    // The workaround is to test each separately.
+    // Using an email that is not associated to any existing account, only the pending invites counter increases (the accepted invites counter remains
+    // at 0).
+
+    // This test only works if the below email is not associated to any existing account.
+    const char* TestUserEmail = "non-existing.account@magnopus.com";
     const char* TestEmailLinkUrl = "https://dev.magnoverse.space/";
     const char* TestSignupUrl = "https://dev.magnoverse.space/";
 
@@ -1859,23 +1867,110 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPendingUserInvitesTest)
     ::Space Space;
     CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, TestUserEmail, nullptr, TestEmailLinkUrl, TestSignupUrl);
+    // Check that there are no pending invites before inviting a user
+    auto [GetInvitesResultBefore] = AWAIT_PRE(SpaceSystem, GetPendingUserInvites, RequestPredicate, Space.Id);
+    EXPECT_EQ(GetInvitesResultBefore.GetResultCode(), csp::systems::EResultCode::Success);
+    auto& PendingInvitesBefore = GetInvitesResultBefore.GetPendingInvitesEmails();
+    EXPECT_EQ(PendingInvitesBefore.Size(), 0);
 
+    // Invite a user to the space
+    auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, TestUserEmail, nullptr, TestEmailLinkUrl, TestSignupUrl);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
+    // Check that there is one pending invite after inviting a user
     auto [GetInvitesResult] = AWAIT_PRE(SpaceSystem, GetPendingUserInvites, RequestPredicate, Space.Id);
-
     EXPECT_EQ(GetInvitesResult.GetResultCode(), csp::systems::EResultCode::Success);
-
     auto& PendingInvites = GetInvitesResult.GetPendingInvitesEmails();
-
     EXPECT_EQ(PendingInvites.Size(), 1);
-
     for (auto idx = 0; idx < PendingInvites.Size(); ++idx)
     {
         std::cerr << "Pending space invite for email: " << PendingInvites[idx] << std::endl;
     }
 
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GET_ACCEPTED_INVITES_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetAcceptedUserInvitesTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = ::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
+    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+
+    char UniqueSpaceName[256];
+    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+    const char* TestEmailLinkUrl = "https://dev.magnoverse.space/";
+    const char* TestSignupUrl = "https://dev.magnoverse.space/";
+
+    // Create users
+    String SpaceCreatorUserId;
+    csp::systems::Profile SpaceCreatorUser = CreateTestUser();
+
+    String User1Id;
+    csp::systems::Profile User1 = CreateTestUser();
+    csp::systems::Profile User2 = CreateTestUser();
+
+    // It is not possible to record pending invites and see them decrement as they are accepted,
+    // because the invites are sent by email and have to be accepted by clicking a link in them.
+    // The test suite does not have the capability to open emails and click links in them.
+    // The workaround is to test each separately.
+    // Using an account that already exists, only the accepted invites counter increases (the pending invites counter remains at 0).
+    // Note that all invites are accepted at once on the test tenant.
+
+    // Log in as Space Creator and create space
+    LogIn(UserSystem, SpaceCreatorUserId, SpaceCreatorUser.Email, GeneratedTestAccountPassword);
+
+    ::Space Space;
+    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+
+    // Check that there are no accepted invites before inviting users
+    auto [GetAcceptedInvitesResultBefore] = AWAIT_PRE(SpaceSystem, GetAcceptedUserInvites, RequestPredicate, Space.Id);
+    EXPECT_EQ(GetAcceptedInvitesResultBefore.GetResultCode(), csp::systems::EResultCode::Success);
+    auto& AcceptedInvitesBefore = GetAcceptedInvitesResultBefore.GetAcceptedInvitesUserIds();
+    EXPECT_EQ(AcceptedInvitesBefore.Size(), 0);
+
+    // Invite User1 and User2 to the space
+    auto [ResultInviteUser1]
+        = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, User1.Email, nullptr, TestEmailLinkUrl, TestSignupUrl);
+    EXPECT_EQ(ResultInviteUser1.GetResultCode(), csp::systems::EResultCode::Success);
+    auto [ResultInviteUser2]
+        = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, User2.Email, nullptr, TestEmailLinkUrl, TestSignupUrl);
+    EXPECT_EQ(ResultInviteUser2.GetResultCode(), csp::systems::EResultCode::Success);
+
+    // Log out as Space Creator
+    LogOut(UserSystem);
+
+    // Log in as User1 and enter the space, which triggers invite acceptance on the test tenant (for all users, so including User2)
+    LogIn(UserSystem, User1Id, User1.Email, GeneratedTestAccountPassword);
+
+    auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    ASSERT_EQ(EnterSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    // Log back in as Space Creator to check the accepted invites
+    LogOut(UserSystem);
+    LogIn(UserSystem, SpaceCreatorUserId, SpaceCreatorUser.Email, GeneratedTestAccountPassword);
+
+    // Check the accepted invites are recorded correctly
+    auto [GetAcceptedInvitesResult] = AWAIT_PRE(SpaceSystem, GetAcceptedUserInvites, RequestPredicate, Space.Id);
+
+    EXPECT_EQ(GetAcceptedInvitesResult.GetResultCode(), csp::systems::EResultCode::Success);
+    auto& AcceptedInvites = GetAcceptedInvitesResult.GetAcceptedInvitesUserIds();
+    EXPECT_EQ(AcceptedInvites.Size(), 2);
+    for (auto idx = 0; idx < AcceptedInvites.Size(); ++idx)
+    {
+        std::cerr << "Accepted space invite for user id: " << AcceptedInvites[idx] << std::endl;
+    }
+
+    // Clean up
     DeleteSpace(SpaceSystem, Space.Id);
 
     LogOut(UserSystem);


### PR DESCRIPTION
- Create getter for the IDs of users who accepted an invite. It works on the same principle as GetPendingInvites, except that it retrieves the user ID, not the email address.
- Improve pending invites test and add a comment
- Add a test for the accepted invites
- Update csp-services to the latest version so it contains the accepted endpoint wrapper
