### PR TITLE
[NT-0] fix: CSP docs deployment on windows machines

### DIFF
--- a/Library/docs/terraform/cloudfront.tf
+++ b/Library/docs/terraform/cloudfront.tf
@@ -126,7 +126,7 @@ resource "aws_cloudfront_distribution" "main" {
 
 resource "null_resource" "cloudfront_cache_invalidation" {
   provisioner "local-exec" {
-    command = "aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.main.id} --paths /'*'"
+    command = "aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.main.id} --paths /*"
   }
 
   triggers = { for file in fileset(var.build_dir, "**/*") : file => filemd5("${var.build_dir}/${file}") }


### PR DESCRIPTION
The `cloudfront.tf` script was written under the assumption it would be run on Linux, however our deploy agents on TeamCity are windows.

On windows, the line:
`command = "aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.main.id} --paths /'*'"`

Should read:
`command = "aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.main.id} --paths /*"`

ie - remove the single-quotes from this part at the end: `'*'"`

The change [has been tested](https://magnopus.teamcity.com/buildConfiguration/Olympus_OlympusFoundation_PublishDocumentation/283921) with our deploy pipeline and validated. So should be good to go.