### PR TITLE
[OB-3917] fix! : change all int_64t exposed script parameters to int_32t

### DIFF
--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
@@ -42,6 +42,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsPlaying);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVisible);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, int64_t, int64_t, AnimationIndex);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, int32_t, int32_t, AnimationIndex);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
@@ -43,7 +43,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
 
-    DECLARE_SCRIPT_PROPERTY(int64_t, AnimationIndex);
+    DECLARE_SCRIPT_PROPERTY(int32_t, AnimationIndex);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.cpp
@@ -25,8 +25,8 @@ csp::multiplayer::AudioSpaceComponentScriptInterface::AudioSpaceComponentScriptI
 }
 
 DEFINE_SCRIPT_PROPERTY_VEC3(AudioSpaceComponent, Position);
-DEFINE_SCRIPT_PROPERTY_TYPE(AudioSpaceComponent, AudioPlaybackState, int64_t, PlaybackState);
-DEFINE_SCRIPT_PROPERTY_TYPE(AudioSpaceComponent, AudioType, int64_t, AudioType);
+DEFINE_SCRIPT_PROPERTY_TYPE(AudioSpaceComponent, AudioPlaybackState, int32_t, PlaybackState);
+DEFINE_SCRIPT_PROPERTY_TYPE(AudioSpaceComponent, AudioType, int32_t, AudioType);
 DEFINE_SCRIPT_PROPERTY_STRING(AudioSpaceComponent, AudioAssetId);
 DEFINE_SCRIPT_PROPERTY_STRING(AudioSpaceComponent, AssetCollectionId);
 DEFINE_SCRIPT_PROPERTY_TYPE(AudioSpaceComponent, float, float, AttenuationRadius);

--- a/Library/src/Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.h
@@ -27,8 +27,8 @@ public:
     AudioSpaceComponentScriptInterface(AudioSpaceComponent* InComponent = nullptr);
 
     DECLARE_SCRIPT_PROPERTY(Vector3, Position);
-    DECLARE_SCRIPT_PROPERTY(int64_t, PlaybackState);
-    DECLARE_SCRIPT_PROPERTY(int64_t, AudioType);
+    DECLARE_SCRIPT_PROPERTY(int32_t, PlaybackState);
+    DECLARE_SCRIPT_PROPERTY(int32_t, AudioType);
     DECLARE_SCRIPT_PROPERTY(std::string, AudioAssetId);
     DECLARE_SCRIPT_PROPERTY(std::string, AssetCollectionId);
     DECLARE_SCRIPT_PROPERTY(float, AttenuationRadius);

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
@@ -33,14 +33,14 @@ DEFINE_SCRIPT_PROPERTY_STRING(AvatarSpaceComponent, AvatarId);
 DEFINE_SCRIPT_PROPERTY_STRING(AvatarSpaceComponent, UserId);
 DEFINE_SCRIPT_PROPERTY_STRING(AvatarSpaceComponent, AgoraUserId);
 DEFINE_SCRIPT_PROPERTY_STRING(AvatarSpaceComponent, CustomAvatarUrl);
-DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarState, int64_t, State);
-DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, int64_t, int64_t, AvatarMeshIndex);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarState, int32_t, State);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, int64_t, int32_t, AvatarMeshIndex);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsHandIKEnabled);
 DEFINE_SCRIPT_PROPERTY_VEC3(AvatarSpaceComponent, TargetHandIKTargetLocation);
 DEFINE_SCRIPT_PROPERTY_VEC4(AvatarSpaceComponent, HandRotation);
 DEFINE_SCRIPT_PROPERTY_VEC4(AvatarSpaceComponent, HeadRotation);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, float, float, WalkRunBlendPercentage);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, float, float, TorsoTwistAlpha);
-DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarPlayMode, int64_t, AvatarPlayMode);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarPlayMode, int32_t, AvatarPlayMode);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
@@ -32,8 +32,8 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(std::string, AvatarId);
     DECLARE_SCRIPT_PROPERTY(std::string, UserId);
