### PR TITLE
[OF-1525] Remove ifdefs from unit tests.

### DIFF
--- a/Tests/SpaceComponentTests.cpp
+++ b/Tests/SpaceComponentTests.cpp
@@ -7,7 +7,6 @@
 
 using namespace oly_multiplayer;
 
-#if RUN_ALL_UNIT_TESTS || RUN_REPLICATEDVALUE_TESTS
 CSP_PUBLIC_TEST(OlympusEngine, SpaceComponentTests, ExternalLinkComponentProperties)
 {
     std::shared_ptr<SpaceEntity> TestSpaceEntity(new SpaceEntity());
@@ -64,7 +63,5 @@ CSP_PUBLIC_TEST(OlympusEngine, SpaceComponentTests, ExternalLinkComponentPropert
         EXPECT_EQ(ExpectedValue, Result);
     }
 }
-
-#endif // RUN_ALL_UNIT_TESTS || RUN_REPLICATEDVALUE_TESTS
 
 #endif // MULTIPLAYER

--- a/Tests/premake5.lua
+++ b/Tests/premake5.lua
@@ -51,12 +51,6 @@ if not Tests then
 		
 		-- We're building LibAsync statically and need this
 		defines { "LIBASYNC_STATIC" }
-       
-        -- If we're running on a build agent, we want to run *all* the tests
-        if CSP.IsRunningOnTeamCityAgent() and not CSP.IsWebAssemblyGeneration() then
-            result = iif(CSP.IsRunningNightlyBuild(), "RUN_NIGHTLY_TESTS", "RUN_ALL_UNIT_TESTS")
-            defines { result }
-        end
         
         -- Config for platforms
         filter "platforms:x64"
@@ -67,9 +61,7 @@ if not Tests then
 
             defines {
                 "CSP_WASM",
-                "USE_STD_MALLOC=1",
-                "SKIP_INTERNAL_TESTS",
-                "RUN_PLATFORM_TESTS"    -- enable platform tests by default for wasm
+                "USE_STD_MALLOC=1"
             }
 
             buildoptions {

--- a/Tests/src/InternalTests/CommonTypeTests/Array.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Array.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_ARRAY_TESTS)
-
 #include "CSP/Common/Array.h"
 #include "CSP/Common/Optional.h"
 
@@ -238,4 +236,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayToListTest)
         FAIL();
     }
 }
-#endif

--- a/Tests/src/InternalTests/CommonTypeTests/Map.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Map.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_MAP_TESTS)
-
 #include "CSP/Common/Map.h"
 
 #include "CSP/Common/Optional.h"
@@ -233,5 +231,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonMapTests, MapClearTest)
 
     EXPECT_EQ(MyMap.Size(), 0);
 }
-
-#endif

--- a/Tests/src/InternalTests/CommonTypeTests/Optional.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Optional.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_OPTIONAL_TESTS)
-
 #include "CSP/Common/Optional.h"
 #include "Memory/Memory.h"
 
@@ -376,4 +374,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonOptionalTests, OptionalAssignNull)
 
     EXPECT_FALSE(OptionalInstance.HasValue());
 }
-#endif

--- a/Tests/src/InternalTests/CommonTypeTests/String.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/String.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_STRING_TESTS)
-
 #include "CSP/Common/String.h"
 #include "CSP/Common/List.h"
 
@@ -670,21 +668,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonStringTests, StringJoinListAllEmptyEntriesTes
         FAIL();
     }
 }
-
-CSP_INTERNAL_TEST(CSPEngine, CommonStringTests, StringContainsTest)
-{
-    String TestStr = "TestStringOneTwoThree";
-
-    EXPECT_TRUE(TestStr.Contains("One"));
-    EXPECT_TRUE(TestStr.Contains("Two"));
-    EXPECT_TRUE(TestStr.Contains("Three"));
-    EXPECT_TRUE(TestStr.Contains("TestStringOneTwoThree"));
-
-    EXPECT_FALSE(TestStr.Contains("Four"));
-    EXPECT_FALSE(TestStr.Contains("TestStringOneTwoThree "));
-    EXPECT_FALSE(TestStr.Contains(""));
-    EXPECT_FALSE(TestStr.Contains(" "));
-    EXPECT_FALSE(TestStr.Contains("TestStringOneTwoThreeFour"));
-}
-
-#endif

--- a/Tests/src/InternalTests/CommonTypeTests/StringFormat.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/StringFormat.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_STRINGFORMAT_TESTS)
-
 #include "CSP/Common/StringFormat.h"
 #include "CSP/Common/List.h"
 
@@ -40,5 +38,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonStringFormatTests, StringFormatTest)
         FAIL();
     }
 }
-
-#endif

--- a/Tests/src/InternalTests/CommonTypeTests/Vector2.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Vector2.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_VECTOR2_TESTS)
-
 #include "CSP/Common/Vector.h"
 
 #include "TestHelpers.h"
@@ -115,5 +113,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonVectorTests, Vector2OneTest)
         FAIL();
     }
 }
-
-#endif

--- a/Tests/src/InternalTests/CommonTypeTests/Vector3.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Vector3.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_VECTOR3_TESTS)
-
 #include "CSP/Common/Vector.h"
 
 #include "TestHelpers.h"
@@ -119,5 +117,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonVectorTests, Vector3OneTest)
         FAIL();
     }
 }
-
-#endif

--- a/Tests/src/InternalTests/CommonTypeTests/Vector4.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Vector4.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_COMMONTYPE_TESTS) || defined(RUN_COMMONTYPE_VECTOR4_TESTS)
-
 #include "CSP/Common/Vector.h"
 
 #include "TestHelpers.h"
@@ -140,5 +138,3 @@ CSP_INTERNAL_TEST(CSPEngine, CommonVectorTests, Vector4IdentityTest)
         FAIL();
     }
 }
-
-#endif

--- a/Tests/src/InternalTests/EncodeTests.cpp
+++ b/Tests/src/InternalTests/EncodeTests.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef SKIP_INTERNAL_TESTS
-
 #include "Common/Encode.h"
 #include "TestHelpers.h"
 
@@ -54,5 +52,3 @@ CSP_INTERNAL_TEST(CSPEngine, EncodeTests, EncodeURI)
         EXPECT_EQ(DecodedString, OriginalURL);
     }
 }
-
-#endif

--- a/Tests/src/InternalTests/EventTests.cpp
+++ b/Tests/src/InternalTests/EventTests.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SKIP_INTERNAL_TESTS
 
 #include "CSP/CSPFoundation.h"
 #include "Events/EventSystem.h"
@@ -127,5 +126,3 @@ CSP_INTERNAL_TEST(CSPEngine, EventTests, EventSystemTest)
     OlyEvents.UnRegisterListener(kTestEventId, &TestHandler);
     OlyEvents.UnRegisterListener(kTestEventId, &AllHandler);
 }
-
-#endif

--- a/Tests/src/InternalTests/JsonTests.cpp
+++ b/Tests/src/InternalTests/JsonTests.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SKIP_INTERNAL_TESTS
 
 #include "TestHelpers.h"
 #include "gtest/gtest.h"
@@ -281,5 +280,3 @@ CSP_INTERNAL_TEST(CSPEngine, JsonTests, JsonObjectContainerObjectTest)
         EXPECT_EQ(Obj.ListMember[i].FloatMember, Obj.ListMember[i].FloatMember);
     }
 }
-
-#endif

--- a/Tests/src/InternalTests/MaterialUnitTests.cpp
+++ b/Tests/src/InternalTests/MaterialUnitTests.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SKIP_INTERNAL_TESTS
 
 #include "TestHelpers.h"
 #include "gtest/gtest.h"
@@ -329,4 +328,3 @@ CSP_INTERNAL_TEST(CSPEngine, MaterialUnitTests, TextureSetterTest)
     Texture.SetCollectionAndAssetId(TestAssetCollectionId, TestAssetId);
     EXPECT_EQ(Texture.GetSourceType(), ETextureResourceType::ImageAsset);
 }
-#endif

--- a/Tests/src/InternalTests/MemoryTests.cpp
+++ b/Tests/src/InternalTests/MemoryTests.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SKIP_INTERNAL_TESTS
 
 #include "CSP/CSPFoundation.h"
 #include "Memory/Memory.h"
@@ -94,5 +93,3 @@ CSP_INTERNAL_TEST(CSPEngine, MemoryTests, ReallocationTest)
     Buffer = CSP_REALLOC(Buffer, 128 * 1024);
     EXPECT_TRUE(*(uint64_t*)Buffer == 0x0123456789ABCDEF);
 }
-
-#endif

--- a/Tests/src/InternalTests/NewFeatureTests.cpp
+++ b/Tests/src/InternalTests/NewFeatureTests.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_NEWFEATURE_TESTS)
-
 #include "CSP/CSPFoundation.h"
 #include "CSP/Common/List.h"
 #include "CSP/Common/Map.h"
@@ -378,5 +376,3 @@ CSP_INTERNAL_TEST(CSPEngine, NewFeatureTests, ValidateNewLODLevelForChainTest)
     Valid = csp::systems::ValidateNewLODLevelForChain(TestChain, 2);
     EXPECT_FALSE(Valid);
 }
-
-#endif

--- a/Tests/src/InternalTests/SchedulerTests.cpp
+++ b/Tests/src/InternalTests/SchedulerTests.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_SCHEDULER_TESTS)
 #include "Common/DateTime.h"
 #include "Common/Scheduler.h"
 #include "TestHelpers.h"
@@ -42,4 +41,3 @@ CSP_INTERNAL_TEST(CSPEngine, SchedulerTests, SchedulerTest)
 
     EXPECT_TRUE(ScheduleCallback);
 }
-#endif

--- a/Tests/src/InternalTests/SerialisationTests.cpp
+++ b/Tests/src/InternalTests/SerialisationTests.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef SKIP_INTERNAL_TESTS
-
 #include "CSP/CSPFoundation.h"
 #include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
 #include "CSP/Multiplayer/Components/CustomSpaceComponent.h"
@@ -443,5 +441,3 @@ CSP_INTERNAL_TEST(CSPEngine, SerialisationTests, MapDeserialisationTest)
 
     csp::CSPFoundation::Shutdown();
 }
-
-#endif

--- a/Tests/src/InternalTests/ServicesTests.cpp
+++ b/Tests/src/InternalTests/ServicesTests.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SKIP_INTERNAL_TESTS
 
 #include "Services/ApiBase/ApiBase.h"
 
@@ -50,5 +49,3 @@ CSP_INTERNAL_TEST(CSPEngine, ServicesTests, IsValidResponseCodeTest)
     ResponseBase.SetResponseCode(csp::web::EResponseCodes::ResponseInternalServerError, csp::web::EResponseCodes::ResponseOK);
     EXPECT_TRUE(ResponseBase.GetResponseCode() == EResponseCode::ResponseFailed);
 }
-
-#endif

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -77,7 +77,6 @@ void CreateAvatarForLeaderElection(csp::multiplayer::SpaceEntitySystem* EntitySy
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_UPDATE_SPACE_ENTITY_GLOBAL_POSITION_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalPositionTest)
 {
     SetRandSeed();
@@ -218,9 +217,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalPositionTest
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_UPDATE_SPACE_ENTITY_GLOBAL_ROTATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalRotationTest)
 {
     SetRandSeed();
@@ -361,9 +357,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalRotationTest
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_UPDATE_SPACE_ENTITY_GLOBAL_SCALE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalScaleTest)
 {
     SetRandSeed();
@@ -504,9 +497,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalScaleTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_UPDATE_SPACE_ENTITY_PARENT_ID_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityParentIdTest)
 {
     SetRandSeed();
@@ -646,9 +636,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityParentIdTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_REMOVE_SPACE_ENTITY_PARENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, RemoveSpaceEntityParentTest)
 {
     SetRandSeed();
@@ -786,9 +773,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, RemoveSpaceEntityParentTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_GET_ROOT_HIERARCHY_ENTITIES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, GetRootHierarchyEntitiesTest)
 {
     SetRandSeed();
@@ -927,5 +911,3 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, GetRootHierarchyEntitiesTest)
     // Log out
     LogOut(UserSystem);
 }
-
-#endif

--- a/Tests/src/InternalTests/SpaceHelperTests.cpp
+++ b/Tests/src/InternalTests/SpaceHelperTests.cpp
@@ -17,8 +17,6 @@
 #include "CSP/Systems/Assets/AssetCollection.h"
 #include "signalrclient/signalr_value.h"
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_SPACE_HELPER_TESTS)
-
 #include "Services/ApiBase/ApiBase.h"
 #include "Systems/Spaces/SpaceSystemHelpers.h"
 #include "TestHelpers.h"
@@ -211,5 +209,3 @@ CSP_INTERNAL_TEST(CSPEngine, SpaceHelperTests, ConvertJsonMetadataToMapMetadataO
 
     EXPECT_EQ(ObjectMetaDataMap[MetaDataSiteKey], MetaSiteData);
 }
-
-#endif

--- a/Tests/src/InternalTests/UniqueStringTest.cpp
+++ b/Tests/src/InternalTests/UniqueStringTest.cpp
@@ -17,8 +17,6 @@
 #include "CSP/Systems/Assets/AssetCollection.h"
 #include "signalrclient/signalr_value.h"
 
-#if !defined(SKIP_INTERNAL_TESTS) || defined(RUN_SPACE_HELPER_TESTS)
-
 #include "Services/ApiBase/ApiBase.h"
 #include "Systems/Spaces/SpaceSystemHelpers.h"
 #include "TestHelpers.h"
