### PR TITLE
[OF-1577] feat!: Add tag controls to Space, removing them from the metadata prototype.

### DIFF
--- a/Library/include/CSP/Common/Array.h
+++ b/Library/include/CSP/Common/Array.h
@@ -24,6 +24,7 @@
 #include <initializer_list>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 #ifndef CSP_DISABLE_OVERFLOW_CHECKING
 #ifdef _MSC_VER
@@ -68,20 +69,6 @@ public:
         }
     }
 
-    /// @brief Constructs an array from a buffer.
-    /// @param Buffer const T* : Pointer to the beginning of the buffer
-    /// @param Size size_t : Number of elements in the buffer
-    CSP_NO_EXPORT Array(const T* Buffer, size_t Size)
-        : ArraySize(0)
-        , ObjectArray(nullptr)
-    {
-        if (Buffer != nullptr && Size > 0)
-        {
-            AllocArray(Size);
-            memcpy(ObjectArray, Buffer, Size * sizeof(T));
-        }
-    }
-
     /// @brief Copy constructor.
     /// @param Other const Array<T>& Other
     CSP_NO_EXPORT Array(const Array<T>& Other)
@@ -97,6 +84,24 @@ public:
             for (size_t i = 0; i < ArraySize; i++)
             {
                 ObjectArray[i] = Other.ObjectArray[i];
+            }
+        }
+    }
+
+    /// @brief Constructs an array from std::vector.
+    /// @param Vector std::Array : Elements to construct the array from. Elements are copied.
+    /// @pre T must be copyable.
+    CSP_NO_EXPORT Array(const std::vector<T>& Vector)
+        : ArraySize(0)
+        , ObjectArray(nullptr)
+    {
+        if (Vector.size() > 0)
+        {
+            AllocArray(Vector.size());
+
+            for (size_t i = 0; i < Vector.size(); ++i)
+            {
+                ObjectArray[i] = Vector[i];
             }
         }
     }
@@ -216,6 +221,10 @@ public:
 
         return std::move(Result);
     }
+
+    /// @brief Returns a copy of this Array as a std::vector
+    /// @return List<T>
+    CSP_NO_EXPORT std::vector<T> ToStdVector() const { return std::vector<T>(begin(), end()); }
 
 private:
     /// @brief Allocates memory for the array.

--- a/Library/include/CSP/Common/Array.h
+++ b/Library/include/CSP/Common/Array.h
@@ -24,7 +24,6 @@
 #include <initializer_list>
 #include <stdexcept>
 #include <utility>
-#include <vector>
 
 #ifndef CSP_DISABLE_OVERFLOW_CHECKING
 #ifdef _MSC_VER
@@ -84,24 +83,6 @@ public:
             for (size_t i = 0; i < ArraySize; i++)
             {
                 ObjectArray[i] = Other.ObjectArray[i];
-            }
-        }
-    }
-
-    /// @brief Constructs an array from std::vector.
-    /// @param Vector std::Array : Elements to construct the array from. Elements are copied.
-    /// @pre T must be copyable.
-    CSP_NO_EXPORT Array(const std::vector<T>& Vector)
-        : ArraySize(0)
-        , ObjectArray(nullptr)
-    {
-        if (Vector.size() > 0)
-        {
-            AllocArray(Vector.size());
-
-            for (size_t i = 0; i < Vector.size(); ++i)
-            {
-                ObjectArray[i] = Vector[i];
             }
         }
     }
@@ -221,10 +202,6 @@ public:
 
         return std::move(Result);
     }
-
-    /// @brief Returns a copy of this Array as a std::vector
-    /// @return List<T>
-    CSP_NO_EXPORT std::vector<T> ToStdVector() const { return std::vector<T>(begin(), end()); }
 
 private:
     /// @brief Allocates memory for the array.

--- a/Library/include/CSP/Common/String.h
+++ b/Library/include/CSP/Common/String.h
@@ -177,6 +177,11 @@ public:
     /// @return String
     static String Join(const std::initializer_list<String>& Parts, Optional<char> Separator = nullptr);
 
+    ///  @brief Checks if the string contains the given substring.
+    ///  @param Substring const String& : Substring to search for.
+    ///  @return bool : Returns true if the substring is found. Always returns false if the substring is empty.
+    bool Contains(const String& Substring) const;
+
 private:
     /// @brief Returns internal buffer.
     /// @return const char*

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -22,6 +22,7 @@
 #include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
 #include "CSP/Multiplayer/EventParameters.h"
 
+#include <chrono>
 #include <deque>
 #include <functional>
 #include <list>

--- a/Library/include/CSP/Systems/Spaces/Space.h
+++ b/Library/include/CSP/Systems/Spaces/Space.h
@@ -99,6 +99,7 @@ public:
     csp::common::String Name;
     csp::common::String Description;
     SpaceAttributes Attributes;
+    csp::common::Array<csp::common::String> Tags;
 };
 
 /// @ingroup Space System
@@ -293,7 +294,6 @@ class CSP_API SpaceMetadataResult : public csp::systems::ResultBase
 
 public:
     const csp::common::Map<csp::common::String, csp::common::String>& GetMetadata() const;
-    const csp::common::Array<csp::common::String>& GetTags() const;
 
     CSP_NO_EXPORT
     SpaceMetadataResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
@@ -305,10 +305,8 @@ private:
     SpaceMetadataResult() {};
 
     void SetMetadata(const csp::common::Map<csp::common::String, csp::common::String>& MetadataAssetCollection);
-    void SetTags(const csp::common::Array<csp::common::String>& TagsAssetCollection);
 
     csp::common::Map<csp::common::String, csp::common::String> Metadata;
-    csp::common::Array<csp::common::String> Tags;
 };
 
 /// @ingroup Space System

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -145,10 +145,11 @@ public:
     /// @param Description csp::common::Optional<csp::common::String> : if a new description is provided it will be used to update the Space
     /// description
     /// @param Type csp::common::Optional<csp::systems::SpaceType> : if a new type is provided it will be used to update the Space type
+    /// @param Tags csp::common::Optional<csp::common::Array<csp::common::String>> : If new tags are provided they will be used to update the Space
     /// @param Callback BasicSpaceResultCallback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void UpdateSpace(const csp::common::String& SpaceId, const csp::common::Optional<csp::common::String>& Name,
         const csp::common::Optional<csp::common::String>& Description, const csp::common::Optional<SpaceAttributes>& Type,
