### PR TITLE
[OF-1585] refac: Connect Continuations

### DIFF
--- a/Library/include/CSP/Multiplayer/Conversation/ConversationSystem.h
+++ b/Library/include/CSP/Multiplayer/Conversation/ConversationSystem.h
@@ -127,8 +127,8 @@ public:
     /// Note that this is already called in MultiplayerConnection::Connect, so this shouldn't need to be called anywhere else.
     /// This should not be called by client code directly, marked as No Export.
     ///
-    /// @param InConnection csp::multiplayer::SignalRConnection : The connection to be used by the conversation system.
-    CSP_NO_EXPORT void SetConnection(csp::multiplayer::SignalRConnection* InConnection);
+    /// @param InConnection csp::multiplayer::ISignalRConnection : The connection to be used by the conversation system.
+    CSP_NO_EXPORT void SetConnection(csp::multiplayer::ISignalRConnection* InConnection);
 
     // Callback to receive ConversationSystem Data when a message is sent.
     typedef std::function<void(const csp::multiplayer::ConversationSystemParams&)> ConversationSystemCallbackHandler;
@@ -152,7 +152,7 @@ private:
 
     void DeleteMessages(const csp::common::Array<csp::systems::AssetCollection>& Messages, csp::systems::NullResultCallback Callback);
 
-    SignalRConnection* Connection;
+    ISignalRConnection* Connection;
 
     ConversationSystemCallbackHandler ConversationSystemCallback;
 };

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -32,6 +32,13 @@ CSP_START_IGNORE
 class CSPEngine_MultiplayerTests_SignalRConnectionTest_Test;
 CSP_END_IGNORE
 