-    DECLARE_SCRIPT_PROPERTY(int64_t, State);
-    DECLARE_SCRIPT_PROPERTY(int64_t, AvatarMeshIndex);
+    DECLARE_SCRIPT_PROPERTY(int32_t, State);
+    DECLARE_SCRIPT_PROPERTY(int32_t, AvatarMeshIndex);
     DECLARE_SCRIPT_PROPERTY(std::string, AgoraUserId);
     DECLARE_SCRIPT_PROPERTY(std::string, CustomAvatarUrl);
     DECLARE_SCRIPT_PROPERTY(bool, IsHandIKEnabled);
@@ -42,7 +42,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector3, HeadRotation);
     DECLARE_SCRIPT_PROPERTY(float, WalkRunBlendPercentage);
     DECLARE_SCRIPT_PROPERTY(float, TorsoTwistAlpha);
-    DECLARE_SCRIPT_PROPERTY(int64_t, AvatarPlayMode);
+    DECLARE_SCRIPT_PROPERTY(int32_t, AvatarPlayMode);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/CollisionSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/CollisionSpaceComponentScriptInterface.cpp
@@ -33,8 +33,8 @@ DEFINE_SCRIPT_PROPERTY_VEC3(CollisionSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(CollisionSpaceComponent, Rotation);
 DEFINE_SCRIPT_PROPERTY_VEC3(CollisionSpaceComponent, Scale);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(CollisionSpaceComponent, csp::multiplayer::CollisionMode, int64_t, CollisionMode);
-DEFINE_SCRIPT_PROPERTY_TYPE(CollisionSpaceComponent, csp::multiplayer::CollisionShape, int64_t, CollisionShape);
+DEFINE_SCRIPT_PROPERTY_TYPE(CollisionSpaceComponent, csp::multiplayer::CollisionMode, int32_t, CollisionMode);
+DEFINE_SCRIPT_PROPERTY_TYPE(CollisionSpaceComponent, csp::multiplayer::CollisionShape, int32_t, CollisionShape);
 
 DEFINE_SCRIPT_PROPERTY_STRING(CollisionSpaceComponent, CollisionAssetId);
 DEFINE_SCRIPT_PROPERTY_STRING(CollisionSpaceComponent, AssetCollectionId);

--- a/Library/src/Multiplayer/Script/ComponentBinding/CollisionSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/CollisionSpaceComponentScriptInterface.h
@@ -32,8 +32,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector3, Position);
     DECLARE_SCRIPT_PROPERTY(Vector3, Scale);
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
-    DECLARE_SCRIPT_PROPERTY(int64_t, CollisionShape);
-    DECLARE_SCRIPT_PROPERTY(int64_t, CollisionMode);
+    DECLARE_SCRIPT_PROPERTY(int32_t, CollisionShape);
+    DECLARE_SCRIPT_PROPERTY(int32_t, CollisionMode);
     DECLARE_SCRIPT_PROPERTY(std::string, CollisionAssetId);
     DECLARE_SCRIPT_PROPERTY(std::string, AssetCollectionId);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/ConversationSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ConversationSpaceComponentScriptInterface.cpp