@@ -40,5 +38,3 @@ CSP_INTERNAL_TEST(CSPEngine, UniqueStringTests, GetUniqueStringTest)
         UniqueHexStrings[i] = HexValue;
     }
 }
-
-#endif

--- a/Tests/src/InternalTests/WebClientTests.cpp
+++ b/Tests/src/InternalTests/WebClientTests.cpp
@@ -125,7 +125,6 @@ void RunWebClientTest(const char* Url, ERequestVerb Verb, uint32_t Port, HttpPay
     }
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_WEB_CLIENT_GET_TEST_EXT_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientGetTestExt)
 {
     InitialiseFoundation();
@@ -136,9 +135,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientGetTestExt)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_WEB_CLIENT_PUT_TEST_EXT_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientPutTestExt)
 {
     InitialiseFoundation();
@@ -155,9 +152,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientPutTestExt)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_WEB_CLIENT_POST_TEST_EXT_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientPostTestExt)
 {
     InitialiseFoundation();
@@ -176,9 +171,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientPostTestExt)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_WEB_CLIENT_DELETE_TEST_EXT_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientDeleteTestExt)
 {
     InitialiseFoundation();
@@ -189,7 +182,6 @@ CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientDeleteTestExt)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
 class PollingLoginResponseReceiver : public ResponseWaiter, public IHttpResponseHandler
 {
@@ -260,7 +252,6 @@ private:
 };
 
 // This test will be fixed and reenabled as part of OF-1536
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_WEB_CLIENT_POLLING_TEST
 CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientPollingTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -312,7 +303,6 @@ CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientPollingTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
 class RetryResponseReceiver : public ResponseWaiter, public IHttpResponseHandler
 {
@@ -371,7 +361,6 @@ private:
     std::thread::id ThreadId;
 };
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_WEB_CLIENT_RETRY_TEST
 CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientRetryTest)
 {
     InitialiseFoundation();
@@ -382,9 +371,7 @@ CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientRetryTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_HTTP_FAIL_404_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebClientTests, HttpFail404Test)
 {
     InitialiseFoundation();
@@ -395,9 +382,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebClientTests, HttpFail404Test)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_HTTP_FAIL_400_TEST
 CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail400Test)
 {
     InitialiseFoundation();
@@ -409,12 +394,10 @@ CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail400Test)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
 // Current fails on wasm platform tests due to CORS policy.
 #ifndef CSP_WASM
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_WEB_CLIENT_USER_AGENT_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientUserAgentTest)
 {
     InitialiseFoundation();
@@ -442,12 +425,10 @@ CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientUserAgentTest)
     csp::CSPFoundation::Shutdown();
 }
 #endif
-#endif
 
 #include "CSP/Systems/SystemsManager.h"
 #include "PublicAPITests/UserSystemTestHelpers.h"
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_HTTP_FAIL_403_TEST
 CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail403Test)
 {
     InitialiseFoundation();
@@ -462,4 +443,3 @@ CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail403Test)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif

--- a/Tests/src/InternalTests/WebSocketClientTests.cpp
+++ b/Tests/src/InternalTests/WebSocketClientTests.cpp
@@ -29,7 +29,6 @@ using namespace csp::multiplayer;
 
 const csp::common::String MULTIPLAYER_URL = "wss://ogs-multiplayer-internal.magnopus-dev.cloud/mag-multiplayer/hubs/v1/multiplayer";
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_SIGNALR_CLIENT_START_STOP_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientStartStopTest)
 {
     // Initialise
@@ -51,9 +50,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientStartStopTest)
     // Logout
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_SIGNALR_CLIENT_SEND_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendTest)
 {
     // Initialise
@@ -78,9 +75,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendTest)
     // Logout
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PLATFORM_TESTS || RUN_SIGNALR_CLIENT_SEND_RECEIVE_TEST
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
 {
     // Initialise
@@ -105,4 +100,3 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
     // Logout
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/Analytics/AnalyticsSystemFunctionalTests.cpp
+++ b/Tests/src/PublicAPITests/Analytics/AnalyticsSystemFunctionalTests.cpp
@@ -27,7 +27,6 @@
 
 // All the analytics tests will be reviewed, and the disabled tests reenabled, as part of OF-1538.
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_TESTS || RUN_ANALYTICSSYSTEM_MACRO_LOG_METRIC_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemTests, MacroLogMetricTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -59,9 +58,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemTests, MacroLogMetricTest)
 
     System->DeregisterProvider(&Provider);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_TESTS || RUN_ANALYTICSSYSTEM_UA_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, UATest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -114,4 +111,3 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, UATest)
 
     csp::CSPFoundation::Tick();
 }
-#endif

--- a/Tests/src/PublicAPITests/Analytics/AnalyticsSystemUnitTests.cpp
+++ b/Tests/src/PublicAPITests/Analytics/AnalyticsSystemUnitTests.cpp
@@ -26,7 +26,6 @@
 
 // All the analytics tests will be reviewed, and the disabled tests reenabled, as part of OF-1538.
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_LOG_METRIC_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemUnitTests, LogMetricTest)
 {
     auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
@@ -57,9 +56,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemUnitTests, LogMetricTest)
 
     AnalyticsSystem->DeregisterProvider(&Provider);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_LOG_MULTIPLE_METRIC_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemUnitTests, LogMultipleMetricTest)
 {
     auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
@@ -111,9 +108,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemUnitTests, LogMultipleMetricT
 
     AnalyticsSystem->DeregisterProvider(&Provider);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_DEREGISTER_PROVIDER_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, DeregisterProviderTest)
 {
     auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
@@ -142,9 +137,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, DeregisterProviderTest)
 
     EXPECT_EQ(Metrics.size(), 0);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_MULTIPLE_THREADS_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemUnitTests, MultipleThreadsTest)
 {
     auto* AnalyticsSystem = csp::systems::SystemsManager::Get().GetAnalyticsSystem();
@@ -197,9 +190,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, AnalyticsSystemUnitTests, MultipleThreadsTes
 
     AnalyticsSystem->DeregisterProvider(&Provider);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UA_PARAMS_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAParamsTest)
 {
     const csp::common::String TestClientId = "TestClientId";
@@ -218,9 +209,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAParamsTest)
 
     EXPECT_EQ(ExpectedEventString, EventString);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UA_INT_PARAM_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAIntParamTest)
 {
     const csp::common::String TestClientId = "TestClientId";
@@ -237,9 +226,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAIntParamTest)
 
     EXPECT_EQ(ExpectedEventString, EventString);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UA_STRING_PARAM_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAStringParamTest)
 {
     const csp::common::String TestClientId = "TestClientId";
@@ -256,9 +243,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAStringParamTest)
 
     EXPECT_EQ(ExpectedEventString, EventString);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UA_INVALID_PARAM_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAInvalidParamTest)
 {
     const csp::common::String TestClientId = "TestClientId";
@@ -275,9 +260,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UAInvalidParamTest)
 
     EXPECT_EQ(ExpectedEventString, EventString);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UNIT_TESTS || RUN_ANALYTICSSYSTEM_UA_TOO_MANY_PARAM_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UATooManyParamTest)
 {
     const csp::common::String TestClientId = "TestClientId";
@@ -298,4 +281,3 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemUnitTests, UATooManyParamTest)
 
     EXPECT_EQ(ExpectedEventString, EventString);
 }
-#endif

