### PR TITLE
[OF-1580] ci: Add DebugStatic build to Unity package

### DIFF
--- a/teamcity/Config.py
+++ b/teamcity/Config.py
@@ -59,6 +59,7 @@ config = Config(
         ],
         ios=[
             "libConnectedSpacesPlatform.a",
+            "libConnectedSpacesPlatform_D.zip",
             "libcrypto.a",
             "libssl.a"
         ],


### PR DESCRIPTION
The Unity Team require CSP debug symbols as part of the package uploaded to npmjs. Given the size of the DebugStatic build (~780Mb) this file dependency has been added to the package as a zipped file (~180Mb). The TeamCity Publish CSP build config has been updated to include this zipped build artifact dependency, and the change introduced by this PR ensures that the file is included in the package.