@@ -33,6 +33,6 @@ DEFINE_SCRIPT_PROPERTY_VEC3(ConversationSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(ConversationSpaceComponent, Rotation);
 DEFINE_SCRIPT_PROPERTY_STRING(ConversationSpaceComponent, Title);
 DEFINE_SCRIPT_PROPERTY_STRING(ConversationSpaceComponent, Date);
-DEFINE_SCRIPT_PROPERTY_TYPE(ConversationSpaceComponent, int64_t, int64_t, NumberOfReplies);
+DEFINE_SCRIPT_PROPERTY_TYPE(ConversationSpaceComponent, int32_t, int32_t, NumberOfReplies);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ConversationSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ConversationSpaceComponentScriptInterface.h
@@ -38,7 +38,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
     DECLARE_SCRIPT_PROPERTY(std::string, Title);
     DECLARE_SCRIPT_PROPERTY(std::string, Date);
-    DECLARE_SCRIPT_PROPERTY(int64_t, NumberOfReplies);
+    DECLARE_SCRIPT_PROPERTY(int32_t, NumberOfReplies);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
@@ -29,7 +29,7 @@ FogSpaceComponentScriptInterface::FogSpaceComponentScriptInterface(FogSpaceCompo
 {
 }
 
-DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, FogMode, int64_t, FogMode);
+DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, FogMode, int32_t, FogMode);
 
 DEFINE_SCRIPT_PROPERTY_VEC3(FogSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(FogSpaceComponent, Rotation);

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
@@ -27,7 +27,7 @@ class FogSpaceComponentScriptInterface : public ComponentScriptInterface
 public:
     FogSpaceComponentScriptInterface(FogSpaceComponent* InComponent = nullptr);
 
-    DECLARE_SCRIPT_PROPERTY(int64_t, FogMode);
+    DECLARE_SCRIPT_PROPERTY(int32_t, FogMode);
 
     DECLARE_SCRIPT_PROPERTY(Vector3, Position);
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
@@ -36,8 +36,8 @@ DEFINE_SCRIPT_PROPERTY_VEC3(ImageSpaceComponent, Scale);
 DEFINE_SCRIPT_PROPERTY_VEC3(ImageSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(ImageSpaceComponent, Rotation);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, csp::multiplayer::BillboardMode, int64_t, BillboardMode);
-DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, csp::multiplayer::DisplayMode, int64_t, DisplayMode);
+DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, csp::multiplayer::BillboardMode, int32_t, BillboardMode);
+DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, csp::multiplayer::DisplayMode, int32_t, DisplayMode);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsEmissive);
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVisible);

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
@@ -37,8 +37,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector3, Scale);
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
 
-    DECLARE_SCRIPT_PROPERTY(int64_t, BillboardMode);
-    DECLARE_SCRIPT_PROPERTY(int64_t, DisplayMode);
+    DECLARE_SCRIPT_PROPERTY(int32_t, BillboardMode);
+    DECLARE_SCRIPT_PROPERTY(int32_t, DisplayMode);
     DECLARE_SCRIPT_PROPERTY(bool, IsEmissive);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
@@ -29,7 +29,7 @@ LightSpaceComponentScriptInterface::LightSpaceComponentScriptInterface(LightSpac
 {
 }
 
-DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, csp::multiplayer::LightType, int64_t, LightType);
+DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, csp::multiplayer::LightType, int32_t, LightType);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, float, float, Intensity);
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, float, float, Range);
@@ -43,6 +43,6 @@ DEFINE_SCRIPT_PROPERTY_VEC4(LightSpaceComponent, Rotation);
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVisible);
 
 DEFINE_SCRIPT_PROPERTY_STRING(LightSpaceComponent, LightCookieAssetId);
-DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, csp::multiplayer::LightCookieType, int64_t, LightCookieType);
+DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, csp::multiplayer::LightCookieType, int32_t, LightCookieType);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
@@ -30,7 +30,7 @@ class LightSpaceComponentScriptInterface : public ComponentScriptInterface
 public:
     LightSpaceComponentScriptInterface(LightSpaceComponent* InComponent = nullptr);
 
-    DECLARE_SCRIPT_PROPERTY(int64_t, LightType);
+    DECLARE_SCRIPT_PROPERTY(int32_t, LightType);
     DECLARE_SCRIPT_PROPERTY(float, Intensity);
     DECLARE_SCRIPT_PROPERTY(float, Range);
     DECLARE_SCRIPT_PROPERTY(float, InnerConeAngle);
