### PR TITLE
[OF-1576] feat: Prevent clients from deleting others messages

### DIFF
--- a/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
@@ -46,6 +46,25 @@ namespace
 
         return true;
     }
+
+    bool EnsureUserHasPermission(const common::String& UserId, const common::String& ConversationUserId, bool IsConversation)
+    {
+        if (UserId != ConversationUserId)
+        {
+            if (IsConversation)
+            {
+                CSP_LOG_ERROR_MSG("User does not have permission to modify this conversation.");
+            }
+            else
+            {
+                CSP_LOG_ERROR_MSG("User does not have permission to modify this message.");
+            }
+
+            return false;
+        }
+
+        return true;
+    }
 }
 
 ConversationSystemInternal::ConversationSystemInternal(
@@ -113,39 +132,54 @@ void ConversationSystemInternal::CreateConversation(const common::String& Messag
 
 void ConversationSystemInternal::DeleteConversation(const common::String& ConversationId, NullResultCallback Callback)
 {
-    // 1.Send multiplayer event
-    const multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler SignalRCallback
-        = [this, Callback, ConversationId](multiplayer::ErrorCode Error)
+    // 1. Get asset collection
+    AssetCollectionResultCallback GetConversationCallback = [this, ConversationId, Callback](const AssetCollectionResult& GetConversationResult)
     {
-        if (Error != multiplayer::ErrorCode::None)
+        if (HandleConversationResult(GetConversationResult, "The retrieval of Message asset collections was not successful.", Callback) == false)
         {
-            CSP_LOG_ERROR_MSG("DeleteConversation: SignalR connection: Error");
-
-            INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
             return;
         }
 
-        // 2. Delete the asset colleciton associated with this conversation
-        AssetCollection ConversationAssetCollection;
-        ConversationAssetCollection.Id = ConversationId;
+        // Ensure client has correct permissions to delete the conversation
+        multiplayer::MessageInfo Info
+            = systems::ConversationSystemHelpers::GetConversationInfoFromConversationAssetCollection(GetConversationResult.GetAssetCollection());
 
-        NullResultCallback DeleteAssetCollectionCallback = [Callback, this](const NullResult& DeleteAssetCollectionResult)
+        // 2.Send multiplayer event
+        const multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler SignalRCallback
+            = [this, Callback, ConversationId](multiplayer::ErrorCode Error)
         {
-            if (HandleConversationResult(
-                    DeleteAssetCollectionResult, "The deletion of the conversation asset collection was not successful.", Callback)
-                == false)
+            if (Error != multiplayer::ErrorCode::None)
             {
+                CSP_LOG_ERROR_MSG("DeleteConversation: SignalR connection: Error");
+
+                INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
                 return;
             }
 
-            Callback(DeleteAssetCollectionResult);
+            // 3. Delete the asset colleciton associated with this conversation
+            AssetCollection ConversationAssetCollection;
+            ConversationAssetCollection.Id = ConversationId;
+
+            NullResultCallback DeleteAssetCollectionCallback = [Callback, this](const NullResult& DeleteAssetCollectionResult)
+            {
+                if (HandleConversationResult(
+                        DeleteAssetCollectionResult, "The deletion of the conversation asset collection was not successful.", Callback)
+                    == false)
+                {
+                    return;
+                }
+
+                Callback(DeleteAssetCollectionResult);
+            };
+
+            this->AssetSystem->DeleteAssetCollection(ConversationAssetCollection, DeleteAssetCollectionCallback);
         };
 
-        this->AssetSystem->DeleteAssetCollection(ConversationAssetCollection, DeleteAssetCollectionCallback);
+        multiplayer::MessageInfo MessageInfo(ConversationId, true, "", "", "", "", "");
+        SendConversationEvent(multiplayer::ConversationEventType::DeleteConversation, MessageInfo, EventBus, SignalRCallback);
     };
 
-    multiplayer::MessageInfo MessageInfo(ConversationId, true, "", "", "", "", "");
-    SendConversationEvent(multiplayer::ConversationEventType::DeleteConversation, MessageInfo, EventBus, SignalRCallback);
+    AssetSystem->GetAssetCollectionById(ConversationId, GetConversationCallback);
 }
 
 void ConversationSystemInternal::AddMessage(
@@ -191,38 +225,60 @@ void ConversationSystemInternal::AddMessage(
 
 void ConversationSystemInternal::DeleteMessage(const common::String& ConversationId, const common::String& MessageId, NullResultCallback Callback)
 {
-    // 1. Send multiplayer event
-    const multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler SignalRCallback
-        = [this, Callback, ConversationId, MessageId](multiplayer::ErrorCode Error)
+    // 1. Get asset collection
+    AssetCollectionResultCallback GetConversationCallback
+        = [this, ConversationId, MessageId, Callback](const AssetCollectionResult& GetConversationResult)
     {
-        if (Error != multiplayer::ErrorCode::None)
+        if (HandleConversationResult(GetConversationResult, "The retrieval of Message asset collections was not successful.", Callback) == false)
         {
-            CSP_LOG_ERROR_MSG("DeleteMessage: SignalR connection: Error");
+            return;
+        }
 
+        // Ensure client has correct permissions to delete the conversation
+        multiplayer::MessageInfo Info
+            = systems::ConversationSystemHelpers::GetMessageInfoFromMessageAssetCollection(GetConversationResult.GetAssetCollection());
+
+        if (EnsureUserHasPermission(UserSystem->GetLoginState().UserId, Info.UserId, false) == false)
+        {
             INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
             return;
         }
 
-        // 2. Delete the message asset collection
-        AssetCollection MessageAssetCollection;
-        MessageAssetCollection.Id = MessageId;
-
-        const NullResultCallback DeleteAssetCollectionCallback
-            = [this, Callback, ConversationId, MessageId](const NullResult& DeleteAssetCollectionResult)
+        // 2. Send multiplayer event
+        const multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler SignalRCallback
+            = [this, Callback, ConversationId, MessageId](multiplayer::ErrorCode Error)
         {
-            if (HandleConversationResult(DeleteAssetCollectionResult, "Failed to delete Message asset collection.", Callback) == false)
+            if (Error != multiplayer::ErrorCode::None)
             {
+                CSP_LOG_ERROR_MSG("DeleteMessage: SignalR connection: Error");
+
+                INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
                 return;
             }
 
-            Callback(DeleteAssetCollectionResult);
+            // 3. Delete the message asset collection
+            AssetCollection MessageAssetCollection;
+            MessageAssetCollection.Id = MessageId;
+
+            const NullResultCallback DeleteAssetCollectionCallback
+                = [this, Callback, ConversationId, MessageId](const NullResult& DeleteAssetCollectionResult)
+            {
+                if (HandleConversationResult(DeleteAssetCollectionResult, "Failed to delete Message asset collection.", Callback) == false)
+                {
+                    return;
+                }
+
+                Callback(DeleteAssetCollectionResult);
+            };
+
+            this->AssetSystem->DeleteAssetCollection(MessageAssetCollection, DeleteAssetCollectionCallback);
         };
 
-        this->AssetSystem->DeleteAssetCollection(MessageAssetCollection, DeleteAssetCollectionCallback);
+        multiplayer::MessageInfo MessageInfo(ConversationId, false, "", "", "", "", MessageId);
+        SendConversationEvent(multiplayer::ConversationEventType::DeleteMessage, MessageInfo, EventBus, SignalRCallback);
     };
 
-    multiplayer::MessageInfo MessageInfo(ConversationId, false, "", "", "", "", MessageId);
-    SendConversationEvent(multiplayer::ConversationEventType::DeleteMessage, MessageInfo, EventBus, SignalRCallback);
+    AssetSystem->GetAssetCollectionById(ConversationId, GetConversationCallback);
 }
 
 void ConversationSystemInternal::GetMessagesFromConversation(const common::String& ConversationId, const common::Optional<int>& ResultsSkipNumber,
@@ -277,6 +333,16 @@ void ConversationSystemInternal::UpdateConversation(
     {
         if (HandleConversationResult(GetConversationResult, "The retrieval of Conversation asset collections was not successful.", Callback) == false)
         {
+            return;
+        }
+
+        // Ensure client has correct permissions to delete the conversation
+        multiplayer::MessageInfo Info
+            = systems::ConversationSystemHelpers::GetConversationInfoFromConversationAssetCollection(GetConversationResult.GetAssetCollection());
+
+        if (EnsureUserHasPermission(UserSystem->GetLoginState().UserId, Info.UserId, true) == false)
+        {
+            INVOKE_IF_NOT_NULL(Callback, MakeInvalid<multiplayer::ConversationResult>());
             return;
         }
 
@@ -356,6 +422,16 @@ void ConversationSystemInternal::UpdateMessage(const common::String& Conversatio
     {
         if (HandleConversationResult(GetMessageResult, "The retrieval of Conversation asset collections was not successful.", Callback) == false)
         {
+            return;
+        }
+
+        // Ensure client has correct permissions to delete the conversation
+        multiplayer::MessageInfo Info
+            = systems::ConversationSystemHelpers::GetMessageInfoFromMessageAssetCollection(GetMessageResult.GetAssetCollection());
+
+        if (EnsureUserHasPermission(UserSystem->GetLoginState().UserId, Info.UserId, false) == false)
+        {
+            INVOKE_IF_NOT_NULL(Callback, MakeInvalid<multiplayer::MessageResult>());
             return;
         }
 

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -23,6 +23,7 @@
 #include "CSP/Multiplayer/Components/ConversationSpaceComponent.h"
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/Log/LogSystem.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "CSP/Systems/Users/UserSystem.h"
 #include "MultiplayerTestRunnerProcess.h"
@@ -914,4 +915,204 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
     LogOut(UserSystem);
 }
 
+#endif
+
+/*
+Tests that other clients can't Delete other clients messages, or edit other clients conversations or messages.
+Other clients can still delete other conversations, as components/entities dont have any restrictions.
+*/
+#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATION_TESTS || RUN_CONVERSATIONCOMPONENT_PERMISSIONS_TEST
+CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
+
+    // Create user
+    auto TestUser = CreateTestUser();
+
+    // Log in
+    csp::common::String UserId;
+    LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
+
+    // Create space
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    // Create a second test user
+    csp::systems::Profile AlternativeTestUser = CreateTestUser();
+
+    uint64_t ConversationObjectId = 0;
+    csp::common::String ConversationId;
+    csp::common::String MessageId;
+
+    // Add the second test user to the space
+    {
+        auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, AlternativeTestUser.Email, true, "", "");
+        EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+    }
+
+    {
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+        // Create object to represent the conversation
+        csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+        ConversationObjectId = Object->GetId();
+        auto* ConversationComponent = (ConversationSpaceComponent*)Object->AddComponent(ComponentType::Conversation);
+
+        Object->QueueUpdate();
+        EntitySystem->ProcessPendingEntityOperations();
+
+        // Create conversation
+        {
+            auto [Result] = AWAIT(ConversationComponent, CreateConversation, "TestMessage");
+
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+            EXPECT_TRUE(Result.GetValue() != "");
+
+            ConversationId = Result.GetValue();
+
+            Object->QueueUpdate();
+            EntitySystem->ProcessPendingEntityOperations();
+        }
+
+        // Create message
+        {
+            auto [Result] = AWAIT(ConversationComponent, AddMessage, "TestMessage");
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+
+            MessageId = Result.GetMessageInfo().MessageId;
+        }
+
+        // Logout
+        auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+        LogOut(UserSystem);
+    }
+
+    // Ensure component data has been written to database by chs before entering the space again
+    std::this_thread::sleep_for(7s);
+
+    {
+        // Log in with the second account
+        csp::common::String SecondTestUserId;
+        LogIn(UserSystem, SecondTestUserId, AlternativeTestUser.Email, GeneratedTestAccountPassword);
+
+        auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        EXPECT_EQ(EnterResult2.GetResultCode(), csp::systems::EResultCode::Success);
+
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+
+        bool EntitiesRetrieved = false;
+
+        EntitySystem->SetInitialEntitiesRetrievedCallback(
+            [&EntitiesRetrieved](bool Ok)
+            {
+                if (Ok)
+                {
+                    EntitiesRetrieved = true;
+                }
+            });
+
+        WaitForCallbackWithUpdate(EntitiesRetrieved, EntitySystem);
+
+        auto* RetrievedConversationEntity = EntitySystem->FindSpaceEntityById(ConversationObjectId);
+        auto* RetrievedConversationComponent = static_cast<ConversationSpaceComponent*>(RetrievedConversationEntity->GetComponent(0));
+
+        static const csp::common::String NoConversationPermissionsErrorLog = "User does not have permission to modify this conversation.";
+        static const csp::common::String NoMessagePermissionsErrorLog = "User does not have permission to modify this message.";
+
+        // Attempt to edit the conversation
+        {
+            bool CallbackCalled = false;
+
+            csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(
+                [&CallbackCalled](const csp::common::String& Message)
+                {
+                    CallbackCalled = true;
+                    EXPECT_EQ(NoConversationPermissionsErrorLog, Message);
+                });
+
+            auto [Result] = AWAIT_PRE(RetrievedConversationComponent, UpdateConversation, RequestPredicate, {});
+            EXPECT_EQ(Result.GetHttpResultCode(), 0);
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+
+            csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(nullptr);
+        }
+
+        // Attempt to edit the message
+        {
+            bool CallbackCalled = false;
+
+            csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(
+                [&CallbackCalled](const csp::common::String& Message)
+                {
+                    CallbackCalled = true;
+                    EXPECT_EQ(NoMessagePermissionsErrorLog, Message);
+                });
+
+            auto [Result] = AWAIT_PRE(RetrievedConversationComponent, UpdateMessage, RequestPredicate, MessageId, {});
+            EXPECT_EQ(Result.GetHttpResultCode(), 0);
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+
+            csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(nullptr);
+        }
+
+        // Attempt to delete the message
+        {
+            bool CallbackCalled = false;
+
+            csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(
+                [&CallbackCalled](const csp::common::String& Message)
+                {
+                    CallbackCalled = true;
+                    EXPECT_EQ(NoMessagePermissionsErrorLog, Message);
+                });
+
+            auto [Result] = AWAIT_PRE(RetrievedConversationComponent, DeleteMessage, RequestPredicate, MessageId);
+            EXPECT_EQ(Result.GetHttpResultCode(), 0);
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+
+            csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(nullptr);
+        }
+
+        csp::common::String MessageId2;
+
+        // Ensure we can still add a message
+        {
+            auto [Result] = AWAIT(RetrievedConversationComponent, AddMessage, "TestMessage2");
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+
+            MessageId2 = Result.GetMessageInfo().MessageId;
+        }
+
+        // Ensure we can still edit our own message
+        {
+            auto [Result] = AWAIT(RetrievedConversationComponent, UpdateMessage, MessageId2, {});
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+        }
+
+        // Ensure we can still delete the conversation
+        {
+            auto [Result] = AWAIT(RetrievedConversationComponent, DeleteConversation);
+            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+        }
+    }
+
+    // Exit space
+    auto [ExitSpaceResult2] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+    // Log out
+    LogOut(UserSystem);
+
+    // Log in with the space creator to delete the space
+    LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
+
+    // Delete space
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    // Log out
+    LogOut(UserSystem);
+}
 #endif


### PR DESCRIPTION
UpdateConversation, DeleteMessage, and UpdateMessage will now fail if the clients attempting these operations aren't the client who created them.