### PR TITLE
[OF-1575] Enable Local CHS, Remove hard-coded URIs, migrate multiplayer URI handling.

### DIFF
--- a/Library/include/CSP/CSPFoundation.h
+++ b/Library/include/CSP/CSPFoundation.h
@@ -107,6 +107,11 @@ public:
     /// @return const EndpointURIs& : The EndpointURIs class with current endpoint data
     static const EndpointURIs& GetEndpoints();
 
+    /// @brief Create an EndpointsURIs object containing URIs to the various services needed by CSP.
+    /// @param EndpointRootURI URI to the root of the cloud services.
+    /// @return EndpointURIs class with deduced endpoint URIs.
+    static EndpointURIs CreateEndpointsFromRoot(const csp::common::String& EndpointRootURI);
+
     /// @brief Sets a class containing all relevant Client info currently set for Foundation.
     /// Used internally to generate ClientUserAgentString.
     /// @param The Client Info class with current Client Info data

--- a/Library/include/CSP/CSPFoundation.h
+++ b/Library/include/CSP/CSPFoundation.h
@@ -108,7 +108,7 @@ public:
     static const EndpointURIs& GetEndpoints();
 
     /// @brief Create an EndpointsURIs object containing URIs to the various services needed by CSP.
-    /// @param EndpointRootURI URI to the root of the cloud services.
+    /// @param EndpointRootURI csp::common::String: URI to the root of the cloud services.
     /// @return EndpointURIs class with deduced endpoint URIs.
     static EndpointURIs CreateEndpointsFromRoot(const csp::common::String& EndpointRootURI);
 

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -232,13 +232,40 @@ csp::common::String* CSPFoundation::DeviceId = nullptr;
 csp::common::String* CSPFoundation::ClientUserAgentString = nullptr;
 csp::common::String* CSPFoundation::Tenant = nullptr;
 