-        BasicSpaceResultCallback Callback);
+        const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags, BasicSpaceResultCallback Callback);
 
     /// @brief Deletes a given space and the corresponding UserService group.
     /// @param Space Space : space to delete
@@ -167,10 +168,17 @@ public:
     /// @param ResultsSkip csp::common::Optional<int> : number of result entries that will be skipped from the result. For no skip pass nullptr.
     /// @param ResultsMax csp::common::Optional<int> : maximum number of result entries to be retrieved. For all available result entries pass
     /// nullptr.
+    /// @param MustContainTags csp::common::Optional<csp::common::Array<csp::common::String>> : Array of tags that must be present in retrieved
+    /// spaces. For no mandatory tags pass nullptr.
+    /// @param MustExcludeTags csp::common::Optional<csp::common::Array<csp::common::String>> : Array of tags that must not be present in retrieved
+    /// spaces. For no excluded tags pass nullptr.
+    /// @param MustIncludeAllTags csp::common::Optional<bool> : Whether all tags in @param MustContainTags must be present in retrieved spaces.
     /// @param Callback SpacesResultCallback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void GetSpacesByAttributes(const csp::common::Optional<bool>& IsDiscoverable, const csp::common::Optional<bool>& IsArchived,
         const csp::common::Optional<bool>& RequiresInvite, const csp::common::Optional<int>& ResultsSkip,
-        const csp::common::Optional<int>& ResultsMax, BasicSpacesResultCallback Callback);
+        const csp::common::Optional<int>& ResultsMax, const csp::common::Optional<csp::common::Array<csp::common::String>>& MustContainTags,
+        const csp::common::Optional<csp::common::Array<csp::common::String>>& MustExcludeTags, const csp::common::Optional<bool>& MustIncludeAllTags,
+        BasicSpacesResultCallback Callback);
 
     /// @brief Retrieves space details corresponding to the provided Space IDs
     /// @param RequestedSpaceIDs csp::common::Array<csp::common::String> : array of Space IDs for which the space details will be retrieved
@@ -263,12 +271,9 @@ public:
     /// @brief Updates the Space metadata information with the new one provided
     /// @param SpaceId csp::common::String : ID of Space for which the metadata will be updated
     /// @param NewMetadata csp::common::String : New metadata information that will replace the previous one
-    /// @param Tags csp::common::Array<csp::common::String> : Array of strings that will replace the tags on the space. If unset, the existing tags on
-    /// the AssetCollection will be unmodified.
     /// @param Callback NullResultCallback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void UpdateSpaceMetadata(const csp::common::String& SpaceId,
-        const csp::common::Map<csp::common::String, csp::common::String>& NewMetadata,
-        const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags, NullResultCallback Callback);
+        const csp::common::Map<csp::common::String, csp::common::String>& NewMetadata, NullResultCallback Callback);
 
     /// @brief Retrieves Spaces metadata information
     /// @param Spaces csp::common::Array<Space> : Spaces for which metadata will be retrieved
@@ -357,8 +362,8 @@ private:
     // Space Metadata
     void GetMetadataAssetCollection(const csp::common::String& SpaceId, AssetCollectionResultCallback Callback);
     void GetMetadataAssetCollections(const csp::common::Array<csp::common::String>& Spaces, AssetCollectionsResultCallback Callback);
-    void AddMetadata(const csp::common::String& SpaceId, const csp::common::Map<csp::common::String, csp::common::String>& Metadata,
-        const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags, NullResultCallback Callback);
+    void AddMetadata(
+        const csp::common::String& SpaceId, const csp::common::Map<csp::common::String, csp::common::String>& Metadata, NullResultCallback Callback);
     void RemoveMetadata(const csp::common::String& SpaceId, NullResultCallback Callback);
 
     // Space Thumbnail

--- a/Library/src/Common/String.cpp
+++ b/Library/src/Common/String.cpp
@@ -420,6 +420,16 @@ String String::Join(const List<String>& Parts, Optional<char> Separator)
     return JoinedString;
 }
 
+bool String::Contains(const String& Substring) const
+{
+    if (Substring.Length() == 0)
+    {
+        return false;
+    }
+
+    return strstr(Get(), Substring.Get()) != nullptr;
+}
+
 String String::Join(const std::initializer_list<String>& Parts, Optional<char> Separator)
 {
     if (Parts.size() == 0)

--- a/Library/src/Systems/Spaces/Space.cpp
+++ b/Library/src/Systems/Spaces/Space.cpp
@@ -17,6 +17,7 @@
 #include "CSP/Systems/Spaces/Space.h"
 
 #include "CSP/Systems/Assets/AssetCollection.h"
+#include "Common/Convert.h"
 #include "Services/SpatialDataService/Api.h"
 #include "Services/UserService/Api.h"
 #include "Services/UserService/Dto.h"
@@ -57,7 +58,7 @@ void GroupLiteDtoToBasicSpace(const chs_users::GroupLiteDto& Dto, csp::systems::
 
     if (Dto.HasTags())
     {
-        BasicSpace.Tags = Array<String> { Dto.GetTags() };
+        BasicSpace.Tags = csp::common::Convert(Dto.GetTags());
     }
 }
 
@@ -86,22 +87,22 @@ void GroupDtoToSpace(const chs_users::GroupDto& Dto, csp::systems::Space& Space)
 
     if (Dto.HasTags())
     {
-        Space.Tags = Array<csp::common::String> { Dto.GetTags() };
+        Space.Tags = csp::common::Convert(Dto.GetTags());
     }
 
     if (Dto.HasUsers())
     {
-        Space.UserIds = Array<String> { Dto.GetUsers() };
+        Space.UserIds = csp::common::Convert(Dto.GetUsers());
     }
 
     if (Dto.HasModerators())
     {
-        Space.ModeratorIds = Array<String> { Dto.GetModerators() };
+        Space.ModeratorIds = csp::common::Convert(Dto.GetModerators());
     }
 
     if (Dto.HasBannedUsers())
     {
-        Space.BannedUserIds = Array<String> { Dto.GetBannedUsers() };
+        Space.BannedUserIds = csp::common::Convert(Dto.GetBannedUsers());
     }
 }
 

