### PR TITLE
[OF-1447] feat: add ability to post to service proxy directly

### DIFF
--- a/Library/include/CSP/Systems/Users/Authentication.h
+++ b/Library/include/CSP/Systems/Users/Authentication.h
@@ -167,6 +167,23 @@ public:
     bool ShareScreen;
 };
 
+/// @brief Data structure for a custom service proxy posting, giving service name, operation name, set help and parameters
+class CSP_API TokenInfoParams
+{
+public:
+    /// @brief The service name for the requested token.
+    csp::common::String ServiceName;
+
+    /// @brief The operation name for the requested token.
+    csp::common::String OperationName;
+
+    /// @brief Whether to set help.
+    bool SetHelp;
+
+    /// @brief Map of parameters required for the operation on the service
+    csp::common::Map<csp::common::String, csp::common::String> Parameters;
+};
+
 typedef std::function<void(const LoginStateResult& Result)> LoginStateResultCallback;
 typedef std::function<void(const NullResult& Result)> NullResultCallback;
 typedef std::function<void(const LoginTokenInfoResult& Result)> LoginTokenInfoResultCallback;

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -213,6 +213,11 @@ public:
     /// @param Callback UserTokenResultCallback : callback to call when a response is received
     CSP_ASYNC_RESULT void GetAgoraUserToken(const AgoraUserTokenParams& Params, StringResultCallback Callback);
 
+    /// @brief Post Service Proxy to perform specified operation of specified service
+    /// @param Params TokenInfoParams : Params to specify service, operation, set help and parameters
+    /// @param Callback UserTokenResultCallback : callback to call when a response is received
+    CSP_ASYNC_RESULT void PostServiceProxy(const TokenInfoParams& Params, StringResultCallback Callback);
+
     /// @brief Re-send user verification email
     /// @param InEmail csp::common::String : User's email address
     /// @param InRedirectUrl csp::common::Optional<csp::common::String> : URL to redirect user to after they have registered

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -209,13 +209,13 @@ public:
     CSP_ASYNC_RESULT void Ping(NullResultCallback Callback);
 
     /// @brief Retrieve User token from Agora
-    /// @param Params AgoraUserTokenParams : Params to configure the User token
-    /// @param Callback UserTokenResultCallback : callback to call when a response is received
+    /// @param Params const AgoraUserTokenParams& : Params to configure the User token
+    /// @param Callback StringResultCallback : callback to call when a response is received
     CSP_ASYNC_RESULT void GetAgoraUserToken(const AgoraUserTokenParams& Params, StringResultCallback Callback);
 
     /// @brief Post Service Proxy to perform specified operation of specified service
-    /// @param Params TokenInfoParams : Params to specify service, operation, set help and parameters
-    /// @param Callback UserTokenResultCallback : callback to call when a response is received
+    /// @param Params const TokenInfoParams& : Params to specify service, operation, set help and parameters
+    /// @param Callback StringResultCallback : callback to call when a response is received
     CSP_ASYNC_RESULT void PostServiceProxy(const TokenInfoParams& Params, StringResultCallback Callback);
 
     /// @brief Re-send user verification email

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -253,6 +253,36 @@ void AgoraUserTokenResult::OnResponse(const services::ApiResponseBase* ApiRespon
     }
 }
 
+void PostServiceProxyResult::OnResponse(const services::ApiResponseBase* ApiResponse)
+{
+    ResultBase::OnResponse(ApiResponse);
+
+    auto AuthResponse = static_cast<chs_aggregation::ServiceResponse*>(ApiResponse->GetDto());
+    const web::HttpResponse* Response = ApiResponse->GetResponse();
+
+    if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
+    {
+        AuthResponse->FromJson(Response->GetPayload().GetContent());
+        std::shared_ptr<rapidjson::Document> Result = AuthResponse->GetOperationResult();
+
+        if (!Result)
+        {
+            CSP_LOG_MSG(LogLevel::Error, "PostServiceProxyResult invalid");
+
+            return;
+        }
+
+        if (!Result->HasMember("token"))
+        {
+            CSP_LOG_MSG(LogLevel::Error, "PostServiceProxyResult doesn't contain expected member: token");
+
+            return;
+        }
+
+        SetValue(Result->operator[]("token").GetString());
+    }
+}
+
 void CheckoutSessionUrlResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
     ResultBase::OnResponse(ApiResponse);