-bool CSPFoundation::Initialise(const csp::common::String& EndpointRootURI, const csp::common::String& InTenant)
+namespace
 {
-    if (IsInitialised)
+    // Take the input endpoint to the cloud services, and get the multiplayer URIS
+    std::string TranslateEndpointRootURIToMultiplayerServiceUri(const std::string& EndpointRootURI)
     {
-        return false;
-    }
+        /* This is not the best, we've hard encoded how the root uri and the multiplayer uri relate, which is no real guarantee.
+         * We should probably take the multiplayer too separately
+         * Remember, this transformation needs to work on both "http://ogs-internal.cloud" sorts of formats, as well as "http://localhost:8081" sort
+         * of formats
+         *
+         * Even if we're doing it this way, we should still be using a URI library to do all this transformation, not doing it as fragile raw strings.
+         * We've got POCO, but we're wanting to remove it ... so didn't want to bleed it into CSPFoundation right now. :(
+         */
 
+        // Check if ogs exists, if so insert "-multiplayer" after it.
+        std::string MultiplayerServiceURI = EndpointRootURI;
+        const std::string OgsFindTarget = "ogs";
+        const size_t OgsFindPos = MultiplayerServiceURI.find(OgsFindTarget, 0);
+        if (OgsFindPos != std::string::npos)
+        {
+            const std::string MultiplayerServiceInsert = "-multiplayer";
+            MultiplayerServiceURI.insert(OgsFindPos + OgsFindTarget.length(), MultiplayerServiceInsert);
+        }
+
+        // Append the hub location
+        const std::string SignalRHubLocation = "/mag-multiplayer/hubs/v1/multiplayer";
+        MultiplayerServiceURI = MultiplayerServiceURI + SignalRHubLocation;
+
+        return MultiplayerServiceURI;
+    }
+}
+
+EndpointURIs CSPFoundation::CreateEndpointsFromRoot(const csp::common::String& EndpointRootURI)
+{
     // remove last char if a slash
     std::string RootURI(EndpointRootURI.c_str());
     while (RootURI.rbegin() != RootURI.rend() && (*RootURI.rbegin() == '\\' || *RootURI.rbegin() == '/'))
@@ -246,33 +273,38 @@ bool CSPFoundation::Initialise(const csp::common::String& EndpointRootURI, const
         RootURI.resize(RootURI.length() - 1);
     }
 
-    Tenant = CSP_NEW csp::common::String(InTenant);
-
     const std::string UserServiceURI = RootURI + "/mag-user";
     const std::string PrototypeServiceURI = RootURI + "/mag-prototype";
     const std::string SpatialDataServiceURI = RootURI + "/mag-spatialdata";
     const std::string AggregationServiceURI = RootURI + "/oly-aggregation";
     const std::string TrackingServiceURI = RootURI + "/mag-tracking";
 
-    // The multiplayer service now has its own hostname, ogs-multiplayer
-    const std::string Hostname = "ogs", MultiplayerHostname = Hostname + "-multiplayer";
-    // This constructs the multiplayer URI by adding -multiplayer after ogs and appending
-    // the rest of RootURI. This accounts for other hostnames like ogs-internal, etc.
-    const std::string RootMultiplayerURI
-        = RootURI.substr(0, RootURI.find(Hostname)) + MultiplayerHostname + RootURI.substr(RootURI.find(Hostname) + Hostname.length());
-    const std::string MultiplayerServiceURI = RootMultiplayerURI + "/mag-multiplayer/hubs/v1/multiplayer";
+    const std::string MultiplayerServiceURI = TranslateEndpointRootURIToMultiplayerServiceUri(RootURI);
 
-    Endpoints = CSP_NEW EndpointURIs();
+    EndpointURIs Endpoints;
+    Endpoints.UserServiceURI = CSP_TEXT(UserServiceURI.c_str());
+    Endpoints.PrototypeServiceURI = CSP_TEXT(PrototypeServiceURI.c_str());
+    Endpoints.SpatialDataServiceURI = CSP_TEXT(SpatialDataServiceURI.c_str());
+    Endpoints.MultiplayerServiceURI = CSP_TEXT(MultiplayerServiceURI.c_str());
+    Endpoints.AggregationServiceURI = CSP_TEXT(AggregationServiceURI.c_str());
+    Endpoints.TrackingServiceURI = CSP_TEXT(TrackingServiceURI.c_str());
+
+    return Endpoints;
+}
+
+bool CSPFoundation::Initialise(const csp::common::String& EndpointRootURI, const csp::common::String& InTenant)
+{
+    if (IsInitialised)
+    {
+        return false;
+    }
+
+    Tenant = CSP_NEW csp::common::String(InTenant);
+
+    Endpoints = CSP_NEW EndpointURIs(CreateEndpointsFromRoot(EndpointRootURI));
     ClientUserAgentInfo = CSP_NEW ClientUserAgent();
     DeviceId = CSP_NEW csp::common::String("");
     ClientUserAgentString = CSP_NEW csp::common::String("");
-
-    Endpoints->UserServiceURI = CSP_TEXT(UserServiceURI.c_str());
-    Endpoints->PrototypeServiceURI = CSP_TEXT(PrototypeServiceURI.c_str());
-    Endpoints->SpatialDataServiceURI = CSP_TEXT(SpatialDataServiceURI.c_str());
-    Endpoints->MultiplayerServiceURI = CSP_TEXT(MultiplayerServiceURI.c_str());
-    Endpoints->AggregationServiceURI = CSP_TEXT(AggregationServiceURI.c_str());
-    Endpoints->TrackingServiceURI = CSP_TEXT(TrackingServiceURI.c_str());
 
     csp::systems::SystemsManager::Instantiate();
 

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -24,6 +24,7 @@
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/HTTPSClientSession.h>
 #include <Poco/Net/NetException.h>
+#include <Poco/URI.h>
 #include <chrono>
 #include <stdexcept>
 #include <thread>
@@ -48,28 +49,48 @@ CSPWebSocketClientPOCO::~CSPWebSocketClientPOCO()
     Stop(nullptr);
 }
 