--- a/Library/src/Systems/Spaces/Space.cpp
+++ b/Library/src/Systems/Spaces/Space.cpp
@@ -54,6 +54,11 @@ void GroupLiteDtoToBasicSpace(const chs_users::GroupLiteDto& Dto, csp::systems::
     {
         BasicSpace.Description = Dto.GetDescription();
     }
+
+    if (Dto.HasTags())
+    {
+        BasicSpace.Tags = Array<String> { Dto.GetTags() };
+    }
 }
 
 void GroupDtoToSpace(const chs_users::GroupDto& Dto, csp::systems::Space& Space)
@@ -79,37 +84,24 @@ void GroupDtoToSpace(const chs_users::GroupDto& Dto, csp::systems::Space& Space)
         Space.Description = Dto.GetDescription();
     }
 
+    if (Dto.HasTags())
+    {
+        Space.Tags = Array<csp::common::String> { Dto.GetTags() };
+    }
+
     if (Dto.HasUsers())
     {
-        auto& users = Dto.GetUsers();
-        Space.UserIds = Array<String>(users.size());
-
-        for (int i = 0; i < users.size(); ++i)
-        {
-            Space.UserIds[i] = users[i];
-        }
+        Space.UserIds = Array<String> { Dto.GetUsers() };
     }
 
     if (Dto.HasModerators())
     {
-        auto& Moderators = Dto.GetModerators();
-        Space.ModeratorIds = Array<String>(Moderators.size());
-
-        for (int i = 0; i < Moderators.size(); ++i)
-        {
-            Space.ModeratorIds[i] = Moderators[i];
-        }
+        Space.ModeratorIds = Array<String> { Dto.GetModerators() };
     }
 
     if (Dto.HasBannedUsers())
     {
-        auto& users = Dto.GetBannedUsers();
-        Space.BannedUserIds = Array<String>(users.size());
-
-        for (int i = 0; i < users.size(); ++i)
-        {
-            Space.BannedUserIds[i] = users[i];
-        }
+        Space.BannedUserIds = Array<String> { Dto.GetBannedUsers() };
     }
 }
 
@@ -255,11 +247,7 @@ void BasicSpacesResult::FillResultTotalCount(const String& JsonContent)
 
 const Map<String, String>& SpaceMetadataResult::GetMetadata() const { return Metadata; }
 
-const Array<String>& SpaceMetadataResult::GetTags() const { return Tags; }
-
 void SpaceMetadataResult::SetMetadata(const Map<String, String>& InMetadata) { Metadata = InMetadata; }
-
-void SpaceMetadataResult::SetTags(const Array<String>& InTags) { Tags = InTags; }
 
 Array<String>& PendingInvitesResult::GetPendingInvitesEmails() { return PendingInvitesEmailAddresses; }
 

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -26,6 +26,7 @@
 #include "CSP/Web/HTTPResponseCodes.h"
 #include "CallHelpers.h"
 #include "Common/Continuations.h"
+#include "Common/Convert.h"
 #include "Debug/Logging.h"
 #include "Events/EventSystem.h"
 #include "Multiplayer/ErrorCodeStrings.h"
@@ -66,7 +67,7 @@ void CreateSpace(chs::GroupApi* GroupAPI, const String& Name, const String& Desc
 
     if (Tags.HasValue())
     {
-        GroupInfo->SetTags(Tags->ToStdVector());
+        GroupInfo->SetTags(csp::common::Convert(Tags).value());
     }
 
     csp::services::ResponseHandlerPtr ResponseHandler
@@ -586,7 +587,7 @@ void SpaceSystem::UpdateSpace(const String& SpaceId, const Optional<String>& Nam
 
     if (Tags.HasValue())
     {
-        LiteGroupInfo->SetTags(Tags->ToStdVector());
+        LiteGroupInfo->SetTags(csp::common::Convert(Tags).value());
     }
 
     // Note that these are required fields from a services point of view.
@@ -638,8 +639,10 @@ void SpaceSystem::GetSpacesByAttributes(const Optional<bool>& InIsDiscoverable, 
         CSP_LOG_WARN_FORMAT("Provided value `%i` for ResultsMax exceeded max value and was reduced to `%i`.", *InResultsMax, MAX_SPACES_RESULTS);
     }
 
-    auto Tags = MustContainTags.HasValue() ? MustContainTags->ToStdVector() : std::optional<std::vector<csp::common::String>>(std::nullopt);
-    auto ExcludedTags = MustExcludeTags.HasValue() ? MustExcludeTags->ToStdVector() : std::optional<std::vector<csp::common::String>>(std::nullopt);
+    auto Tags
+        = MustContainTags.HasValue() ? csp::common::Convert(MustContainTags).value() : std::optional<std::vector<csp::common::String>>(std::nullopt);
+    auto ExcludedTags
+        = MustExcludeTags.HasValue() ? csp::common::Convert(MustExcludeTags).value() : std::optional<std::vector<csp::common::String>>(std::nullopt);
     auto MustIncludeAllTags = InMustIncludeAllTags.HasValue() ? *InMustIncludeAllTags : std::optional<bool>(std::nullopt);
 
     csp::services::ResponseHandlerPtr ResponseHandler

--- a/Tests/src/InternalTests/CommonTypeTests/Array.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Array.cpp
@@ -91,48 +91,6 @@ CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArraySizeTooLargeInitialisationTe
     FAIL();
 }
 
-CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayBufferInitialisationTest)
-{
-    constexpr int ARRAY_SIZE = 5;
-
-    try
-    {
-        int Values[] = { 1, 2, 3, 4, 5 };
-        Array<int> Instance(Values, ARRAY_SIZE);
-
-        EXPECT_FALSE(Instance.IsEmpty());
-        EXPECT_EQ(Instance.Size(), ARRAY_SIZE);
-        EXPECT_NE(Instance.Data(), nullptr);
-
-        // All elements should match those in the provided buffer, but should not have the same address
-        for (int i = 0; i < ARRAY_SIZE; ++i)
-        {
-            EXPECT_EQ(Instance[i], Values[i]);
-            EXPECT_NE(&Instance[i], &Values[i]);
-        }
-    }
-    catch (...)
-    {
-        FAIL();
-    }
-}
-
-CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayBufferNullptrInitialisationTest)
-{
-    try
-    {
-        Array<int> Instance(nullptr, 5);
-
-        EXPECT_TRUE(Instance.IsEmpty());
-        EXPECT_EQ(Instance.Size(), 0);
-        EXPECT_EQ(Instance.Data(), nullptr);
-    }
-    catch (...)
-    {
-        FAIL();
-    }
-}
-
 CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayCopyInitialisationTest)
 {
     constexpr int ARRAY_SIZE = 2;
@@ -273,6 +231,48 @@ CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayToListTest)
         {
             EXPECT_EQ(ConvertedList[i], Instance[i]);
             EXPECT_NE(&ConvertedList[i], &Instance[i]);
+        }
+    }
+    catch (...)
+    {
+        FAIL();
+    }
+}
+
+CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayToVectorTest)
+{
+    try
+    {
+        Array<String> Instance = { "asd", "fgh", "jkl", "123" };
+        const auto ConvertedVector = Instance.ToStdVector();
+        EXPECT_EQ(ConvertedVector.size(), Instance.Size());
+
+        // All elements should match those in the array, but should not have the same address
+        for (int i = 0; i < Instance.Size(); ++i)
+        {
+            EXPECT_EQ(ConvertedVector[i], Instance[i]);
+            EXPECT_NE(&ConvertedVector[i], &Instance[i]);
+        }
+    }
+    catch (...)
+    {
+        FAIL();
+    }
+}
+
+CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayFromVectorTest)
+{
+    try
+    {
+        std::vector<String> Instance = { "asd", "fgh", "jkl", "123" };
+        const Array<String> ConvertedArray { Instance };
+        EXPECT_EQ(ConvertedArray.Size(), Instance.size());
+
+        // All elements should match those in the array, but should not have the same address
+        for (int i = 0; i < Instance.size(); ++i)
+        {
+            EXPECT_EQ(ConvertedArray[i], Instance[i]);
+            EXPECT_NE(&ConvertedArray[i], &Instance[i]);
         }
     }
     catch (...)

--- a/Tests/src/InternalTests/CommonTypeTests/Array.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Array.cpp
@@ -238,47 +238,4 @@ CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayToListTest)
         FAIL();
     }
 }