@@ -43,7 +43,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
 
     DECLARE_SCRIPT_PROPERTY(std::string, LightCookieAssetId);
-    DECLARE_SCRIPT_PROPERTY(int64_t, LightCookieType);
+    DECLARE_SCRIPT_PROPERTY(int32_t, LightCookieType);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ReflectionSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ReflectionSpaceComponentScriptInterface.cpp
@@ -36,6 +36,6 @@ DEFINE_SCRIPT_PROPERTY_STRING(ReflectionSpaceComponent, AssetCollectionId);
 DEFINE_SCRIPT_PROPERTY_VEC3(ReflectionSpaceComponent, Scale);
 DEFINE_SCRIPT_PROPERTY_VEC3(ReflectionSpaceComponent, Position);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(ReflectionSpaceComponent, csp::multiplayer::ReflectionShape, int64_t, ReflectionShape);
+DEFINE_SCRIPT_PROPERTY_TYPE(ReflectionSpaceComponent, csp::multiplayer::ReflectionShape, int32_t, ReflectionShape);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ReflectionSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ReflectionSpaceComponentScriptInterface.h
@@ -37,7 +37,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector3, Position);
     DECLARE_SCRIPT_PROPERTY(Vector3, Scale);
 
-    DECLARE_SCRIPT_PROPERTY(int64_t, ReflectionShape);
+    DECLARE_SCRIPT_PROPERTY(int32_t, ReflectionShape);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
@@ -39,7 +39,7 @@ DEFINE_SCRIPT_PROPERTY_VEC3(TextSpaceComponent, TextColor);
 DEFINE_SCRIPT_PROPERTY_VEC3(TextSpaceComponent, BackgroundColor);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsBackgroundVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, BillboardMode, int64_t, BillboardMode);
+DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, BillboardMode, int32_t, BillboardMode);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Width);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Height);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVisible);

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
@@ -38,7 +38,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsBackgroundVisible);
     DECLARE_SCRIPT_PROPERTY(uint32_t, Width);
     DECLARE_SCRIPT_PROPERTY(uint32_t, Height);
-    DECLARE_SCRIPT_PROPERTY(int64_t, BillboardMode);
+    DECLARE_SCRIPT_PROPERTY(int32_t, BillboardMode);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
@@ -45,11 +45,11 @@ DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsLoopPlaybac
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsAutoResize);
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, float, float, AttenuationRadius);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::VideoPlayerPlaybackState, int64_t, PlaybackState);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::VideoPlayerPlaybackState, int32_t, PlaybackState);
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, float, float, CurrentPlayheadPosition);
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, float, float, TimeSincePlay);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::VideoPlayerSourceType, int64_t, VideoPlayerSourceType);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::VideoPlayerSourceType, int32_t, VideoPlayerSourceType);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVisible);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
@@ -46,11 +46,11 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsAutoResize);
     DECLARE_SCRIPT_PROPERTY(float, AttenuationRadius);
 
-    DECLARE_SCRIPT_PROPERTY(int64_t, PlaybackState);
+    DECLARE_SCRIPT_PROPERTY(int32_t, PlaybackState);
     DECLARE_SCRIPT_PROPERTY(float, CurrentPlayheadPosition);
     DECLARE_SCRIPT_PROPERTY(float, TimeSincePlay);
 
-    DECLARE_SCRIPT_PROPERTY(int64_t, VideoPlayerSourceType);
+    DECLARE_SCRIPT_PROPERTY(int32_t, VideoPlayerSourceType);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
 


### PR DESCRIPTION
This is because our current version of quickjs does not support BigInt (64 bits ints), which led to an error if using BigInt in a script on Web, or an unsupported conversion warning if using a Number.

Now that we expose 32 bits ints, the web scripts no longer show an unsupported conversion warning when using a Number.

Breaking: This change requires the web client team to update their script interface to match the new types.