+CSPWebSocketClientPOCO::ParsedURIInfo CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(const std::string& MultiplayerServiceUriEndpoint)
+{
+    Poco::URI EndpointURI { MultiplayerServiceUriEndpoint.c_str() };
+
+    // It's common folk may provide a "localhost:port/path/path" sort of string, with omits the protocol, just make sure one's there.
+    if ((EndpointURI.getScheme() != "https") && (EndpointURI.getScheme() != "http"))
+    {
+        throw std::runtime_error("CSPWebSocketclientPOCO::ParsedURIInfo, Expected `https` or `http` scheme, found neither.");
+    }
+
+    CSPWebSocketClientPOCO::ParsedURIInfo Out;
+    Out.Endpoint = EndpointURI.toString();
+    Out.Protocol = EndpointURI.getScheme();
+    Out.Domain = EndpointURI.getHost();
+    Out.Path = EndpointURI.getPath();
+    Out.Port = EndpointURI.getPort();
+
+    return Out;
+}
+
 void CSPWebSocketClientPOCO::Start(const std::string& Url, CallbackHandler Callback)
 {
     CSP_PROFILE_SCOPED();
 
-    std::string endpoint = csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str();
-    auto index = endpoint.find(':');
-    std::string protocol = endpoint.substr(0, index);
-    index += 3; // "://"
-    auto endIndex = endpoint.find('/', index);
-    std::string domain = endpoint.substr(index, endIndex - index);
-    index = endIndex;
-    std::string path = endpoint.substr(index);
+    CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint
+        = ParseMultiplayerServiceUriEndPoint(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str());
+
+    auto domain = ParsedEndpoint.Domain;
+    auto protocol = ParsedEndpoint.Protocol;
+    auto path = ParsedEndpoint.Path;
+    auto endpoint = ParsedEndpoint.Endpoint;
+    auto port = ParsedEndpoint.Port;
 
     Poco::Net::HTTPClientSession* cs;
 
     if (protocol == "https")
     {
-        cs = CSP_NEW Poco::Net::HTTPSClientSession(domain, 443);
+        cs = CSP_NEW Poco::Net::HTTPSClientSession(domain, port);
     }
     else
     {
-        cs = CSP_NEW Poco::Net::HTTPClientSession(domain, 80);
+        cs = CSP_NEW Poco::Net::HTTPClientSession(domain, port);
     }
 
     Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, path, Poco::Net::HTTPMessage::HTTP_1_1);

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -73,40 +73,40 @@ void CSPWebSocketClientPOCO::Start(const std::string& Url, CallbackHandler Callb
 {
     CSP_PROFILE_SCOPED();
 
-    CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint
-        = ParseMultiplayerServiceUriEndPoint(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str());
-
-    auto domain = ParsedEndpoint.Domain;
-    auto protocol = ParsedEndpoint.Protocol;
-    auto path = ParsedEndpoint.Path;
-    auto endpoint = ParsedEndpoint.Endpoint;
-    auto port = ParsedEndpoint.Port;
-
-    Poco::Net::HTTPClientSession* cs;
-
-    if (protocol == "https")
-    {
-        cs = CSP_NEW Poco::Net::HTTPSClientSession(domain, port);
-    }
-    else
-    {
-        cs = CSP_NEW Poco::Net::HTTPClientSession(domain, port);
-    }
-
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, path, Poco::Net::HTTPMessage::HTTP_1_1);
-    Poco::Net::HTTPResponse response;
-
-    if (csp::web::HttpAuth::GetAccessToken().c_str() != nullptr)
-    {
-        char Str[1024];
-        snprintf(Str, 1024, "Bearer %s", csp::web::HttpAuth::GetAccessToken().c_str());
-        request.set("Authorization", Str);
-    }
-
-    StopFlag = false;
-
     try
     {
+        CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint
+            = ParseMultiplayerServiceUriEndPoint(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str());
+
+        auto domain = ParsedEndpoint.Domain;
+        auto protocol = ParsedEndpoint.Protocol;
+        auto path = ParsedEndpoint.Path;
+        auto endpoint = ParsedEndpoint.Endpoint;
+        auto port = ParsedEndpoint.Port;
+
+        std::unique_ptr<Poco::Net::HTTPClientSession> cs;
+
+        if (protocol == "https")
+        {
+            cs = std::make_unique<Poco::Net::HTTPSClientSession>(domain, port);
+        }
+        else
+        {
+            cs = std::make_unique<Poco::Net::HTTPClientSession>(domain, port);
+        }
+
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, path, Poco::Net::HTTPMessage::HTTP_1_1);
+        Poco::Net::HTTPResponse response;
+
+        if (csp::web::HttpAuth::GetAccessToken().c_str() != nullptr)
+        {
+            char Str[1024];
+            snprintf(Str, 1024, "Bearer %s", csp::web::HttpAuth::GetAccessToken().c_str());
+            request.set("Authorization", Str);
+        }
+
+        StopFlag = false;
+
         PocoWebSocket = CSP_NEW Poco::Net::WebSocket(*cs, request, response);
         // Receive worker thread
         ReceiveThread = std::thread([this]() { ReceiveThreadFunc(); });
@@ -120,8 +120,6 @@ void CSPWebSocketClientPOCO::Start(const std::string& Url, CallbackHandler Callb
 
         Callback(false);
     }
-
-    CSP_DELETE(cs);
 }
 
 void CSPWebSocketClientPOCO::Stop(CallbackHandler Callback)

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.h
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.h
@@ -23,7 +23,6 @@
 #include <signalrclient/hub_exception.h>
 #include <signalrclient/signalr_client_config.h>
 #include <thread>