-
-CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayToVectorTest)
-{
-    try
-    {
-        Array<String> Instance = { "asd", "fgh", "jkl", "123" };
-        const auto ConvertedVector = Instance.ToStdVector();
-        EXPECT_EQ(ConvertedVector.size(), Instance.Size());
-
-        // All elements should match those in the array, but should not have the same address
-        for (int i = 0; i < Instance.Size(); ++i)
-        {
-            EXPECT_EQ(ConvertedVector[i], Instance[i]);
-            EXPECT_NE(&ConvertedVector[i], &Instance[i]);
-        }
-    }
-    catch (...)
-    {
-        FAIL();
-    }
-}
-
-CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayFromVectorTest)
-{
-    try
-    {
-        std::vector<String> Instance = { "asd", "fgh", "jkl", "123" };
-        const Array<String> ConvertedArray { Instance };
-        EXPECT_EQ(ConvertedArray.Size(), Instance.size());
-
-        // All elements should match those in the array, but should not have the same address
-        for (int i = 0; i < Instance.size(); ++i)
-        {
-            EXPECT_EQ(ConvertedArray[i], Instance[i]);
-            EXPECT_NE(&ConvertedArray[i], &Instance[i]);
-        }
-    }
-    catch (...)
-    {
-        FAIL();
-    }
-}
-
 #endif

--- a/Tests/src/InternalTests/CommonTypeTests/String.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/String.cpp
@@ -671,4 +671,20 @@ CSP_INTERNAL_TEST(CSPEngine, CommonStringTests, StringJoinListAllEmptyEntriesTes
     }
 }
 
+CSP_INTERNAL_TEST(CSPEngine, CommonStringTests, StringContainsTest)
+{
+    String TestStr = "TestStringOneTwoThree";
+
+    EXPECT_TRUE(TestStr.Contains("One"));
+    EXPECT_TRUE(TestStr.Contains("Two"));
+    EXPECT_TRUE(TestStr.Contains("Three"));
+    EXPECT_TRUE(TestStr.Contains("TestStringOneTwoThree"));
+
+    EXPECT_FALSE(TestStr.Contains("Four"));
+    EXPECT_FALSE(TestStr.Contains("TestStringOneTwoThree "));
+    EXPECT_FALSE(TestStr.Contains(""));
+    EXPECT_FALSE(TestStr.Contains(" "));
+    EXPECT_FALSE(TestStr.Contains("TestStringOneTwoThreeFour"));
+}
+
 #endif

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1052,8 +1052,14 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetFilteredByTagInclusionSpacesTest
     std::string TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
 
-    std::vector<std::pair<std::string, csp::common::Array<csp::common::String>>> SpacesWithTags
-        = { { TestSpaceName + "Space1", { "tag1" } }, { TestSpaceName + "Space2", { "tag2" } }, { TestSpaceName + "Space3", { "tag1", "tag2" } } };
+    UUIDv4::UUIDGenerator<std::mt19937_64> uuidGenerator;
+
+    const std::string Tag1 = uuidGenerator.getUUID().str();
+    const std::string Tag2 = uuidGenerator.getUUID().str();
+    const std::string Tag3 = uuidGenerator.getUUID().str();
+
+    std::vector<std::pair<std::string, csp::common::Array<csp::common::String>>> SpacesWithTags = { { TestSpaceName + "Space1", { Tag1.c_str() } },
+        { TestSpaceName + "Space2", { Tag2.c_str() } }, { TestSpaceName + "Space3", { Tag1.c_str(), Tag2.c_str() } } };
     std::array<csp::common::String, 3> SpaceIds;
 
     for (size_t i = 0; i < SpacesWithTags.size(); ++i)