+namespace async
+{
+CSP_START_IGNORE
+template <typename T> class task;
+CSP_END_IGNORE
+}
+
 namespace csp::systems
 {
 
@@ -177,23 +184,25 @@ private:
 
     typedef std::function<void(std::exception_ptr)> ExceptionCallbackHandler;
 
-    /// @brief Start the connection and register to start receiving updates from the server.
-    /// Connect should be called after LogIn and before EnterSpace.
-    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-    void Connect(ErrorCodeCallbackHandler Callback);
+    void Start(ExceptionCallbackHandler Callback) const;
+
+    //<void> template tags not supported in wrapper generator. (Why we're even wrapping private methods is a mystery to me though)
+    CSP_START_IGNORE
+    async::task<void> Start() const;
+    /* Connect Continuations */
+    // Delete the entity specified by the EntityId. std::numeric_limits<uint64_t>::max() means ALL_ENTITIES_ID, and deletes everything.s
+    auto DeleteEntities(uint64_t EntityId) const;
+    // Get the client ID and return it (does not set it locally)
+    auto RequestClientId();
+    // Invoke "StartListening" on already created Connection
+    std::function<async::task<void>()> StartListening();
+    CSP_END_IGNORE
 
     /// @brief End the multiplayer connection.
     /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
     void Disconnect(ErrorCodeCallbackHandler Callback);
-
-    void Start(ExceptionCallbackHandler Callback) const;
     void Stop(ExceptionCallbackHandler Callback) const;
-
-    void StartListening(ErrorCodeCallbackHandler Callback);
     void StopListening(ErrorCodeCallbackHandler Callback);
-
-    void InternalDeleteEntity(uint64_t EntityId, ErrorCodeCallbackHandler Callback) const;
-    void DeleteOwnedEntities(ErrorCodeCallbackHandler Callback);
 
     /// @brief Subscribes the connected user to the specified space's scope.
     /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
@@ -202,8 +211,6 @@ private:
     /// @brief Clears the connected user's subscription to their current set of scopes.
     /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
     void ResetScopes(ErrorCodeCallbackHandler Callback);
-
-    void RequestClientId(ErrorCodeCallbackHandler Callback);
 
     void DisconnectWithReason(const csp::common::String& Reason, ErrorCodeCallbackHandler Callback);
 

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -190,7 +190,7 @@ private:
     CSP_START_IGNORE
     async::task<void> Start() const;
     /* Connect Continuations */
-    // Delete the entity specified by the EntityId. std::numeric_limits<uint64_t>::max() means ALL_ENTITIES_ID, and deletes everything.s
+    // Delete the entity specified by the EntityId. std::numeric_limits<uint64_t>::max() means ALL_ENTITIES_ID, and deletes everything.
     auto DeleteEntities(uint64_t EntityId) const;
     // Get the client ID and return it (does not set it locally)
     auto RequestClientId();

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -148,6 +148,16 @@ public:
     /// @return True if self messaging is allowed, false otherwise.
     bool GetAllowSelfMessagingFlag() const;
 
+    /// @brief Parse a SignalR multiplayer error. Unpacks the exception and forwards to @ref ParseMultiplayerError
+    /// @param std::exception_ptr Exception : Pointer to the exception to parse.
+    /// @return std::pair<ErrorCode, std::string> First element being the deduced error code, second being the exception message.
+    CSP_NO_EXPORT static std::pair<ErrorCode, std::string> ParseMultiplayerErrorFromExceptionPtr(std::exception_ptr Exception);
+
+    /// @brief Parse a SignalR multiplayer error.
+    /// @param const std::exception& Exception : The exception to parse
+    /// @return std::pair<ErrorCode, std::string> First element being the deduced error code, second being the exception message.
+    CSP_NO_EXPORT static std::pair<ErrorCode, std::string> ParseMultiplayerError(const std::exception& Exception);
+
     /// @brief Create a default SignalRConnection configured to the configured MultiplayerServiceURI
     /// @return ISignalRConnection* Pointer to SignalR connection. The caller should take ownership of the pointer.
     CSP_NO_EXPORT static ISignalRConnection* MakeSignalRConnection();

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -58,7 +58,7 @@ class ReplicatedValue;
 class SpaceEntitySystem;
 class ConversationSystem;
 class ClientElectionManager;
-class SignalRConnection;
+class ISignalRConnection;
 class IWebSocketClient;
 class EventBus;
 
@@ -148,6 +148,17 @@ public:
     /// @return True if self messaging is allowed, false otherwise.
     bool GetAllowSelfMessagingFlag() const;
 
+    /// @brief Create a default SignalRConnection configured to the configured MultiplayerServiceURI
+    /// @return ISignalRConnection* Pointer to SignalR connection. The caller should take ownership of the pointer.
+    CSP_NO_EXPORT static ISignalRConnection* MakeSignalRConnection();
+
+    /// @brief Start the connection and register to start receiving updates from the server.
+    /// Connect should be called after LogIn and before EnterSpace.
+    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
+    /// @param ISignalRConnection* SignalRConnection : The SignalR connection to use when talking to the server. The MultiplayerConnection takes
+    /// ownership of this pointer.
+    CSP_NO_EXPORT void Connect(ErrorCodeCallbackHandler Callback, ISignalRConnection* SignalRConnection);
+
 private:
     MultiplayerConnection();
     ~MultiplayerConnection();
@@ -186,7 +197,7 @@ private:
 
     void DisconnectWithReason(const csp::common::String& Reason, ErrorCodeCallbackHandler Callback);
 
-    class csp::multiplayer::SignalRConnection* Connection;
+    class csp::multiplayer::ISignalRConnection* Connection;
     class csp::multiplayer::IWebSocketClient* WebSocketClient;
     class NetworkEventManagerImpl* NetworkEventManager;
     ConversationSystem* ConversationSystemPtr;

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -60,7 +60,7 @@ namespace csp::multiplayer
 
 class ClientElectionManager;
 class MultiplayerConnection;
-class SignalRConnection;
+class ISignalRConnection;
 class SpaceEntity;
 class SpaceTransform;
 
@@ -203,8 +203,8 @@ public:
     /// Note that this is already called in MultiplayerConnection::Connect, so this shouldn't need to be called anywhere else.
     /// This should not be called by client code directly, marked as No Export.
     ///
-    /// @param InConnection csp::multiplayer::SignalRConnection : A pointer to the connection object to be used by the system.
-    CSP_NO_EXPORT void SetConnection(csp::multiplayer::SignalRConnection* InConnection);
+    /// @param InConnection csp::multiplayer::ISignalRConnection : A pointer to the connection object to be used by the system.
+    CSP_NO_EXPORT void SetConnection(csp::multiplayer::ISignalRConnection* InConnection);
 
     /// @brief Sets a callback to be executed when all existing entities have been retrieved after entering a space.
     /// @param Callback CallbackHandler : the callback to execute.
@@ -321,7 +321,7 @@ private:
     ~SpaceEntitySystem();
 
     MultiplayerConnection* MultiplayerConnectionInst;
-    csp::multiplayer::SignalRConnection* Connection;
+    csp::multiplayer::ISignalRConnection* Connection;
 
     using SpaceEntityQueue = std::deque<SpaceEntity*>;
     using PatchMessageQueue = std::deque<signalr::value*>;

--- a/Library/src/Multiplayer/Conversation/ConversationSystem.cpp
+++ b/Library/src/Multiplayer/Conversation/ConversationSystem.cpp
@@ -42,7 +42,7 @@ ConversationSystem::ConversationSystem(MultiplayerConnection* Connection)
 
 ConversationSystem::~ConversationSystem() { DeregisterSystemCallback(); }
 
-void ConversationSystem::SetConnection(csp::multiplayer::SignalRConnection* InConnection) { Connection = InConnection; }
+void ConversationSystem::SetConnection(csp::multiplayer::ISignalRConnection* InConnection) { Connection = InConnection; }
 
 void ConversationSystem::StoreConversationMessage(const csp::common::String& ConversationId, const csp::systems::Space& Space,
     const csp::common::String& UserId, const csp::common::String& SenderDisplayName, const csp::common::String& Message,

--- a/Library/src/Multiplayer/EventBus.cpp
+++ b/Library/src/Multiplayer/EventBus.cpp
@@ -27,8 +27,6 @@
 namespace csp::multiplayer
 {
 
-extern ErrorCode ParseError(std::exception_ptr Exception);
-
 constexpr const uint64_t ALL_CLIENTS_ID = std::numeric_limits<uint64_t>::max();
 
 EventBus::~EventBus() { }

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -29,6 +29,7 @@
 #include "Multiplayer/SignalR/SignalRClient.h"
 #include "Multiplayer/SignalR/SignalRConnection.h"
 #include "NetworkEventManagerImpl.h"
+#include <Multiplayer/SignalR/ISignalRConnection.h>
 
 #ifdef CSP_WASM
 #include "Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.h"
@@ -110,6 +111,11 @@ ErrorCode ParseError(std::exception_ptr Exception)
 
 constexpr const uint64_t ALL_ENTITIES_ID = std::numeric_limits<uint64_t>::max();
 constexpr const uint32_t KEEP_ALIVE_INTERVAL = 15;
+ISignalRConnection* MultiplayerConnection::MakeSignalRConnection()
+{
+    return CSP_NEW csp::multiplayer::SignalRConnection(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str(), KEEP_ALIVE_INTERVAL,
+        std::make_shared<csp::multiplayer::CSPWebsocketClient>());
+}
 
 /// @brief MultiplayerConnection
 MultiplayerConnection::MultiplayerConnection()
@@ -161,6 +167,7 @@ MultiplayerConnection::MultiplayerConnection(const MultiplayerConnection& InBoun
 }
 
 void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback)
+void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback, ISignalRConnection* SignalRConnection)
 {
     if (Connection != nullptr)
     {
@@ -181,8 +188,7 @@ void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback)
 #endif
     csp::multiplayer::SetWebSocketClient(WebSocketClient);
 
-    Connection = CSP_NEW csp::multiplayer::SignalRConnection(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str(), KEEP_ALIVE_INTERVAL,
-        std::make_shared<csp::multiplayer::CSPWebsocketClient>());
+    Connection = SignalRConnection;
     NetworkEventManager->SetConnection(Connection);
     ConversationSystemPtr->SetConnection(Connection);
     csp::systems::SystemsManager::Get().GetSpaceEntitySystem()->SetConnection(Connection);

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -403,7 +403,7 @@ void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback, ISignalRC
             {
                 // Success
                 INVOKE_IF_NOT_NULL(ConnectionCallback, "Successfully connected to SignalR hub.");
-                INVOKE_IF_NOT_NULL(Callback, ErrorCode::None); // ????
+                INVOKE_IF_NOT_NULL(Callback, ErrorCode::None);
             })
         .then(async::inline_scheduler(),
             csp::common::continuations::InvokeIfExceptionInChain(

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -21,10 +21,11 @@
 #include "CallHelpers.h"
 #include "Multiplayer/MultiplayerConstants.h"
 #include "Multiplayer/SignalR/SignalRClient.h"
-#include "Multiplayer/SignalR/SignalRConnection.h"
+#include <Multiplayer/SignalR/ISignalRConnection.h>
 
 #include <iostream>
 #include <limits>
+#include <signalrclient/signalr_value.h>
 
 namespace csp::multiplayer
 {
@@ -39,7 +40,7 @@ NetworkEventManagerImpl::NetworkEventManagerImpl(MultiplayerConnection* InMultip
 {
 }
 
-void NetworkEventManagerImpl::SetConnection(csp::multiplayer::SignalRConnection* InConnection) { Connection = InConnection; }
+void NetworkEventManagerImpl::SetConnection(csp::multiplayer::ISignalRConnection* InConnection) { Connection = InConnection; }
 
 void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventName, const csp::common::Array<ReplicatedValue>& Arguments,
     uint64_t TargetClientId, ErrorCodeCallbackHandler Callback)
@@ -51,7 +52,7 @@ void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventN
         return;
     }
 
-    csp::multiplayer::SignalRConnection* SignalRConnectionPtr = static_cast<csp::multiplayer::SignalRConnection*>(Connection);
+    csp::multiplayer::ISignalRConnection* ISignalRConnectionPtr = static_cast<csp::multiplayer::ISignalRConnection*>(Connection);
 
     std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value Result, std::exception_ptr Except)
     {
@@ -164,7 +165,7 @@ void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventN
     std::vector<signalr::value> InvokeArguments;
     InvokeArguments.push_back(EventMessage);
 
-    SignalRConnectionPtr->Invoke("SendEventMessage", InvokeArguments, LocalCallback);
+    ISignalRConnectionPtr->Invoke("SendEventMessage", InvokeArguments, LocalCallback);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -30,8 +30,6 @@
 namespace csp::multiplayer
 {
 
-extern ErrorCode ParseError(std::exception_ptr Exception);
-
 constexpr const uint64_t ALL_CLIENTS_ID = std::numeric_limits<uint64_t>::max();
 
 NetworkEventManagerImpl::NetworkEventManagerImpl(MultiplayerConnection* InMultiplayerConnection)
@@ -58,7 +56,7 @@ void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventN
     {
         if (Except != nullptr)
         {
-            auto Error = ParseError(Except);
+            auto [Error, ExceptionErrorMsg] = MultiplayerConnection::ParseMultiplayerErrorFromExceptionPtr(Except);
             INVOKE_IF_NOT_NULL(Callback, Error);
 
             return;

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.h
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.h
@@ -27,7 +27,7 @@ namespace csp::multiplayer
 
 class MultiplayerConnection;
 class ReplicatedValue;
-class SignalRConnection;
+class ISignalRConnection;
 enum class ErrorCode;
 
 class NetworkEventManagerImpl
@@ -37,14 +37,14 @@ public:
 
     typedef std::function<void(ErrorCode)> ErrorCodeCallbackHandler;
 
-    void SetConnection(csp::multiplayer::SignalRConnection* InConnection);
+    void SetConnection(csp::multiplayer::ISignalRConnection* InConnection);
 
     CSP_NO_EXPORT void SendNetworkEvent(const csp::common::String& EventName, const csp::common::Array<ReplicatedValue>& Arguments,
         uint64_t TargetClientId, ErrorCodeCallbackHandler Callback);
 
 private:
     MultiplayerConnection* MultiplayerConnectionInst;
-    csp::multiplayer::SignalRConnection* Connection;
+    csp::multiplayer::ISignalRConnection* Connection;
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/SignalR/ISignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/ISignalRConnection.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <exception>
+#include <functional>
+#include <map>
+
+namespace signalr
+{
+class value;
+}
+
+namespace csp::multiplayer
+{
+// This interface written initially to allow Mocks to be created in tests for the SignalRConnection
+class ISignalRConnection
+{
+public:
+    enum class ConnectionState
+    {
+        Connecting,
+        Connected,
+        Disconnecting,
+        Disconnected
+    };
+
+    using MethodInvokedHandler = std::function<void(const signalr::value&)>;
+
+    virtual ~ISignalRConnection() = default;
+
+    virtual void Start(std::function<void(std::exception_ptr)> Callback) = 0;
+    virtual void Stop(std::function<void(std::exception_ptr)> Callback) = 0;
+    virtual ISignalRConnection::ConnectionState GetConnectionState() const = 0;
+    virtual std::string GetConnectionId() const = 0;
+    virtual void SetDisconnected(const std::function<void(std::exception_ptr)>& DisconnectedCallback) = 0;
+    virtual void On(const std::string& EventName, const MethodInvokedHandler& Handler) = 0;
+    virtual void Invoke(
+        const std::string& MethodName, const signalr::value& Arguments,
+        std::function<void(const signalr::value&, std::exception_ptr)> Callback = [](const signalr::value&, std::exception_ptr) {})
+        = 0;
+    virtual void Send(
+        const std::string& MethodName, const signalr::value& Arguments, std::function<void(std::exception_ptr)> Callback = [](std::exception_ptr) {})
+        = 0;
+    virtual const std::map<std::string, std::string>& HTTPHeaders() const = 0;
+};
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
@@ -142,4 +142,6 @@ void SignalRConnection::Send(const std::string& MethodName, const signalr::value
     Connection.send(MethodName, Arguments, Callback);
 }
 
+const std::map<std::string, std::string>& SignalRConnection::HTTPHeaders() const { return config.get_http_headers(); }
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.h
@@ -17,8 +17,8 @@
 
 #include "Web/Uri.h"
 
+#include <Multiplayer/SignalR/ISignalRConnection.h>
 #include <atomic>
-#include <functional>
 #include <signalrclient/hub_connection_builder.h>
 
 CSP_START_IGNORE
@@ -28,7 +28,7 @@ CSP_END_IGNORE
 namespace csp::multiplayer
 {
 
-class SignalRConnection
+class SignalRConnection : public ISignalRConnection
 {
 public:
     /** @cond DO_NOT_DOCUMENT */
@@ -40,32 +40,25 @@ public:
     SignalRConnection(const std::string& url, const uint32_t KeepAliveSeconds, std::shared_ptr<signalr::websocket_client> WebSocketClient);
     virtual ~SignalRConnection();
 
-    void Start(std::function<void(std::exception_ptr)> Callback);
-    void Stop(std::function<void(std::exception_ptr)> Callback);
+    void Start(std::function<void(std::exception_ptr)> Callback) override;
+    void Stop(std::function<void(std::exception_ptr)> Callback) override;
 
-    enum class ConnectionState
-    {
-        Connecting,
-        Connected,
-        Disconnecting,
-        Disconnected
-    };
+    ConnectionState GetConnectionState() const override;
 
-    ConnectionState GetConnectionState() const;
+    std::string GetConnectionId() const override;
 
-    std::string GetConnectionId() const;
+    void SetDisconnected(const std::function<void(std::exception_ptr)>& DisconnectedCallback) override;
 
-    void SetDisconnected(const std::function<void(std::exception_ptr)>& DisconnectedCallback);
-
-    void On(const std::string& EventName, const MethodInvokedHandler& Handler);
+    void On(const std::string& EventName, const MethodInvokedHandler& Handler) override;
 
     void Invoke(
         const std::string& MethodName, const signalr::value& Arguments = signalr::value(),
-        std::function<void(const signalr::value&, std::exception_ptr)> Callback = [](const signalr::value&, std::exception_ptr) {});
+        std::function<void(const signalr::value&, std::exception_ptr)> Callback = [](const signalr::value&, std::exception_ptr) {}) override;
 
     void Send(
         const std::string& MethodName, const signalr::value& Arguments = signalr::value(),
-        std::function<void(std::exception_ptr)> Callback = [](std::exception_ptr) {});
+        std::function<void(std::exception_ptr)> Callback = [](std::exception_ptr) {}) override;
+
 
 private:
     signalr::hub_connection Connection;

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.h
@@ -59,6 +59,7 @@ public:
         const std::string& MethodName, const signalr::value& Arguments = signalr::value(),
         std::function<void(std::exception_ptr)> Callback = [](std::exception_ptr) {}) override;
 
+    const std::map<std::string, std::string>& HTTPHeaders() const override;
 
 private:
     signalr::hub_connection Connection;

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -18,6 +18,7 @@
 #include "CSP/Common/List.h"
 #include "CSP/Common/StringFormat.h"
 #include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
+#include <Multiplayer/SignalR/ISignalRConnection.h>
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "CSP/Multiplayer/Script/EntityScriptMessages.h"
@@ -34,7 +35,6 @@
 #include "Multiplayer/MultiplayerConstants.h"
 #include "Multiplayer/Script/EntityScriptBinding.h"
 #include "Multiplayer/SignalR/SignalRClient.h"
-#include "Multiplayer/SignalR/SignalRConnection.h"
 #include "Multiplayer/SignalRMsgPackEntitySerialiser.h"
 
 #ifdef CSP_WASM
@@ -633,7 +633,7 @@ void SpaceEntitySystem::BindOnRequestToDisconnect() const
         });
 }
 
-void SpaceEntitySystem::SetConnection(csp::multiplayer::SignalRConnection* InConnection)
+void SpaceEntitySystem::SetConnection(csp::multiplayer::ISignalRConnection* InConnection)
 {
     Connection = InConnection;
 
@@ -1128,7 +1128,7 @@ void SpaceEntitySystem::AddEntity(SpaceEntity* EntityToAdd)
     PendingAdds->emplace_back(EntityToAdd);
 }
 
-void SendPatches(csp::multiplayer::SignalRConnection* Connection, const csp::common::List<SpaceEntity*> PendingEntities)
+void SendPatches(csp::multiplayer::ISignalRConnection* Connection, const csp::common::List<SpaceEntity*> PendingEntities)
 {
     const std::function LocalCallback = [](const signalr::value& /*Result*/, const std::exception_ptr& Except)
     {

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -271,8 +271,9 @@ void SpaceSystem::EnterSpace(const String& SpaceId, NullResultCallback Callback)
                 "SpaceSystem: EnterSpace, successfully refreshed multiplayer scopes", EResultCode::Failed,
                 csp::web::EResponseCodes::ResponseInternalServerError, ERequestFailureReason::Unknown, csp::systems::LogLevel::Error))
         .then(async::inline_scheduler(), csp::common::continuations::ReportSuccess(Callback, "Successfully entered space."))
-        .then(
-            async::inline_scheduler(), csp::common::continuations::InvokeIfExceptionInChain([&CurrentSpace = CurrentSpace]() { CurrentSpace = {}; }));
+        .then(async::inline_scheduler(),
+            csp::common::continuations::InvokeIfExceptionInChain(
+                [&CurrentSpace = CurrentSpace](const std::exception& /*Except*/) { CurrentSpace = {}; }));
 }
 
 void SpaceSystem::ExitSpace(NullResultCallback Callback)

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -134,23 +134,27 @@ void SpaceSystem::RefreshMultiplayerConnectionToEnactScopeChange(
                         CSP_LOG_MSG(csp::systems::LogLevel::Verbose, "SetScopes was called successfully");
                     }
 
-                    MultiplayerConnection->StartListening(
-                        [this, RefreshMultiplayerContinuationEvent](csp::multiplayer::ErrorCode Error)
-                        {
-                            if (Error != csp::multiplayer::ErrorCode::None)
+                    MultiplayerConnection->StartListening()()
+                        .then(async::inline_scheduler(),
+                            [this, RefreshMultiplayerContinuationEvent]()
                             {
-                                RefreshMultiplayerContinuationEvent->set(Error);
-                                return;
-                            }
+                                CSP_LOG_MSG(csp::systems::LogLevel::Log, " MultiplayerConnection->StartListening success");
 
-                            CSP_LOG_MSG(csp::systems::LogLevel::Log, " MultiplayerConnection->StartListening success");
+                                // TODO: Support getting errors from RetrieveAllEntities
+                                csp::systems::SystemsManager::Get().GetSpaceEntitySystem()->RetrieveAllEntities();
 
-                            // TODO: Support getting errors from RetrieveAllEntities
-                            csp::systems::SystemsManager::Get().GetSpaceEntitySystem()->RetrieveAllEntities();
-
-                            // Success!
-                            RefreshMultiplayerContinuationEvent->set({});
-                        });
+                                // Success!
+                                RefreshMultiplayerContinuationEvent->set({});
+                            })
+                        .then(async::inline_scheduler(),
+                            csp::common::continuations::InvokeIfExceptionInChain(
+                                [&RefreshMultiplayerContinuationEvent](const std::exception& Except)
+                                {
+                                    // Error case
+                                    auto [Error, ExceptionMsg] = csp::multiplayer::MultiplayerConnection::ParseMultiplayerError(Except);
+                                    RefreshMultiplayerContinuationEvent->set(Error);
+                                    return;
+                                }));
                 });
         });
 }