--- a/Library/src/Systems/Users/Authentication.h
+++ b/Library/src/Systems/Users/Authentication.h
@@ -57,6 +57,23 @@ private:
     void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 };
 
+/// @brief @brief Data class used to contain information posting a service proxy
+class CSP_API PostServiceProxyResult : public StringResult
+{
+    /** @cond DO_NOT_DOCUMENT */
+    CSP_START_IGNORE
+    template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
+    friend class UserSystem;
+    CSP_END_IGNORE
+    /** @endcond */
+
+private:
+    PostServiceProxyResult() = default;
+    PostServiceProxyResult(void*) {};
+
+    void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+};
+
 /// @brief Result url for a tier checkout session request
 class CSP_API CheckoutSessionUrlResult : public StringResult
 {

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -21,6 +21,7 @@
 #include "CSP/Multiplayer/EventParameters.h"
 #include "CSP/Systems/Users/Authentication.h"
 #include "CSP/Systems/Users/Profile.h"
+#include "Common/Convert.h"
 #include "Common/UUIDGenerator.h"
 #include "Multiplayer/ErrorCodeStrings.h"
 #include "Multiplayer/EventSerialisation.h"
@@ -718,16 +719,7 @@ void UserSystem::PostServiceProxy(const TokenInfoParams& Params, StringResultCal
     TokenInfo->SetServiceName(Params.ServiceName);
     TokenInfo->SetOperationName(Params.OperationName);
     TokenInfo->SetHelp(Params.SetHelp);
-    std::map<csp::common::String, csp::common::String> ParamsMap;
-    auto* Keys = Params.Parameters.Keys();
-    for (auto idx = 0; idx < Keys->Size(); ++idx)
-    {
-        auto Key = Keys->operator[](idx);
-        auto Value = Params.Parameters.operator[](Key);
-        // This conversion is necessary because TokenInfoParams uses csp::common::Map for the Wrapper Generator, and SetParameters expects a std::map.
-        ParamsMap.insert(std::pair<csp::common::String, csp::common::String>(Key, Value));
-    }
-    TokenInfo->SetParameters(ParamsMap);
+    TokenInfo->SetParameters(Convert(Params.Parameters));
 
     csp::services::ResponseHandlerPtr ResponseHandler
         = ExternalServiceProxyApi->CreateHandler<StringResultCallback, PostServiceProxyResult, void, chs_aggregation::ServiceResponse>(

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -998,7 +998,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
     EXPECT_FALSE(Result.GetValue().IsEmpty());
     WaitForCallback(LogConfirmed1);
     EXPECT_FALSE(LogConfirmed1);
-    WaitForCallback(LogConfirmed1);
+    WaitForCallback(LogConfirmed2);
     EXPECT_FALSE(LogConfirmed2);
 
     LogSystem.ClearAllCallbacks();
@@ -1067,7 +1067,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, PostServiceProxyTest)
     EXPECT_FALSE(Result.GetValue().IsEmpty());
     WaitForCallback(LogConfirmed1);
     EXPECT_FALSE(LogConfirmed1);
-    WaitForCallback(LogConfirmed1);
+    WaitForCallback(LogConfirmed2);
     EXPECT_FALSE(LogConfirmed2);
 
     LogSystem.ClearAllCallbacks();

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -951,9 +951,9 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-    const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
+    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
+    const char* TestAssetCollectionName = "CSP-UNITTEST-ASSETCOLLECTION-MAG";
 
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -1018,9 +1018,9 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, PostServiceProxyTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-    const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
+    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
+    const char* TestAssetCollectionName = "CSP-UNITTEST-ASSETCOLLECTION-MAG";
 
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());


### PR DESCRIPTION
Expose ServiceProxyPost and allow user to pass their own token info parameters. 
Add a new test and check error messages are not emitted in the log for both the new ServiceProxyPost test and the old AgoraUserToken tests