### PR TITLE
[OF-1580] chore: Remove DebugStatic build from Unity package

### DIFF
--- a/teamcity/Config.py
+++ b/teamcity/Config.py
@@ -59,7 +59,6 @@ config = Config(
         ],
         ios=[
             "libConnectedSpacesPlatform.a",
-            "libConnectedSpacesPlatform_D.zip",
             "libcrypto.a",
             "libssl.a"
         ],


### PR DESCRIPTION
Reverts change [29613a8](https://github.com/magnopus-opensource/connected-spaces-platform/pull/623)

The addition of the iOS DebugStatic build meant that the Unity package exceeded the npmjs package limit.