@@ -174,7 +178,7 @@ auto SpaceSystem::AddUserToSpaceIfNecessary(NullResultCallback Callback, SpaceSy
         /* If we need permissions, check that the user has permission to enter this specific space */
         if (JoiningSpaceRequiresInvite && !UserIsRecognizedBySpace)
         {
-            csp::common::continuations::LogErrorAndCancelContinuation(Callback,
+            csp::common::continuations::LogHTTPErrorAndCancelContinuation(Callback,
                 "Logged in user does not have permission to join this space. Failed to add to space.", EResultCode::Failed,
                 csp::web::EResponseCodes::ResponseForbidden, ERequestFailureReason::UserSpaceAccessDenied);
         }

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -171,7 +171,7 @@ void UserSystem::Login(const csp::common::String& UserName, const csp::common::S
                 };
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-                MultiplayerConnection->Connect(ErrorCallback);
+                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection());
             }
             else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
             {
@@ -231,7 +231,7 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
                 };
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-                MultiplayerConnection->Connect(ErrorCallback);
+                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection());
             }
             else
             {
@@ -319,7 +319,7 @@ void UserSystem::LoginAsGuest(const csp::common::Optional<bool>& UserHasVerified
                 };
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-                MultiplayerConnection->Connect(ErrorCallback);
+                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection());
             }
             else
             {
@@ -444,7 +444,7 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
             };
 
             auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-            MultiplayerConnection->Connect(ErrorCallback);