-
 namespace csp::multiplayer
 {
 
@@ -37,6 +36,17 @@ public:
     void Stop(CallbackHandler Callback) override;
     void Send(const std::string& Message, CallbackHandler Callback) override;
     void Receive(ReceiveHandler Callback) override;
+
+    struct ParsedURIInfo
+    {
+        std::string Endpoint;
+        std::string Protocol;
+        std::string Domain;
+        std::string Path;
+        unsigned short Port;
+    };
+
+    static ParsedURIInfo ParseMultiplayerServiceUriEndPoint(const std::string& MultiplayerServiceUriEndpoint);
 
 private:
     void ReceiveThreadFunc();

--- a/MultiplayerTestRunner/src/Main.cpp
+++ b/MultiplayerTestRunner/src/Main.cpp
@@ -99,6 +99,7 @@ int main(int argc, char* argv[])
         CLIArgs::RunnerSettings Settings = CLIArgs::ProcessCLI(argc, argv);
 
         // Get setup with CSP and CHS.
+        std::cout << "Initializing Multiplayer Test Runner with Endpoint : " << Settings.Endpoint << std::flush;
         Utils::InitialiseCSPWithUserAgentInfo(Settings.Endpoint.c_str());
 
         // Log in

--- a/Tests/src/InternalTests/WebClientTests.cpp
+++ b/Tests/src/InternalTests/WebClientTests.cpp
@@ -439,7 +439,7 @@ CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail403Test)
 
     HttpPayload Payload;
     RunWebClientTest<RetryResponseReceiver>(
-        "https://ogs-internal.magnopus-dev.cloud/mag-user/appsettings", ERequestVerb::Get, 80, Payload, EResponseCodes::ResponseForbidden);
+        (std::string(EndpointBaseURI()) + "/mag-user/appsettings").c_str(), ERequestVerb::Get, 80, Payload, EResponseCodes::ResponseForbidden);
 
     csp::CSPFoundation::Shutdown();
 }

--- a/Tests/src/InternalTests/WebSocketClientTests.cpp
+++ b/Tests/src/InternalTests/WebSocketClientTests.cpp
@@ -100,3 +100,100 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
     // Logout
     LogOut(UserSystem);
 }