@@ -1067,7 +1073,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetFilteredByTagInclusionSpacesTest
     {
         // Query for spaces with "tag1"
         auto [SpacesWithTag1] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 10,
-            csp::common::Array<csp::common::String> { "tag1" }, nullptr, nullptr); // Space1, Space3
+            csp::common::Array<csp::common::String> { Tag1.c_str() }, nullptr, nullptr); // Space1, Space3
 
         EXPECT_EQ(SpacesWithTag1.GetSpaces().Size(), 2);
         EXPECT_NE(std::find_if(SpacesWithTag1.GetSpaces().cbegin(), SpacesWithTag1.GetSpaces().cend(),
@@ -1080,7 +1086,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetFilteredByTagInclusionSpacesTest
     {
         // Query for spaces with "tag1" and "tag2", without needing every tag to be on the spaces
         auto [SpacesWithTags1And2WithoutEveryTag] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr,
-            nullptr, 10, csp::common::Array<csp::common::String> { "tag1", "tag2" }, nullptr, false); // Space1, Space2, Space3
+            nullptr, 10, csp::common::Array<csp::common::String> { Tag1.c_str(), Tag2.c_str() }, nullptr, false); // Space1, Space2, Space3
 
         EXPECT_EQ(SpacesWithTags1And2WithoutEveryTag.GetSpaces().Size(), 3);
         EXPECT_NE(std::find_if(SpacesWithTags1And2WithoutEveryTag.GetSpaces().cbegin(), SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend(),
@@ -1096,7 +1102,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetFilteredByTagInclusionSpacesTest
     {
         // Query for spaces with "tag1" and "tag2", needing every tag to be on the spaces
         auto [SpacesWithTag1And2WithEveryTag] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr,
-            10, csp::common::Array<csp::common::String> { "tag1", "tag2" }, nullptr, true); // Space3
+            10, csp::common::Array<csp::common::String> { Tag1.c_str(), Tag2.c_str() }, nullptr, true); // Space3
 
         EXPECT_EQ(SpacesWithTag1And2WithEveryTag.GetSpaces().Size(), 1);
         EXPECT_NE(std::find_if(SpacesWithTag1And2WithEveryTag.GetSpaces().cbegin(), SpacesWithTag1And2WithEveryTag.GetSpaces().cend(),
@@ -1106,20 +1112,20 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetFilteredByTagInclusionSpacesTest
     {
         // Query for spaces without "tag1"
         auto [SpacesWithoutTag1] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 1, nullptr,
-            csp::common::Array<csp::common::String> { "tag1" },
-            true); // This will just be any space (in the entire database!) without "tag1", we can't guarantee which one it'll be, so we just check
+            csp::common::Array<csp::common::String> { Tag1.c_str() },
+            true); // This will just be any space (in the entire database!) without Tag1, we can't guarantee which one it'll be, so we just check
                    // that it doesn't have the tag
 
         EXPECT_EQ(SpacesWithoutTag1.GetSpaces().Size(), 1);
         // Check that "tag1" isn't in the tags.
         EXPECT_EQ(std::find_if(SpacesWithoutTag1.GetSpaces()[0].Tags.cbegin(), SpacesWithoutTag1.GetSpaces()[0].Tags.cend(),
-                      [](const csp::common::String& Tag) { return Tag.Contains("tag1"); }),
+                      [&Tag1](const csp::common::String& Tag) { return Tag.Contains(Tag1.c_str()); }),
             SpacesWithoutTag1.GetSpaces()[0].Tags.cend());
     }
     {
         // Query for spaces with "tag1" but without "tag2"
         auto [SpacesWithTag1ButWithoutTag2] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 10,
-            csp::common::Array<csp::common::String> { "tag1" }, csp::common::Array<csp::common::String> { "tag2" }, true); // Space1
+            csp::common::Array<csp::common::String> { Tag1.c_str() }, csp::common::Array<csp::common::String> { Tag2.c_str() }, true); // Space1
 
         EXPECT_EQ(SpacesWithTag1ButWithoutTag2.GetSpaces().Size(), 1);
         EXPECT_NE(std::find_if(SpacesWithTag1ButWithoutTag2.GetSpaces().cbegin(), SpacesWithTag1ButWithoutTag2.GetSpaces().cend(),

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -28,6 +28,7 @@
 #include "gtest/gtest-param-test.h"
 #include "gtest/gtest.h"
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <tuple>
 #include <uuid_v4.h>
@@ -108,8 +109,8 @@ void GetSpace(::SpaceSystem* SpaceSystem, const String& SpaceId, Space& OutSpace
 Array<BasicSpace> GetSpacesByAttributes(::SpaceSystem* SpaceSystem, const Optional<bool>& IsDiscoverable, const Optional<bool>& IsArchived,
     const Optional<bool>& RequiresInvite, const Optional<int>& ResultsSkipNo, const Optional<int>& ResultsMaxNo)
 {
-    auto [Result]
-        = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, IsDiscoverable, IsArchived, RequiresInvite, ResultsSkipNo, ResultsMaxNo);
+    auto [Result] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, IsDiscoverable, IsArchived, RequiresInvite, ResultsSkipNo,
+        ResultsMaxNo, nullptr, nullptr, nullptr);
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -134,9 +135,9 @@ Array<Space> GetSpacesByIds(::SpaceSystem* SpaceSystem, const Array<String>& Spa
 }
 
 void UpdateSpace(::SpaceSystem* SpaceSystem, const String& SpaceId, const Optional<String>& NewName, const Optional<String>& NewDescription,
-    const Optional<SpaceAttributes>& NewAttributes, BasicSpace& OutSpace)
+    const Optional<SpaceAttributes>& NewAttributes, const Optional<Array<String>>& NewTags, BasicSpace& OutSpace)
 {
-    auto [Result] = AWAIT_PRE(SpaceSystem, UpdateSpace, RequestPredicate, SpaceId, NewName, NewDescription, NewAttributes);
+    auto [Result] = AWAIT_PRE(SpaceSystem, UpdateSpace, RequestPredicate, SpaceId, NewName, NewDescription, NewAttributes, NewTags);
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -235,12 +236,11 @@ void GetUsersRoles(::SpaceSystem* SpaceSystem, const String& SpaceId, const Arra
     }
 }
 
-void UpdateAndAssertSpaceMetadata(
-    ::SpaceSystem* SpaceSystem, const String& SpaceId, const Optional<Map<String, String>>& NewMetadata, const Optional<Array<String>>& Tags)
+void UpdateAndAssertSpaceMetadata(::SpaceSystem* SpaceSystem, const String& SpaceId, const Optional<Map<String, String>>& NewMetadata)
 {
     Map<String, String> Metadata = NewMetadata.HasValue() ? *NewMetadata : Map<String, String>();
 
-    auto [Result] = AWAIT_PRE(SpaceSystem, UpdateSpaceMetadata, RequestPredicate, SpaceId, Metadata, Tags);
+    auto [Result] = AWAIT_PRE(SpaceSystem, UpdateSpaceMetadata, RequestPredicate, SpaceId, Metadata);
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -263,24 +263,6 @@ Map<String, Map<String, String>> GetAndAssertSpacesMetadata(::SpaceSystem* Space
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     return Result.GetMetadata();
-}
-
-Array<String> GetAndAssertSpaceTags(::SpaceSystem* SpaceSystem, const String& SpaceId)
-{
-    auto [Result] = AWAIT_PRE(SpaceSystem, GetSpaceMetadata, RequestPredicate, SpaceId);
-
-    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
-
-    return Result.GetTags();
-}
-
-Map<String, Array<String>> GetAndAssertSpacesTags(::SpaceSystem* SpaceSystem, const Array<String>& SpaceIds)
-{
-    auto [Result] = AWAIT_PRE(SpaceSystem, GetSpacesMetadata, RequestPredicate, SpaceIds);
-
-    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
-
-    return Result.GetTags();
 }
 
 bool IsUriValid(const std::string& Uri, const std::string& FileName)
@@ -581,7 +563,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceDescriptionTest)
     SPRINTF(UpdatedDescription, "%s-Updated", TestSpaceDescription);
 
     BasicSpace UpdatedBasicSpace;
-    UpdateSpace(SpaceSystem, Space.Id, nullptr, UpdatedDescription, nullptr, UpdatedBasicSpace);
+    UpdateSpace(SpaceSystem, Space.Id, nullptr, UpdatedDescription, nullptr, nullptr, UpdatedBasicSpace);
 
     EXPECT_EQ(UpdatedBasicSpace.Name, Space.Name);
     EXPECT_EQ(UpdatedBasicSpace.Description, UpdatedDescription);
@@ -630,7 +612,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTypeTest)
     auto UpdatedAttributes = SpaceAttributes::Public;
 
     BasicSpace UpdatedBasicSpace;