+            MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection());
         }
         else
         {

--- a/Tests/src/Mocks/SignalRConnectionMock.h
+++ b/Tests/src/Mocks/SignalRConnectionMock.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../../Library/src/Multiplayer/SignalR/ISignalRConnection.h"
+#include <gmock/gmock.h>
+
+class SignalRConnectionMock : public csp::multiplayer::ISignalRConnection
+{
+public:
+    MOCK_METHOD(void, Start, (std::function<void(std::exception_ptr)>), (override));
+    MOCK_METHOD(void, Stop, (std::function<void(std::exception_ptr)>), (override));
+    MOCK_METHOD(csp::multiplayer::ISignalRConnection::ConnectionState, GetConnectionState, (), (const, override));
+    MOCK_METHOD(std::string, GetConnectionId, (), (const, override));
+    MOCK_METHOD(void, SetDisconnected, (const std::function<void(std::exception_ptr)>&), (override));
+    MOCK_METHOD(void, On, (const std::string&, const MethodInvokedHandler&), (override));
+    MOCK_METHOD(
+        void, Invoke, (const std::string&, const signalr::value&, std::function<void(const signalr::value&, std::exception_ptr)>), (override));
+    MOCK_METHOD(void, Send, (const std::string&, const signalr::value&, std::function<void(std::exception_ptr)>), (override));
+    MOCK_METHOD((const std::map<std::string, std::string>&), HTTPHeaders, (), (const, override));
+};

--- a/Tests/src/PublicAPITests/EventBusTests.cpp
+++ b/Tests/src/PublicAPITests/EventBusTests.cpp
@@ -640,7 +640,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SetCallbackBeforeConnectedTest)
     // Check Connection callback was called
     WaitForCallback(ConnectionCallbackCalled);
     EXPECT_TRUE(ConnectionCallbackCalled);