+
+/*
+ * These tests test the POCO client specifically.
+ * The motive was that we added the ability for the POCO client to point to localhost in order
+ * to allow local testing, so there's logic to test there, mostly around port extraction.
+ */
+
+CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, RegularMultiplayerServiceURI)
+{
+    const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://ogs-internal.magnopus-dev.cloud");
+    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://ogs-multiplayer-internal.magnopus-dev.cloud/mag-multiplayer/hubs/v1/multiplayer");
+
+    CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+
+    EXPECT_EQ(ParsedURI.Protocol, "https");
+    EXPECT_EQ(ParsedURI.Domain, "ogs-multiplayer-internal.magnopus-dev.cloud");
+    EXPECT_EQ(ParsedURI.Path, "/mag-multiplayer/hubs/v1/multiplayer");
+    EXPECT_EQ(ParsedURI.Port, 443);
+    EXPECT_EQ(ParsedURI.Endpoint, "https://ogs-multiplayer-internal.magnopus-dev.cloud/mag-multiplayer/hubs/v1/multiplayer");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURI)
+{
+    const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://localhost:8081");
+    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://localhost:8081/mag-multiplayer/hubs/v1/multiplayer");
+
+    CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+
+    EXPECT_EQ(ParsedURI.Protocol, "https");
+    EXPECT_EQ(ParsedURI.Domain, "localhost");
+    EXPECT_EQ(ParsedURI.Path, "/mag-multiplayer/hubs/v1/multiplayer");
+    EXPECT_EQ(ParsedURI.Port, 8081);
+    EXPECT_EQ(ParsedURI.Endpoint, "https://localhost:8081/mag-multiplayer/hubs/v1/multiplayer");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURIHttp)
+{
+    const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("http://localhost");
+    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "http://localhost/mag-multiplayer/hubs/v1/multiplayer");
+
+    CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+
+    EXPECT_EQ(ParsedURI.Protocol, "http");
+    EXPECT_EQ(ParsedURI.Domain, "localhost");
+    EXPECT_EQ(ParsedURI.Path, "/mag-multiplayer/hubs/v1/multiplayer");
+    EXPECT_EQ(ParsedURI.Port, 80);
+    EXPECT_EQ(ParsedURI.Endpoint, "http://localhost/mag-multiplayer/hubs/v1/multiplayer");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalVariantMultiplayerServiceURI)
+{
+    const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://127.0.0.1:8081");
+    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://127.0.0.1:8081/mag-multiplayer/hubs/v1/multiplayer");
+
+    CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+
+    EXPECT_EQ(ParsedURI.Protocol, "https");
+    EXPECT_EQ(ParsedURI.Domain, "127.0.0.1");
+    EXPECT_EQ(ParsedURI.Path, "/mag-multiplayer/hubs/v1/multiplayer");
+    EXPECT_EQ(ParsedURI.Port, 8081);
+    EXPECT_EQ(ParsedURI.Endpoint, "https://127.0.0.1:8081/mag-multiplayer/hubs/v1/multiplayer");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURINoScheme)
+{
+    const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("localhost:8081");
+    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "localhost:8081/mag-multiplayer/hubs/v1/multiplayer");
+
+    EXPECT_THROW(CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str()), std::runtime_error);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalNoPortMultiplayerServiceURI)
+{
+    const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://localhost");
+    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://localhost/mag-multiplayer/hubs/v1/multiplayer");
+
+    CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+
+    EXPECT_EQ(ParsedURI.Protocol, "https");
+    EXPECT_EQ(ParsedURI.Domain, "localhost");
+    EXPECT_EQ(ParsedURI.Path, "/mag-multiplayer/hubs/v1/multiplayer");
+    EXPECT_EQ(ParsedURI.Port, 443);
+    EXPECT_EQ(ParsedURI.Endpoint, "https://localhost/mag-multiplayer/hubs/v1/multiplayer");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMalformedMultiplayerServiceURI)
+{
+    const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://localhost:notanumber");
+    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://localhost:notanumber/mag-multiplayer/hubs/v1/multiplayer");
+
+    EXPECT_THROW(CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str()), Poco::SyntaxException);
+}

--- a/Tests/src/InternalTests/WebSocketClientTests.cpp
+++ b/Tests/src/InternalTests/WebSocketClientTests.cpp
@@ -18,7 +18,9 @@
 #include "CSP/CSPFoundation.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "CSP/Systems/Users/UserSystem.h"
+#include "Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.h"
 #include "PlatformTestUtils.h"
+#include "Poco/Exception.h"
 #include "TestHelpers.h"
 
 #include "gtest/gtest.h"
@@ -26,8 +28,6 @@
 using namespace csp::multiplayer;
 
 // The WebSocketClientTests will be reviewed as part of OF-1532.
-
-const csp::common::String MULTIPLAYER_URL = "wss://ogs-multiplayer-internal.magnopus-dev.cloud/mag-multiplayer/hubs/v1/multiplayer";
 
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientStartStopTest)
 {
@@ -42,7 +42,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientStartStopTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(MULTIPLAYER_URL);
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI);
 
     // Stop
     WebSocketStop(WebSocket);
@@ -64,7 +64,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(MULTIPLAYER_URL);
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI);
 
     // Send
     WebSocketSend(WebSocket, "test");
@@ -89,7 +89,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(MULTIPLAYER_URL);
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI);
 
     // Receive
     WebSocketSendReceive(WebSocket);