-    UpdateSpace(SpaceSystem, Space.Id, nullptr, nullptr, UpdatedAttributes, UpdatedBasicSpace);
+    UpdateSpace(SpaceSystem, Space.Id, nullptr, nullptr, UpdatedAttributes, nullptr, UpdatedBasicSpace);
 
     EXPECT_EQ(UpdatedBasicSpace.Name, Space.Name);
     EXPECT_EQ(UpdatedBasicSpace.Description, ""); // This should be empty because we elected to not give one when we invoked `UpdateSpace`.
@@ -1030,7 +1012,8 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPaginatedPrivateSpacesTest)
 
     // Get private spaces paginated
     {
-        auto [Result] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, false, false, true, 0, static_cast<int>(SPACE_COUNT / 2));
+        auto [Result] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, false, false, true, 0, static_cast<int>(SPACE_COUNT / 2),
+            nullptr, nullptr, nullptr);
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -1052,7 +1035,109 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPaginatedPrivateSpacesTest)
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_JOINPUBLICSPACE_TEST
+#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GET_FILTERED_BY_TAG_SPACES_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetFilteredByTagInclusionSpacesTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = ::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    // Log in
+    String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Create test spaces with tags
+    std::string TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
+    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+
+    std::vector<std::pair<std::string, csp::common::Array<csp::common::String>>> SpacesWithTags
+        = { { TestSpaceName + "Space1", { "tag1" } }, { TestSpaceName + "Space2", { "tag2" } }, { TestSpaceName + "Space3", { "tag1", "tag2" } } };
+    std::array<csp::common::String, 3> SpaceIds;
+
+    for (size_t i = 0; i < SpacesWithTags.size(); ++i)
+    {
+        ::Space Space;
+        CreateSpace(SpaceSystem, SpacesWithTags[i].first.c_str(), TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr,
+            SpacesWithTags[i].second, Space);
+        SpaceIds[i] = Space.Id;
+    }
+
+    {
+        // Query for spaces with "tag1"
+        auto [SpacesWithTag1] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 10,
+            csp::common::Array<csp::common::String> { "tag1" }, nullptr, nullptr); // Space1, Space3
+
+        EXPECT_EQ(SpacesWithTag1.GetSpaces().Size(), 2);
+        EXPECT_NE(std::find_if(SpacesWithTag1.GetSpaces().cbegin(), SpacesWithTag1.GetSpaces().cend(),
+                      [](const BasicSpace& Space) { return Space.Name.Contains("Space1"); }),
+            SpacesWithTag1.GetSpaces().cend());
+        EXPECT_NE(std::find_if(SpacesWithTag1.GetSpaces().cbegin(), SpacesWithTag1.GetSpaces().cend(),
+                      [](const BasicSpace& Space) { return Space.Name.Contains("Space3"); }),
+            SpacesWithTag1.GetSpaces().cend());
+    }
+    {
+        // Query for spaces with "tag1" and "tag2", without needing every tag to be on the spaces
+        auto [SpacesWithTags1And2WithoutEveryTag] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr,
+            nullptr, 10, csp::common::Array<csp::common::String> { "tag1", "tag2" }, nullptr, false); // Space1, Space2, Space3
+
+        EXPECT_EQ(SpacesWithTags1And2WithoutEveryTag.GetSpaces().Size(), 3);
+        EXPECT_NE(std::find_if(SpacesWithTags1And2WithoutEveryTag.GetSpaces().cbegin(), SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend(),
+                      [](const BasicSpace& Space) { return Space.Name.Contains("Space1"); }),
+            SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend());
+        EXPECT_NE(std::find_if(SpacesWithTags1And2WithoutEveryTag.GetSpaces().cbegin(), SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend(),
+                      [](const BasicSpace& Space) { return Space.Name.Contains("Space2"); }),
+            SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend());
+        EXPECT_NE(std::find_if(SpacesWithTags1And2WithoutEveryTag.GetSpaces().cbegin(), SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend(),
+                      [](const BasicSpace& Space) { return Space.Name.Contains("Space3"); }),
+            SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend());
+    }
+    {
+        // Query for spaces with "tag1" and "tag2", needing every tag to be on the spaces
+        auto [SpacesWithTag1And2WithEveryTag] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr,
+            10, csp::common::Array<csp::common::String> { "tag1", "tag2" }, nullptr, true); // Space3
+
+        EXPECT_EQ(SpacesWithTag1And2WithEveryTag.GetSpaces().Size(), 1);
+        EXPECT_NE(std::find_if(SpacesWithTag1And2WithEveryTag.GetSpaces().cbegin(), SpacesWithTag1And2WithEveryTag.GetSpaces().cend(),
+                      [](const BasicSpace& Space) { return Space.Name.Contains("Space3"); }),
+            SpacesWithTag1And2WithEveryTag.GetSpaces().cend());
+    }
+    {
+        // Query for spaces without "tag1"
+        auto [SpacesWithoutTag1] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 1, nullptr,
+            csp::common::Array<csp::common::String> { "tag1" },
+            true); // This will just be any space (in the entire database!) without "tag1", we can't guarantee which one it'll be, so we just check
+                   // that it doesn't have the tag
+
+        EXPECT_EQ(SpacesWithoutTag1.GetSpaces().Size(), 1);
+        // Check that "tag1" isn't in the tags.
+        EXPECT_EQ(std::find_if(SpacesWithoutTag1.GetSpaces()[0].Tags.cbegin(), SpacesWithoutTag1.GetSpaces()[0].Tags.cend(),
+                      [](const csp::common::String& Tag) { return Tag.Contains("tag1"); }),
+            SpacesWithoutTag1.GetSpaces()[0].Tags.cend());
+    }
+    {
+        // Query for spaces with "tag1" but without "tag2"
+        auto [SpacesWithTag1ButWithoutTag2] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 10,
+            csp::common::Array<csp::common::String> { "tag1" }, csp::common::Array<csp::common::String> { "tag2" }, true); // Space1
+
+        EXPECT_EQ(SpacesWithTag1ButWithoutTag2.GetSpaces().Size(), 1);
+        EXPECT_NE(std::find_if(SpacesWithTag1ButWithoutTag2.GetSpaces().cbegin(), SpacesWithTag1ButWithoutTag2.GetSpaces().cend(),
+                      [](const BasicSpace& Space) { return Space.Name.Contains("Space1"); }),
+            SpacesWithTag1ButWithoutTag2.GetSpaces().cend());
+    }
+
+    for (const auto& SpaceID : SpaceIds)
+    {
+        DeleteSpace(SpaceSystem, SpaceID);
+    }
+
+    // Log out
+    LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_JOINPUBLICsSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, JoinPublicSpaceTest)
 {
     SetRandSeed();
@@ -1438,7 +1523,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceMetadataTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     Map<String, String> TestSpaceMetadata = { { "site", "Void" } };
-    Array<String> Tags = { "tag-test" };
 
     ::Space Space;
     CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, TestSpaceMetadata, nullptr, nullptr, nullptr, Space);