-    EXPECT_EQ(ConnectionMessage, "Success");
+    EXPECT_EQ(ConnectionMessage, "Successfully connected to SignalR hub.");
     EXPECT_EQ(Connection->GetConnectionState(), ConnectionState::Connected);
 
     // Create space

--- a/Tests/src/PublicAPITests/GeneralContinuationsTests.cpp
+++ b/Tests/src/PublicAPITests/GeneralContinuationsTests.cpp
@@ -228,25 +228,25 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestAssertRequestSuccessOr
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenNoExceptionThrownInContinuationChainThenHandlerNotCalled)
 {
     // No exception, expect exception handler callable not called.
-    ::testing::MockFunction<void()> MockExceptionHandlerCallable;
-    EXPECT_CALL(MockExceptionHandlerCallable, Call()).Times(0);
+    ::testing::MockFunction<void(const std::exception&)> MockExceptionHandlerCallable;
+    EXPECT_CALL(MockExceptionHandlerCallable, Call(::testing::_)).Times(0);
     csp::common::continuations::detail::testing::SpawnChainThatThrowsNoExceptionWithHandlerAtEnd(MockExceptionHandlerCallable.AsStdFunction());
 }
 
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenExceptionThrownInContinuationChainThenHandlerCalled)
 {
     // Exception thrown, expect exception handler callable called
-    ::testing::MockFunction<void()> MockExceptionHandlerCallable;
-    EXPECT_CALL(MockExceptionHandlerCallable, Call()).Times(1);
+    ::testing::MockFunction<void(const std::exception&)> MockExceptionHandlerCallable;
+    EXPECT_CALL(MockExceptionHandlerCallable, Call(::testing::_)).Times(1);
     csp::common::continuations::detail::testing::SpawnChainThatThrowsGeneralExceptionWithHandlerAtEnd(MockExceptionHandlerCallable.AsStdFunction());
 }
 
 CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenContinuationChainCancelledThenHandlerAndResultCallbackCalled)
 {
     // Exception thrown, expect exception handler callable called, as well as result callback called. (Just testing our specific way of throwing here)
-    ::testing::MockFunction<void()> MockExceptionHandlerCallable;
+    ::testing::MockFunction<void(const std::exception&)> MockExceptionHandlerCallable;
     ::testing::MockFunction<void(const NullResult& Result)> MockResultCallback;
-    EXPECT_CALL(MockExceptionHandlerCallable, Call()).Times(1);
+    EXPECT_CALL(MockExceptionHandlerCallable, Call(::testing::_)).Times(1);
     EXPECT_CALL(MockResultCallback, Call(::testing::_)).Times(1);
     csp::common::continuations::detail::testing::SpawnChainThatCallsLogErrorAndCancelContinuationWithHandlerAtEnd(
         MockExceptionHandlerCallable.AsStdFunction(), MockResultCallback.AsStdFunction());
@@ -256,10 +256,10 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestCallableCalledAndInter
 {
     // Exception thrown higher in chain, expect exception handler callable intermediate method not called, but exception handler callable called.
     ::testing::MockFunction<void()> MockIntermediateStepCallable;
-    ::testing::MockFunction<void()> MockExceptionHandlerCallable;
+    ::testing::MockFunction<void(const std::exception&)> MockExceptionHandlerCallable;
     ::testing::MockFunction<void(const NullResult& Result)> MockResultCallback;
     EXPECT_CALL(MockIntermediateStepCallable, Call()).Times(0);
-    EXPECT_CALL(MockExceptionHandlerCallable, Call()).Times(1);
+    EXPECT_CALL(MockExceptionHandlerCallable, Call(::testing::_)).Times(1);
     EXPECT_CALL(MockResultCallback, Call(::testing::_)).Times(1);
     csp::common::continuations::detail::testing::SpawnChainThatCallsLogErrorAndCancelContinuationWithIntermediateStepAndHandlerAtEnd(
         MockIntermediateStepCallable.AsStdFunction(), MockExceptionHandlerCallable.AsStdFunction(), MockResultCallback.AsStdFunction());
@@ -272,7 +272,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestCallableCalledOnSameTh
     // testing the library now...).
 
     const auto ThisThreadId = std::this_thread::get_id();
-    auto VerifyThread = [ThisThreadId]() { ASSERT_EQ(ThisThreadId, std::this_thread::get_id()); };
+    auto VerifyThread = [ThisThreadId](const std::exception& /*Except*/) { ASSERT_EQ(ThisThreadId, std::this_thread::get_id()); };
     // Just use the exception handler to serve as a general purpose way to call a callable in tests.
     // Could simply have made another detail::testing function ... but why bother when this already exists.
     csp::common::continuations::detail::testing::SpawnChainThatThrowsGeneralExceptionWithHandlerAtEnd(VerifyThread);

--- a/Tests/src/PublicAPITests/GeneralContinuationsTests.cpp
+++ b/Tests/src/PublicAPITests/GeneralContinuationsTests.cpp
@@ -91,7 +91,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestLogErrorAndCancel)
     EXPECT_CALL(MockLogger.MockLogCallback, Call(ErrorMsg)).Times(1);
 
     // This throws a async++::task_cancelled exception, but we don't want to link that lib in the tests, so just expect any exception.
-    ASSERT_ANY_THROW(csp::common::continuations::LogErrorAndCancelContinuation(
+    ASSERT_ANY_THROW(csp::common::continuations::LogHTTPErrorAndCancelContinuation(
         MockResultCallback.AsStdFunction(), ErrorMsg.c_str(), ResultCode, HttpResultCode, FailureReason));
 }
 
@@ -248,7 +248,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestWhenContinuationChainC
     ::testing::MockFunction<void(const NullResult& Result)> MockResultCallback;
     EXPECT_CALL(MockExceptionHandlerCallable, Call(::testing::_)).Times(1);
     EXPECT_CALL(MockResultCallback, Call(::testing::_)).Times(1);
-    csp::common::continuations::detail::testing::SpawnChainThatCallsLogErrorAndCancelContinuationWithHandlerAtEnd(
+    csp::common::continuations::detail::testing::SpawnChainThatCallsLogHTTPErrorAndCancelContinuationWithHandlerAtEnd(
         MockExceptionHandlerCallable.AsStdFunction(), MockResultCallback.AsStdFunction());
 }
 
@@ -261,7 +261,7 @@ CSP_PUBLIC_TEST(CSPEngine, GeneralContinuationsTests, TestCallableCalledAndInter
     EXPECT_CALL(MockIntermediateStepCallable, Call()).Times(0);
     EXPECT_CALL(MockExceptionHandlerCallable, Call(::testing::_)).Times(1);
     EXPECT_CALL(MockResultCallback, Call(::testing::_)).Times(1);
-    csp::common::continuations::detail::testing::SpawnChainThatCallsLogErrorAndCancelContinuationWithIntermediateStepAndHandlerAtEnd(
+    csp::common::continuations::detail::testing::SpawnChainThatCallsLogHTTPErrorAndCancelContinuationWithIntermediateStepAndHandlerAtEnd(
         MockIntermediateStepCallable.AsStdFunction(), MockExceptionHandlerCallable.AsStdFunction(), MockResultCallback.AsStdFunction());
 }
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2952,7 +2952,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRStartErrorsThenDisconnec
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<SignalRConnectionMock> SignalRMock = std::make_unique<SignalRConnectionMock>();
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
 
     // The start function will throw internally
     EXPECT_CALL(*SignalRMock, Start)
@@ -2967,7 +2968,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRStartErrorsThenDisconnec
     EXPECT_CALL(MockDisconnectionCallback, Call(csp::common::String("MultiplayerConnection::Start, Error when starting SignalR connection.")));
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock.release());
+    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsErrorsThenDisconnectionFunctionsCalled)
@@ -2975,7 +2976,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<SignalRConnectionMock> SignalRMock = std::make_unique<SignalRConnectionMock>();
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
 
     // Start and stop will call their callbacks
     StartAlwaysSucceeds(*SignalRMock);
@@ -2997,7 +2999,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
         Call(csp::common::String("MultiplayerConnection::DeleteEntities, Unexpected error response from SignalR \"DeleteObjects\" invocation.")));
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock.release());
+    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsThenDisconnectionFunctionsCalled)
@@ -3005,7 +3007,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<SignalRConnectionMock> SignalRMock = std::make_unique<SignalRConnectionMock>();
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
 
     // Start and stop will call their callbacks
     StartAlwaysSucceeds(*SignalRMock);