--- a/Tests/src/MultiplayerTestRunnerProcess.cpp
+++ b/Tests/src/MultiplayerTestRunnerProcess.cpp
@@ -209,7 +209,7 @@ void MultiplayerTestRunnerProcess::StartProcess()
         {
             // STDOUT
             std::string StdOutStr = std::string(bytes, n);
-            // You might want to put std::cout << StdOutStr << std::endl; here when debugging.
+            std::cout << StdOutStr << std::endl;
 
             if (ContainsStr(StdOutStr, MultiplayerTestRunner::ProcessDescriptors::LOGGED_IN_DESCRIPTOR))
             {

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -294,6 +294,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceT
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
 
+    std::this_thread::sleep_for(std::chrono::seconds(7));
+
     {
         // Re-enter space
         bool EntitiesCreated = false;

--- a/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
@@ -188,13 +188,10 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
 
+    std::this_thread::sleep_for(std::chrono::seconds(7));
+
     // Re-Enter space and verify contents
     {
-        // Reload the space and verify the contents match
-        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
-
-        EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
-
         // Retrieve all entities
         auto GotAllEntities = false;
         SpaceEntity* LoadedObject;
@@ -209,6 +206,10 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
                 }
             });
 
+        // Reload the space and verify the contents match
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
         // Wait until loaded
         auto Start = std::chrono::steady_clock::now();
         auto Current = std::chrono::steady_clock::now();
@@ -222,7 +223,7 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
             TestTime = std::chrono::duration_cast<std::chrono::seconds>(Current - Start).count();
         }
 
-        EXPECT_TRUE(GotAllEntities);
+        ASSERT_TRUE(GotAllEntities);
 
         const auto& Components = *LoadedObject->GetComponents();
 

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -276,6 +276,8 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
 
+    std::this_thread::sleep_for(std::chrono::seconds(7));
+
     {
         // Re-enter space
         bool EntitiesCreated = false;

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -808,14 +808,16 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
               .SetSpaceId(Space.Id.c_str())
               .SetLoginEmail(TestUser1.Email.c_str())
               .SetPassword(GeneratedTestAccountPassword)
-              .SetTimeoutInSeconds(60);
+              .SetTimeoutInSeconds(60)
+              .SetEndpoint(EndpointBaseURI());
 
     MultiplayerTestRunnerProcess CreateAvatarRunner2
         = MultiplayerTestRunnerProcess(MultiplayerTestRunner::TestIdentifiers::TestIdentifier::CREATE_AVATAR)
               .SetSpaceId(Space.Id.c_str())
               .SetLoginEmail(TestUser2.Email.c_str())
               .SetPassword(GeneratedTestAccountPassword)
-              .SetTimeoutInSeconds(60);
+              .SetTimeoutInSeconds(60)
+              .SetEndpoint(EndpointBaseURI());
 
     std::array<MultiplayerTestRunnerProcess, 2> Runners = { CreateAvatarRunner, CreateAvatarRunner2 };
     std::array<std::future<void>, 2> ReadyForAssertionsFutures = { Runners[0].ReadyForAssertionsFuture(), Runners[1].ReadyForAssertionsFuture() };

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2469,6 +2469,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTe
     // Log out
     LogOut(UserSystem);
 
+    std::this_thread::sleep_for(std::chrono::seconds(7));
+
     // Log in again
     LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
 

--- a/Tests/src/PublicAPITests/MultiplayerTestRunnerProcessTests.cpp
+++ b/Tests/src/PublicAPITests/MultiplayerTestRunnerProcessTests.cpp
@@ -16,6 +16,7 @@
 
 #include "MultiplayerTestRunnerProcess.h"
 #include "TestHelpers.h"
+#include "UserSystemTestHelpers.h"
 
 #include "gtest/gtest.h"
 #include <PublicAPITests/UserSystemTestHelpers.h>
@@ -64,7 +65,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTestRunnerProcessTests, FutureTest)
     Process.SetLoginEmail(TestUser.Email.c_str());
     Process.SetPassword(GeneratedTestAccountPassword);
     Process.SetTimeoutInSeconds(0); // So we don't sit at ready for assertions for any real time.
-
+    Process.SetEndpoint(EndpointBaseURI());
     Process.StartProcess();
 
     // We need to spin up a process, login, create a space, join it, ... so we're a bit permissive with the timeouts to try and prevent flakiness.