@@ -1450,7 +1534,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceMetadataTest)
 
     TestSpaceMetadata["site"] = "MagOffice";
 
-    UpdateAndAssertSpaceMetadata(SpaceSystem, Space.Id, TestSpaceMetadata, Tags);
+    UpdateAndAssertSpaceMetadata(SpaceSystem, Space.Id, TestSpaceMetadata);
 
     RetrievedSpaceMetadata = GetAndAssertSpaceMetadata(SpaceSystem, Space.Id);
 
@@ -1458,6 +1542,57 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceMetadataTest)
     EXPECT_EQ(RetrievedSpaceMetadata["site"], "MagOffice");
 
     DeleteSpace(SpaceSystem, Space.Id);
+
+    LogOut(UserSystem);
+}
+#endif
+
+#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACES_METADATA_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpacesMetadataTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = ::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
+    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+
+    char UniqueSpaceName[256];
+    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+    String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    Map<String, String> TestSpaceMetadata = { { "site", "Void" } };
+
+    ::Space Space1, Space2;
+    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, TestSpaceMetadata, nullptr, nullptr, nullptr, Space1);
+    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, TestSpaceMetadata, nullptr, nullptr, nullptr, Space2);
+
+    Map<String, Map<String, String>> RetrievedSpaceMetadata = GetAndAssertSpacesMetadata(SpaceSystem, { Space1.Id, Space2.Id });
+
+    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id].Size(), TestSpaceMetadata.Size());
+    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id].Size(), TestSpaceMetadata.Size());
+    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id]["site"], "Void");
+    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id]["site"], "Void");
+
+    TestSpaceMetadata["site"] = "MagOffice";
+
+    // OB-3939 fix: passing tags as nullptr should leave them unchanged
+    UpdateAndAssertSpaceMetadata(SpaceSystem, Space1.Id, TestSpaceMetadata);
+    UpdateAndAssertSpaceMetadata(SpaceSystem, Space2.Id, TestSpaceMetadata);
+
+    RetrievedSpaceMetadata = GetAndAssertSpacesMetadata(SpaceSystem, { Space1.Id, Space2.Id });
+
+    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id].Size(), TestSpaceMetadata.Size());
+    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id].Size(), TestSpaceMetadata.Size());
+    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id]["site"], "MagOffice");
+    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id]["site"], "MagOffice");
+
+    DeleteSpace(SpaceSystem, Space1.Id);
+    DeleteSpace(SpaceSystem, Space2.Id);
 
     LogOut(UserSystem);
 }
@@ -1508,8 +1643,8 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesMetadataTest)
 }
 #endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACETAGS_METADATA_TEST
-CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTagsMetadataTest)
+#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACETAGS_TEST
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTagsTest)
 {
     SetRandSeed();
 
@@ -1525,97 +1660,23 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTagsMetadataTest)
 
     String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
-
-    Map<String, String> TestSpaceMetadata = { { "site", "Void" } };
-    Array<String> Tags = { "tag-test" };
 
     ::Space Space;
-    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, TestSpaceMetadata, nullptr, nullptr, Tags, Space);
+    CreateSpace(
+        SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr, Array<String> { "tag-test" }, Space);
 