@@ -3038,7 +3041,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
         MockDisconnectionCallback, Call(csp::common::String("MultiplayerConnection::RequestClientId, Error when starting requesting Client Id.")));
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock.release());
+    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErrorsThenDisconnectionFunctionsCalled)
@@ -3046,7 +3049,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<SignalRConnectionMock> SignalRMock = std::make_unique<SignalRConnectionMock>();
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
 
     // Start and stop will call their callbacks
     StartAlwaysSucceeds(*SignalRMock);
@@ -3083,7 +3087,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
     EXPECT_CALL(MockDisconnectionCallback, Call(csp::common::String("MultiplayerConnection::StartListening, Error when starting listening.")));
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock.release());
+    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCallbacksCalled)
@@ -3091,7 +3095,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<SignalRConnectionMock> SignalRMock = std::make_unique<SignalRConnectionMock>();
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
 
     // Start and stop will call their callbacks
     StartAlwaysSucceeds(*SignalRMock);
@@ -3132,7 +3137,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
     EXPECT_CALL(MockDisconnectionCallback, Call(::testing::_)).Times(0);
 
     Connection->SetConnectionCallback(std::bind(&MockConnectionCallback::Call, &MockSuccessConnectionCallback, std::placeholders::_1));
-    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock.release());
+    Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, TestParseMultiplayerError)

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -359,7 +359,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
 
     InitialiseTestingConnection();
 
