### PR TITLE
[NT-0] test: Hail Mary attempt to fix avatar test

### DIFF
--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -16,6 +16,7 @@
 
 #include "CreateAvatar.h"
 
+#include "uuid_v4.h"
 #include <CSP/Multiplayer/SpaceEntitySystem.h>
 #include <CSP/Multiplayer/SpaceTransform.h>
 #include <CSP/Systems/Spaces/SpaceSystem.h>
@@ -36,7 +37,10 @@ void RunTest()
     auto& SpaceSystem = *SystemsManager.GetSpaceSystem();
     auto& EntitySystem = *SystemsManager.GetSpaceEntitySystem();
 
-    constexpr const char* UniqueSpaceName = "MakeThisReallyUniqueBeforeCommit";
+    UUIDv4::UUIDGenerator<std::mt19937_64> uuidGenerator;
+    const UUIDv4::UUID uuid = uuidGenerator.getUUID();
+    std::string UniqueSpaceName = "MultiplayerTestRunnerSpace" + std::string("-") + uuid.str();
+
     constexpr const char* TestSpaceDescription = "Test space from the CSP multiplayer test runner";
 
     // Create avater
@@ -58,5 +62,8 @@ void RunTest()
     csp::multiplayer::SpaceEntity* Avatar = ResultFuture.get();
 
     EntitySystem.ProcessPendingEntityOperations();
+
+    // This is a hail mary attempt to get this to stop being flaky on CI. CHS is known to sometimes have a processing delay, which is unfortunate.
+    std::this_thread::sleep_for(std::chrono::seconds(7));
 }
 } // namespace CreateAvatar


### PR DESCRIPTION
So, i never connected the flaky avatar test to the fact that it was the MultiplayerTestRunner one I wrote. If I had, I would have jumped on this earlier to satisfy my stupid pride.

I would say about 15-20% of the time this fails on CI, never locally though, ran it for 15 minutes in a loop.

Unfortunately, I don't really know why it's failing. It's possible a CHS processing delay may cause it, but I've assumed up until now receiving a result is like an ACID transaction, when perhaps it more means "Request acknowledged?" (Documentation for this sort of stuff exists? It might. CHS feels like such a black box at the moment 😖 )

In any case, let's try this. I'll rerun the functional tests on the CI 4 or 5 times from this PR to see if it stays stable, and if so put it in. Fingers crossed eh 🤞 