--- a/Tests/src/PublicAPITests/AnchorSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnchorSystemTests.cpp
@@ -140,7 +140,6 @@ void CreateAnchorResolution(
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANCHORSYSTEM_TESTS || RUN_ANCHORSYSTEM_CREATE_ANCHOR_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorTest)
 {
     SetRandSeed();
@@ -178,9 +177,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorTest)
     DeleteAssetCollection(AssetSystem, AssetCollection);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANCHORSYSTEM_TESTS || RUN_ANCHORSYSTEM_CREATE_ANCHOR_IN_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorInSpaceTest)
 {
     SetRandSeed();
@@ -241,9 +238,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorInSpaceTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANCHORSYSTEM_TESTS || RUN_ANCHORSYSTEM_DELETE_MULTIPLE_ANCHORS_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, DeleteMultipleAnchorsTest)
 {
     SetRandSeed();
@@ -322,9 +317,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, DeleteMultipleAnchorsTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANCHORSYSTEM_TESTS || RUN_ANCHORSYSTEM_GET_ANCHORS_INSIDE_CIRCULAR_AREA_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
 {
     SetRandSeed();
@@ -453,9 +446,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANCHORSYSTEM_TESTS || RUN_ANCHORSYSTEM_GETANCHORSINSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInSpaceTest)
 {
     SetRandSeed();
@@ -541,9 +532,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInSpaceTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANCHORSYSTEM_TESTS || RUN_ANCHORSYSTEM_GETANCHORSBYASSETCOLLECTIONID_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsByAssetCollectionIdTest)
 {
     SetRandSeed();
@@ -603,9 +592,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsByAssetCollectionIdTest)
     DeleteAssetCollection(AssetSystem, AssetCollection);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANCHORSYSTEM_TESTS || RUN_ANCHORSYSTEM_CREATE_ANCHOR_RESOLUTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorResolutionTest)
 {
     SetRandSeed();
@@ -668,4 +655,3 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorResolutionTest)
 
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -257,7 +257,6 @@ void UpdateAssetCollectionMetadata(csp::systems::AssetSystem* AssetSystem, csp::
     OutMetaData = ResultAssetCollection.GetMetadataImmutable();
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_CREATEASSETCOLLECTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetCollectionTest)
 {
     SetRandSeed();
@@ -307,9 +306,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetCollectionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_CREATEASSETCOLLECTION_NOSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetCollectionNoSpaceTest)
 {
     SetRandSeed();
@@ -346,9 +343,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetCollectionNoSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_GETASSETCOLLECTIONSBYIDS_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetCollectionsByIdsTest)
 {
     SetRandSeed();
@@ -420,9 +415,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetCollectionsByIdsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_CREATEASSET_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetTest)
 {
     SetRandSeed();
@@ -490,9 +483,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_CREATEASSET_NOSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetNoSpaceTest)
 {
     SetRandSeed();
@@ -547,9 +538,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetNoSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPDATEXTERNALURIEASSET_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateExternalUriAssetTest)
 {
     SetRandSeed();
@@ -630,9 +619,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateExternalUriAssetTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_GETASSETSBYCOLLECTIONIDS_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsByCollectionIdsTest)
 {
     SetRandSeed();
@@ -723,9 +710,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsByCollectionIdsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_FINDASSETCOLLECTIONS_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, FindAssetCollectionsTest)
 {
     SetRandSeed();
@@ -861,9 +846,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, FindAssetCollectionsTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_GETASSETS_BY_DIFFERENT_CRITERIA_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsByDifferentCriteriaTest)
 {
     SetRandSeed();
@@ -969,9 +952,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsByDifferentCriteriaTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_GETASSETS_FROM_MULTIPLE_ASSET_COLLECTIONS_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsFromMultipleAssetCollectionsTest)
 {
     SetRandSeed();
@@ -1073,9 +1054,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsFromMultipleAssetCollectio
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_AS_FILE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileTest)
 {
     SetRandSeed();
@@ -1193,9 +1172,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_AS_INCORRECT_FILE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsIncorrectFileTest)
 {
     SetRandSeed();
@@ -1260,9 +1237,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsIncorrectFileTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_AS_FILE_NOSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileNoSpaceTest)
 {
     SetRandSeed();
@@ -1364,9 +1339,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileNoSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_WITH_UNENCODED_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetWithUnencodedSpace)
 {
     SetRandSeed();
@@ -1434,9 +1407,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetWithUnencodedSpace)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_WITH_ENCODED_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetWithEncodedSpace)
 {
     SetRandSeed();
@@ -1504,9 +1475,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetWithEncodedSpace)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPLOADASSET_AS_BUFFER_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsBufferTest)
 {
     SetRandSeed();
@@ -1596,9 +1565,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsBufferTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPDATEASSETDATA_AS_FILE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsFileTest)
 {
     SetRandSeed();
@@ -1685,9 +1652,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsFileTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPDATEASSETDATA_AS_BUFFER_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsBufferTest)
 {
     SetRandSeed();
@@ -1783,9 +1748,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsBufferTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_UPDATEASSETMETADATA_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetCollectionMetadataTest)
 {
     SetRandSeed();
@@ -1839,9 +1802,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetCollectionMetadataTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_GETASSETDATASIZE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetDataSizeTest)
 {
     SetRandSeed();
@@ -1907,8 +1868,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetDataSizeTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_THIRDPARTYPACKAGEDASSETIDENTIFIER_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, ThirdPartyPackagedAssetIdentifierTest)
 {
     SetRandSeed();
@@ -1990,9 +1949,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, ThirdPartyPackagedAssetIdentifierTe
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_PROCESSED_CALLBACK_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
 {
     SetRandSeed();
@@ -2087,9 +2044,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_PROCESS_GRACEFUL_FAILURE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessGracefulFailureCallbackTest)
 {
     SetRandSeed();
@@ -2163,9 +2118,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessGracefulFailureCallback
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_DOWNLOADASSETDATA_INVALIDURL_TEST
 CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, DownloadAssetDataInvalidURLTest)
 {
     SetRandSeed();
@@ -2192,9 +2145,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, DownloadAssetDataInvalidURLTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ASSETSYSTEM_TESTS || RUN_ASSETSYSTEM_COPY_ASSET_COLLECTION_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, AssetSystemTests, CopyAssetCollectionTest)
 {
     SetRandSeed();
@@ -2349,4 +2300,3 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, AssetSystemTests, CopyAssetCollectionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/CancellationTokenTests.cpp
+++ b/Tests/src/PublicAPITests/CancellationTokenTests.cpp
@@ -24,11 +24,8 @@
 namespace
 {
 
-#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_CONSTRUCTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, ConstructionAndDestructionTest) { EXPECT_NO_THROW(csp::common::CancellationToken()); }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_CANCEL_TEST
 CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelStateTest)
 {
     csp::common::CancellationToken CancellationToken;
@@ -40,9 +37,7 @@ CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CancelStateTest)
     EXPECT_NO_THROW(CancellationToken.Cancel()); // Test that multiple cancellations don't affect the state
     EXPECT_TRUE(CancellationToken.Cancelled());
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CANCELLATION_TOKEN_TESTS || RUN_CANCELLATIONTOKEN_COPYMOVE_TEST
 CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CopyMoveTest)
 {
     // Ensure copy and move operations are deleted
@@ -51,6 +46,5 @@ CSP_PUBLIC_TEST(CSPEngine, CancellationTokenTests, CopyMoveTest)
     ASSERT_FALSE(std::is_copy_assignable_v<csp::common::CancellationToken>);
     ASSERT_FALSE(std::is_move_assignable_v<csp::common::CancellationToken>);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -41,7 +41,6 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANIMATED_MODEL_TESTS || RUN_ANIMATED_MODEL_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
 {
     SetRandSeed();
@@ -166,9 +165,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ANIMATED_MODEL_TESTS || RUN_ANIMATED_MODEL_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 {
     SetRandSeed();
@@ -249,9 +246,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_STATIC_MODEL_TESTS || RUN_ANIMATED_MODEL_ENTER_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceTest)
 {
     SetRandSeed();
@@ -375,4 +370,3 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceT
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
@@ -39,7 +39,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_AUDIO_TESTS || RUN_AUDIO_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioComponentTest)
 {
     SetRandSeed();
@@ -138,9 +137,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_AUDIO_TESTS || RUN_AUDIO_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
 {
     SetRandSeed();
@@ -265,6 +262,5 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -41,7 +41,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_CINEMATIC_CAMERA_TESTS || RUN_CINEMATIC_CAMERA_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
 {
     SetRandSeed();
@@ -127,9 +126,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CINEMATIC_CAMERA_TESTS || RUN_CINEMATIC_CAMERA_COMPONENT_FOV_TEST
 CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest)
 {
     SetRandSeed();
@@ -202,9 +199,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CINEMATIC_CAMERA_TESTS || RUN_CINEMATIC_CAMERA_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceTest)
 {
     SetRandSeed();
@@ -288,6 +283,5 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
@@ -38,7 +38,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_COLLISION_TESTS || RUN_MULTIPLAYER_COLLISION_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, CollisionTests, CollisionComponentTest)
 {
     SetRandSeed();
@@ -127,6 +126,5 @@ CSP_PUBLIC_TEST(CSPEngine, CollisionTests, CollisionComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -44,7 +44,6 @@ namespace
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_COMPONENT_TESTS
 CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ApplicationOriginTest)
 {
     SpaceEntity* MySpaceEntity = new SpaceEntity();
@@ -269,4 +268,3 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -38,7 +38,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATION_TESTS || RUN_CONVERSATION_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentTest)
 {
     SetRandSeed();
@@ -290,9 +289,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATION_TESTS || RUN_CONVERSATION_COMPONENT_MOVE_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentMoveTest)
 {
     SetRandSeed();
@@ -436,9 +433,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentMoveTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATION_TESTS || RUN_CONVERSATION_COMPONENT_SCRIPT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentScriptTest)
 {
     SetRandSeed();
@@ -535,6 +530,5 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentScriptTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
@@ -40,7 +40,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_CUSTOM_TESTS || RUN_CUSTOM_PROPERTY_TEST
 CSP_PUBLIC_TEST(CSPEngine, CustomTests, SetGetCustomPropertyTest)
 {
     SpaceEntity* MySpaceEntity = new SpaceEntity();
@@ -54,9 +53,7 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, SetGetCustomPropertyTest)
 
     EXPECT_TRUE(MyCustomComponent.GetCustomProperty(PropertyKey) == TestStringValue);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CUSTOM_TESTS || RUN_CUSTOM_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
 {
     SetRandSeed();
@@ -281,6 +278,5 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
@@ -39,7 +39,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceComponentTest)
 {
     SetRandSeed();
@@ -101,9 +100,7 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceScriptInterfaceTest)
 {
     SetRandSeed();
@@ -175,6 +172,5 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -42,7 +42,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_FIDUCIALMARKER_TESTS || RUN_FIDUCIALMARKER_TEST
 CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 {
     SetRandSeed();
@@ -158,9 +157,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_FIDUCIALMARKER_TESTS || RUN_FIDUCIALMARKER_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTest)
 {
     SetRandSeed();
@@ -233,6 +230,5 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -41,7 +41,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_FOG_TESTS || RUN_FOG_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
 {
     SetRandSeed();
@@ -128,9 +127,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_FOG_TESTS || RUN_FOG_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
 {
     SetRandSeed();
@@ -214,6 +211,5 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -42,7 +42,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_GAUSSIAN_SPLAT_TESTS || RUN_GAUSSIAN_SPLAT_TEST
 CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
 {
     SetRandSeed();
@@ -133,9 +132,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GAUSSIAN_SPLAT_TESTS || RUN_GAUSSIAN_SPLAT_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
 {
     SetRandSeed();
@@ -205,6 +202,5 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -40,7 +40,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOT_TESTS || RUN_HOTSPOT_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 {
     SetRandSeed();
@@ -138,9 +137,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOT_TESTS || RUN_HOTSPOT_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTest)
 {
     SetRandSeed();
@@ -232,6 +229,5 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -42,7 +42,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_IMAGE_TESTS || RUN_IMAGE_TEST
 CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
 {
     SetRandSeed();
@@ -165,9 +164,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_IMAGE_TESTS || RUN_IMAGE_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
 {
     SetRandSeed();
@@ -249,6 +246,5 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
@@ -40,7 +40,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_LIGHT_TESTS || RUN_LIGHT_TEST
 CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
 {
     SetRandSeed();
@@ -180,9 +179,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LIGHT_TESTS || RUN_ACTIONHANDLER_TEST
 CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
 {
     SetRandSeed();
@@ -254,6 +251,5 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -40,7 +40,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_LINK_TESTS || RUN_EXTERNAL_LINK_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
 {
     SetRandSeed();
@@ -137,6 +136,5 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -40,7 +40,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_PORTAL_TESTS || RUN_USE_PORTAL_TEST
 CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 {
     SetRandSeed();
@@ -130,9 +129,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PORTAL_TESTS || RUN_PORTAL_THUMBNAIL_TEST
 CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalThumbnailTest)
 {
     SetRandSeed();
@@ -214,9 +211,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalThumbnailTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_PORTAL_TESTS || RUN_PORTAL_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalScriptInterfaceTest)
 {
     SetRandSeed();
@@ -301,7 +296,5 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
@@ -40,7 +40,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_REFLECTION_TESTS || RUN_REFLECTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
 {
     SetRandSeed();
@@ -154,6 +153,5 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
@@ -39,7 +39,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPLINE_TESTS || RUN_USE_SPLINE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SplineTests, UseSplineTest)
 {
     SetRandSeed();
@@ -133,9 +132,7 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, UseSplineTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPLINE_TESTS || RUN_SPLINE_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SplineTests, SplineScriptInterfaceTest)
 {
     SetRandSeed();
@@ -209,6 +206,5 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, SplineScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -41,7 +41,6 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_STATIC_MODEL_TESTS || RUN_STATIC_MODEL_TEST
 CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
 {
     SetRandSeed();
@@ -154,9 +153,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_STATIC_MODEL_TESTS || RUN_STATIC_MODEL_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 {
     SetRandSeed();
@@ -231,9 +228,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_STATIC_MODEL_TESTS || RUN_STATIC_MODEL_ENTER_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
 {
     SetRandSeed();
@@ -357,4 +352,3 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -40,7 +40,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_TEXT_TESTS || RUN_TEXT_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
 {
     SetRandSeed();
@@ -154,9 +153,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_TEXT_TESTS || RUN_TEXT_SCRIPT_INTERFACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
 {
     SetRandSeed();
@@ -260,6 +257,5 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -38,7 +38,6 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-#if RUN_ALL_UNIT_TESTS || RUN_VIDEO_TESTS || RUN_VIDEO_PLAYER_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
 {
     SetRandSeed();
@@ -145,6 +144,5 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/ConversationSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ConversationSystemTests.cpp
@@ -74,7 +74,6 @@ csp::multiplayer::MessageInfo AddMessageToConversation(csp::multiplayer::Convers
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATIONSYSTEM_CREATE_CONVERSATION_ID
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, CreateConversationId)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -179,9 +178,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, CreateConversationId)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATIONSYSTEM_GET_MESSAGES_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, GetMessagesTest)
 {
     SetRandSeed();
@@ -390,9 +387,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, GetMessagesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATIONSYSTEM_TWO_CONVERSATIONS_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, TwoConversationsTest)
 {
     SetRandSeed();
@@ -699,9 +694,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, TwoConversationsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATION_NEWMESSAGE_NETWORKEVENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationNewMessageNetworkEventTest)
 {
     SetRandSeed();
@@ -833,9 +826,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationNewMessageNetwor
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATION_DELETEMESSAGE_NETWORKEVENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationDeleteMessageNetworkEventTest)
 {
     SetRandSeed();
@@ -977,9 +968,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationDeleteMessageNet
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATION_DELETECONVERSATION_NETWORKEVENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationDeleteConversationNetworkEventTest)
 {
     SetRandSeed();
@@ -1119,9 +1108,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationDeleteConversati
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATIONSYSTEM_UPDATE_CONVERSATION_INFO
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, UpdateConversationInfo)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -1295,9 +1282,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, UpdateConversationInfo)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_CONVERSATIONSYSTEM_TESTS || RUN_CONVERSATIONSYSTEM_UPDATE_MESSAGE_INFO
 CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, UpdateMessageInfo)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -1442,4 +1427,3 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, UpdateMessageInfo)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/DateTimeTests.cpp
+++ b/Tests/src/PublicAPITests/DateTimeTests.cpp
@@ -20,7 +20,6 @@
 #include "gtest/gtest.h"
 #include <chrono>
 
-#if RUN_ALL_UNIT_TESTS || RUN_DATE_TIME_TESTS || RUN_DATE_TIME_STRING_CONVERSION_TESTS
 CSP_PUBLIC_TEST(CSPEngine, DateTimeTests, UTCStringConversion)
 {
     {
@@ -91,9 +90,7 @@ CSP_PUBLIC_TEST(CSPEngine, DateTimeTests, UTCStringConversion)
         EXPECT_EQ(UTCTime->tm_sec, 54);
     }
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_DATE_TIME_TESTS || RUN_DATE_TIME_COMPARSION
 CSP_PUBLIC_TEST(CSPEngine, DateTimeTests, Comparison)
 {
     using namespace std::chrono_literals;
@@ -105,4 +102,3 @@ CSP_PUBLIC_TEST(CSPEngine, DateTimeTests, Comparison)
     const csp::common::DateTime FutureDateTime(TimeFuture);
     ASSERT_GE(FutureDateTime, CurrentDateTime);
 }
-#endif

--- a/Tests/src/PublicAPITests/ECommerceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ECommerceSystemTests.cpp
@@ -57,7 +57,6 @@ csp::common::Map<csp::common::String, csp::common::String> GetShopifyDetails()
 /*These test are currently internal tests because they utilise that is currently only available
 through internal CSP infrastructure.*/
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_GET_PRODUCT_INFORMATION_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationTest)
 {
     /*Steps needed to be performed before running this test are:
@@ -149,9 +148,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationT
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_GET_PRODUCT_INFORMATION_BY_VARIANT_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationByVariantTest)
 {
     /*Steps needed to be performed before running this test are:
@@ -245,9 +242,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationB
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_GET_CHECKOUT_INFORMATION_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetCheckoutInformationTest)
 {
     SetRandSeed();
@@ -305,9 +300,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetCheckoutInformation
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_CREATEANDGETCART_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, CreateAndGetCartTest)
 {
     SetRandSeed();
@@ -363,9 +356,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, CreateAndGetCartTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_CREATECART_BADINPUTS_TEST
 CSP_PUBLIC_TEST(CSPEngine, ECommerceSystemTests, CreateCartBadInputTest)
 {
     SetRandSeed();
@@ -387,9 +378,7 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceSystemTests, CreateCartBadInputTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_GETCART_BADINPUTS_TEST
 CSP_PUBLIC_TEST(CSPEngine, ECommerceSystemTests, GetCartBadInputTest)
 {
     SetRandSeed();
@@ -412,9 +401,6 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceSystemTests, GetCartBadInputTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_ADDCARTLINES_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, AddCartLinesTest)
 {
     SetRandSeed();
@@ -502,8 +488,6 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, AddCartLinesTest)
     };
 }
 
-#endif
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_UPDATECARTLINES_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, UpdateCartLinesTest)
 {
     SetRandSeed();
@@ -623,9 +607,6 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, UpdateCartLinesTest)
     };
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_DELETECARTLINES_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, DeleteCartLinesTest)
 {
     SetRandSeed();
@@ -737,9 +718,6 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, DeleteCartLinesTest)
     EXPECT_EQ(DeleteCartLinesCart.TotalQuantity, 0);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_ADDSHOPIFYSTORE_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, AddShopifyStoreTest)
 {
     SetRandSeed();
@@ -802,9 +780,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, AddShopifyStoreTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_ECOMMERCE_TESTS || RUN_ECOMMERCE_GETSHOPIFYSTORES_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetShopifyStoresTest)
 {
     SetRandSeed();
@@ -854,4 +830,3 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetShopifyStoresTest)
 
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/EventBusTests.cpp
+++ b/Tests/src/PublicAPITests/EventBusTests.cpp
@@ -158,7 +158,6 @@ TestSystem* TestSystem2;
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTBUS_TESTS || RUN_EVENTBUS_EVENT_EMPTY_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventEmptyTest)
 {
     SetRandSeed();
@@ -250,9 +249,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventEmptyTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTBUS_TESTS || RUN_EVENTBUS_EVENT_MULTITYPE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventMultiTypeTest)
 {
     SetRandSeed();
@@ -357,9 +354,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventMultiTypeTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTBUS_TESTS || RUN_EVENTBUS_EVENT_CALLBACKS_SYSTEMS_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventBusTests, EventCallbacksSystemsTest)
 {
     SetRandSeed();
@@ -568,9 +563,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventBusTests, EventCallbacksSystemsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTBUS_TESTS || RUN_EVENTBUS_SETCALLBACKBEFORECONNECTED_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SetCallbackBeforeConnectedTest)
 {
     SetRandSeed();
@@ -682,4 +675,3 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SetCallbackBeforeConnectedTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
+++ b/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
@@ -42,7 +42,6 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_CREATETICKETEDEVENT_ACTIVE_TRUE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveTrueTest)
 {
     SetRandSeed();
@@ -81,9 +80,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveT
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_CREATETICKETEDEVENT_ACTIVE_FALSE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveFalseTest)
 {
     SetRandSeed();
@@ -122,9 +119,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventActiveF
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_CREATETICKETEDEVENT_TWICE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventTwiceTest)
 {
     SetRandSeed();
@@ -178,9 +173,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, CreateTicketedEventTwiceTe
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventTest)
 {
     SetRandSeed();
@@ -233,9 +226,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_BADSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventBadSpaceTest)
 {
     SetRandSeed();
@@ -274,9 +265,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventBadSpaceT
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_UPDATETICKETEDEVENT_BADEVENTID_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventBadEventIdTest)
 {
     SetRandSeed();
@@ -315,9 +304,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, UpdateTicketEventBadEventI
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_NO_EVENTS_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsNoEventsTest)
 {
     SetRandSeed();
@@ -349,9 +336,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsNoEventsT
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_ONE_EVENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsOneEventTest)
 {
     SetRandSeed();
@@ -396,9 +381,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsOneEventT
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETISSPACETICKETED_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetIsSpaceTicketedTest)
 {
     SetRandSeed();
@@ -434,9 +417,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetIsSpaceTicketedTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETINGSYSTEM_TESTS || RUN_EVENTTICKETINGSYSTEM_GETISSPACETICKETEDFAILURE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetIsSpaceTicketedFailureTest)
 {
     SetRandSeed();
@@ -480,9 +461,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetIsSpaceTicketedFailureT
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_TWO_EVENTS_SAME_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEventsSameSpaceTest)
 {
     SetRandSeed();
@@ -561,9 +540,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEvents
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_TWO_EVENTS_TWO_SPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEventsTwoSpacesTest)
 {
     SetRandSeed();
@@ -649,9 +626,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEvents
     DeleteSpace(SpaceSystem, Space2.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETTICKETEDEVENTS_PAGINATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsPaginationTest)
 {
     SetRandSeed();
@@ -740,9 +715,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsPaginatio
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETVENDORAUTHORIZEINFO_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthorizeInfoTest)
 {
     SetRandSeed();
@@ -768,9 +741,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthorizeInfoTest
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_GETVENDORAUTHORIZEINFO_BADDATA_TEST
 CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthorizeInfoBadDataTest)
 {
     SetRandSeed();
@@ -832,7 +803,6 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthorizeInfoBadD
 
     LogOut(UserSystem);
 }
-#endif
 
 // This test currently requires manual steps and will be reviewed as part of OF-1535.
 /*
@@ -854,7 +824,6 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetVendorAuthorizeInfoBadD
  *
  * When done testing, make sure to delete the event in Eventbrite.
  */
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_SUBMITEVENTTICKET_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventTicketingSystemTests, SubmitEventTicketTest)
 {
     SetRandSeed();
@@ -936,14 +905,12 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventTicketingSystemTests, SubmitEventTicket
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
 // This test currently requires manual steps and will be reviewed as part of OF-1535.
 /*
  * This test is disabled by default and works the same as the previous test with one difference in that the ticket
  * is submitted by the superuser on behalf of the alternative user.
  */
-#if RUN_ALL_UNIT_TESTS || RUN_EVENTTICKETING_TESTS || RUN_EVENTTICKETING_SUBMITEVENTTICKET_ONBEHALFOF_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventTicketingSystemTests, SubmitEventTicketOnBehalfOfTest)
 {
     SetRandSeed();
@@ -1019,4 +986,3 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventTicketingSystemTests, SubmitEventTicket
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/GeneralContinuationsTests.cpp
+++ b/Tests/src/PublicAPITests/GeneralContinuationsTests.cpp
@@ -51,7 +51,6 @@ struct RAIIMockLogger
 };
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_REPORT_SUCCESS_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestReportSuccess)
 {
     RAIIMockLogger MockLogger {};
@@ -72,9 +71,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestReportSuccess)
 
     csp::common::continuations::ReportSuccess(MockResultCallback.AsStdFunction(), SuccessMsg.c_str())();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_LOG_ERROR_AND_CANCEL_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestLogErrorAndCancel)
 {
     RAIIMockLogger MockLogger {};
@@ -97,9 +94,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestLogErrorAndCancel)
     ASSERT_ANY_THROW(csp::common::continuations::LogErrorAndCancelContinuation(
         MockResultCallback.AsStdFunction(), ErrorMsg.c_str(), ResultCode, HttpResultCode, FailureReason));
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_ASSERT_REQUEST_SUCCESS_OR_ERROR_FROM_RESULT_WHEN_SUCCESS_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOrErrorFromResultWhenSuccess)
 {
     RAIIMockLogger MockLogger {};
@@ -119,9 +114,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOr
                   MockResultCallback.AsStdFunction(), SuccessMsg.c_str(), ErrorMsg.c_str(), {}, {}, {}, LogLevel::Log)(SuccessResult),
         SuccessResult);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_ASSERT_REQUEST_SUCCESS_OR_ERROR_FROM_RESULT_WHEN_ERROR_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOrErrorFromResultWhenError)
 {
     RAIIMockLogger MockLogger {};
@@ -169,9 +162,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOr
             std::make_optional(FailureReasonExplicit), LogLevel::Log)(ExpectedFailureResult));
     }
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_ASSERT_REQUEST_SUCCESS_OR_ERROR_FROM_ERRORCODE_WHEN_SUCCESS_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOrErrorFromErrorCodeWhenSuccess)
 {
     RAIIMockLogger MockLogger {};
@@ -185,9 +176,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOr
     csp::common::continuations::AssertRequestSuccessOrErrorFromErrorCode(
         MockResultCallback.AsStdFunction(), SuccessMsg.c_str(), {}, {}, {}, LogLevel::Log)({});
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_ASSERT_REQUEST_SUCCESS_OR_ERROR_FROM_ERRORCODE_WHEN_ERROR_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOrErrorFromErrorCodeWhenError)
 {
     RAIIMockLogger MockLogger {};
@@ -234,10 +223,8 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOr
             MockResultCallback.AsStdFunction(), SuccessMsg.c_str(), {}, {}, {}, LogLevel::Log)(ErrorCode));
     }
 }
-#endif
 
 // See `Continuation.h::detail::testing` for specifics of how these tests run
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_WHEN_NO_EXCEPTION_THROWN_IN_CONTINUATION_CHAIN_THEN_HANDLER_NOT_CALLED_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenNoExceptionThrownInContinuationChainThenHandlerNotCalled)
 {
     // No exception, expect exception handler callable not called.
@@ -245,9 +232,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenNoExceptionThrownI
     EXPECT_CALL(MockExceptionHandlerCallable, Call()).Times(0);
     csp::common::continuations::detail::testing::SpawnChainThatThrowsNoExceptionWithHandlerAtEnd(MockExceptionHandlerCallable.AsStdFunction());
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_WHEN_EXCEPTION_THROWN_IN_CONTINUATION_CHAIN_THEN_HANDLER_CALLED_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenExceptionThrownInContinuationChainThenHandlerCalled)
 {
     // Exception thrown, expect exception handler callable called
@@ -255,9 +240,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenExceptionThrownInC
     EXPECT_CALL(MockExceptionHandlerCallable, Call()).Times(1);
     csp::common::continuations::detail::testing::SpawnChainThatThrowsGeneralExceptionWithHandlerAtEnd(MockExceptionHandlerCallable.AsStdFunction());
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_WHEN_CONTINUATION_CHAIN_CANCELLED_THEN_HANDLER_AND_RESULTCALLBACK_CALLED_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenContinuationChainCancelledThenHandlerAndResultCallbackCalled)
 {
     // Exception thrown, expect exception handler callable called, as well as result callback called. (Just testing our specific way of throwing here)
@@ -268,9 +251,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenContinuationChainC
     csp::common::continuations::detail::testing::SpawnChainThatCallsLogErrorAndCancelContinuationWithHandlerAtEnd(
         MockExceptionHandlerCallable.AsStdFunction(), MockResultCallback.AsStdFunction());
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_CALLABLE_CALLED_AND_INTERMEDIATE_NOT_WHEN_EXCEPTION_THROWN_HIGHER_IN_CHAIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestCallableCalledAndIntermediateNotWhenExceptionThrownHigherInChain)
 {
     // Exception thrown higher in chain, expect exception handler callable intermediate method not called, but exception handler callable called.
@@ -283,9 +264,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestCallableCalledAndInter
     csp::common::continuations::detail::testing::SpawnChainThatCallsLogErrorAndCancelContinuationWithIntermediateStepAndHandlerAtEnd(
         MockIntermediateStepCallable.AsStdFunction(), MockExceptionHandlerCallable.AsStdFunction(), MockResultCallback.AsStdFunction());
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GENERAL_CONTINUATIONS_TESTS || RUN_CALLABLE_CALLED_ON_SAME_THREAD_IN_CONTINUATION_CHAIN
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestCallableCalledOnSameThreadInContinuationChain)
 {
     // Since we're exposing callbacks to chains anyway, might as well verify the WASM requirement that
@@ -298,4 +277,3 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestCallableCalledOnSameTh
     // Could simply have made another detail::testing function ... but why bother when this already exists.
     csp::common::continuations::detail::testing::SpawnChainThatThrowsGeneralExceptionWithHandlerAtEnd(VerifyThread);
 }
-#endif

--- a/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
+++ b/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
@@ -32,7 +32,6 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_GRAPHQLSYSTEM_TESTS || RUN_GRAPHQLSYSTEM_QUERY_TEST
 CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, QueryTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -81,9 +80,7 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, QueryTest)
     // Log Out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GRAPHQLSYSTEM_TESTS || RUN_GRAPHQLSYSTEM_QUERY_BADINPUT_TEST
 CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunQueryBadInputTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -100,9 +97,7 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunQueryBadInputTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_GRAPHQLSYSTEM_TESTS || RUN_GRAPHQLSYSTEM_REQUEST_BADINPUT_TEST
 CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunRequestBadInputTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -119,4 +114,3 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunRequestBadInputTest)
 
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -162,7 +162,6 @@ void CompareGroups(const csp::systems::HotspotGroup& S1, const csp::systems::Hot
 static constexpr const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 static constexpr const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_CREATE_HOTSPOTGROUP_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
 {
     SetRandSeed();
@@ -234,9 +233,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_GET_HOTSPOT_GROUP_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotGroupTest)
 {
     SetRandSeed();
@@ -282,9 +279,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotGroupTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_UPDATE_HOTSPOT_GROUP_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, UpdateHotspotGroupTest)
 {
     SetRandSeed();
@@ -338,9 +333,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, UpdateHotspotGroupTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_RENAME_HOTSPOT_GROUP_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameHotspotGroupTest)
 {
     SetRandSeed();
@@ -418,9 +411,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameHotspotGroupTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_RENAME_FAIL_HOTSPOT_GROUP_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameFailHotspotGroupTest)
 {
     SetRandSeed();
@@ -468,9 +459,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameFailHotspotGroupTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_GET_HOTSPOT_NO_GROUP_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotNoGroupTest)
 {
     SetRandSeed();
@@ -510,9 +499,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotNoGroupTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_GET_HOTSPOT_GROUPS_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotsGroupsTest)
 {
     SetRandSeed();
@@ -576,9 +563,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotsGroupsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_DELETE_HOTSPOT_NO_GROUP_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotNoGroupTest)
 {
     SetRandSeed();
@@ -614,9 +599,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotNoGroupTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_GENERATE_SEQUENCE_KEY_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GenerateSequenceKeyTest)
 {
     SetRandSeed();
@@ -657,9 +639,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GenerateSequenceKeyTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_DELETE_HOTSPOT_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
 {
     // Tests the deletion of corresponding sequences when the HotspotComponent is deleted.
@@ -803,9 +783,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_DELETE_ENTITY_HOTSPOT_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteEntityWithHotspotComponentTest)
 {
     // Tests the deletion of corresponding sequences when an entity is deleted with a HotspotComponent
@@ -946,9 +924,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteEntityWithHotspotComponen
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_HOTSPOTSEQUENCESYSTEM_TESTS || RUN_SEQUENCE_PERSISTENCE_TEST
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
 {
     // Ensures hotspot sequences still exist when re-entering a space
@@ -1059,4 +1035,3 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/LODTests.cpp
+++ b/Tests/src/PublicAPITests/LODTests.cpp
@@ -54,7 +54,6 @@ void RegisterAssetToLODChain(
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOD_TESTS || RUN_LOD_GET_EMPTY_LODCHAIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, LODTests, GetEmptyLODChainTest)
 {
     SetRandSeed();
@@ -98,9 +97,7 @@ CSP_PUBLIC_TEST(CSPEngine, LODTests, GetEmptyLODChainTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOD_TESTS || RUN_LOD_REGISTER_ASSETS_TO_LODCHAIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, LODTests, RegisterAssetsToLODChainTest)
 {
     SetRandSeed();
@@ -172,4 +169,3 @@ CSP_PUBLIC_TEST(CSPEngine, LODTests, RegisterAssetsToLODChainTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/LogSystemTests.cpp
+++ b/Tests/src/PublicAPITests/LogSystemTests.cpp
@@ -53,7 +53,6 @@ void LogFormatLevelTest(
     }
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_LOG_MESSAGE_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogMessageTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -164,9 +163,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogMessageTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_LOG_FORMAT_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogFormatTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -280,9 +277,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogFormatTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_LOG_ERROR_MESSAGE_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogErrorMessageTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -357,9 +352,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogErrorMessageTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_LOG_WARN_MESSAGE_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogWarnMessageTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -434,9 +427,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogWarnMessageTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_LOG_WARN_FORMAT_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogWarnFormatTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -514,9 +505,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogWarnFormatTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_LOG_ERROR_FORMAT_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogErrorFormatTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -594,9 +583,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, LogErrorFormatTest)
 
     csp::CSPFoundation::Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_PROFILE_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, ProfileTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -659,14 +646,11 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, ProfileTest)
     EXPECT_FALSE(EndConfirmed);
     EXPECT_FALSE(EventConfirmed);
 #endif
-
     LogSystem.ClearAllCallbacks();
 
     csp::CSPFoundation::Shutdown();
 }
 
-#endif
-#if RUN_ALL_UNIT_TESTS || RUN_LOGSYSTEM_TESTS || RUN_LOGSYSTEM_FAILURE_MESSAGE_TEST
 CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, FailureMessageTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -698,4 +682,3 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, FailureMessageTest)
 
     EXPECT_TRUE(LogConfirmed);
 }
-#endif

--- a/Tests/src/PublicAPITests/MaintenanceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/MaintenanceSystemTests.cpp
@@ -67,8 +67,6 @@ csp::common::String CreateTimeString(system_clock::time_point tp)
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_MAINTENANCESYSTEM_TESTS || RUN_MAINTENANCESYSTEM_GETMAINTENANCEINFO_TEST
-
 CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, GetMaintenanceInfoTest)
 {
     auto& SystemsManager = SystemsManager::Get();
@@ -77,9 +75,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, GetMaintenanceInfoTest)
     auto [Result] = AWAIT(MaintenanceSystem, GetMaintenanceInfo, "https://maintenance-windows.magnopus-dev.cloud/maintenance-windows.json");
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MAINTENANCESYSTEM_TESTS || RUN_MAINTENANCESYSTEM_ISINSIDEMAINTENANCEWINDOW_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, IsInsideMaintenanceWindowInfoTest)
 {
@@ -94,9 +89,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, IsInsideMaintenanceWindowInfo
 
     EXPECT_FALSE(LatestMaintenanceInfo.IsInsideWindow());
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MAINTENANCESYSTEM_TESTS || RUN_MAINTENANCESYSTEM_GET_LATEST_MAINTENANCEWINDOW_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, GetLatestMaintenanceWindowInfoTest)
 {
@@ -123,9 +115,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, GetLatestMaintenanceWindowInf
         EXPECT_EQ(LatestMaintenanceInfo.EndDateTimestamp, Result.GetDefaultMaintenanceInfo().EndDateTimestamp);
     }
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MAINTENANCESYSTEM_TESTS || RUN_MAINTENANCESYSTEM_SORTMAINTENANCEINFOS_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, SortMaintenanceInfosTest)
 {
@@ -154,7 +143,5 @@ CSP_PUBLIC_TEST(CSPEngine, MaintenanceSystemTests, SortMaintenanceInfosTest)
 
     EXPECT_EQ(MaintenanceInfos2[0].Description, "Info2");
 }
-
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -78,8 +78,6 @@ void GetMaterial(AssetSystem* AssetSystem, const csp::common::String& AssetColle
     OutMaterial = Result.GetGLTFMaterial();
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_CREATEMATERIAL_TEST
-
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, CreateMaterialTest)
 {
     SetRandSeed();
@@ -106,9 +104,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, CreateMaterialTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_UPDATEMATERIAL_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, UpdateMaterialTest)
 {
@@ -151,9 +146,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, UpdateMaterialTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_GETEMPTYMATERIALS_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetEmptyMaterialsTest)
 {
@@ -182,9 +174,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetEmptyMaterialsTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_GETMULTIPLEMATERIALS_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMultipleMaterialsTest)
 {
@@ -265,9 +254,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMultipleMaterialsTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_GETMATERIAL_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMaterialTest)
 {
@@ -304,9 +290,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMaterialTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_GETINVALIDMATERIAL_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetInvalidMaterialTest)
 {
@@ -339,9 +322,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetInvalidMaterialTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_DELETEMATERIAL_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, DeleteMaterialTest)
 {
@@ -391,9 +371,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, DeleteMaterialTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_MATERIALEVENTTEST_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
 {
@@ -490,9 +467,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_MATERIAL_TESTS || RUN_MATERIAL_MATERIALASSETEVENTTEST_TEST
 
 CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
 {
@@ -595,4 +569,3 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/MimeTypeHelperTests.cpp
+++ b/Tests/src/PublicAPITests/MimeTypeHelperTests.cpp
@@ -21,7 +21,6 @@
 
 using namespace csp::common;
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_BASIC_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, BasicTest)
 {
     auto Helper = MimeTypeHelper::Get();
@@ -35,60 +34,43 @@ CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, BasicTest)
     EXPECT_EQ(Helper.GetMimeType("some/file/path.zip"), "application/zip");
     EXPECT_EQ(Helper.GetMimeType("some/file/path.unknown"), "application/octet-stream");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_UPPERCASE_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, UppercaseTests)
 {
     auto Helper = MimeTypeHelper::Get();
     EXPECT_EQ(Helper.GetMimeType("SOME/FILE/PATH.JPG"), "image/jpeg");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_WITH_UNKNOWN_INPUT_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, UnknownInputTest)
 {
     auto Helper = MimeTypeHelper::Get();
     EXPECT_EQ(Helper.GetMimeType("some/path/to/a/file.unknown"), "application/octet-stream");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_WITH_EMPTY_INPUT_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, EmptyInputTest)
 {
     auto Helper = MimeTypeHelper::Get();
     EXPECT_EQ(Helper.GetMimeType(""), "application/octet-stream");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_NO_EXTENSION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, NoExtensionTest)
 {
     auto Helper = MimeTypeHelper::Get();
     EXPECT_EQ(Helper.GetMimeType("path_with_no_extension"), "application/octet-stream");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_MULTIPLE_PERIODS_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, MultiplePeriodsTest)
 {
     auto Helper = MimeTypeHelper::Get();
     EXPECT_EQ(Helper.GetMimeType("path.jpg.zip"), "application/zip");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_WHITESPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, WhitespaceTest)
 {
     auto Helper = MimeTypeHelper::Get();
     EXPECT_EQ(Helper.GetMimeType("path.jpg      \n   "), "image/jpeg");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_ACCESS_MIMETYPES_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, AccessMimeTypesTest) { EXPECT_EQ(MimeTypeHelper::Get().MimeType.IMAGE_JPEG, "image/jpeg"); }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MIMETYPEHELPER_TESTS || RUN_MIMETYPEHELPER_ACCESS_FILEEXTENSIONS_TEST
 CSP_PUBLIC_TEST(CSPEngine, MimeTypeHelperTests, AccessFileExtensionsTest) { EXPECT_EQ(MimeTypeHelper::Get().FileExtension.JPEG, "jpeg"); }
-#endif

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -264,7 +264,6 @@ void OnUserCreated(SpaceEntity* InUser, SpaceEntitySystem* EntitySystem)
 }
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_MANUAL_SIGNALRCONNECTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
 {
     SetRandSeed();
@@ -326,9 +325,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_SIGNALRCONNECTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
 {
     SetRandSeed();
@@ -380,9 +377,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_KEEPALIVE_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
 {
     SetRandSeed();
@@ -438,9 +433,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_ENTITYREPLICATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
 {
     SetRandSeed();
@@ -520,9 +513,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_SELF_REPLICATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
 {
     SetRandSeed();
@@ -621,9 +612,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_CREATE_AVATAR_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
 {
     SetRandSeed();
@@ -697,9 +686,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_CREATE_CREATOR_AVATAR_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
 {
     SetRandSeed();
@@ -773,9 +760,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_CREATE_MANY_AVATAR_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
 {
     /*
@@ -868,9 +853,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_AVATAR_MOVEMENT_DIRECTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
 {
     SetRandSeed();
@@ -938,9 +921,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_OBJECT_CREATE_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
 {
     SetRandSeed();
@@ -1002,9 +983,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_OBJECT_ADDCOMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
 {
     SetRandSeed();
@@ -1105,9 +1084,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_OBJECT_REMOVECOMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
 {
     SetRandSeed();
@@ -1205,9 +1182,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_OBJECT_REMOVECOMPONENTREENTERSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpace)
 {
     SetRandSeed();
@@ -1332,10 +1307,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpa
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 // This test currently requires manual steps and will be reviewed as part of OF-1535.
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_CONNECTION_INTERRUPT_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -1414,9 +1387,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
     // Log out
     Awaitable(&csp::systems::UserSystem::Logout, UserSystem).Await();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_DELETE_MULTIPLE_ENTITIES_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
 {
     // Test for OB-1046
@@ -1489,9 +1460,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_ENTITY_SELECTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
 {
     SetRandSeed();
@@ -1557,7 +1526,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 // Derived type that allows us to access protected members of SpaceEntitySystem
 class InternalSpaceEntitySystem : public csp::multiplayer::SpaceEntitySystem
@@ -1576,7 +1544,6 @@ public:
 };
 
 // Disabled by default as it can be slow
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_MANYENTITIES_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 {
     SetRandSeed();
@@ -1672,9 +1639,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_INVALID_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
 {
     SetRandSeed();
@@ -1735,9 +1700,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_FIND_COMPONENT_BY_ID_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, FindComponentByIdTest)
 {
     SetRandSeed();
@@ -1805,7 +1768,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, FindComponentByIdTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 void RunParentEntityReplicationTest(bool Local)
 {
@@ -2021,25 +1983,20 @@ void RunParentEntityReplicationTest(bool Local)
     LogOut(UserSystem);
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_LOCAL_PARENT_ENTITY_REPLICATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityLocalReplicationTest)
 {
     // Tests the SpaceEntity::SerializeFromPatch and SpaceEntity::ApplyLocalPatch functionality
     // for ParentId and ChildEntities
     RunParentEntityReplicationTest(true);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_PARENT_ENTITY_REPLICATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityReplicationTest)
 {
     // Tests the SpaceEntity::SerializeFromPatch and SpaceEntity::DeserializeFromPatch functionality
     // for ParentId and ChildEntities
     RunParentEntityReplicationTest(false);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_GLOBAL_POSITION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
 {
     // Tests the SpaceEntitySystem::OnAllEntitiesCreated
@@ -2136,9 +2093,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_PARENT_ENTITY_GLOBAL_ROTATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
 {
     // Tests the SpaceEntitySystem::OnAllEntitiesCreated
@@ -2235,9 +2190,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_PARENT_ENTITY_GLOBAL_SCALE_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
 {
     // Tests the SpaceEntitySystem::OnAllEntitiesCreated
@@ -2337,9 +2290,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_PARENT_ENTITY_GLOBAL_TRANSFORM_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
 {
     // Tests the SpaceEntitySystem::OnAllEntitiesCreated
@@ -2431,9 +2382,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_PARENT_ENTITY_ENTER_SPACE_REPLICATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTest)
 {
     // Tests the SpaceEntitySystem::OnAllEntitiesCreated
@@ -2560,7 +2509,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTe
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 void RunParentChildDeletionTest(bool Local)
 {
@@ -2725,25 +2673,20 @@ void RunParentChildDeletionTest(bool Local)
     }
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_LOCAL_PARENT_CHILD_DELETION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentChildLocalDeletionTest)
 {
     // Tests the SpaceEntity::SerializeFromPatch and SpaceEntity::ApplyLocalPatch functionality
     // for deletion of child and parent entities
     RunParentChildDeletionTest(true);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_PARENT_CHILD_DELETION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentChildDeletionTest)
 {
     // Tests the SpaceEntity::SerializeFromPatch and SpaceEntity::DeserializeFromPatch functionality
     // for deletion of child and parent entities
     RunParentChildDeletionTest(false);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_CREATE_OBJECT_PARENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateObjectParentTest)
 {
     SetRandSeed();
@@ -2799,7 +2742,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateObjectParentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 void RunParentDeletionTest(bool Local)
 {
@@ -3027,20 +2969,16 @@ void RunParentDeletionTest(bool Local)
     LogOut(UserSystem);
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_LOCAL_PARENT_DELETION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentLocalDeletionTest)
 {
     // Tests the SpaceEntity::SerializeFromPatch and SpaceEntity::ApplyLocalPatch functionality
     // for deletion of child and parent entities
     RunParentDeletionTest(true);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TESTS || RUN_MULTIPLAYER_PARENT_DELETION_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentDeletionTest)
 {
     // Tests the SpaceEntity::SerializeFromPatch and SpaceEntity::DeserializeFromPatch functionality
     // for deletion of child and parent entities
     RunParentDeletionTest(false);
 }
-#endif

--- a/Tests/src/PublicAPITests/MultiplayerTestRunnerProcessTests.cpp
+++ b/Tests/src/PublicAPITests/MultiplayerTestRunnerProcessTests.cpp
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef SKIP_INTERNAL_TESTS
 
 #include "MultiplayerTestRunnerProcess.h"
 #include "TestHelpers.h"
 
 #include "gtest/gtest.h"
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_ARG_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTestRunnerProcessTests, ArgTest)
 {
     MultiplayerTestRunnerProcess Process(MultiplayerTestRunner::TestIdentifiers::TestIdentifier::CREATE_AVATAR);
@@ -63,9 +61,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTestRunnerProcessTests, ArgTest)
         (std::vector<std::string> { "MultiplayerTestRunner", "--test", "CreateAvatar", "--email", "FakeEmail@MrMoustacheMan.com", "--password",
             "Hunter2", "--space", "MyFakeSpaceId", "--timeout", "5", "--endpoint", "https://www.website.com" }));
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_TESTS || RUN_MULTIPLAYER_TEST_RUNNER_PROCESS_FUTURE_TEST
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTestRunnerProcessTests, FutureTest)
 {
     // Actually invoke the runner and make sure the future's are all set
@@ -90,6 +86,3 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTestRunnerProcessTests, FutureTest)
     auto LoggedOutFutureStatus = Process.LoggedOutFuture().wait_for(std::chrono::seconds(20));
     EXPECT_EQ(LoggedOutFutureStatus, std::future_status::ready);
 }
-#endif
-
-#endif

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -144,7 +144,6 @@ bool AreTestAssetCollectionsEqual(const csp::systems::AssetCollection& Lhs, cons
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_POISYSTEM_TESTS || RUN_POISYSTEM_CREATEPOI_TEST
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOITest)
 {
     SetRandSeed();
@@ -164,9 +163,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOITest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_POISYSTEM_TESTS || RUN_POISYSTEM_CREATEPOI_WITH_TAGS_TEST
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOIWithTagsTest)
 {
     SetRandSeed();
@@ -190,9 +187,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOIWithTagsTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_POISYSTEM_TESTS || RUN_POISYSTEM_GETPOI_INSIDE_CIRCULAR_AREA_TEST
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaTest)
 {
     SetRandSeed();
@@ -257,9 +252,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaT
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_POISYSTEM_TESTS || RUN_POISYSTEM_GET_ASSETCOLLECTION_FROM_POI_TEST
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOITest)
 {
     SetRandSeed();
@@ -307,9 +300,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_POISYSTEM_TESTS || RUN_POISYSTEM_QUERY_POI_TYPE_TEST
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 {
     SetRandSeed();
@@ -450,4 +441,3 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -35,7 +35,6 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_QUERY_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, TierNameEnumTesttoStringTest)
 {
     EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Basic), "basic");
@@ -43,9 +42,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, TierNameEnumTesttoStringTest)
     EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Pro), "pro");
     EXPECT_EQ(TierNameEnumToString(csp::systems::TierNames::Enterprise), "enterprise");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_QUERY_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, StringToTierNameEnumTestTest)
 {
     EXPECT_EQ(StringToTierNameEnum("basic"), csp::systems::TierNames::Basic);
@@ -53,9 +50,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, StringToTierNameEnumTestTest)
     EXPECT_EQ(StringToTierNameEnum("pro"), csp::systems::TierNames::Pro);
     EXPECT_EQ(StringToTierNameEnum("enterprise"), csp::systems::TierNames::Enterprise);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_QUERY_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, TierFeatureEnumTesttoStringTest)
 {
     EXPECT_EQ(TierFeatureEnumToString(csp::systems::TierFeatures::Agora), "Agora");
@@ -68,9 +63,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, TierFeatureEnumTesttoStringTest)
     EXPECT_EQ(TierFeatureEnumToString(csp::systems::TierFeatures::TicketedSpace), "TicketedSpace");
     EXPECT_EQ(TierFeatureEnumToString(csp::systems::TierFeatures::TotalUploadSizeInKilobytes), "TotalUploadSizeInKilobytes");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_STRINGTOTIERFEATUREENUM_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, StringToTierFeatureEnumTestTest)
 {
     EXPECT_EQ(StringToTierFeatureEnum("Agora"), csp::systems::TierFeatures::Agora);
@@ -83,9 +76,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, StringToTierFeatureEnumTestTest)
     EXPECT_EQ(StringToTierFeatureEnum("TicketedSpace"), csp::systems::TierFeatures::TicketedSpace);
     EXPECT_EQ(StringToTierFeatureEnum("TotalUploadSizeInKilobytes"), csp::systems::TierFeatures::TotalUploadSizeInKilobytes);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTOTALSPACESOWNEDBYUSER_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTotalSpacesOwnedByUserTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -102,9 +93,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTotalSpacesOwnedByUserTest)
     EXPECT_EQ(Result.GetFeatureLimitInfo().Limit, -1);
     EXPECT_EQ(Result.GetFeatureLimitInfo().FeatureName, csp::systems::TierFeatures::SpaceOwner);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETCURRENTUSERTIER_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetCurrentUserTierTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -121,9 +110,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetCurrentUserTierTest)
     EXPECT_EQ(Result.GetUserTierInfo().AssignToId, UserId);
     EXPECT_EQ(Result.GetUserTierInfo().AssignToType, "user");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATUREPROGRESSFORUSER_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForUser)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -147,9 +134,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForUser)
         EXPECT_EQ(Result.GetFeaturesLimitInfo()[i].ActivityCount, 0);
     }
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATUREPROGRESSFORSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForSpace)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -190,9 +175,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForSpace)
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATUREQUOTA_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureQuota)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -220,9 +203,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureQuota)
         EXPECT_EQ(Result.GetFeatureQuotaInfo().TierName, TierNames::Pro);
     }
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTIERFEATURESQUOTA_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeaturesQuota)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -256,9 +237,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeaturesQuota)
         EXPECT_EQ(Result.GetFeaturesQuotaInfo()[i].Period, ExpectedInfoArray[i].Period);
     }
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETCONCURRENTUSERSINSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetConcurrentUsersInSpace)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -314,9 +293,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetConcurrentUsersInSpace)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_QUOTASYSTEM_TESTS || RUN_QUOTASYSTEM_GETTOTALSPACESIZEINKILOBYTES_TEST
 CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTotalSpaceSizeinKilobytes)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -406,4 +383,3 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTotalSpaceSizeinKilobytes)
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);
 }
-#endif

--- a/Tests/src/PublicAPITests/ReplicatedValueTests2.cpp
+++ b/Tests/src/PublicAPITests/ReplicatedValueTests2.cpp
@@ -20,7 +20,6 @@
 
 using namespace csp::multiplayer;
 
-#if RUN_ALL_UNIT_TESTS || RUN_REPLICATEDVALUE_TESTS
 CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, InvalidTest)
 {
     ReplicatedValue MyValue;
@@ -226,4 +225,3 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapAssignmentTest)
     EXPECT_TRUE(MyValue.GetReplicatedValueType() == ReplicatedValueType::StringMap);
     EXPECT_TRUE(MyValue.GetStringMap() == MyMap);
 }
-#endif

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -60,7 +60,6 @@ void OnUserCreated(SpaceEntity* InUser)
     std::cerr << "OnUserCreated" << std::endl;
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_SCRIPTSYSTEM_SCRIPT_BINDING_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptBindingTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -110,9 +109,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptBindingTest)
     ScriptSystem.DestroyContext(ContextId);
     ScriptSystem.Shutdown();
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_SCRIPT_CREATE_SCRIPT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CreateScriptTest)
 {
     SetRandSeed();
@@ -193,9 +190,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CreateScriptTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_SCRIPT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
 {
     SetRandSeed();
@@ -330,9 +325,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_SCRIPT_AVATAR_SCRIPT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AvatarScriptTest)
 {
     SetRandSeed();
@@ -427,9 +419,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AvatarScriptTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_SCRIPT_LOG_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptLogTest)
 {
     SetRandSeed();
@@ -504,9 +494,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptLogTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_DELETE_SCRIPT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteScriptTest)
 {
     SetRandSeed();
@@ -612,9 +600,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteScriptTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_SCRIPT_DELETE_AND_CHANGE_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteAndChangeComponentTest)
 {
     // Test for: OB-864
@@ -722,9 +708,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteAndChangeComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_ADD_SECOND_SCRIPT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
 {
     // Test for OB-1407
@@ -884,9 +868,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_SCRIPT_DELTA_TIME_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptDeltaTimeTest)
 {
     SetRandSeed();
@@ -982,9 +964,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptDeltaTimeTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_CUSTOM_COMPONENT_SCRIPT_INTERFACE_SUBSCRIPTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubscriptionTest)
 {
     SetRandSeed();
@@ -1115,9 +1094,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubs
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_MULTIPLE_SCRIPT_COMPONENT_TEST
 CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
 {
     SetRandSeed();
@@ -1193,10 +1170,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 // This test will be fixed and re-instated as part of OF-1539
-#if RUN_ALL_UNIT_TESTS || RUN_SCRIPTSYSTEM_TESTS || RUN_MODIFY_EXISTING_SCRIPT_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, ScriptSystemTests, ModifyExistingScriptTest)
 {
     SetRandSeed();
@@ -1300,6 +1275,5 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ScriptSystemTests, ModifyExistingScriptTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 } // namespace

--- a/Tests/src/PublicAPITests/SequenceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceSystemTests.cpp
@@ -235,7 +235,6 @@ void CompareSequences(const csp::systems::Sequence& S1, const csp::systems::Sequ
 static constexpr const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 static constexpr const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_CREATESEQUENCE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceTest)
 {
     SetRandSeed();
@@ -289,9 +288,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_CREATESEQUENCE_INVALIDKEY_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceInvalidKeyTest)
 {
     SetRandSeed();
@@ -342,9 +339,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceInvalidKeyTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_CREATESEQUENCENOITEMS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoItemsTest)
 {
     SetRandSeed();
@@ -389,9 +384,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoItemsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_CREATESEQUENCE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoSpaceTest)
 {
     SetRandSeed();
@@ -422,9 +415,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_GETSEQUENCE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceTest)
 {
     SetRandSeed();
@@ -475,9 +466,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_GETSEQUENCE_INVALIDKEY_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceInvalidKeyTest)
 {
     SetRandSeed();
@@ -527,9 +516,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceInvalidKeyTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_UPDATESEQUENCE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, UpdateSequenceTest)
 {
     SetRandSeed();
@@ -580,9 +567,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, UpdateSequenceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_UPDATESEQUENCE_INVALIDKEY_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, UpdateSequenceInvalidKeyTest)
 {
     SetRandSeed();
@@ -640,9 +625,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, UpdateSequenceInvalidKeyTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_RENAMESEQUENCE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceTest)
 {
     SetRandSeed();
@@ -694,9 +677,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_RENAMESEQUENCE_INVALIDKEY_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceInvalidKeyTest)
 {
     SetRandSeed();
@@ -765,9 +746,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RenameSequenceInvalidKeyTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_GETSEQUENCEBYCRITERIA_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaTest)
 {
     SetRandSeed();
@@ -859,9 +838,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_GETSEQUENCEBYCRITERIA_INVALIDKEY_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaInvalidKeyTest)
 {
     SetRandSeed();
@@ -915,9 +892,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequencesByCriteriaInvalidKey
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_REGISTERSEQUENCEUPDATED_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RegisterSequenceUpdatedTest)
 {
     SetRandSeed();
@@ -1018,9 +993,6 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RegisterSequenceUpdatedTest)
     LogOut(UserSystem);
 }
 
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_SEQUENCE_PERMISSIONS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, SequencePermissionsTest)
 {
     SetRandSeed();
@@ -1101,9 +1073,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, SequencePermissionsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SEQUENCESYSTEM_TESTS || RUN_SEQUENCESYSTEM_GETALLSEQUENCESCONTAINING_TEST
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetAllSequencesContainingItemsTest)
 {
     SetRandSeed();
@@ -1190,4 +1160,3 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetAllSequencesContainingItemsTe
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/SettingsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SettingsSystemTests.cpp
@@ -65,7 +65,6 @@ bool IsUriValid(const std::string& Uri, const std::string& FileName)
 
 } // namespace
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_NDASTATUS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, NDAStatusTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -90,9 +89,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, NDAStatusTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_NEWSLETTERSTATUS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, NewsletterStatusTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -117,9 +114,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, NewsletterStatusTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_RECENTSPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, RecentSpacesTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -146,9 +141,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, RecentSpacesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_BLOCKEDSPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, BlockedSpacesTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -179,9 +172,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, BlockedSpacesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_REMOVEBLOCKEDSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, RemoveBlockedSpaceTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -315,9 +306,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, RemoveBlockedSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_MULIBLOCKEDSPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, MultiBlockedSpacesTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -365,9 +354,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, MultiBlockedSpacesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_AVATARPORTRAIT_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, UpdateAvatarPortraitTest)
 {
     SetRandSeed();
@@ -412,9 +399,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, UpdateAvatarPortraitTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SPACESYSTEM_UPDATEAVATAR_PORTRAIT_WITH_BUFFER_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, UpdateAvatarPortraitWithBufferTest)
 {
     SetRandSeed();
@@ -467,9 +452,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, UpdateAvatarPortraitWithBufferTe
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SETTINGSSYSTEM_TESTS || RUN_SETTINGSSYSTEM_AVATARINFOSTRING_TEST
 CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, AvatarInfoTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -502,4 +485,3 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, AvatarInfoTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -314,7 +314,6 @@ InviteUserRoleInfoCollection CreateInviteUsers()
     return InviteUsers;
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_CREATESPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceTest)
 {
     SetRandSeed();
@@ -344,9 +343,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_CREATESPACE_WITH_TAGS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithTagsTest)
 {
     SetRandSeed();
@@ -378,9 +375,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithTagsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_CREATESPACE_WITH_BULK_INVITE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBulkInviteTest)
 {
     SetRandSeed();
@@ -423,9 +418,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBulkInviteTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_CREATESPACEWITHBUFFER_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBufferTest)
 {
     SetRandSeed();
@@ -471,9 +464,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBufferTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_CREATESPACEWITHBUFFER_WITH_BULK_INVITE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBufferWithBulkInviteTest)
 {
     SetRandSeed();
@@ -532,9 +523,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBufferWithBulkInvite
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATESPACEDESCRIPTION_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceDescriptionTest)
 {
     SetRandSeed();
@@ -582,9 +571,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceDescriptionTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATESPACETYPE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTypeTest)
 {
     SetRandSeed();
@@ -632,9 +619,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTypeTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETSPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesTest)
 {
     SetRandSeed();
@@ -687,9 +672,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceTest)
 {
     SetRandSeed();
@@ -724,9 +707,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETSPACESBYIDS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesByIdsTest)
 {
     SetRandSeed();
@@ -788,9 +769,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesByIdsTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETPUBLICSPACESASGUEST_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesAsGuestTest)
 {
     SetRandSeed();
@@ -858,9 +837,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesAsGuestTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETPUBLICSPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesTest)
 {
     SetRandSeed();
@@ -916,9 +893,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETPRIVATESPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPrivateSpacesTest)
 {
     SetRandSeed();
@@ -974,9 +949,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPrivateSpacesTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETPAGINATEDPRIVATESPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPaginatedPrivateSpacesTest)
 {
     SetRandSeed();
@@ -1033,117 +1006,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPaginatedPrivateSpacesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GET_FILTERED_BY_TAG_SPACES_TEST
-CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetFilteredByTagInclusionSpacesTest)
-{
-    SetRandSeed();
-
-    auto& SystemsManager = ::SystemsManager::Get();
-    auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-
-    // Log in
-    String UserId;
-    LogInAsNewTestUser(UserSystem, UserId);
-
-    // Create test spaces with tags
-    std::string TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    UUIDv4::UUIDGenerator<std::mt19937_64> uuidGenerator;
-
-    const std::string Tag1 = uuidGenerator.getUUID().str();
-    const std::string Tag2 = uuidGenerator.getUUID().str();
-    const std::string Tag3 = uuidGenerator.getUUID().str();
-
-    std::vector<std::pair<std::string, csp::common::Array<csp::common::String>>> SpacesWithTags = { { TestSpaceName + "Space1", { Tag1.c_str() } },
-        { TestSpaceName + "Space2", { Tag2.c_str() } }, { TestSpaceName + "Space3", { Tag1.c_str(), Tag2.c_str() } } };
-    std::array<csp::common::String, 3> SpaceIds;
-
-    for (size_t i = 0; i < SpacesWithTags.size(); ++i)
-    {
-        ::Space Space;
-        CreateSpace(SpaceSystem, SpacesWithTags[i].first.c_str(), TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr,
-            SpacesWithTags[i].second, Space);
-        SpaceIds[i] = Space.Id;
-    }
-
-    {
-        // Query for spaces with "tag1"
-        auto [SpacesWithTag1] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 10,
-            csp::common::Array<csp::common::String> { Tag1.c_str() }, nullptr, nullptr); // Space1, Space3
-
-        EXPECT_EQ(SpacesWithTag1.GetSpaces().Size(), 2);
-        EXPECT_NE(std::find_if(SpacesWithTag1.GetSpaces().cbegin(), SpacesWithTag1.GetSpaces().cend(),
-                      [](const BasicSpace& Space) { return Space.Name.Contains("Space1"); }),
-            SpacesWithTag1.GetSpaces().cend());
-        EXPECT_NE(std::find_if(SpacesWithTag1.GetSpaces().cbegin(), SpacesWithTag1.GetSpaces().cend(),
-                      [](const BasicSpace& Space) { return Space.Name.Contains("Space3"); }),
-            SpacesWithTag1.GetSpaces().cend());
-    }
-    {
-        // Query for spaces with "tag1" and "tag2", without needing every tag to be on the spaces
-        auto [SpacesWithTags1And2WithoutEveryTag] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr,
-            nullptr, 10, csp::common::Array<csp::common::String> { Tag1.c_str(), Tag2.c_str() }, nullptr, false); // Space1, Space2, Space3
-
-        EXPECT_EQ(SpacesWithTags1And2WithoutEveryTag.GetSpaces().Size(), 3);
-        EXPECT_NE(std::find_if(SpacesWithTags1And2WithoutEveryTag.GetSpaces().cbegin(), SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend(),
-                      [](const BasicSpace& Space) { return Space.Name.Contains("Space1"); }),
-            SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend());
-        EXPECT_NE(std::find_if(SpacesWithTags1And2WithoutEveryTag.GetSpaces().cbegin(), SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend(),
-                      [](const BasicSpace& Space) { return Space.Name.Contains("Space2"); }),
-            SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend());
-        EXPECT_NE(std::find_if(SpacesWithTags1And2WithoutEveryTag.GetSpaces().cbegin(), SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend(),
-                      [](const BasicSpace& Space) { return Space.Name.Contains("Space3"); }),
-            SpacesWithTags1And2WithoutEveryTag.GetSpaces().cend());
-    }
-    {
-        // Query for spaces with "tag1" and "tag2", needing every tag to be on the spaces
-        auto [SpacesWithTag1And2WithEveryTag] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr,
-            10, csp::common::Array<csp::common::String> { Tag1.c_str(), Tag2.c_str() }, nullptr, true); // Space3
-
-        EXPECT_EQ(SpacesWithTag1And2WithEveryTag.GetSpaces().Size(), 1);
-        EXPECT_NE(std::find_if(SpacesWithTag1And2WithEveryTag.GetSpaces().cbegin(), SpacesWithTag1And2WithEveryTag.GetSpaces().cend(),
-                      [](const BasicSpace& Space) { return Space.Name.Contains("Space3"); }),
-            SpacesWithTag1And2WithEveryTag.GetSpaces().cend());
-    }
-    {
-        // Query for spaces without "tag1"
-        auto [SpacesWithoutTag1] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 1, nullptr,
-            csp::common::Array<csp::common::String> { Tag1.c_str() },
-            true); // This will just be any space (in the entire database!) without Tag1, we can't guarantee which one it'll be, so we just check
-                   // that it doesn't have the tag
-
-        EXPECT_EQ(SpacesWithoutTag1.GetSpaces().Size(), 1);
-        // Check that "tag1" isn't in the tags.
-        EXPECT_EQ(std::find_if(SpacesWithoutTag1.GetSpaces()[0].Tags.cbegin(), SpacesWithoutTag1.GetSpaces()[0].Tags.cend(),
-                      [&Tag1](const csp::common::String& Tag) { return Tag.Contains(Tag1.c_str()); }),
-            SpacesWithoutTag1.GetSpaces()[0].Tags.cend());
-    }
-    {
-        // Query for spaces with "tag1" but without "tag2"
-        auto [SpacesWithTag1ButWithoutTag2] = AWAIT_PRE(SpaceSystem, GetSpacesByAttributes, RequestPredicate, nullptr, nullptr, nullptr, nullptr, 10,
-            csp::common::Array<csp::common::String> { Tag1.c_str() }, csp::common::Array<csp::common::String> { Tag2.c_str() }, true); // Space1
-
-        EXPECT_EQ(SpacesWithTag1ButWithoutTag2.GetSpaces().Size(), 1);
-        EXPECT_NE(std::find_if(SpacesWithTag1ButWithoutTag2.GetSpaces().cbegin(), SpacesWithTag1ButWithoutTag2.GetSpaces().cend(),
-                      [](const BasicSpace& Space) { return Space.Name.Contains("Space1"); }),
-            SpacesWithTag1ButWithoutTag2.GetSpaces().cend());
-    }
-
-    for (const auto& SpaceID : SpaceIds)
-    {
-        DeleteSpace(SpaceSystem, SpaceID);
-    }
-
-    // Log out
-    LogOut(UserSystem);
-}
-#endif
-
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_JOINPUBLICsSPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, JoinPublicSpaceTest)
 {
     SetRandSeed();
@@ -1210,9 +1073,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, JoinPublicSpaceTest)
     DeleteSpace(SpaceSystem, PublicSpace.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_ADD_SITE_INFO_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, AddSiteInfoTest)
 {
     SetRandSeed();
@@ -1243,9 +1104,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, AddSiteInfoTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GET_SITE_INFO_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSiteInfoTest)
 {
     SetRandSeed();
@@ -1302,9 +1161,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSiteInfoTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_USER_ROLES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateUserRolesTest)
 {
     SetRandSeed();
@@ -1410,9 +1267,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateUserRolesTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_GUEST_USER_ROLE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateGuestUserRoleTest)
 {
     SetRandSeed();
@@ -1459,9 +1314,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateGuestUserRoleTest)
     DeleteSpace(SpaceSystem, PublicSpace.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_SET_USER_ROLE_ON_INVITE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, SetUserRoleOnInviteTest)
 {
     SetRandSeed();
@@ -1508,9 +1361,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, SetUserRoleOnInviteTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACE_METADATA_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceMetadataTest)
 {
     SetRandSeed();
@@ -1551,10 +1402,8 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceMetadataTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACES_METADATA_TEST
-CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpacesMetadataTest)
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesMetadataTest)
 {
     SetRandSeed();
 
@@ -1602,10 +1451,8 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpacesMetadataTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GET_SPACES_METADATA_TEST
-CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesMetadataTest)
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTagsMetadataTest)
 {
     SetRandSeed();
 
@@ -1647,10 +1494,8 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesMetadataTest)
     DeleteSpace(SpaceSystem, Spaces[1]);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACETAGS_TEST
-CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTagsTest)
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpacesTagsMetadataTest)
 {
     SetRandSeed();
 
@@ -1686,9 +1531,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceTagsTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATESPACE_THUMBNAIL_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceThumbnailTest)
 {
     SetRandSeed();
@@ -1752,9 +1595,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceThumbnailTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATESPACE_THUMBNAIL_WITH_BUFFER_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceThumbnailWithBufferTest)
 {
     SetRandSeed();
@@ -1833,9 +1674,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceThumbnailWithBufferTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_CREATE_SPACE_EMPTY_METADATA_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithEmptyMetadataTest)
 {
     SetRandSeed();
@@ -1865,9 +1704,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithEmptyMetadataTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_UPDATE_SPACE_EMPTY_METADATA_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceWithEmptyMetadataTest)
 {
     SetRandSeed();
@@ -1898,10 +1735,8 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateSpaceWithEmptyMetadataTest)
 
     LogOut(UserSystem);
 }
-#endif
 
 // - TODO - JQ - Rename this test to InviteUserToSpaceTest?
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GET_PENDING_INVITES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPendingUserInvitesTest)
 {
     SetRandSeed();
@@ -1958,9 +1793,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPendingUserInvitesTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GET_ACCEPTED_INVITES_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetAcceptedUserInvitesTest)
 {
     SetRandSeed();
@@ -2042,9 +1875,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetAcceptedUserInvitesTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_BULK_INVITE_TO_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, BulkInvitetoSpaceTest)
 {
     SetRandSeed();
@@ -2088,9 +1919,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, BulkInvitetoSpaceTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETPUBLICSPACEMETADATA_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
 {
     SetRandSeed();
@@ -2154,9 +1983,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETSPACE_THUMBNAIL_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceThumbnailTest)
 {
     SetRandSeed();
@@ -2217,9 +2044,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceThumbnailTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GETSPACE_THUMBNAIL_WITH_GUEST_USER_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceThumbnailWithGuestUserTest)
 {
     SetRandSeed();
@@ -2278,9 +2103,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceThumbnailWithGuestUserTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_BAN_GUESTUSER_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, BanGuestUserTest)
 {
     SetRandSeed();
@@ -2344,9 +2167,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, BanGuestUserTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_BAN_USER_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, BanUserTest)
 {
     SetRandSeed();
@@ -2410,9 +2231,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, BanUserTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_ENTER_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
 {
     SetRandSeed();
@@ -2468,9 +2287,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_ENTER_SPACE_ASNONMODERATOR_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsNonModeratorTest)
 {
     SetRandSeed();
@@ -2513,9 +2330,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsNonModeratorTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_ENTER_SPACE_ASMODERATOR_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsModeratorTest)
 {
     SetRandSeed();
@@ -2573,9 +2388,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsModeratorTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GEOLOCATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationTest)
 {
     SetRandSeed();
@@ -2701,9 +2514,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GEOLOCATION_VALIDATION_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationValidationTest)
 {
     SetRandSeed();
@@ -2853,9 +2664,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationValidationTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GEOLOCATION_WITHOUT_PERMISSION_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationWithoutPermissionTest)
 {
     SetRandSeed();
@@ -2949,9 +2758,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationWithoutPermissionTest)
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_GEOLOCATION_WITHOUT_PERMISSION_PUBLIC_SPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationWithoutPermissionPublicSpaceTest)
 {
     SetRandSeed();
@@ -3048,9 +2855,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationWithoutPermissionPublicS
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_DUPLICATESPACE_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceTest)
 {
     SetRandSeed();
@@ -3119,9 +2924,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACESYSTEM_TESTS || RUN_SPACESYSTEM_ENTER_SPACE_PERMISSIONS_MATRIX_TESTS
 namespace CSPEngine
 {
 /*
@@ -3473,4 +3276,3 @@ INSTANTIATE_TEST_SUITE_P(SpaceSystemTests, EnterSpaceWhenBanned,
         std::make_tuple(SpaceAttributes::Unlisted, csp::systems::EResultCode::Failed,
             "Logged in user does not have permission to discover this space. Failed to enter space.")));
 }
-#endif

--- a/Tests/src/PublicAPITests/SpaceTransformTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceTransformTests.cpp
@@ -22,7 +22,6 @@
 
 #include "gtest/gtest.h"
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_DEFAULT_CONSTRUCT_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, DefaultConstructTest)
 {
     const csp::multiplayer::SpaceTransform SpaceTransform;
@@ -30,9 +29,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, DefaultConstructTest)
     EXPECT_EQ(SpaceTransform.Rotation, csp::common::Vector4::Identity());
     EXPECT_EQ(SpaceTransform.Scale, csp::common::Vector3::One());
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_CONSTRUCT_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, ConstructTest)
 {
     const csp::common::Vector3 Pos { 1.0f, 2.0f, 3.0f };
@@ -44,9 +41,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, ConstructTest)
     EXPECT_EQ(SpaceTransform.Rotation, Rot);
     EXPECT_EQ(SpaceTransform.Scale, Scale);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_EQUALITY_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, EqualityTest)
 {
     const csp::common::Vector3 Pos { 1.0f, 2.0f, 3.0f };
@@ -60,18 +55,14 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, EqualityTest)
     EXPECT_EQ(SpaceTransform1, SpaceTransform2);
     EXPECT_NE(SpaceTransform1, SpaceTransformIdentity);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_IDENTITY_AXIOM_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityAxiomTest)
 {
     // Two identity matrices should be identity
     const csp::multiplayer::SpaceTransform Identity;
     EXPECT_EQ((Identity * Identity), Identity);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_IDENTITY_TRANSFORM_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityTransformTest)
 {
     const csp::multiplayer::SpaceTransform Identity;
@@ -91,9 +82,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationIdentityTransformT
     EXPECT_EQ((Identity * Scaled), Scaled);
     EXPECT_EQ((Scaled * Identity), Scaled);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_TRS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTest)
 {
     const csp::multiplayer::SpaceTransform Identity;
@@ -119,9 +108,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTest)
 
     EXPECT_EQ(Output.Scale, (csp::common::Vector3 { 2.0f, 1.0f, 4.0f }));
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_SPACETRANSFORM_TESTS || RUN_SPACETRANSFORM_MULTIPLICATION_NON_NORMAL_QUAT_TRS_TEST
 CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTestNonNormalQuat)
 {
     const csp::multiplayer::SpaceTransform Identity;
@@ -148,4 +135,3 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceTransformTests, MulitplicationTRSTestNonNormalQu
 
     EXPECT_EQ(Output.Scale, (csp::common::Vector3 { 2.0f, 1.0f, 4.0f }));
 }
-#endif

--- a/Tests/src/PublicAPITests/SystemResultTests.cpp
+++ b/Tests/src/PublicAPITests/SystemResultTests.cpp
@@ -113,17 +113,14 @@ void NullResultTestFunction(NullResultCallback Callback)
     }
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_SYSTEMRESULT_TESTS || RUN_SYSTEMRESULT_NULLRESULT_TEST
 CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, NullResultTest)
 {
     NullResultCallback NullTestCallback
         = [this](const NullResult& _Result) { EXPECT_EQ(_Result.GetResultCode(), csp::systems::EResultCode::Success); };
     NullResultTestFunction(NullTestCallback);
 }
-#endif
 
 // BaseResult
-#if RUN_ALL_UNIT_TESTS || RUN_SYSTEMRESULT_TESTS || RUN_SYSTEMRESULT_BASERESULT_TEST
 CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, BaseResultTest)
 {
     const csp::web::EResponseCodes MyTestResponseCode = csp::web::EResponseCodes::ResponseOK;
@@ -154,6 +151,5 @@ CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, BaseResultTest)
     EXPECT_EQ(MyRequest->GetPayload().GetContent(), "1234");
     EXPECT_EQ(ResponseBase.GetResponseCode(), csp::services::EResponseCode::ResponseSuccess);
 }
-#endif
 
 } // namespace SystemResultsTest

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -183,7 +183,6 @@ void ValidateThirdPartyAuthoriseURL(const csp::common::String& AuthoriseURL, con
     EXPECT_EQ(RetrievedRedirectURL, RedirectURL.c_str());
 }
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_FORGOTPASSWORD_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -215,9 +214,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)
 
     EXPECT_EQ(FailResult2.GetResultCode(), csp::systems::EResultCode::Failed);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_RESETPASSWORD_BADTOKEN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ResetPasswordBadTokenTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -230,9 +227,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ResetPasswordBadTokenTest)
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_LOGIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -249,9 +244,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_LOGINASNEWTESTUSER_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInAsNewTestUserTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -265,9 +258,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInAsNewTestUserTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_LOGIN_AS_GUEST_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInAsGuestTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -281,9 +272,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInAsGuestTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_BADTOKENLOGIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, BadTokenLogInTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -303,9 +292,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, BadTokenLogInTest)
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
     EXPECT_EQ(Result.GetFailureReason(), csp::systems::ERequestFailureReason::UserTokenRefreshFailed);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_EMPTY_USER_CREDENTIALS_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EmptyUserCredentialsTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -331,9 +318,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EmptyUserCredentialsTest)
 
     csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(nullptr);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_EMPTY_PASSWORD_CREDENTIALS_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EmptyPasswordCredentialsTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -359,9 +344,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EmptyPasswordCredentialsTest)
 
     csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(nullptr);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_EMPTY_USER_CREDENTIALS_REFRESHTOKEN_LOGIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EmptyUserCredentialsRefreshTokenLoginTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -387,9 +370,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EmptyUserCredentialsRefreshTokenLogi
 
     csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(nullptr);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_BADLOGOUT_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, BadLogOutTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -400,9 +381,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, BadLogOutTest)
     // Log out without logging in first
     LogOut(UserSystem, csp::systems::EResultCode::Failed);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_BADDUALLOGIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, BadDualLoginTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -422,9 +401,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, BadDualLoginTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_LOGINERROR_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginErrorTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -441,10 +418,8 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginErrorTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
 // This will be updated and re-instated in OF-1533
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_REFRESH_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, RefreshTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -465,9 +440,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, RefreshTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_UPDATE_DISPLAY_NAME_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameTest)
 {
     SetRandSeed();
@@ -515,9 +488,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_UPDATE_DISPLAY_NAME_INCLUDING_BLANK_SPACES_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameIncludingBlankSpacesTest)
 {
     SetRandSeed();
@@ -547,9 +518,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameIncludingBlankSpace
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_UPDATE_DISPLAY_NAME_INCLUDING_SYMBOLS_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameIncludingSymbolsTest)
 {
     SetRandSeed();
@@ -579,9 +548,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, UpdateDisplayNameIncludingSymbolsTes
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_PING_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, PingTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -591,9 +558,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, PingTest)
     auto [Result] = AWAIT_PRE(UserSystem, Ping, RequestPredicate);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_CREATE_USER_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserTest)
 {
     SetRandSeed();
@@ -647,9 +612,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_DELETE_USER_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DeleteUserTest)
 {
     SetRandSeed();
@@ -697,9 +660,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DeleteUserTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_CREATE_USER_EMPTY_USERNAME_DISPLAYNAME_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserEmptyUsernameDisplaynameTest)
 {
     SetRandSeed();
@@ -738,9 +699,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserEmptyUsernameDisplaynameTe
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GET_SUPPORTED_PROVIDERS_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetThirdPartySupportedProvidersTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -775,9 +734,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetThirdPartySupportedProvidersTest)
 
     EXPECT_TRUE(FoundGoogle && FoundDiscord && FoundApple);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GET_AUTHORISE_URL_FOR_GOOGLE_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForGoogleTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -793,9 +750,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForGoogleTest)
     const auto& AuthoriseURL = ResGoogle.GetValue();
     ValidateThirdPartyAuthoriseURL(AuthoriseURL, RedirectURL);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GET_AUTHORISE_URL_FOR_DISCORD_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForDiscordTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -811,9 +766,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForDiscordTest)
     const auto& AuthoriseURL = Result.GetValue();
     ValidateThirdPartyAuthoriseURL(AuthoriseURL, RedirectURL);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GET_AUTHORISE_URL_FOR_APPLE_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForAppleTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -829,12 +782,10 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForAppleTest)
     const auto& AuthoriseURL = Result.GetValue();
     ValidateThirdPartyAuthoriseURL(AuthoriseURL, RedirectURL);
 }
-#endif
 
-// As the following two tests require manual actions explained inside, they are currently disabled
+// As the following three tests require manual actions explained inside, they are currently disabled
 // ATM only the WASM tests would be able to have a end-to-end testing flow using Selenium for the URL redirects
 #if 0
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GOOGLE_LOGIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GoogleLogInTest)
 {
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -886,9 +837,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GoogleLogInTest)
 	// Log out
 	LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_DISCORD_LOGIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DiscordLogInTest)
 {
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -940,9 +889,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DiscordLogInTest)
 	// Log out
 	LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_APPLE_LOGIN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AppleLogInTest)
 {
 	auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -995,9 +942,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AppleLogInTest)
 	LogOut(UserSystem);
 }
 #endif
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GET_AGORA_USER_TOKEN_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
 {
     SetRandSeed();
@@ -1047,9 +992,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
     // Log out
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_GETPROFILEASGUEST_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetGuestProfileTest)
 {
     SetRandSeed();
@@ -1068,9 +1011,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetGuestProfileTest)
 
     LogOut(UserSystem);
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_AGE_NOT_VERIFIED_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AgeNotVerifiedTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -1102,11 +1043,9 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AgeNotVerifiedTest)
 
     LogOut(UserSystem);
 }
-#endif
 
 // Currently disabled whilst stripe testing is unavailable for OKO_TESTS
 // This test will be reviewed and reinstated as part of OF-1534.
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_CUSTOMER_PORTAL_URL_TEST
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, GetCustomerPortalUrlTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -1129,9 +1068,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, GetCustomerPortalUrlTest)
 
     EXPECT_NE(Result.GetValue(), "");
 }
-#endif
 
-#if RUN_ALL_UNIT_TESTS || RUN_USERSYSTEM_TESTS || RUN_USERSYSTEM_CHECKOUT_SESSION_URL_TEST
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetCheckoutSessionUrlTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -1154,4 +1091,3 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetCheckoutSessionUrlTest)
 
     EXPECT_NE(Result.GetValue(), "");
 }
-#endif

--- a/Tests/src/PublicAPITests/VectorTests.cpp
+++ b/Tests/src/PublicAPITests/VectorTests.cpp
@@ -21,7 +21,6 @@
 
 using namespace csp::common;
 
-#if RUN_ALL_UNIT_TESTS || RUN_VECTOR_TESTS
 CSP_PUBLIC_TEST(CSPEngine, VectorTests, IsNearlyEqualTest)
 {
     const Vector3 MyVector = { 0, 0, 0 };
@@ -40,4 +39,3 @@ CSP_PUBLIC_TEST(CSPEngine, VectorTests, IsNearlyEqualTest)
 
     EXPECT_TRUE(MyVector4_A != MyVector4_C);
 }
-#endif


### PR DESCRIPTION
Remove all conditional compilation from the tests project.
Making this change seems to have no significant compile time implications, nor any immediate evident effects on builds on CI.

## Locally
### VS Test Explorer
Continues to look and work exactly as before as if you had `RUN_ALL_UNIT_TESTS` defined. You don't need to go messing around in the preprocessor settings each time you regenerate your project now.

![image](https://github.com/user-attachments/assets/e1f85f44-0aaa-4d43-b16e-84029461e614)


### Command line
Can pass a `gtest_filter=FILTER_PATTERN` arg to run specific tests

![image](https://github.com/user-attachments/assets/053f1db7-5e5c-4032-a6ff-31d137d669ab)

## CI
GTest runs all tests by default with no args passed, which is what we were doing anyway.

You can now use the `GTEST_FILTER` environment variable directly in the teamcity CI, to rerun problematic or investigative tests without having to run the full suite, or even do any rebuilding. (To be fair you could probably have done this beforehand, it was just a little muddy with the conditional compilation)

![image](https://github.com/user-attachments/assets/e49f4060-a4f6-4516-98be-8c4789b97179)


![image](https://github.com/user-attachments/assets/0ba01b78-eadb-4bed-9649-27b0b7c2fadf)

**Can anyone think of any reason we wouldn't do this? I was expecting this to have more evident problems. There must have be a reason it was done in the first place?**