--- a/Tests/src/PublicAPITests/SettingsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SettingsSystemTests.cpp
@@ -50,12 +50,6 @@ bool RequestPredicateWithProgress(const csp::systems::ResultBase& Result)
 
 bool IsUriValid(const std::string& Uri, const std::string& FileName)
 {
-    // check that Uri starts with something valid
-    if (Uri.find("https://world-streaming.magnopus-dev.cloud/", 0) != 0)
-    {
-        return false;
-    }
-
     // check that the correct filename is present in the Uri
     const auto PosLastSlash = Uri.rfind('/');
     const auto UriFileName = Uri.substr(PosLastSlash + 1, FileName.size());

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -267,12 +267,6 @@ Map<String, Map<String, String>> GetAndAssertSpacesMetadata(::SpaceSystem* Space
 
 bool IsUriValid(const std::string& Uri, const std::string& FileName)
 {
-    // check that Uri starts with something valid
-    if (Uri.find("https://world-streaming.magnopus-dev.cloud/", 0) != 0)
-    {
-        return false;
-    }
-
     // check that the correct filename is present in the Uri
     const auto PosLastSlash = Uri.rfind('/');
     const auto UriFileName = Uri.substr(PosLastSlash + 1, FileName.size());


### PR DESCRIPTION
## Summary
**tl;dr: Local CHS works now, but a couple of tests have (probably timing related) issues that still need to be shaken out. Full test suite runs are 4-5 minutes long.**

Do the CSP work to allow local CHS to function. 

This changeset does a fair amount more than what was specified in the ticket. There had as of yet been no thought put into the issues with the multiplayer signalR connection. It was never going to just work, so the changes to get that going have been done here too.

This change involves, broadly, 3 things.
- ✔️ Remove all hard-coded URI references to the cloud services throughout the codebase.
- ✔️ Revamp our URI handling for the multiplayer signalR connection
- 🟡 Fix any tests that are demonstrating new issues from the faster cloud services response. 

The first two are complete in this PR. On the tests, I have fixed the easy tests, but the ones that weren't obvious have been left. The ticket only wanted the first item to be complete, but if we kept working like that, we'd never get local CHS over the line. Nonetheless, I'm troubled not to be able to deal with these, but I wanted to get this up for review sooner rather than later, considering how I need to start AOI implementation.

> [!IMPORTANT]  
> **Local CHS still will not function on WASM**, as the URI parsing changes have been done for the POCO client _only_, (as this is what our tests use). I didn't want to blow the scope of this change even further beyond it has been already, especially considering my upcoming time off. You'll probably tell from the tone of the changes that I think this area needs some TLC, but we shouldn't forget to do this, leaving WASM/Non-WASM with a difference in capability will only come back to bite us, when we add WASM testing especially.

## Tests
See here, a manually run local CHS run on teamcity, the whole suite runs, only 2 tests fail :
https://magnopus.teamcity.com/buildConfiguration/Olympus_Foundation_X64_TestsLocalChsInstance/284828

However, this isn't the whole story, as a local run consistently shows these failures also:

- ❌  [  FAILED  ] CSPEngine.PointOfInterestSystemTests.GetPOIInsideCircularAreaTest- 
- ❌  [ FAILED  ] CSPEngine.PointOfInterestSystemTests.QuerySpacePOITest
- ❌  [  FAILED  ] CSPEngine.UserSystemTests.GetAgoraUserTokenTest

Additionally, about 20% of the time, have observed this error running the full suite locally. :
```
[ RUN      ] CSPEngine.MaterialTests.GetMultipleMaterialsTest
mimalloc: error: allocation request is too large (16131858542891098112 bytes)
mimalloc: assertion failed: at "C:\dev\connected-spaces-platform\ThirdParty\mimalloc\src\segment.c":544, _mi_segment_thread_collect
  assertion: "tld->pages_reset.first == NULL"
```
16131858542891098112 bytes is 16 thousand petabyes, probably an underflow or something. 🤔 

@MAG-AdamThorn @MAG-SamBirley I would like to progress shaking out the remaining tests as soon as reasonably possible, as the local CHS story needs to be closed. I think that's a good story for anyone else on the team though. That's why I'm getting this PR up perhaps a bit earlier than I normally would, want to move fast.

> [!NOTE]  
> I have tested the OKO-WASM build locally to make sure you can still enter spaces, as this does technically touch CSPFoundation so there's a risk there. Crazy how you can still test this stuff even when there's breaking changes (the tag stuff). Dynamic languages are wild.

> [!NOTE]  
> These tests are so fast now that the sleeps we put in are actually significant, each 7 second sleep is 2.3% of total execution time. I also half-suspect our console logging might be a slowdown worth considering too. It's great to be at 5 minutes, but we should never be satisfied. I want everything, including instant test runs.

## Action items
- Log work for getting the multiplayer system working with local CHS on WASM.
- Log work for shaking out the errors in the remaining tests well enough to enable local CHS on teamcity.