-    auto Headers = Connection->Connection->config.get_http_headers();
+    auto Headers = Connection->Connection->HTTPHeaders();
     ASSERT_NE(Headers.find("X-DeviceUDID"), Headers.end());
 
     // Enter space

--- a/Tests/src/PublicTestBase.cpp
+++ b/Tests/src/PublicTestBase.cpp
@@ -42,10 +42,6 @@ void PublicTestBase::TearDown()
 {
     ::testing::Test::TearDown();
 
-    auto Connection = csp::systems::SystemsManager::Get().GetMultiplayerConnection();
-
-    AWAIT(Connection, SetAllowSelfMessagingFlag, false);
-
     if (!csp::CSPFoundation::GetIsInitialised())
     {
         fprintf(stderr, "%s\n",


### PR DESCRIPTION
> [!TIP]
>This benefits from a commit-by-commit review

Refactor the `Connect` function to continuations. 

Several refactorings are done as part of this work:
 - Create a mocking pattern via `SignalRClient`, and show the first use of full type mocks in our tests.
 - Use that pattern to test untriggerable network errors through the `Connect` flow.
 - Slightly evolve the error handling for the Connection Object, to at least try to give some context
 - Rename existing continuations utilities to `HTTP`, to better represent their difference from Multiplayer results.
 
 ## Discussion
 Three points jump out to me having done this work, for future consideration.
 - Our conversion from SignalR errors to our own error reporting mechanism is rather confused.
 - There are four callbacks in play, which is too many and very confusing. I think we should reduce this.
   - The regular callback passed to the connect function (Called the ErrorCallback sometimes, but not treated consistently as that)
   - The network interrupted callback (connected to the SignalR `set_disconnected` method)
   - The disconnection callback, called when there's an error during connection, or when the connection shuts down. Almost always called redundantly with the regular callback.
   - The connection callback, called when connection is a success
- The use of mimalloc and CSP_NEW in our codebase makes taking ownership of pointers from external to CSP fragile, how are users to know that they have to be constructed with CSP_NEW? 
   