-    Map<String, String> RetrievedSpaceMetadata = GetAndAssertSpaceMetadata(SpaceSystem, Space.Id);
-    Array<String> RetrievedTags = GetAndAssertSpaceTags(SpaceSystem, Space.Id);
+    EXPECT_EQ(Space.Tags.Size(), 1);
+    EXPECT_EQ(Space.Tags[0], "tag-test");
 
-    EXPECT_EQ(RetrievedSpaceMetadata.Size(), TestSpaceMetadata.Size());
-    EXPECT_EQ(RetrievedSpaceMetadata["site"], "Void");
-    EXPECT_EQ(RetrievedTags.Size(), Tags.Size());
-    EXPECT_EQ(RetrievedTags[0], "tag-test");
+    // Update tags
+    ::Space UpdatedSpace;
+    UpdateSpace(SpaceSystem, Space.Id, nullptr, nullptr, nullptr, Array<String> { "new-tag-test", "new-tag-test-2" }, UpdatedSpace);
 
-    TestSpaceMetadata["site"] = "MagOffice";
-
-    // OB-3939 fix: passing tags as nullptr should leave them unchanged
-    UpdateAndAssertSpaceMetadata(SpaceSystem, Space.Id, TestSpaceMetadata, nullptr);
-
-    RetrievedSpaceMetadata = GetAndAssertSpaceMetadata(SpaceSystem, Space.Id);
-    RetrievedTags = GetAndAssertSpaceTags(SpaceSystem, Space.Id);
-
-    EXPECT_EQ(RetrievedSpaceMetadata.Size(), TestSpaceMetadata.Size());
-    EXPECT_EQ(RetrievedSpaceMetadata["site"], "MagOffice");
-    EXPECT_EQ(RetrievedTags.Size(), Tags.Size());
-    EXPECT_EQ(RetrievedTags[0], "tag-test");
+    EXPECT_EQ(UpdatedSpace.Tags.Size(), 2);
+    EXPECT_EQ(UpdatedSpace.Tags[0], "new-tag-test");
+    EXPECT_EQ(UpdatedSpace.Tags[1], "new-tag-test-2");
 
     DeleteSpace(SpaceSystem, Space.Id);
-
-    LogOut(UserSystem);
-}
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACESTAGS_METADATA_TEST
-CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpacesTagsMetadataTest)
-{
-    SetRandSeed();
-
-    auto& SystemsManager = ::SystemsManager::Get();
-    auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
-    String UserId;
-    LogInAsNewTestUser(UserSystem, UserId);
-
-    Map<String, String> TestSpaceMetadata = { { "site", "Void" } };
-    Array<String> Tags = { "tag-test" };
-
-    ::Space Space1, Space2;
-    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, TestSpaceMetadata, nullptr, nullptr, Tags, Space1);
-    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, TestSpaceMetadata, nullptr, nullptr, Tags, Space2);
-
-    Map<String, Map<String, String>> RetrievedSpaceMetadata = GetAndAssertSpacesMetadata(SpaceSystem, { Space1.Id, Space2.Id });
-    Map<String, Array<String>> RetrievedTags = GetAndAssertSpacesTags(SpaceSystem, { Space1.Id, Space2.Id });
-
-    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id].Size(), TestSpaceMetadata.Size());
-    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id].Size(), TestSpaceMetadata.Size());
-    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id]["site"], "Void");
-    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id]["site"], "Void");
-    EXPECT_EQ(RetrievedTags[Space1.Id].Size(), Tags.Size());
-    EXPECT_EQ(RetrievedTags[Space2.Id].Size(), Tags.Size());
-    EXPECT_EQ(RetrievedTags[Space1.Id][0], "tag-test");
-    EXPECT_EQ(RetrievedTags[Space2.Id][0], "tag-test");
-
-    TestSpaceMetadata["site"] = "MagOffice";
-
-    // OB-3939 fix: passing tags as nullptr should leave them unchanged
-    UpdateAndAssertSpaceMetadata(SpaceSystem, Space1.Id, TestSpaceMetadata, nullptr);
-    UpdateAndAssertSpaceMetadata(SpaceSystem, Space2.Id, TestSpaceMetadata, nullptr);
-
-    RetrievedSpaceMetadata = GetAndAssertSpacesMetadata(SpaceSystem, { Space1.Id, Space2.Id });
-    RetrievedTags = GetAndAssertSpacesTags(SpaceSystem, { Space1.Id, Space2.Id });
-
-    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id].Size(), TestSpaceMetadata.Size());
-    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id].Size(), TestSpaceMetadata.Size());
-    EXPECT_EQ(RetrievedSpaceMetadata[Space1.Id]["site"], "MagOffice");
-    EXPECT_EQ(RetrievedSpaceMetadata[Space2.Id]["site"], "MagOffice");
-    EXPECT_EQ(RetrievedTags[Space1.Id].Size(), Tags.Size());
-    EXPECT_EQ(RetrievedTags[Space2.Id].Size(), Tags.Size());
-    EXPECT_EQ(RetrievedTags[Space1.Id][0], "tag-test");
-    EXPECT_EQ(RetrievedTags[Space2.Id][0], "tag-test");
-
-    DeleteSpace(SpaceSystem, Space1.Id);
-    DeleteSpace(SpaceSystem, Space2.Id);
 
     LogOut(UserSystem);
 }
@@ -1821,7 +1882,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceWithEmptyMetadataTest)
     ::Space Space;
     CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    UpdateAndAssertSpaceMetadata(SpaceSystem, Space.Id, nullptr, nullptr);
+    UpdateAndAssertSpaceMetadata(SpaceSystem, Space.Id, nullptr);
 
     Map<String, String> RetrievedSpaceMetadata = GetAndAssertSpaceMetadata(SpaceSystem, Space.Id);
 


### PR DESCRIPTION
Tags are now on spaces directly, rather than bundled with the metadata, as they were before. 

This seems like a more natural design to me.

The consequences of this that you'll see in this PR:
- Any place where metadata was set, tags used to also be set ... they are no longer
- Tags are fundamental elements of a space now, much like the name and attributes
- Tags can be gotten from the `Space` object, and updated with `UpdateSpace`

Updating the services is also done in this PR, as it was a breaking change and needed code changes around it.