### PR TITLE
[OF-1550] chore: Raise warning level to 4

### DIFF
--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -154,9 +154,9 @@ protected:
     ComponentBase(ComponentType Type, SpaceEntity* Parent);
 
     const ReplicatedValue& GetProperty(uint32_t Key) const;
-    const bool GetBooleanProperty(uint32_t Key) const;
-    const int64_t GetIntegerProperty(uint32_t Key) const;
-    const float GetFloatProperty(uint32_t Key) const;
+    bool GetBooleanProperty(uint32_t Key) const;
+    int64_t GetIntegerProperty(uint32_t Key) const;
+    float GetFloatProperty(uint32_t Key) const;
     const csp::common::String& GetStringProperty(uint32_t Key) const;
     const csp::common::Vector2& GetVector2Property(uint32_t Key) const;
     const csp::common::Vector3& GetVector3Property(uint32_t Key) const;

--- a/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
@@ -128,7 +128,7 @@ public:
     /// @brief Gets the ID of the mesh of the avatar of this component.
     /// @note  Used to establish which mesh this avatar should use among a collection of predefined meshes.
     /// @return The ID of the mesh of the avatar of this component.
-    const int64_t GetAvatarMeshIndex() const;
+    int64_t GetAvatarMeshIndex() const;
 
     /// @brief Sets the ID of the mesh of the avatar of this component.
     /// @note Used to establish which mesh this avatar should use among a collection of predefined meshes.
@@ -160,7 +160,7 @@ public:
     /// @brief Checks if the Hands Inverse Kinematics (IK) are enabled for this avatar.
     /// @note Intended for use in VR or with virtual hands controllers.
     /// @return True if the avatar uses IK, false otherwise.
-    const bool GetIsHandIKEnabled() const;
+    bool GetIsHandIKEnabled() const;
 
     /// @brief Sets if the Hands Inverse Kinematics (IK) are enabled for this avatar.
     /// @note Intended for use in VR or with virtual hands controllers.
@@ -229,7 +229,7 @@ public:
     /// @note Used to calculate a smooth transition between an avatar walking and an avatar running.
     ///       When 0 the avatar is fully walking, when 100 the avatar is fully running.
     /// @return The percentage of the blending between walk and run states.
-    const float GetWalkRunBlendPercentage() const;
+    float GetWalkRunBlendPercentage() const;
 
     /// @brief Sets blending between walk and run states expressed in percentage.
     /// @note Used to calculate a smooth transition between an avatar walking and an avatar running.
@@ -243,7 +243,7 @@ public:
     ///       The greater the difference, the further the torso should be twisted.
     ///       Positive value if the torso is turning right, negative if avatar is turning left.
     /// @return The angle to use to twist the avatar's torso.
-    const float GetTorsoTwistAlpha() const;
+    float GetTorsoTwistAlpha() const;
 
     /// @brief Sets the angle to use to twist the avatar's torso.
     /// @note To calculate the twist of the avatar torso, it is convention to evaluate the

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -229,7 +229,7 @@ public:
 
     /// @brief Get the third party platform type of this entity.
     /// @return A string representing third party platform type set for this entity.
-    const csp::systems::EThirdPartyPlatform GetThirdPartyPlatformType() const;
+    csp::systems::EThirdPartyPlatform GetThirdPartyPlatformType() const;
 
     /// @brief Set third party platform type for this entity.
     /// @param InThirdPartyPlatformType csp::systems::EThirdPartyPlatform : The third party platform type to set.

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -287,7 +287,7 @@ public:
 
     /// @brief Retrieve the state of the patch rate limiter. If true, patches are limited for each individual entity to a fixed rate.
     /// @return True if enabled, false otherwise.
-    const bool GetEntityPatchRateLimitEnabled() const;
+    bool GetEntityPatchRateLimitEnabled() const;
 
     /// @brief Set the state of the patch rate limiter. If true, patches are limited for each individual entity to a fixed rate.
     ///

--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystemUtils.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystemUtils.h
@@ -34,9 +34,9 @@ public:
     void AddFloat(csp::common::String Key, float Value);
     void AddBool(csp::common::String Key, bool Value);
 
-    const int64_t GetInt(csp::common::String Key) const;
+    int64_t GetInt(csp::common::String Key) const;
     const csp::common::String& GetString(csp::common::String Key) const;
-    const float GetFloat(csp::common::String Key) const;
+    float GetFloat(csp::common::String Key) const;
     bool GetBool(csp::common::String Key) const;
 
     const csp::common::String& GetTag() const;

--- a/Library/include/CSP/Systems/Assets/Material.h
+++ b/Library/include/CSP/Systems/Assets/Material.h
@@ -94,11 +94,11 @@ public:
 
     /// @brief Gets the shader type of the material.
     /// @return csp::systems::EShaderType : Returns the shader type.
-    const csp::systems::EShaderType GetShaderType() const;
+    csp::systems::EShaderType GetShaderType() const;
 
     /// @brief Gets the version of the material.
     /// @return int : Returns the version of the material.
-    const int GetVersion() const;
+    int GetVersion() const;
 
     /// @brief Gets the collection id for the material.
     /// @return const csp::common::String& : Returns the collection id.

--- a/Library/include/CSP/Systems/EventTicketing/EventTicketing.h
+++ b/Library/include/CSP/Systems/EventTicketing/EventTicketing.h
@@ -208,7 +208,7 @@ public:
 
     /// @brief Gets the ticketed status of the space from the result.
     /// @return A bool describing if the space is ticketed.
-    const bool GetIsTicketedEvent() const;
+    bool GetIsTicketedEvent() const;
 
 private:
     SpaceIsTicketedResult(void*)

--- a/Library/include/CSP/Systems/Quota/Quota.h
+++ b/Library/include/CSP/Systems/Quota/Quota.h
@@ -238,12 +238,12 @@ const csp::common::String TierFeatureEnumToString(const TierFeatures& Value);
 /// @brief Retrieves an array of feature quota results.
 /// @param Value csp::common::String : EnumValue as a string
 /// @TierNames : Const string as an enum value
-const TierNames StringToTierNameEnum(const csp::common::String& Value);
+TierNames StringToTierNameEnum(const csp::common::String& Value);
 
 /// @brief Retrieves an array of feature quota results.
 /// @param Value csp::common::String : EnumValue as a string
 /// @TierFeatures : Const string as an enum value
-const TierFeatures StringToTierFeatureEnum(const csp::common::String& Value);
+TierFeatures StringToTierFeatureEnum(const csp::common::String& Value);
 
 /// @brief Callback containing array of feature progress.
 /// @param Result FeatureProgressResult : result class

--- a/Library/include/CSP/Systems/Spaces/Space.h
+++ b/Library/include/CSP/Systems/Spaces/Space.h
@@ -409,7 +409,7 @@ class CSP_API SpaceGeoLocationResult : public csp::systems::ResultBase
 public:
     /// @brief Utility to check if a geo location actually exists for the space
     /// @return bool : true if GetSpaceGeoLocation will return a valid geo location for the space, false otherwise
-    const bool HasSpaceGeoLocation() const;
+    bool HasSpaceGeoLocation() const;
 
     /// @brief Returns the geo location of the space if one exists
     /// @return SpaceGeoLocation : Geo location of the space

--- a/Library/include/CSP/Systems/WebService.h
+++ b/Library/include/CSP/Systems/WebService.h
@@ -106,11 +106,11 @@ public:
 
     /// @brief Status of this response.
     /// @return EResultCode
-    const EResultCode GetResultCode() const;
+    EResultCode GetResultCode() const;
 
     /// @brief Result of http request.
     /// @return uint16_t
-    const uint16_t GetHttpResultCode() const;
+    uint16_t GetHttpResultCode() const;
 
     /// @brief Body of the response.
     const csp::common::String& GetResponseBody() const;

--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -173,9 +173,8 @@ if not Project then
 			buildoptions {
 				"-Wno-error=deprecated-declarations", --Don't error on deprecation warnings, this is because we use Uri a lot in our services generated code, which has deprecation warnings for some unused but still generated endpoints.
 				"-Wno-braced-scalar-init", -- Don't warn against doing stuff like `return {0}`, which we do in the interop output.
-				"-Wno-missing-field-initializers", -- Don't warn against missing field initializers (because of the wrapper generator)
-				"-Wno-error=unused-lambda-capture", --This shouldn't be disabled, we just had to rush to unblock android builds. Take all the this captures out and remove.
-				"-Wno-unknown-pragmas", --Also not the greatest. This is to try and suppress a signalR warning, even though the signalR project dosen't emit warnings (I think this error is a bit unique cause of preprocessor stuff)
+				"-Wno-missing-field-initializers", -- Don't warn against missing field initializers, e.g. uninitialized fields in structs (because of the wrapper generator)
+				"-Wno-unknown-pragmas", --Not the greatest. This is to try and suppress a signalR warning, even though the signalR project dosen't emit warnings (I think this error is a bit unique cause of preprocessor stuff)
 				"-Wno-error=nonportable-include-path", --Include paths dont match file structure. Should get around to fixing
 				"-Wno-error=format-security" --In logging, __android_log_print(ANDROID_LOG_VERBOSE, "CSP", InMessage.c_str()) is unnaceptable for some reason.
             }
@@ -258,8 +257,8 @@ if not Project then
                 "-fwasm-exceptions",    -- enable native wasm exceptions
                 "-Wno-error=deprecated-declarations", --Don't error on deprecation warnings, this is because we use Uri a lot in our services generated code, which has deprecation warnings for some unused but still generated endpoints.
                 "-Wno-braced-scalar-init", -- Don't warn against doing stuff like `return {0}`, which we do in the interop output.
-                "-Wno-missing-field-initializers", -- Don't warn against missing field initializers (because of the wrapper generator)
-                "-Wno-ignored-qualifiers" -- Don't warn against ignored qualifiers
+                "-Wno-missing-field-initializers", -- Don't warn against missing field initializers, e.g. uninitialized fields in structs (because of the wrapper generator)
+                "-Wno-ignored-qualifiers" -- Don't warn against ignored qualifiers, e.g. "const qualifier on return type has no effect" (because of the wrapper generator)
             }
 
             linkoptions { 

--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -173,6 +173,7 @@ if not Project then
 			buildoptions {
 				"-Wno-error=deprecated-declarations", --Don't error on deprecation warnings, this is because we use Uri a lot in our services generated code, which has deprecation warnings for some unused but still generated endpoints.
 				"-Wno-braced-scalar-init", -- Don't warn against doing stuff like `return {0}`, which we do in the interop output.
+				"-Wno-missing-field-initializers", -- Don't warn against missing field initializers (because of the wrapper generator)
 				"-Wno-error=unused-lambda-capture", --This shouldn't be disabled, we just had to rush to unblock android builds. Take all the this captures out and remove.
 				"-Wno-unknown-pragmas", --Also not the greatest. This is to try and suppress a signalR warning, even though the signalR project dosen't emit warnings (I think this error is a bit unique cause of preprocessor stuff)
 				"-Wno-error=nonportable-include-path", --Include paths dont match file structure. Should get around to fixing
@@ -215,7 +216,7 @@ if not Project then
 			-- Could not manage to get xcode to co-operate in any other less specific manner of setting the flags.
 			-- These disables are to do with warnings in generated code that we should get around to dealing with.
 			xcodebuildsettings {
-				["WARNING_CFLAGS"] = "-Wno-error=deprecated-declarations -Wno-braced-scalar-init"
+				["WARNING_CFLAGS"] = "-Wextra -Wno-error=deprecated-declarations -Wno-braced-scalar-init -Wno-missing-field-initializers -Wno-ignored-qualifiers"
 			}
 
             links { 
@@ -236,7 +237,7 @@ if not Project then
 			-- Could not manage to get xcode to co-operate in any other less specific manner of setting the flags.
 			-- These disables are to do with warnings in generated code that we should get around to dealing with.
 			xcodebuildsettings {
-				["WARNING_CFLAGS"] = "-Wno-error=deprecated-declarations -Wno-braced-scalar-init"
+				["WARNING_CFLAGS"] = "-Wextra -Wno-error=deprecated-declarations -Wno-braced-scalar-init -Wno-missing-field-initializers -Wno-ignored-qualifiers"
 			}
 
             links {
@@ -254,9 +255,11 @@ if not Project then
             buildoptions {
                 "--no-entry",           -- remove default library entry point
                 "-pthread",             -- enable threading
-                "-fwasm-exceptions",     -- enable native wasm exceptions
-				"-Wno-error=deprecated-declarations", --Don't error on deprecation warnings, this is because we use Uri a lot in our services generated code, which has deprecation warnings for some unused but still generated endpoints.
-				"-Wno-braced-scalar-init" -- Don't warn against doing stuff like `return {0}`, which we do in the interop output.
+                "-fwasm-exceptions",    -- enable native wasm exceptions
+                "-Wno-error=deprecated-declarations", --Don't error on deprecation warnings, this is because we use Uri a lot in our services generated code, which has deprecation warnings for some unused but still generated endpoints.
+                "-Wno-braced-scalar-init", -- Don't warn against doing stuff like `return {0}`, which we do in the interop output.
+                "-Wno-missing-field-initializers", -- Don't warn against missing field initializers (because of the wrapper generator)
+                "-Wno-ignored-qualifiers" -- Don't warn against ignored qualifiers
             }
 
             linkoptions { 

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -416,7 +416,7 @@ void Free(void* Pointer) { CSP_FREE(Pointer); }
 
 void* ModuleHandle = nullptr;
 
-void* GetFunctionAddress(const csp::common::String& Name)
+void* GetFunctionAddress([[maybe_unused]] const csp::common::String& Name)
 {
 #if defined(CSP_WASM)
     return nullptr;

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -281,15 +281,15 @@ EndpointURIs CSPFoundation::CreateEndpointsFromRoot(const csp::common::String& E
 
     const std::string MultiplayerServiceURI = TranslateEndpointRootURIToMultiplayerServiceUri(RootURI);
 
-    EndpointURIs Endpoints;
-    Endpoints.UserServiceURI = CSP_TEXT(UserServiceURI.c_str());
-    Endpoints.PrototypeServiceURI = CSP_TEXT(PrototypeServiceURI.c_str());
-    Endpoints.SpatialDataServiceURI = CSP_TEXT(SpatialDataServiceURI.c_str());
-    Endpoints.MultiplayerServiceURI = CSP_TEXT(MultiplayerServiceURI.c_str());
-    Endpoints.AggregationServiceURI = CSP_TEXT(AggregationServiceURI.c_str());
-    Endpoints.TrackingServiceURI = CSP_TEXT(TrackingServiceURI.c_str());
+    EndpointURIs EndpointsURI;
+    EndpointsURI.UserServiceURI = CSP_TEXT(UserServiceURI.c_str());
+    EndpointsURI.PrototypeServiceURI = CSP_TEXT(PrototypeServiceURI.c_str());
+    EndpointsURI.SpatialDataServiceURI = CSP_TEXT(SpatialDataServiceURI.c_str());
+    EndpointsURI.MultiplayerServiceURI = CSP_TEXT(MultiplayerServiceURI.c_str());
+    EndpointsURI.AggregationServiceURI = CSP_TEXT(AggregationServiceURI.c_str());
+    EndpointsURI.TrackingServiceURI = CSP_TEXT(TrackingServiceURI.c_str());
 
-    return Endpoints;
+    return EndpointsURI;
 }
 
 bool CSPFoundation::Initialise(const csp::common::String& EndpointRootURI, const csp::common::String& InTenant)

--- a/Library/src/Common/DateTime.cpp
+++ b/Library/src/Common/DateTime.cpp
@@ -88,8 +88,21 @@ DateTime::DateTime(const csp::common::String& DateString)
         &OffsetHours, &OffsetMinutes);
 #endif
 
-    std::tm TM = { Second, Minute, Hour, Day, Month - 1, Year - 1900 };
-    TM.tm_isdst = -1;
+    std::tm TM = {
+        Second, // tm_sec
+        Minute, // tm_min
+        Hour, // tm_hour
+        Day, // tm_mday
+        Month - 1, // tm_mon
+        Year - 1900, // tm_year
+        0, // tm_wday
+        0, // tm_yday
+        -1, // tm_isdst
+#ifndef CSP_WINDOWS
+        0, // tm_gmtoff
+        nullptr // tm_zone
+#endif
+    };
 
     if (OffsetModifier == '-')
     {

--- a/Library/src/Common/Encode.cpp
+++ b/Library/src/Common/Encode.cpp
@@ -69,7 +69,7 @@ csp::common::String Decode::URI(const csp::common::String& UriToDecode, bool Dou
     std::string EncodedString(UriToDecode.c_str());
     std::string RawString;
 
-    for (int i = 0; i < EncodedString.length(); i++)
+    for (size_t i = 0; i < EncodedString.length(); i++)
     {
         if (EncodedString[i] != '%')
         {

--- a/Library/src/Common/MimeTypeHelper.cpp
+++ b/Library/src/Common/MimeTypeHelper.cpp
@@ -38,7 +38,7 @@ String& MimeTypeHelper::GetMimeType(const String& FilePath)
 
     auto LowerChars = std::make_unique<char[]>(Length);
 
-    for (auto i = 0; i < Length; ++i)
+    for (size_t i = 0; i < Length; ++i)
     {
         LowerChars[i] = static_cast<char>(std::tolower(Chars[i]));
     }

--- a/Library/src/Common/String.cpp
+++ b/Library/src/Common/String.cpp
@@ -358,7 +358,7 @@ String String::ToLower() const
     auto Length = Copy.ImplPtr->Length;
     auto Text = Copy.ImplPtr->Text;
 
-    for (int i = 0; i < Length; ++i)
+    for (size_t i = 0; i < Length; ++i)
     {
         Text[i] = static_cast<char>(std::tolower(Text[i]));
     }
@@ -375,7 +375,7 @@ String String::Join(const List<String>& Parts, Optional<char> Separator)
 
     size_t Length = 0;
 
-    for (int i = 0; i < Parts.Size(); ++i)
+    for (size_t i = 0; i < Parts.Size(); ++i)
     {
         Length += Parts[i].Length();
     }
@@ -439,7 +439,7 @@ String String::Join(const std::initializer_list<String>& Parts, Optional<char> S
 
     size_t Length = 0;
 
-    for (int i = 0; i < Parts.size(); ++i)
+    for (size_t i = 0; i < Parts.size(); ++i)
     {
         Length += (Parts.begin() + i)->Length();
     }

--- a/Library/src/Events/Event.cpp
+++ b/Library/src/Events/Event.cpp
@@ -35,9 +35,9 @@ public:
     void AddFloat(const char* Key, const float Value);
     void AddBool(const char* Key, const bool Value);
 
-    const int GetInt(const char* Key) const;
+    int GetInt(const char* Key) const;
     const char* GetString(const char* Key) const;
-    const float GetFloat(const char* Key) const;
+    float GetFloat(const char* Key) const;
     bool GetBool(const char* Key) const;
 
 private:
@@ -148,7 +148,7 @@ void EventPayloadImpl::AddBool(const char* Key, const bool Value)
     Parameters.insert(ParamMap::value_type(Key, Param));
 }
 
-const int EventPayloadImpl::GetInt(const char* Key) const
+int EventPayloadImpl::GetInt(const char* Key) const
 {
     ParamMap::const_iterator it = Parameters.find(Key);
     if (it != Parameters.end())
@@ -172,7 +172,7 @@ const char* EventPayloadImpl::GetString(const char* Key) const
     return nullptr;
 }
 
-const float EventPayloadImpl::GetFloat(const char* Key) const
+float EventPayloadImpl::GetFloat(const char* Key) const
 {
     ParamMap::const_iterator it = Parameters.find(Key);
     if (it != Parameters.end())
@@ -212,11 +212,11 @@ void Event::AddFloat(const char* Key, const float Value) { Impl->AddFloat(Key, V
 
 void Event::AddBool(const char* Key, const bool Value) { Impl->AddBool(Key, Value); }
 
-const int Event::GetInt(const char* Key) const { return Impl->GetInt(Key); }
+int Event::GetInt(const char* Key) const { return Impl->GetInt(Key); }
 
 const char* Event::GetString(const char* Key) const { return Impl->GetString(Key); }
 
-const float Event::GetFloat(const char* Key) const { return Impl->GetFloat(Key); }
+float Event::GetFloat(const char* Key) const { return Impl->GetFloat(Key); }
 
 bool Event::GetBool(const char* Key) const { return Impl->GetBool(Key); }
 

--- a/Library/src/Events/Event.h
+++ b/Library/src/Events/Event.h
@@ -38,9 +38,9 @@ public:
     void AddBool(const char* Key, const bool Value);
 
     // Get Payload params
-    const int GetInt(const char* Key) const;
+    int GetInt(const char* Key) const;
     const char* GetString(const char* Key) const;
-    const float GetFloat(const char* Key) const;
+    float GetFloat(const char* Key) const;
     bool GetBool(const char* Key) const;
 
     const EventId& GetId() const;

--- a/Library/src/Json/JsonSerializer.cpp
+++ b/Library/src/Json/JsonSerializer.cpp
@@ -37,7 +37,7 @@ void JsonSerializer::SerializeValue(const csp::common::String& Value) { Writer.S
 
 void JsonSerializer::SerializeValue(const char* Value) { Writer.String(Value); }
 
-void JsonSerializer::SerializeValue(std::nullptr_t Value) { Writer.Null(); }
+void JsonSerializer::SerializeValue(std::nullptr_t /*Value*/) { Writer.Null(); }
 
 void JsonDeserializer::DeserializeValue(int32_t& Value) const { Value = ValueStack.top()->GetInt(); }
 

--- a/Library/src/Json/JsonSerializer.cpp
+++ b/Library/src/Json/JsonSerializer.cpp
@@ -35,8 +35,6 @@ void JsonSerializer::SerializeValue(double Value) { Writer.Double(Value); }
 
 void JsonSerializer::SerializeValue(const csp::common::String& Value) { Writer.String(Value); }
 
-void JsonSerializer::SerializeValue(const char* Value) { Writer.String(Value); }
-
 void JsonSerializer::SerializeValue(std::nullptr_t /*Value*/) { Writer.Null(); }
 
 void JsonDeserializer::DeserializeValue(int32_t& Value) const { Value = ValueStack.top()->GetInt(); }
@@ -54,6 +52,4 @@ void JsonDeserializer::DeserializeValue(float& Value) const { Value = static_cas
 void JsonDeserializer::DeserializeValue(double& Value) const { Value = ValueStack.top()->GetDouble(); }
 
 void JsonDeserializer::DeserializeValue(csp::common::String& Value) const { Value = ValueStack.top()->GetString(); }
-
-void JsonDeserializer::DeserializeValue(const char* Value) const { Value = ValueStack.top()->GetString(); }
 } // namespace csp::json

--- a/Library/src/Json/JsonSerializer.h
+++ b/Library/src/Json/JsonSerializer.h
@@ -132,7 +132,7 @@ public:
     /// If the member is another custom type, this was internally call FromJson on that type.
     /// @param Key const char* : The key which references this member.
     /// @param Val T& : The member to deserialize to.
-    template <typename T> const void DeserializeMember(const char* Key, T& Val) const
+    template <typename T> void DeserializeMember(const char* Key, T& Val) const
     {
         ValueStack.push(&(*ValueStack.top())[Key]);
         DeserializeValue(Val);

--- a/Library/src/Json/JsonSerializer.h
+++ b/Library/src/Json/JsonSerializer.h
@@ -92,7 +92,6 @@ private:
     void SerializeValue(float Value);
     void SerializeValue(double Value);
     void SerializeValue(const csp::common::String& Value);
-    void SerializeValue(const char* Value);
     void SerializeValue(std::nullptr_t Value);
 
     template <typename T> void SerializeValue(const csp::common::Array<T>& Value);
@@ -177,7 +176,6 @@ private:
     void DeserializeValue(float& Value) const;
     void DeserializeValue(double& Value) const;
     void DeserializeValue(csp::common::String& Value) const;
-    void DeserializeValue(const char* Value) const;
 
     template <typename T> void DeserializeValue(csp::common::Array<T>& Value) const;
     template <typename T> void DeserializeValue(csp::common::List<T>& Value) const;

--- a/Library/src/Memory/Allocator.h
+++ b/Library/src/Memory/Allocator.h
@@ -39,7 +39,7 @@ public:
     virtual void Deallocate(void* Ptr) = 0;
     virtual void Deallocate(void* Ptr, size_t Bytes) = 0;
 
-    virtual const size_t GetAllocatedBytes() const = 0;
+    virtual size_t GetAllocatedBytes() const = 0;
 };
 
 } // namespace csp::memory

--- a/Library/src/Memory/Allocators/StandardAllocator.h
+++ b/Library/src/Memory/Allocators/StandardAllocator.h
@@ -97,7 +97,7 @@ template <typename TLockTrait> StandardAllocator<TLockTrait>::~StandardAllocator
 
 template <typename TLockTrait> void* StandardAllocator<TLockTrait>::Allocate(size_t n) { return Allocate(n, CSP_ALLOCATOR_MIN_ALIGNMENT); }
 
-template <typename TLockTrait> void* StandardAllocator<TLockTrait>::Allocate(size_t n, std::align_val_t alignment)
+template <typename TLockTrait> void* StandardAllocator<TLockTrait>::Allocate(size_t n, [[maybe_unused]] std::align_val_t alignment)
 {
     AllocatedBytes += n;
 
@@ -135,7 +135,7 @@ template <typename TLockTrait> void* StandardAllocator<TLockTrait>::Reallocate(v
     return Reallocate(p, n, CSP_ALLOCATOR_MIN_ALIGNMENT);
 }
 
-template <typename TLockTrait> void* StandardAllocator<TLockTrait>::Reallocate(void* p, size_t n, std::align_val_t alignment)
+template <typename TLockTrait> void* StandardAllocator<TLockTrait>::Reallocate(void* p, size_t n, [[maybe_unused]] std::align_val_t alignment)
 {
     // TODO increment with the difference between the old allocation and the new one
     // AllocatedBytes += n;

--- a/Library/src/Memory/Allocators/StandardAllocator.h
+++ b/Library/src/Memory/Allocators/StandardAllocator.h
@@ -80,7 +80,7 @@ public:
     void Deallocate(void* Ptr) override;
     void Deallocate(void* Ptr, size_t Bytes) override;
 
-    const size_t GetAllocatedBytes() const override;
+    size_t GetAllocatedBytes() const override;
 
 private:
     std::atomic<size_t> AllocatedBytes;
@@ -191,6 +191,6 @@ template <typename TLockTrait> void StandardAllocator<TLockTrait>::Deallocate(vo
     }
 }
 
-template <typename TLockTrait> const size_t StandardAllocator<TLockTrait>::GetAllocatedBytes() const { return AllocatedBytes; }
+template <typename TLockTrait> size_t StandardAllocator<TLockTrait>::GetAllocatedBytes() const { return AllocatedBytes; }
 
 } // namespace csp::memory

--- a/Library/src/Memory/Memory.cpp
+++ b/Library/src/Memory/Memory.cpp
@@ -62,14 +62,17 @@ void operator delete(void* Ptr, std::align_val_t /*Alignment*/, csp::memory::All
 
 void operator delete[](void* Ptr, csp::memory::Allocator* Allocator) { csp::memory::Deallocate(Ptr, Allocator); }
 
-void operator delete[](void* Ptr, std::align_val_t Alignment, csp::memory::Allocator* Allocator) { csp::memory::Deallocate(Ptr, Allocator); }
+void operator delete[](void* Ptr, std::align_val_t /*Alignment*/, csp::memory::Allocator* Allocator) { csp::memory::Deallocate(Ptr, Allocator); }
 
 // Overrides for EASTL Debug builds when using the standard allocator
 // Note that these needs to call global new/malloc, since they will be deleted with delete[] in standard EASTL allocator
-void* operator new[](size_t size, const char* pName, int flags, unsigned debugFlags, const char* file, int line) { return std::malloc(size); }
+void* operator new[](size_t size, const char* /*pName*/, int /*flags*/, unsigned /*debugFlags*/, const char* /*file*/, int /*line*/)
+{
+    return std::malloc(size);
+}
 
-void* operator new[](
-    size_t size, size_t alignment, size_t alignmentOffset, const char* pName, int flags, unsigned debugFlags, const char* file, int line)
+void* operator new[](size_t size, size_t /*alignment*/, size_t /*alignmentOffset*/, const char* /*pName*/, int /*flags*/, unsigned /*debugFlags*/,
+    const char* /*file*/, int /*line*/)
 {
     return std::malloc(size);
 }

--- a/Library/src/Memory/Memory.h
+++ b/Library/src/Memory/Memory.h
@@ -131,7 +131,7 @@ template <typename T, typename std::enable_if_t<!std::is_integral_v<T>>*> inline
         auto BufferSize = *(size_t*)RealPointer;
         auto Count = BufferSize / sizeof(T);
 
-        for (int i = 0; i < Count; ++i)
+        for (unsigned long long i = 0; i < Count; ++i)
         {
             (Ptr + i)->~T();
         }

--- a/Library/src/Memory/SimpleBufferPool.cpp
+++ b/Library/src/Memory/SimpleBufferPool.cpp
@@ -25,7 +25,7 @@ SimpleBufferPool::SimpleBufferPool(size_t BufferSize, size_t InitialPoolSize)
 {
     Buffers.reserve(InitialPoolSize);
 
-    for (int i = 0; i < InitialPoolSize; ++i)
+    for (size_t i = 0; i < InitialPoolSize; ++i)
     {
         Buffers[i] = CSP_NEW unsigned char[BufferSize];
     }

--- a/Library/src/Memory/SimpleRingBuffer.h
+++ b/Library/src/Memory/SimpleRingBuffer.h
@@ -30,7 +30,7 @@ public:
 
     inline bool IsDataAvailable() { return AvailableDataLength > 0; }
 
-    inline const size_t GetAvailableDataLength() { return AvailableDataLength; }
+    inline size_t GetAvailableDataLength() { return AvailableDataLength; }
 
     size_t Read(void* OutBuffer, size_t Length);
     void Write(const void* InBuffer, size_t Length);

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -72,7 +72,7 @@ const ReplicatedValue& ComponentBase::GetProperty(uint32_t Key) const
     return InvalidValue;
 }
 
-const bool ComponentBase::GetBooleanProperty(uint32_t Key) const
+bool ComponentBase::GetBooleanProperty(uint32_t Key) const
 {
     const auto& RepVal = GetProperty(Key);
 
@@ -86,7 +86,7 @@ const bool ComponentBase::GetBooleanProperty(uint32_t Key) const
     return false;
 }
 
-const int64_t ComponentBase::GetIntegerProperty(uint32_t Key) const
+int64_t ComponentBase::GetIntegerProperty(uint32_t Key) const
 {
     const auto& RepVal = GetProperty(Key);
 
@@ -100,7 +100,7 @@ const int64_t ComponentBase::GetIntegerProperty(uint32_t Key) const
     return 0;
 }
 
-const float ComponentBase::GetFloatProperty(uint32_t Key) const
+float ComponentBase::GetFloatProperty(uint32_t Key) const
 {
     const auto& RepVal = GetProperty(Key);
 

--- a/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
@@ -84,7 +84,7 @@ void AvatarSpaceComponent::SetAvatarPlayMode(AvatarPlayMode Value)
     SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarPlayMode), static_cast<int64_t>(Value));
 }
 
-const int64_t AvatarSpaceComponent::GetAvatarMeshIndex() const
+int64_t AvatarSpaceComponent::GetAvatarMeshIndex() const
 {
     return GetIntegerProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarMeshIndex));
 }
@@ -114,7 +114,7 @@ void AvatarSpaceComponent::SetCustomAvatarUrl(const csp::common::String& Value)
     SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::CustomAvatarUrl), Value);
 }
 
-const bool AvatarSpaceComponent::GetIsHandIKEnabled() const
+bool AvatarSpaceComponent::GetIsHandIKEnabled() const
 {
     return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsHandIKEnabled));
 }
@@ -151,7 +151,7 @@ void AvatarSpaceComponent::SetHeadRotation(const csp::common::Vector4& Value)
     SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::HeadRotation), Value);
 }
 
-const float AvatarSpaceComponent::GetWalkRunBlendPercentage() const
+float AvatarSpaceComponent::GetWalkRunBlendPercentage() const
 {
     return GetFloatProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::WalkRunBlendPercentage));
 }
@@ -161,7 +161,7 @@ void AvatarSpaceComponent::SetWalkRunBlendPercentage(float Value)
     SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::WalkRunBlendPercentage), Value);
 }
 
-const float AvatarSpaceComponent::GetTorsoTwistAlpha() const
+float AvatarSpaceComponent::GetTorsoTwistAlpha() const
 {
     return GetFloatProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::TorsoTwistAlpha));
 }

--- a/Library/src/Multiplayer/Components/ConversationSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ConversationSpaceComponent.cpp
@@ -408,7 +408,7 @@ void ConversationSpaceComponent::OnLocalDelete()
 {
     // The component has been deleted by this client,
     // also delete the conversation
-    const auto Callback = [](const NullResult& Result) {};
+    const auto Callback = [](const NullResult& /*Result*/) {};
     DeleteConversation(Callback);
 }
 

--- a/Library/src/Multiplayer/Components/CustomSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CustomSpaceComponent.cpp
@@ -154,7 +154,7 @@ void CustomSpaceComponent::RemoveKey(const csp::common::String& Key)
         KeyList.RemoveItem(Key);
         if (KeyList.Size() != 0)
         {
-            for (int i = 0; i < KeyList.Size(); ++i)
+            for (size_t i = 0; i < KeyList.Size(); ++i)
             {
                 if (i == 0)
                 {

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -102,7 +102,7 @@ void HotspotSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast
 
 void HotspotSpaceComponent::OnLocalDelete()
 {
-    auto CB = [](const csp::systems::NullResult& Result) {
+    auto CB = [](const csp::systems::NullResult& /*Result*/) {
 
     };
 

--- a/Library/src/Multiplayer/Components/SplineSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/SplineSpaceComponent.cpp
@@ -37,7 +37,7 @@ csp::common::Vector3 SplineSpaceComponent::GetLocationAlongSpline(float Normalis
     {
         std::vector<tinyspline::real> Internalpoints;
 
-        for (int i = 0; i < ListPoints.Size(); ++i)
+        for (size_t i = 0; i < ListPoints.Size(); ++i)
         {
             Internalpoints.push_back(static_cast<double>(ListPoints[i].X));
             Internalpoints.push_back(static_cast<double>(ListPoints[i].Y));
@@ -75,7 +75,7 @@ void SplineSpaceComponent::SetWaypoints(const csp::common::List<csp::common::Vec
 {
     SetProperty(static_cast<uint32_t>(SplinePropertyKeys::Waypoints), (int64_t)Waypoints.Size());
 
-    for (int i = 0; i < Waypoints.Size(); ++i)
+    for (size_t i = 0; i < Waypoints.Size(); ++i)
     {
         SetProperty(static_cast<uint32_t>((static_cast<int>(SplinePropertyKeys::Waypoints) + 1) + i), Waypoints[i]);
     }

--- a/Library/src/Multiplayer/Conversation/Conversation.cpp
+++ b/Library/src/Multiplayer/Conversation/Conversation.cpp
@@ -127,7 +127,7 @@ void MessageCollectionResult::FillMessageInfoCollection(const csp::common::Array
 
     MessageInfo MsgInfo;
 
-    for (auto idx = 0; idx < MessagesAssetCollections.Size(); ++idx)
+    for (size_t idx = 0; idx < MessagesAssetCollections.Size(); ++idx)
     {
         MsgInfo = systems::ConversationSystemHelpers::GetMessageInfoFromMessageAssetCollection(MessagesAssetCollections[idx]);
         ConversationMessages[idx] = MsgInfo;

--- a/Library/src/Multiplayer/Conversation/Conversation.cpp
+++ b/Library/src/Multiplayer/Conversation/Conversation.cpp
@@ -80,14 +80,14 @@ MessageInfo::MessageInfo()
 {
 }
 
-MessageInfo::MessageInfo(const csp::common::String& ConversationId, bool IsConversation, const csp::common::String& Message)
+MessageInfo::MessageInfo(const csp::common::String& ConversationId, bool /*IsConversation*/, const csp::common::String& Message)
     : ConversationId(ConversationId)
     , Message(Message)
 {
 }
 
 MessageInfo::MessageInfo(
-    const csp::common::String& ConversationId, bool IsConversation, const csp::common::String& Message, const csp::common::String& MessageId)
+    const csp::common::String& ConversationId, bool /*IsConversation*/, const csp::common::String& Message, const csp::common::String& MessageId)
     : ConversationId(ConversationId)
     , Message(Message)
     , MessageId(MessageId)
@@ -171,9 +171,9 @@ const csp::common::Map<csp::common::String, csp::systems::Asset>& AnnotationThum
 
 uint64_t AnnotationThumbnailCollectionResult::GetTotalCount() const { return AnnotationThumbnailAssetsMap.Size(); }
 
-void AnnotationThumbnailCollectionResult::ParseAssets(const systems::AssetsResult& Result)
+void AnnotationThumbnailCollectionResult::ParseAssets(const systems::AssetsResult& AssetResult)
 {
-    common::Array<systems::Asset> Assets = Result.GetAssets();
+    common::Array<systems::Asset> Assets = AssetResult.GetAssets();
 
     for (size_t i = 0; i < Assets.Size(); ++i)
     {

--- a/Library/src/Multiplayer/Election/ClientElectionManager.cpp
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.cpp
@@ -88,7 +88,7 @@ ClientElectionManager::~ClientElectionManager()
     }
 }
 
-void ClientElectionManager::OnConnect(const SpaceEntitySystem::SpaceEntityList& Avatars, const SpaceEntitySystem::SpaceEntityList& Objects)
+void ClientElectionManager::OnConnect(const SpaceEntitySystem::SpaceEntityList& Avatars, const SpaceEntitySystem::SpaceEntityList& /*Objects*/)
 {
     CSP_LOG_MSG(csp::systems::LogLevel::Verbose, "ClientElectionManager::OnConnect called");
 
@@ -149,25 +149,25 @@ void ClientElectionManager::OnLocalClientAdd(const SpaceEntity* ClientAvatar, co
     }
 }
 
-void ClientElectionManager::OnClientAdd(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& Avatars)
+void ClientElectionManager::OnClientAdd(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& /*Avatars*/)
 {
     CSP_LOG_FORMAT(csp::systems::LogLevel::VeryVerbose, "ClientElectionManager::OnClientAdd called : ClientId=%d", ClientAvatar->GetOwnerId());
     AddClientUsingAvatar(ClientAvatar);
 }
 
-void ClientElectionManager::OnClientRemove(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& Avatars)
+void ClientElectionManager::OnClientRemove(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& /*Avatars*/)
 {
     CSP_LOG_FORMAT(csp::systems::LogLevel::VeryVerbose, "ClientElectionManager::OnClientRemove called : ClientId=%d", ClientAvatar->GetOwnerId());
     RemoveClientUsingAvatar(ClientAvatar);
 }
 
-void ClientElectionManager::OnObjectAdd(const SpaceEntity* Object, const SpaceEntitySystem::SpaceEntityList& Objects)
+void ClientElectionManager::OnObjectAdd(const SpaceEntity* /*Object*/, const SpaceEntitySystem::SpaceEntityList& /*Objects*/)
 {
     CSP_LOG_MSG(csp::systems::LogLevel::VeryVerbose, "ClientElectionManager::OnObjectAdd called");
     // @Todo - This event allows us to track individual object ownership
 }
 
-void ClientElectionManager::OnObjectRemove(const SpaceEntity* Object, const SpaceEntitySystem::SpaceEntityList& Objects)
+void ClientElectionManager::OnObjectRemove(const SpaceEntity* /*Object*/, const SpaceEntitySystem::SpaceEntityList& /*Objects*/)
 {
     CSP_LOG_MSG(csp::systems::LogLevel::VeryVerbose, "ClientElectionManager::OnObjectRemove called");
     // @Todo - This event allows us to track individual object ownership
@@ -483,10 +483,10 @@ void ClientElectionManager::BindNetworkEvents()
     EventBus* EventBus = SystemsManager.GetEventBus();
 
     EventBus->ListenNetworkEvent(
-        ClientElectionMessage, [this](bool ok, const csp::common::Array<ReplicatedValue>& Data) { this->OnClientElectionEvent(Data); });
+        ClientElectionMessage, [this](bool /*ok*/, const csp::common::Array<ReplicatedValue>& Data) { this->OnClientElectionEvent(Data); });
 
     EventBus->ListenNetworkEvent(
-        RemoteRunScriptMessage, [this](bool ok, const csp::common::Array<ReplicatedValue>& Data) { this->OnRemoteRunScriptEvent(Data); });
+        RemoteRunScriptMessage, [this](bool /*ok*/, const csp::common::Array<ReplicatedValue>& Data) { this->OnRemoteRunScriptEvent(Data); });
 }
 
 void ClientElectionManager::UnBindNetworkEvents()

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -69,8 +69,6 @@ std::pair<ErrorCode, std::string> MultiplayerConnection::ParseMultiplayerErrorFr
     {
         return ParseMultiplayerError(e);
     }
-
-    return { ErrorCode::Unknown, "MultiplayerConnection::ParseMultiplayerErrorFromExceptionPtr, Unexpectedly no exception was thrown." };
 }
 
 std::pair<ErrorCode, std::string> MultiplayerConnection::ParseMultiplayerError(const std::exception& Exception)

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -235,7 +235,7 @@ auto MultiplayerConnection::DeleteEntities(uint64_t EntityId) const
         }
 
         std::function<void(signalr::value, std::exception_ptr)> LocalCallback
-            = [EntitiesDeletedEvent](signalr::value Result, std::exception_ptr Except)
+            = [EntitiesDeletedEvent](signalr::value /*Result*/, std::exception_ptr Except)
         {
             if (Except != nullptr)
             {
@@ -324,7 +324,7 @@ std::function<async::task<void>()> MultiplayerConnection::StartListening()
         }
 
         std::function<void(signalr::value, std::exception_ptr)> LocalCallback
-            = [StartListeningEvent](signalr::value Result, std::exception_ptr Except)
+            = [StartListeningEvent](signalr::value /*Result*/, std::exception_ptr Except)
         {
             if (Except != nullptr)
             {
@@ -508,7 +508,7 @@ void MultiplayerConnection::SetScopes(csp::common::String InSpaceId, ErrorCodeCa
         return;
     }
 
-    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value Result, std::exception_ptr Except)
+    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value /*Result*/, std::exception_ptr Except)
     {
         if (Except != nullptr)
         {
@@ -542,7 +542,7 @@ void MultiplayerConnection::ResetScopes(ErrorCodeCallbackHandler Callback)
         return;
     }
 
-    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value Result, std::exception_ptr Except)
+    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value /*Result*/, std::exception_ptr Except)
     {
         if (Except != nullptr)
         {
@@ -569,7 +569,7 @@ void MultiplayerConnection::StopListening(ErrorCodeCallbackHandler Callback)
         return;
     }
 
-    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value Result, std::exception_ptr Except)
+    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value /*Result*/, std::exception_ptr Except)
     {
         if (Except != nullptr)
         {
@@ -611,7 +611,7 @@ CSP_ASYNC_RESULT void MultiplayerConnection::SetAllowSelfMessagingFlag(const boo
     }
 
     std::function<void(signalr::value, std::exception_ptr)> LocalCallback
-        = [this, Callback, InAllowSelfMessaging](signalr::value Result, std::exception_ptr Except)
+        = [this, Callback, InAllowSelfMessaging](signalr::value /*Result*/, std::exception_ptr Except)
     {
         if (Except != nullptr)
         {

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -63,7 +63,14 @@ std::pair<ErrorCode, std::string> MultiplayerConnection::ParseMultiplayerErrorFr
 {
     try
     {
-        rethrow_exception(Exception);
+        if (Exception)
+        {
+            rethrow_exception(Exception);
+        }
+        else
+        {
+            return { ErrorCode::Unknown, "MultiplayerConnection::ParseMultiplayerErrorFromExceptionPtr, Unexpectedly no exception was thrown." };
+        }
     }
     catch (const std::exception& e)
     {

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -52,7 +52,7 @@ void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventN
 
     csp::multiplayer::ISignalRConnection* ISignalRConnectionPtr = static_cast<csp::multiplayer::ISignalRConnection*>(Connection);
 
-    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value Result, std::exception_ptr Except)
+    std::function<void(signalr::value, std::exception_ptr)> LocalCallback = [Callback](signalr::value /*Result*/, std::exception_ptr Except)
     {
         if (Except != nullptr)
         {

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -67,7 +67,7 @@ void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventN
 
     std::map<uint64_t, signalr::value> Components;
 
-    for (int i = 0; i < Arguments.Size(); ++i)
+    for (size_t i = 0; i < Arguments.Size(); ++i)
     {
         switch (Arguments[i].GetReplicatedValueType())
         {

--- a/Library/src/Multiplayer/Script/ComponentBinding/CustomSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/CustomSpaceComponentScriptInterface.cpp
@@ -94,7 +94,7 @@ std::vector<std::string> CustomSpaceComponentScriptInterface::GetCustomPropertyK
     std::vector<std::string> ReturnValue;
     csp::common::List<csp::common::String> Keys = static_cast<CustomSpaceComponent*>(Component)->GetCustomPropertyKeys();
 
-    for (int i = 0; i < Keys.Size(); ++i)
+    for (size_t i = 0; i < Keys.Size(); ++i)
     {
         ReturnValue.push_back(Keys[i].c_str());
     }

--- a/Library/src/Multiplayer/Script/ComponentBinding/SplineSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/SplineSpaceComponentScriptInterface.cpp
@@ -40,7 +40,7 @@ std::vector<ComponentScriptInterface::Vector3> SplineSpaceComponentScriptInterfa
 
     auto Result = static_cast<SplineSpaceComponent*>(Component)->GetWaypoints();
 
-    for (int i = 0; i < Result.Size(); ++i)
+    for (size_t i = 0; i < Result.Size(); ++i)
     {
         ReturnList.push_back({ Result[i].X, Result[i].Y, Result[i].Z });
     }
@@ -52,7 +52,7 @@ void SplineSpaceComponentScriptInterface::SetWaypoints(std::vector<Vector3> Wayp
 {
     csp::common::List<csp::common::Vector3> ConvertedList;
 
-    for (int i = 0; i < Waypoints.size(); ++i)
+    for (size_t i = 0; i < Waypoints.size(); ++i)
     {
         ConvertedList.Append({ Waypoints[i][0], Waypoints[i][1], Waypoints[i][2] });
     }

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -147,7 +147,7 @@ public:
             for (size_t i = 0; i < EntitySystem->GetNumEntities(); ++i)
             {
                 const SpaceEntity* Entity = EntitySystem->GetEntityByIndex(i);
-                if (static_cast<int32_t>(Entity->GetId()) == EntityId)
+                if (Entity->GetId() == static_cast<uint64_t>(EntityId))
                 {
                     IndexOfEntity = static_cast<int32_t>(i);
                     break;
@@ -170,7 +170,7 @@ public:
             for (size_t i = 0; i < EntitySystem->GetNumEntities(); ++i)
             {
                 SpaceEntity* Entity = EntitySystem->GetEntityByIndex(i);
-                if (static_cast<int32_t>(Entity->GetId()) == EntityId)
+                if (Entity->GetId() == static_cast<uint64_t>(EntityId))
                 {
                     ScriptInterface = Entity->GetScriptInterface();
                     break;

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -147,7 +147,7 @@ public:
             for (size_t i = 0; i < EntitySystem->GetNumEntities(); ++i)
             {
                 const SpaceEntity* Entity = EntitySystem->GetEntityByIndex(i);
-                if (Entity->GetId() == EntityId)
+                if (static_cast<int32_t>(Entity->GetId()) == EntityId)
                 {
                     IndexOfEntity = static_cast<int32_t>(i);
                     break;
@@ -170,7 +170,7 @@ public:
             for (size_t i = 0; i < EntitySystem->GetNumEntities(); ++i)
             {
                 SpaceEntity* Entity = EntitySystem->GetEntityByIndex(i);
-                if (Entity->GetId() == EntityId)
+                if (static_cast<int32_t>(Entity->GetId()) == EntityId)
                 {
                     ScriptInterface = Entity->GetScriptInterface();
                     break;
@@ -213,7 +213,7 @@ public:
         {
             EntitySystem->LockEntityUpdate();
 
-            for (int i = 0; i < EntitySystem->GetRootHierarchyEntities()->Size(); ++i)
+            for (size_t i = 0; i < EntitySystem->GetRootHierarchyEntities()->Size(); ++i)
             {
                 SpaceEntity* Entity = (*EntitySystem->GetRootHierarchyEntities())[i];
                 RootHierarchyEntities.push_back(Entity->GetScriptInterface());

--- a/Library/src/Multiplayer/Script/EntityScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptInterface.cpp
@@ -232,7 +232,7 @@ std::vector<ComponentScriptInterface*> EntityScriptInterface::GetComponents()
         const csp::common::Map<uint16_t, ComponentBase*>& ComponentMap = *Entity->GetComponents();
         const auto ComponentKeys = ComponentMap.Keys();
 
-        for (int i = 0; i < ComponentKeys->Size(); ++i)
+        for (size_t i = 0; i < ComponentKeys->Size(); ++i)
         {
             ComponentBase* Component = ComponentMap[ComponentKeys->operator[](i)];
 

--- a/Library/src/Multiplayer/Script/EntityScriptInterface.h
+++ b/Library/src/Multiplayer/Script/EntityScriptInterface.h
@@ -89,7 +89,7 @@ template <typename ScriptInterface, ComponentType Type> std::vector<ScriptInterf
         const auto& ComponentMap = *Entity->GetComponents();
         const auto ComponentKeys = ComponentMap.Keys();
 
-        for (int i = 0; i < ComponentKeys->Size(); ++i)
+        for (size_t i = 0; i < ComponentKeys->Size(); ++i)
         {
             ComponentBase* Component = ComponentMap[ComponentKeys->operator[](i)];
 

--- a/Library/src/Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.cpp
@@ -209,7 +209,7 @@ size_t CSPWebSocketClientEmscripten::ProcessReceivedMessage(uint8_t* RecvData, u
     // Handshake needs to be handled differently as it is in JSON format
     if (!ReceivedHandshake)
     {
-        int Idx;
+        uint32_t Idx;
         for (Idx = 0; Idx < NumRecvBytes; ++Idx)
         {
             // JSON messages are terminated with the 0x1E character
@@ -229,8 +229,8 @@ size_t CSPWebSocketClientEmscripten::ProcessReceivedMessage(uint8_t* RecvData, u
     }
     else
     {
-        auto Length = 0;
-        int Idx;
+        uint32_t Length = 0;
+        uint32_t Idx;
 
         for (Idx = 0; Idx < 5; ++Idx)
         {

--- a/Library/src/Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.cpp
@@ -36,7 +36,7 @@ constexpr const unsigned short SOCKET_CLOSE_CODE = 1000; // TODO random number f
 constexpr const char* SOCKET_CLOSE_REASON = "Close";
 constexpr const char* URL_QUERY_SEPARATOR = "?";
 
-EM_BOOL onSocketOpened(int EventType, const EmscriptenWebSocketOpenEvent* WebsocketEvent, void* UserData)
+EM_BOOL onSocketOpened([[maybe_unused]] int EventType, [[maybe_unused]] const EmscriptenWebSocketOpenEvent* WebsocketEvent, void* UserData)
 {
     EMS_LOG("EMS onSocketOpened");
 
@@ -49,7 +49,7 @@ EM_BOOL onSocketOpened(int EventType, const EmscriptenWebSocketOpenEvent* Websoc
     return EM_TRUE;
 }
 
-EM_BOOL onSocketError(int EventType, const EmscriptenWebSocketErrorEvent* WebsocketEvent, void* UserData)
+EM_BOOL onSocketError([[maybe_unused]] int EventType, [[maybe_unused]] const EmscriptenWebSocketErrorEvent* WebsocketEvent, void* UserData)
 {
     // TODO handle the socket error
     EMS_LOG("EMS onSocketError");
@@ -64,7 +64,7 @@ EM_BOOL onSocketError(int EventType, const EmscriptenWebSocketErrorEvent* Websoc
     return EM_TRUE;
 }
 
-EM_BOOL onSocketClosed(int EventType, const EmscriptenWebSocketCloseEvent* WebsocketEvent, void* UserData)
+EM_BOOL onSocketClosed([[maybe_unused]] int EventType, const EmscriptenWebSocketCloseEvent* WebsocketEvent, void* UserData)
 {
     EMS_FORMATTED_LOG("EMS onSocketClosed Reason: %s", WebsocketEvent->reason);
 
@@ -83,7 +83,7 @@ EM_BOOL onSocketClosed(int EventType, const EmscriptenWebSocketCloseEvent* Webso
 /*
    Runs on main thread
  */
-EM_BOOL onDataReceived(int EventType, const EmscriptenWebSocketMessageEvent* WebsocketEvent, void* UserData)
+EM_BOOL onDataReceived([[maybe_unused]] int EventType, const EmscriptenWebSocketMessageEvent* WebsocketEvent, void* UserData)
 {
     EMS_FORMATTED_LOG("EMS onDataReceived NumBytes: %d, isText: %d", WebsocketEvent->numBytes, (int)WebsocketEvent->isText);
 
@@ -195,7 +195,7 @@ std::string CSPWebSocketClientEmscripten::GetWebSocketConnectURL(const std::stri
     return WebSocketConnectURL;
 }
 
-size_t CSPWebSocketClientEmscripten::ProcessReceivedMessage(uint8_t* RecvData, uint32_t NumRecvBytes, EM_BOOL IsPlainText)
+size_t CSPWebSocketClientEmscripten::ProcessReceivedMessage(uint8_t* RecvData, uint32_t NumRecvBytes, [[maybe_unused]] EM_BOOL IsPlainText)
 {
     std::string CallbackMessage;
     bool CallbackHasData = false;

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -425,8 +425,6 @@ void CSPWebSocketClientPOCO::ReceiveThreadFunc()
         auto Callback = ReceiveCallback;
         Callback(CallbackMessage, true);
     }
-
-    StopFlag = false;
 }
 
 void CSPWebSocketClientPOCO::HandleReceiveError(const std::string& Message)

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -69,7 +69,7 @@ CSPWebSocketClientPOCO::ParsedURIInfo CSPWebSocketClientPOCO::ParseMultiplayerSe
     return Out;
 }
 
-void CSPWebSocketClientPOCO::Start(const std::string& Url, CallbackHandler Callback)
+void CSPWebSocketClientPOCO::Start(const std::string& /*Url*/, CallbackHandler Callback)
 {
     CSP_PROFILE_SCOPED();
 

--- a/Library/src/Multiplayer/SignalR/SignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRClient.cpp
@@ -68,7 +68,7 @@ void CSPWebsocketClient::stop(std::function<void(std::exception_ptr)> callback)
     CSPWebSocketClientPtr->Stop(LocalCallback);
 }
 
-void CSPWebsocketClient::send(const std::string& payload, signalr::transfer_format format, std::function<void(std::exception_ptr)> callback)
+void CSPWebsocketClient::send(const std::string& payload, signalr::transfer_format /*format*/, std::function<void(std::exception_ptr)> callback)
 {
     IWebSocketClient::CallbackHandler LocalCallback
         = [callback](bool ok) { ok ? callback(nullptr) : callback(std::make_exception_ptr(std::runtime_error("Socket Stop Error"))); };
@@ -152,7 +152,8 @@ CSPHttpClient::CSPHttpClient()
 #endif
 }
 
-void CSPHttpClient::send(const std::string& url, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback)
+void CSPHttpClient::send(
+    const std::string& /*url*/, const http_request& request, std::function<void(const http_response&, std::exception_ptr)> callback)
 {
     CSP_PROFILE_SCOPED();
 

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
@@ -120,7 +120,7 @@ void SignalRConnection::Invoke(
         if (PendingStopCallback && PendingInvocations == 0)
         {
             Connection.stop(
-                [this, ExceptionPtr](auto Exception)
+                [this, ExceptionPtr](auto /*Exception*/)
                 {
                     // making a copy of the PendingStopCallback in case the SignalRConnection object gets deleted inside the callback itself
                     auto _PendingStopCallback = PendingStopCallback;

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -130,7 +130,7 @@ SpaceEntity::~SpaceEntity()
 {
     auto& Keys = *Components.Keys();
 
-    auto i = 0;
+    size_t i = 0;
     for (i = 0; i < Keys.Size(); ++i)
     {
         CSP_DELETE(Components[Keys[i]]);
@@ -514,7 +514,7 @@ void SpaceEntity::SerialisePatch(IEntitySerialiser& Serialiser) const
 
             const csp::common::Array<uint16_t>& DirtyComponentKeys = *DirtyComponents.Keys();
 
-            int i = 0;
+            size_t i = 0;
             for (i = 0; i < DirtyComponentKeys.Size(); ++i)
             {
                 if (DirtyComponents[DirtyComponentKeys[i]].Component != nullptr)
@@ -572,7 +572,7 @@ void SpaceEntity::Serialise(IEntitySerialiser& Serialiser) const
 
             const csp::common::Array<uint16_t>& DirtyComponentKeys = *DirtyComponents.Keys();
 
-            for (int i = 0; i < DirtyComponentKeys.Size(); ++i)
+            for (size_t i = 0; i < DirtyComponentKeys.Size(); ++i)
             {
                 auto* Component = DirtyComponents[DirtyComponentKeys[i]].Component;
 
@@ -636,7 +636,7 @@ void SpaceEntity::Deserialise(IEntityDeserialiser& Deserialiser)
                         {
                             Components[ComponentId] = Component;
 
-                            for (int i = 0; i < Deserialiser.GetNumProperties(); ++i)
+                            for (uint64_t i = 0; i < Deserialiser.GetNumProperties(); ++i)
                             {
                                 uint64_t PropertyKey;
                                 auto PropertyValue = Deserialiser.ReadProperty(PropertyKey);
@@ -781,7 +781,7 @@ void SpaceEntity::DeserialiseFromPatch(IEntityDeserialiser& Deserialiser)
                         {
                             auto* Component = Components[ComponentKey];
 
-                            for (int i = 0; i < Deserialiser.GetNumProperties(); ++i)
+                            for (uint64_t i = 0; i < Deserialiser.GetNumProperties(); ++i)
                             {
                                 uint64_t PropertyKey;
                                 auto PropertyValue = Deserialiser.ReadProperty(PropertyKey);
@@ -798,7 +798,7 @@ void SpaceEntity::DeserialiseFromPatch(IEntityDeserialiser& Deserialiser)
                             // if Component != nullptr component has not been Instantiate, so is skipped.
                             if (Component != nullptr)
                             {
-                                for (int i = 0; i < Deserialiser.GetNumProperties(); ++i)
+                                for (uint64_t i = 0; i < Deserialiser.GetNumProperties(); ++i)
                                 {
                                     uint64_t PropertyKey;
                                     auto PropertyValue = Deserialiser.ReadProperty(PropertyKey);
@@ -860,7 +860,7 @@ void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback)
         {
             UpdateFlags = static_cast<SpaceEntityUpdateFlags>(UpdateFlags | UPDATE_FLAGS_COMPONENTS);
 
-            for (int i = 0; i < DirtyComponentKeys->Size(); ++i)
+            for (size_t i = 0; i < DirtyComponentKeys->Size(); ++i)
             {
                 uint16_t ComponentKey = DirtyComponentKeys->operator[](i);
 
@@ -887,7 +887,7 @@ void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback)
                     /*const csp::common::Map<uint32_t, ReplicatedValue> DirtyComponentProperties = DirtyComponents[i].Component->DirtyProperties;
                     const csp::common::Array<uint32_t>* DirtyComponentPropertyKeys			  = DirtyComponentProperties.Keys();
 
-                    for (int j = 0; j < DirtyComponentPropertyKeys->Size(); j++)
+                    for (size_t j = 0; j < DirtyComponentPropertyKeys->Size(); j++)
                     {
                             uint32_t PropertyKey							  = DirtyComponentPropertyKeys->operator[](j);
                             Components[ComponentKey]->Properties[PropertyKey] = DirtyComponentProperties[PropertyKey];
@@ -913,7 +913,7 @@ void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback)
         {
             const csp::common::Array<uint16_t>* DirtyViewKeys = DirtyProperties.Keys();
 
-            for (int i = 0; i < DirtyViewKeys->Size(); ++i)
+            for (size_t i = 0; i < DirtyViewKeys->Size(); ++i)
             {
                 uint16_t PropertyKey = DirtyViewKeys->operator[](i);
                 switch (PropertyKey)
@@ -963,7 +963,7 @@ void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback)
         {
             DirtyComponentKeys = DirtyComponents.Keys();
 
-            for (int i = 0; i < TransientDeletionComponentIds.Size(); ++i)
+            for (size_t i = 0; i < TransientDeletionComponentIds.Size(); ++i)
             {
                 if (Components.HasKey(TransientDeletionComponentIds[i]))
                 {
@@ -1114,7 +1114,7 @@ void SpaceEntity::SerialiseComponent(IEntitySerialiser& Serialiser, ComponentBas
         auto& Properties = Component->Properties;
         const auto& Keys = Properties.Keys();
 
-        for (int j = 0; j < Keys->Size(); ++j)
+        for (size_t j = 0; j < Keys->Size(); ++j)
         {
             auto& Key = Keys->operator[](j);
             auto& Property = Properties[Key];
@@ -1268,7 +1268,7 @@ ComponentBase* SpaceEntity::FindFirstComponentOfType(ComponentType Type, bool Se
     const csp::common::Array<uint16_t>* ComponentKeys = Components.Keys();
     ComponentBase* LocatedComponent = nullptr;
 
-    for (int i = 0; i < ComponentKeys->Size(); ++i)
+    for (size_t i = 0; i < ComponentKeys->Size(); ++i)
     {
         ComponentBase* Component = Components[ComponentKeys->operator[](i)];
 
@@ -1285,7 +1285,7 @@ ComponentBase* SpaceEntity::FindFirstComponentOfType(ComponentType Type, bool Se
     {
         const csp::common::Array<uint16_t>* DirtyComponentKeys = DirtyComponents.Keys();
 
-        for (int i = 0; i < DirtyComponentKeys->Size(); ++i)
+        for (size_t i = 0; i < DirtyComponentKeys->Size(); ++i)
         {
             const DirtyComponent& Component = DirtyComponents[DirtyComponentKeys->operator[](i)];
 

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -324,7 +324,7 @@ void SpaceEntity::SetThirdPartyPlatformType(const csp::systems::EThirdPartyPlatf
     }
 }
 
-const csp::systems::EThirdPartyPlatform SpaceEntity::GetThirdPartyPlatformType() const { return ThirdPartyPlatform; }
+csp::systems::EThirdPartyPlatform SpaceEntity::GetThirdPartyPlatformType() const { return ThirdPartyPlatform; }
 
 SpaceEntityType SpaceEntity::GetEntityType() const { return Type; }
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -1040,7 +1040,7 @@ uint64_t SpaceEntitySystem::GetLeaderId() const
     }
 }
 
-const bool SpaceEntitySystem::GetEntityPatchRateLimitEnabled() const { return EntityPatchRateLimitEnabled; }
+bool SpaceEntitySystem::GetEntityPatchRateLimitEnabled() const { return EntityPatchRateLimitEnabled; }
 
 void SpaceEntitySystem::SetEntityPatchRateLimitEnabled(bool Enabled) { EntityPatchRateLimitEnabled = Enabled; }
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -1320,37 +1320,37 @@ void SpaceEntitySystem::RemovePendingEntity(SpaceEntity* EntityToRemove)
     CSP_DELETE(EntityToRemove);
 }
 
-void SpaceEntitySystem::OnAvatarAdd(const SpaceEntity* Avatar, const SpaceEntityList& Avatars)
+void SpaceEntitySystem::OnAvatarAdd(const SpaceEntity* Avatar, const SpaceEntityList& AddedAvatars)
 {
     if (ElectionManager != nullptr)
     {
         // Note we are assuming Avatar==Client,
         // which is true now but may not be in the future
-        ElectionManager->OnClientAdd(Avatar, Avatars);
+        ElectionManager->OnClientAdd(Avatar, AddedAvatars);
     }
 }
 
-void SpaceEntitySystem::OnAvatarRemove(const SpaceEntity* Avatar, const SpaceEntityList& Avatars)
+void SpaceEntitySystem::OnAvatarRemove(const SpaceEntity* Avatar, const SpaceEntityList& RemovedAvatars)
 {
     if (ElectionManager != nullptr)
     {
-        ElectionManager->OnClientRemove(Avatar, Avatars);
+        ElectionManager->OnClientRemove(Avatar, RemovedAvatars);
     }
 }
 
-void SpaceEntitySystem::OnObjectAdd(const SpaceEntity* Object, const SpaceEntityList& Objects)
+void SpaceEntitySystem::OnObjectAdd(const SpaceEntity* Object, const SpaceEntityList& AddedObjects)
 {
     if (ElectionManager != nullptr)
     {
-        ElectionManager->OnObjectAdd(Object, Objects);
+        ElectionManager->OnObjectAdd(Object, AddedObjects);
     }
 }
 
-void SpaceEntitySystem::OnObjectRemove(const SpaceEntity* Object, const SpaceEntityList& Objects)
+void SpaceEntitySystem::OnObjectRemove(const SpaceEntity* Object, const SpaceEntityList& RemovedObjects)
 {
     if (ElectionManager != nullptr)
     {
-        ElectionManager->OnObjectRemove(Object, Objects);
+        ElectionManager->OnObjectRemove(Object, RemovedObjects);
     }
 }
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -339,7 +339,7 @@ void SpaceEntitySystem::DestroyEntity(SpaceEntity* Entity, CallbackHandler Callb
 {
     const auto& Children = Entity->ChildEntities;
 
-    const std::function LocalCallback = [this, Callback, Children](const signalr::value& /*EntityMessage*/, const std::exception_ptr& Except)
+    const std::function LocalCallback = [Callback](const signalr::value& /*EntityMessage*/, const std::exception_ptr& Except)
     {
         try
         {
@@ -623,7 +623,7 @@ void SpaceEntitySystem::BindOnRequestToSendObject()
 void SpaceEntitySystem::BindOnRequestToDisconnect() const
 {
     Connection->On("OnRequestToDisconnect",
-        [this](const signalr::value& Params)
+        [](const signalr::value& Params)
         {
             const std::string Reason = Params.as_array()[0].as_string();
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -129,7 +129,7 @@ void SpaceEntityEventHandler::OnEvent(const csp::events::Event& InEvent)
         csp::common::String Reason(InEvent.GetString("Reason"));
 
         auto Done = false;
-        Connection->DisconnectWithReason(Reason, [&Done](ErrorCode Error) { Done = true; });
+        Connection->DisconnectWithReason(Reason, [&Done](ErrorCode /*Error*/) { Done = true; });
 
         int TimeoutCounter = 2000;
 
@@ -721,7 +721,7 @@ void SpaceEntitySystem::LocalDestroyAllEntities()
         // as these are only ever valid for a single connected session
         if (Entity->GetIsTransient() && Entity->GetOwnerId() == csp::systems::SystemsManager::Get().GetMultiplayerConnection()->GetClientId())
         {
-            DestroyEntity(Entity, [](auto Ok) {});
+            DestroyEntity(Entity, [](bool /*Ok*/) {});
         }
         // Otherwise we clear up all all locally represented entities
         else

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -684,7 +684,7 @@ std::function<void(const signalr::value&, std::exception_ptr)> SpaceEntitySystem
 
         int CurrentEntityCount = Skip + static_cast<int>(Items.size());
 
-        if (CurrentEntityCount < ItemTotalCount)
+        if (static_cast<uint64_t>(CurrentEntityCount) < ItemTotalCount)
         {
             GetEntitiesPaged(CurrentEntityCount, ENTITY_PAGE_LIMIT, CreateRetrieveAllEntitiesCallback(CurrentEntityCount));
         }
@@ -1147,7 +1147,7 @@ void SendPatches(csp::multiplayer::ISignalRConnection* Connection, const csp::co
     SignalRMsgPackEntitySerialiser Serialiser;
     std::vector<signalr::value> ObjectPatches;
 
-    for (int i = 0; i < PendingEntities.Size(); ++i)
+    for (size_t i = 0; i < PendingEntities.Size(); ++i)
     {
         PendingEntities[i]->SerialisePatch(Serialiser);
         auto SerialisedEntity = Serialiser.Finalise();
@@ -1240,7 +1240,7 @@ void SpaceEntitySystem::ProcessPendingEntityOperations()
             SendPatches(Connection, PendingEntities);
 
             // Loop through and apply local patches from generated list
-            for (int i = 0; i < PendingEntities.Size(); ++i)
+            for (size_t i = 0; i < PendingEntities.Size(); ++i)
             {
                 PendingEntities[i]->ApplyLocalPatch(true);
             }
@@ -1464,7 +1464,7 @@ void SpaceEntitySystem::ApplyIncomingPatch(const signalr::value* EntityMessage)
         if (Destroy)
         {
             // Deletion
-            for (int i = 0; i < Entities.Size(); ++i)
+            for (size_t i = 0; i < Entities.Size(); ++i)
             {
                 SpaceEntity* Entity = Entities[i];
 
@@ -1478,7 +1478,7 @@ void SpaceEntitySystem::ApplyIncomingPatch(const signalr::value* EntityMessage)
 
                         // Loop through all entities and check if the deleted avatar owned any of them. If they did, deselect them.
                         // This covers disconnected clients as their avatar gets cleaned up after timing out.
-                        for (int j = 0; j < Entities.Size(); ++j)
+                        for (size_t j = 0; j < Entities.Size(); ++j)
                         {
                             if (Entities[j]->GetSelectingClientID() == EntityID)
                             {
@@ -1497,7 +1497,7 @@ void SpaceEntitySystem::ApplyIncomingPatch(const signalr::value* EntityMessage)
             bool EntityFound = false;
 
             // Update
-            for (int i = 0; i < Entities.Size(); ++i)
+            for (size_t i = 0; i < Entities.Size(); ++i)
             {
                 if (Entities[i]->GetId() == EntityID)
                 {

--- a/Library/src/Multiplayer/SpaceTransform.cpp
+++ b/Library/src/Multiplayer/SpaceTransform.cpp
@@ -78,17 +78,18 @@ csp::multiplayer::SpaceTransform csp::multiplayer::SpaceTransform::operator*(con
     const auto TRS2 = T2 * R2 * S2;
     const auto ComposedTRS = TRS1 * TRS2;
 
-    glm::vec3 Scale;
-    glm::quat Rotation;
+    glm::vec3 TransformScale;
+    glm::quat TransformRotation;
     glm::vec3 Translation;
     glm::vec3 Skew;
     glm::vec4 Perspective;
-    glm::decompose(ComposedTRS, Scale, Rotation, Translation, Skew, Perspective);
+    glm::decompose(ComposedTRS, TransformScale, TransformRotation, Translation, Skew, Perspective);
     // We're ignoring skew and perspective, as TRS composition should not have introduced any,
     // provided inputs are normalized.
     // Note, if you're getting confusing outputs for rotation when you have negative scales, you're
     // probably flipping the rotation, which is _fine_, but hard to understand without visualization.
 
-    return SpaceTransform(
-        { Translation.x, Translation.y, Translation.z }, { Rotation.x, Rotation.y, Rotation.z, Rotation.w }, { Scale.x, Scale.y, Scale.z });
+    return SpaceTransform({ Translation.x, Translation.y, Translation.z },
+        { TransformRotation.x, TransformRotation.y, TransformRotation.z, TransformRotation.w },
+        { TransformScale.x, TransformScale.y, TransformScale.z });
 }

--- a/Library/src/Services/DtoBase/DtoBase.h
+++ b/Library/src/Services/DtoBase/DtoBase.h
@@ -43,7 +43,7 @@ public:
     virtual ~DtoBase() { }
 
     virtual utility::string_t ToJson() const;
-    virtual void FromJson(const utility::string_t& Json) { }
+    virtual void FromJson(const utility::string_t& /*Json*/) { }
 };
 
 class EnumBase
@@ -53,7 +53,7 @@ public:
     virtual ~EnumBase() { }
 
     virtual utility::string_t ToJson() const;
-    virtual void FromJson(const utility::string_t& Json) { }
+    virtual void FromJson(const utility::string_t& /*Json*/) { }
 };
 
 /// @brief Null Dto object
@@ -67,7 +67,7 @@ public:
     virtual ~NullDto() { }
 
     utility::string_t ToJson() const override;
-    void FromJson(const utility::string_t& Json) override { }
+    void FromJson(const utility::string_t& /*Json*/) override { }
 };
 
 } // namespace csp::services

--- a/Library/src/Services/PrototypeService/AssetFileDto.cpp
+++ b/Library/src/Services/PrototypeService/AssetFileDto.cpp
@@ -22,6 +22,6 @@ AssetFileDto::AssetFileDto() { }
 
 AssetFileDto::~AssetFileDto() { }
 
-void AssetFileDto::FromJson(const csp::common::String& Json) { }
+void AssetFileDto::FromJson(const csp::common::String& /*Json*/) { }
 
 } // namespace csp::services

--- a/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
@@ -80,7 +80,7 @@ csp::common::String CreateUAEventString(const csp::common::String& ClientId, con
     bool HasIntegerParam = false;
     bool HasStringParam = false;
 
-    for (int i = 0; i < Values->Size(); ++i)
+    for (size_t i = 0; i < Values->Size(); ++i)
     {
         if (Values->operator[](i).GetReplicatedValueType() == csp::multiplayer::ReplicatedValueType::Integer)
         {

--- a/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
@@ -46,7 +46,7 @@ public:
 class ResponseReceiver : public csp::web::IHttpResponseHandler
 {
 public:
-    void OnHttpResponse(csp::web::HttpResponse& InResponse) override { }
+    void OnHttpResponse(csp::web::HttpResponse& /*InResponse*/) override { }
 
     bool ShouldDelete() const override { return true; }
 };

--- a/Library/src/Systems/Analytics/AnalyticsSystem.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsSystem.cpp
@@ -35,7 +35,7 @@ public:
 
     ~AnalyticsSystemImpl() { }
 
-    void OnEvent(const csp::events::Event& InEvent) override
+    void OnEvent(const csp::events::Event& /*InEvent*/) override
     {
         /* std::scoped_lock<std::mutex> ProviderLock(ProviderMutex);
 
@@ -53,7 +53,7 @@ public:
         }*/
     }
 
-    void Log(AnalyticsEvent* Event)
+    void Log(AnalyticsEvent* /*Event*/)
     {
         /* if (Provider)
         {
@@ -63,7 +63,7 @@ public:
 
     void RegisterProvider(IAnalyticsProvider* InProvider) { Provider = InProvider; }
 
-    void DeregisterProvider(IAnalyticsProvider* InProvider)
+    void DeregisterProvider(IAnalyticsProvider* /*InProvider*/)
     {
         /* if (Provider == InProvider)
         {

--- a/Library/src/Systems/Analytics/AnalyticsSystemUtils.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsSystemUtils.cpp
@@ -52,11 +52,11 @@ void AnalyticsEvent::AddBool(csp::common::String Key, bool Value)
     Parameters[Key] = Metric;
 }
 
-const int64_t AnalyticsEvent::GetInt(csp::common::String Key) const { return Parameters[Key].GetInt(); }
+int64_t AnalyticsEvent::GetInt(csp::common::String Key) const { return Parameters[Key].GetInt(); }
 
 const csp::common::String& AnalyticsEvent::GetString(csp::common::String Key) const { return Parameters[Key].GetString(); }
 
-const float AnalyticsEvent::GetFloat(csp::common::String Key) const { return Parameters[Key].GetFloat(); }
+float AnalyticsEvent::GetFloat(csp::common::String Key) const { return Parameters[Key].GetFloat(); }
 
 bool AnalyticsEvent::GetBool(csp::common::String Key) const { return Parameters[Key].GetBool(); }
 

--- a/Library/src/Systems/Assets/Asset.cpp
+++ b/Library/src/Systems/Assets/Asset.cpp
@@ -231,7 +231,7 @@ Asset& AssetResult::GetAsset() { return Asset; }
 
 const Asset& AssetResult::GetAsset() const { return Asset; }
 
-void AssetResult::SetAsset(const csp::systems::Asset& Asset) { this->Asset = Asset; }
+void AssetResult::SetAsset(const csp::systems::Asset& SetAsset) { this->Asset = SetAsset; }
 
 void AssetResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
 {

--- a/Library/src/Systems/Assets/AssetCollection.cpp
+++ b/Library/src/Systems/Assets/AssetCollection.cpp
@@ -75,8 +75,8 @@ void PrototypeDtoToAssetCollection(const chs::PrototypeDto& Dto, csp::systems::A
 
         for (auto& Pair : Metadata)
         {
-            auto& Metadata = AssetCollection.GetMetadataMutable();
-            Metadata[Pair.first] = Pair.second;
+            auto& MetadataMutable = AssetCollection.GetMetadataMutable();
+            MetadataMutable[Pair.first] = Pair.second;
         }
     }
 

--- a/Library/src/Systems/Assets/AssetCollection.cpp
+++ b/Library/src/Systems/Assets/AssetCollection.cpp
@@ -63,7 +63,7 @@ void PrototypeDtoToAssetCollection(const chs::PrototypeDto& Dto, csp::systems::A
         auto& Tags = Dto.GetTags();
         AssetCollection.Tags = csp::common::Array<csp::common::String>(Tags.size());
 
-        for (int i = 0; i < Tags.size(); ++i)
+        for (size_t i = 0; i < Tags.size(); ++i)
         {
             AssetCollection.Tags[i] = Tags[i];
         }

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -1373,7 +1373,7 @@ CSP_ASYNC_RESULT_WITH_PROGRESS void AssetSystem::RegisterAssetToLODChain(
         }
 
         // UpdateAsset
-        auto UpdateAssetCallback = [this, AssetCollection, Callback, Assets](const AssetResult& Result) { INVOKE_IF_NOT_NULL(Callback, Result); };
+        auto UpdateAssetCallback = [AssetCollection, Callback, Assets](const AssetResult& Result) { INVOKE_IF_NOT_NULL(Callback, Result); };
 
         // Add new LOD style
         Asset NewAsset = InAsset;
@@ -1427,7 +1427,7 @@ void AssetSystem::CreateMaterial(const csp::common::String& Name, const csp::sys
             // Serialse material data.
             SerializeMaterialOfType(ShaderType, NewlyCreatedMaterial, MaterialJson);
 
-            auto UploadMaterialCallback = [this, Callback, NewlyCreatedMaterial, SpaceId, Name](const UriResult& UploadResult)
+            auto UploadMaterialCallback = [Callback, NewlyCreatedMaterial, SpaceId, Name](const UriResult& UploadResult)
             {
                 if (UploadResult.GetResultCode() == EResultCode::InProgress)
                 {
@@ -1500,8 +1500,8 @@ void AssetSystem::UpdateMaterial(const Material& Material, NullResultCallback Ca
             }
 
             // 3. Upload material
-            auto UploadMaterialCallback = [this, Callback, &Material](const UriResult& UploadResult)
-            { Callback(NullResult(UploadResult.GetResultCode(), UploadResult.GetHttpResultCode())); };
+            auto UploadMaterialCallback
+                = [Callback](const UriResult& UploadResult) { Callback(NullResult(UploadResult.GetResultCode(), UploadResult.GetHttpResultCode())); };
 
             csp::common::String MaterialJson;
 
@@ -1538,7 +1538,7 @@ void AssetSystem::DeleteMaterial(const Material& Material, NullResultCallback Ca
         }
 
         // 2. Delete asset collection
-        auto DeleteAssetCollectionCB = [this, Callback](const NullResult& DeleteAssetCollectionResult) { Callback(DeleteAssetCollectionResult); };
+        auto DeleteAssetCollectionCB = [Callback](const NullResult& DeleteAssetCollectionResult) { Callback(DeleteAssetCollectionResult); };
 
         DeleteAssetCollectionById(Material.GetMaterialCollectionId(), DeleteAssetCollectionCB);
     };
@@ -1607,7 +1607,7 @@ void AssetSystem::GetMaterials(const csp::common::String& SpaceId, MaterialsResu
                     return;
                 }
 
-                auto DownloadMaterialCallback = [this, Callback, AssetsToDownload, i, AssetCollectionId, AssetId, ShaderType, DownloadedMaterials,
+                auto DownloadMaterialCallback = [Callback, AssetsToDownload, i, AssetCollectionId, AssetId, ShaderType, DownloadedMaterials,
                                                     AssetsDownloaded, Failed](const AssetDataResult& DownloadResult)
                 {
                     // Return early as one of the calls has already failed
@@ -1696,7 +1696,7 @@ void AssetSystem::GetMaterial(const csp::common::String& AssetCollectionId, cons
             // 3. Download material
             const Asset& FoundAsset = CreateAssetResult.GetAsset();
 
-            auto DownloadMaterialCallback = [this, Callback, FoundAssetCollection, FoundAsset](const AssetDataResult& DownloadResult)
+            auto DownloadMaterialCallback = [Callback, FoundAssetCollection, FoundAsset](const AssetDataResult& DownloadResult)
             {
                 if (DownloadResult.GetResultCode() != EResultCode::Success)
                 {

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -179,7 +179,7 @@ std::shared_ptr<chs::PrototypeDto> CreatePrototypeDto(const Optional<String>& Sp
 
         auto* Keys = Metadata->Keys();
 
-        for (auto idx = 0; idx < Keys->Size(); ++idx)
+        for (size_t idx = 0; idx < Keys->Size(); ++idx)
         {
             auto Key = Keys->operator[](idx);
             auto Value = Metadata->operator[](Key);
@@ -1199,7 +1199,7 @@ void AssetSystem::GetAssetsByCollectionIds(const Array<String>& AssetCollectionI
 
     std::vector<String> Ids;
 
-    for (int i = 0; i < AssetCollectionIds.Size(); ++i)
+    for (size_t i = 0; i < AssetCollectionIds.Size(); ++i)
     {
         Ids.push_back(AssetCollectionIds[i]);
     }
@@ -1379,7 +1379,7 @@ CSP_ASYNC_RESULT_WITH_PROGRESS void AssetSystem::RegisterAssetToLODChain(
         Asset NewAsset = InAsset;
         Array<String> NewStyles(NewAsset.Styles.Size() + 1);
 
-        for (int i = 0; i < NewAsset.Styles.Size(); ++i)
+        for (size_t i = 0; i < NewAsset.Styles.Size(); ++i)
         {
             NewStyles[i] = NewAsset.Styles[i];
         }

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -488,7 +488,7 @@ async::task<NullResult> AssetSystem::DeleteAssetCollection(const AssetCollection
     }
 
     services::ResponseHandlerPtr ResponseHandler = PrototypeAPI->CreateHandler<NullResultCallback, NullResult, void, services::NullDto>(
-        [](const NullResult& s) {}, nullptr, web::EResponseCodes::ResponseNoContent, std::move(OnCompleteEvent));
+        [](const NullResult& /*s*/) {}, nullptr, web::EResponseCodes::ResponseNoContent, std::move(OnCompleteEvent));
 
     static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdDelete(PrototypeId, ResponseHandler);
 

--- a/Library/src/Systems/Assets/LODHelpers.cpp
+++ b/Library/src/Systems/Assets/LODHelpers.cpp
@@ -62,7 +62,7 @@ LODChain CreateLODChainFromAssets(const csp::common::Array<Asset>& Assets, const
     }
     else
     {
-        for (int i = 0; i < Assets.Size(); ++i)
+        for (size_t i = 0; i < Assets.Size(); ++i)
         {
             const csp::systems::Asset& Asset = Assets[i];
             int LODLevel = csp::systems::GetLODLevelFromStylesArray(Asset.Styles);
@@ -76,7 +76,7 @@ LODChain CreateLODChainFromAssets(const csp::common::Array<Asset>& Assets, const
 
     Chain.LODAssets = csp::common::Array<LODAsset>(AssetList.Size());
 
-    for (int i = 0; i < Chain.LODAssets.Size(); ++i)
+    for (size_t i = 0; i < Chain.LODAssets.Size(); ++i)
     {
         Chain.LODAssets[i] = std::move(AssetList[i]);
     }

--- a/Library/src/Systems/Assets/Material.cpp
+++ b/Library/src/Systems/Assets/Material.cpp
@@ -58,9 +58,9 @@ Material::Material(const csp::common::String& Name, const csp::common::String& I
 
 const csp::common::String& Material::GetName() const { return Name; }
 
-const csp::systems::EShaderType Material::GetShaderType() const { return Type; }
+csp::systems::EShaderType Material::GetShaderType() const { return Type; }
 
-const int Material::GetVersion() const { return Version; }
+int Material::GetVersion() const { return Version; }
 
 const csp::common::String& Material::GetMaterialCollectionId() const { return CollectionId; }
 

--- a/Library/src/Systems/Assets/Material.cpp
+++ b/Library/src/Systems/Assets/Material.cpp
@@ -72,7 +72,7 @@ Material* MaterialResult::GetMaterial() { return Material; }
 
 void MaterialResult::SetMaterial(csp::systems::Material* InMaterial) { Material = InMaterial; }
 
-void MaterialResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse) { }
+void MaterialResult::OnResponse(const csp::services::ApiResponseBase* /*ApiResponse*/) { }
 
 const csp::common::Array<Material*>* MaterialsResult::GetMaterials() const { return &Materials; }
 
@@ -80,6 +80,6 @@ csp::common::Array<Material*>* MaterialsResult::GetMaterials() { return &Materia
 
 void MaterialsResult::SetMaterials(const csp::common::Array<Material*>& InMaterials) { Materials = InMaterials; }
 
-void MaterialsResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse) { }
+void MaterialsResult::OnResponse(const csp::services::ApiResponseBase* /*ApiResponse*/) { }
 
 } // namespace csp::systems

--- a/Library/src/Systems/Conversation/ConversationSystemHelpers.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemHelpers.cpp
@@ -244,7 +244,7 @@ multiplayer::AnnotationData GetAnnotationDataFromMessageAssetCollection(const As
 
     Data.SetAnnotationId(MetadataMap[ASSET_COLLECTION_METADATA_KEY_ANNOTATION_ID]);
     Data.SetAnnotationThumbnailId(MetadataMap[ASSET_COLLECTION_METADATA_KEY_THUMBNAIL_ID]);
-    Data.SetVerticalFov(std::stoi(MetadataMap[ASSET_COLLECTION_METADATA_KEY_VERTICAL_FOV].c_str()));
+    Data.SetVerticalFov(static_cast<uint16_t>(std::stoi(MetadataMap[ASSET_COLLECTION_METADATA_KEY_VERTICAL_FOV].c_str())));
     Data.SetAuthorCameraPosition(StringToVector3(MetadataMap[ASSET_COLLECTION_METADATA_KEY_CAMERA_POSITION]));
     Data.SetAuthorCameraRotation(StringToVector4(MetadataMap[ASSET_COLLECTION_METADATA_KEY_CAMERA_ROTATION]));
 

--- a/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
@@ -163,7 +163,6 @@ namespace
             }
 
             throw std::exception();
-            return async::task<NullResult>();
         };
     }
 
@@ -233,7 +232,6 @@ namespace
                             CSP_LOG_MSG(csp::systems::LogLevel::Log, "Invalid number of annotation assets exist for this message");
 
                             throw std::exception();
-                            return async::task<AssetResult>();
                         }
                     });
         };
@@ -373,7 +371,7 @@ void ConversationSystemInternal::CreateConversation(const common::String& Messag
 
         // 2.Send multiplayer event
         const multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler SignalRCallback
-            = [this, Callback, AddCommentContainerResult](multiplayer::ErrorCode Error)
+            = [Callback, AddCommentContainerResult](multiplayer::ErrorCode Error)
         {
             if (Error != multiplayer::ErrorCode::None)
             {
@@ -427,7 +425,7 @@ void ConversationSystemInternal::DeleteConversation(const common::String& Conver
             }
 
             // 3. Delete the asset colleciton associated with this conversation
-            NullResultCallback DeleteAssetCollectionCallback = [Callback, this](const NullResult& DeleteAssetCollectionResult)
+            NullResultCallback DeleteAssetCollectionCallback = [Callback](const NullResult& DeleteAssetCollectionResult)
             {
                 if (HandleConversationResult(
                         DeleteAssetCollectionResult, "The deletion of the conversation asset collection was not successful.", Callback)
@@ -465,7 +463,7 @@ void ConversationSystemInternal::AddMessage(
         }
 
         // 2. Send multiplayer event
-        const auto SignalRCallback = [this, Callback, MessageResultCallbackResult](multiplayer::ErrorCode Error)
+        const auto SignalRCallback = [Callback, MessageResultCallbackResult](multiplayer::ErrorCode Error)
         {
             if (Error != multiplayer::ErrorCode::None)
             {
@@ -525,8 +523,7 @@ void ConversationSystemInternal::DeleteMessage(const common::String& Conversatio
             AssetCollection MessageAssetCollection;
             MessageAssetCollection.Id = MessageId;
 
-            const NullResultCallback DeleteAssetCollectionCallback
-                = [this, Callback, ConversationId, MessageId](const NullResult& DeleteAssetCollectionResult)
+            const NullResultCallback DeleteAssetCollectionCallback = [Callback](const NullResult& DeleteAssetCollectionResult)
             {
                 if (HandleConversationResult(DeleteAssetCollectionResult, "Failed to delete Message asset collection.", Callback) == false)
                 {
@@ -657,7 +654,7 @@ void ConversationSystemInternal::UpdateConversation(
 }
 
 void ConversationSystemInternal::GetMessageInfo(
-    const common::String& ConversationId, const common::String& MessageId, multiplayer::MessageResultCallback Callback)
+    const common::String& /*ConversationId*/, const common::String& MessageId, multiplayer::MessageResultCallback Callback)
 {
     const AssetCollectionResultCallback GetMessageCallback = [Callback](const AssetCollectionResult& GetMessageResult)
     {
@@ -674,7 +671,7 @@ void ConversationSystemInternal::GetMessageInfo(
     AssetSystem->GetAssetCollectionById(MessageId, GetMessageCallback);
 }
 
-void ConversationSystemInternal::UpdateMessage(const common::String& ConversationId, const common::String& MessageId,
+void ConversationSystemInternal::UpdateMessage(const common::String& /*ConversationId*/, const common::String& MessageId,
     const multiplayer::MessageUpdateParams& NewData, multiplayer::MessageResultCallback Callback)
 {
     // 1. Get message asset collection
@@ -761,7 +758,7 @@ void ConversationSystemInternal::StoreConversationMessage(
 }
 
 void ConversationSystemInternal::DeleteMessages(
-    const common::String& ConversationId, common::Array<AssetCollection>& Messages, NullResultCallback Callback)
+    const common::String& /*ConversationId*/, common::Array<AssetCollection>& Messages, NullResultCallback Callback)
 {
     if (Messages.Size() == 0)
     {
@@ -822,7 +819,7 @@ void ConversationSystemInternal::GetConversationAnnotation(const csp::common::St
         .then(CreateAnnotationResult(ConversationAssetCollection, AnnotationAsset, AnnotationThumbnailAsset))
         .then(common::continuations::SendResult(Callback, "Successfully retrieved annotation."))
         .then(common::continuations::InvokeIfExceptionInChain(
-            [Callback](const std::exception& exception) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
+            [Callback](const std::exception& /*exception*/) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
 }
 
 void ConversationSystemInternal::SetConversationAnnotation(const csp::common::String& ConversationId,
@@ -891,7 +888,7 @@ void ConversationSystemInternal::SetConversationAnnotation(const csp::common::St
         .then(CreateAnnotationResult(ConversationAssetCollection, AnnotationAsset, AnnotationThumbnailAsset))
         .then(common::continuations::SendResult(Callback, "Successfully set annotation."))
         .then(common::continuations::InvokeIfExceptionInChain(
-            [Callback](const std::exception& exception) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
+            [Callback](const std::exception& /*exception*/) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
 }
 
 void ConversationSystemInternal::DeleteConversationAnnotation(const csp::common::String& ConversationId, systems::NullResultCallback Callback)
@@ -930,7 +927,8 @@ void ConversationSystemInternal::DeleteConversationAnnotation(const csp::common:
             "Failed to deleted annotation thumbnail asset.", {}, {}, {}))
         // 6. Process result
         .then(common::continuations::ReportSuccess(Callback, "Successfully deleted annotation."))
-        .then(common::continuations::InvokeIfExceptionInChain([Callback](const std::exception& exception) { Callback(MakeInvalid<NullResult>()); }));
+        .then(common::continuations::InvokeIfExceptionInChain(
+            [Callback](const std::exception& /*exception*/) { Callback(MakeInvalid<NullResult>()); }));
 }
 
 void ConversationSystemInternal::GetAnnotation(
@@ -967,7 +965,7 @@ void ConversationSystemInternal::GetAnnotation(
         .then(CreateAnnotationResult(MessageAssetCollection, AnnotationAsset, AnnotationThumbnailAsset))
         .then(common::continuations::SendResult(Callback, "Successfully retrieved annotation."))
         .then(common::continuations::InvokeIfExceptionInChain(
-            [Callback](const std::exception& exception) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
+            [Callback](const std::exception& /*exception*/) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
 }
 
 void ConversationSystemInternal::SetAnnotation(const csp::common::String& ConversationId, const csp::common::String& MessageId,
@@ -1036,7 +1034,7 @@ void ConversationSystemInternal::SetAnnotation(const csp::common::String& Conver
         .then(CreateAnnotationResult(MessageAssetCollection, AnnotationAsset, AnnotationThumbnailAsset))
         .then(common::continuations::SendResult(Callback, "Successfully set annotation."))
         .then(common::continuations::InvokeIfExceptionInChain(
-            [Callback](const std::exception& exception) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
+            [Callback](const std::exception& /*exception*/) { Callback(MakeInvalid<multiplayer::AnnotationResult>()); }));
 }
 
 void ConversationSystemInternal::DeleteAnnotation(
@@ -1077,7 +1075,8 @@ void ConversationSystemInternal::DeleteAnnotation(
             "Failed to deleted annotation thumbnail asset.", {}, {}, {}))
         // 6. Process result
         .then(common::continuations::ReportSuccess(Callback, "Successfully deleted annotation."))
-        .then(common::continuations::InvokeIfExceptionInChain([Callback](const std::exception& exception) { Callback(MakeInvalid<NullResult>()); }));
+        .then(common::continuations::InvokeIfExceptionInChain(
+            [Callback](const std::exception& /*exception*/) { Callback(MakeInvalid<NullResult>()); }));
 }
 
 void ConversationSystemInternal::GetAnnotationThumbnailsForConversation(
@@ -1100,7 +1099,7 @@ void ConversationSystemInternal::GetAnnotationThumbnailsForConversation(
         .then(CreateAnnotationThumbnailCollectionResult())
         .then(common::continuations::SendResult(Callback, "Successfully retrieved annotation thumbnails."))
         .then(common::continuations::InvokeIfExceptionInChain(
-            [Callback](const std::exception& exception) { Callback(MakeInvalid<multiplayer::AnnotationThumbnailCollectionResult>()); }));
+            [Callback](const std::exception& /*exception*/) { Callback(MakeInvalid<multiplayer::AnnotationThumbnailCollectionResult>()); }));
 }
 
 void ConversationSystemInternal::RegisterComponent(csp::multiplayer::ConversationSpaceComponent* Component)

--- a/Library/src/Systems/ECommerce/ECommerce.cpp
+++ b/Library/src/Systems/ECommerce/ECommerce.cpp
@@ -47,7 +47,7 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
         auto VariantProductInformation = Dto.GetVariants();
         ProductInfo.Variants = common::Array<ProductVariantInfo>(VariantProductInformation.size());
 
-        for (int i = 0; i < VariantProductInformation.size(); ++i)
+        for (size_t i = 0; i < VariantProductInformation.size(); ++i)
         {
             ProductInfo.Variants[i].Id = VariantProductInformation[i]->GetId();
             ProductInfo.Variants[i].Title = VariantProductInformation[i]->GetTitle();
@@ -101,7 +101,7 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 
                 ProductInfo.Variants[i].Options = common::Array<VariantOptionInfo>(VariantOptionInformation.size());
 
-                for (int n = 0; n < VariantOptionInformation.size(); ++n)
+                for (size_t n = 0; n < VariantOptionInformation.size(); ++n)
                 {
                     ProductInfo.Variants[i].Options[n].Name = VariantOptionInformation[n]->GetOptionName();
                     ProductInfo.Variants[i].Options[n].Value = VariantOptionInformation[n]->GetOptionValue();
@@ -149,7 +149,7 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 
         ProductInfo.Tags = common::Array<common::String>(TagsProductInformation.size());
 
-        for (int i = 0; i < TagsProductInformation.size(); ++i)
+        for (size_t i = 0; i < TagsProductInformation.size(); ++i)
         {
             ProductInfo.Tags[i] = TagsProductInformation[i];
         }
@@ -165,7 +165,7 @@ void ProductInfoDtoToProductInfo(const chs_aggregation::ShopifyProductDto& Dto, 
 
         ProductInfo.Media = common::Array<ProductMediaInfo>(MediaProductInformation.size());
 
-        for (int i = 0; i < MediaProductInformation.size(); ++i)
+        for (size_t i = 0; i < MediaProductInformation.size(); ++i)
         {
             if (MediaProductInformation[i]->HasAlt())
             {
@@ -204,13 +204,13 @@ void ProductInfoDtoToProductInfoVariantCollection(
     ProductInfoCollection = common::Array<csp::systems::ProductInfo>(ProductInfoCollection.Size());
     int TotalVariantIndex = 0; // Count the total number of variants included in the product Dto's
 
-    for (int DtoCount = 0; DtoCount < DtoArray.size(); DtoCount++) // Loop all Dto's (products)
+    for (size_t DtoCount = 0; DtoCount < DtoArray.size(); DtoCount++) // Loop all Dto's (products)
     {
         const chs_aggregation::ShopifyProductDto& Dto = DtoArray[DtoCount];
 
         if (Dto.HasVariants()) // if there are no variants, we don't process the dto (shouldn't happen)
         {
-            for (int VariantCount = 0; VariantCount < Dto.GetVariants().size();
+            for (size_t VariantCount = 0; VariantCount < Dto.GetVariants().size();
                  VariantCount++) // Loop each variant in the product dto and store the info into the indexed output array
             {
                 auto VariantProductInformation = Dto.GetVariants()[VariantCount];
@@ -273,7 +273,7 @@ void ProductInfoDtoToProductInfoVariantCollection(
 
                     ProductInfoCollection[TotalVariantIndex].Variants[0].Options = common::Array<VariantOptionInfo>(VariantOptionInformation.size());
 
-                    for (int n = 0; n < VariantOptionInformation.size(); ++n)
+                    for (size_t n = 0; n < VariantOptionInformation.size(); ++n)
                     {
                         ProductInfoCollection[TotalVariantIndex].Variants[0].Options[n].Name = VariantOptionInformation[n]->GetOptionName();
                         ProductInfoCollection[TotalVariantIndex].Variants[0].Options[n].Value = VariantOptionInformation[n]->GetOptionValue();
@@ -318,7 +318,7 @@ void ProductInfoDtoToProductInfoVariantCollection(
 
                     ProductInfoCollection[TotalVariantIndex].Tags = common::Array<common::String>(TagsProductInformation.size());
 
-                    for (int j = 0; j < TagsProductInformation.size(); ++j)
+                    for (size_t j = 0; j < TagsProductInformation.size(); ++j)
                     {
                         ProductInfoCollection[TotalVariantIndex].Tags[j] = TagsProductInformation[j];
                     }
@@ -334,7 +334,7 @@ void ProductInfoDtoToProductInfoVariantCollection(
 
                     ProductInfoCollection[TotalVariantIndex].Media = common::Array<ProductMediaInfo>(MediaProductInformation.size());
 
-                    for (int j = 0; j < MediaProductInformation.size(); ++j)
+                    for (size_t j = 0; j < MediaProductInformation.size(); ++j)
                     {
                         if (MediaProductInformation[j]->HasAlt())
                         {
@@ -406,7 +406,7 @@ void CartDtoToCartInfo(const chs_aggregation::ShopifyCartDto& CartDto, csp::syst
         auto DtoLines = CartDto.GetLines();
         Cart.CartLines = csp::common::Array<csp::systems::CartLine>(DtoLines.size());
 
-        for (auto i = 0; i < DtoLines.size(); ++i)
+        for (size_t i = 0; i < DtoLines.size(); ++i)
         {
             auto CartLineDto = *DtoLines[i];
 
@@ -506,7 +506,7 @@ void ShopifyStoreDtoToShopifyStoreInfo(const chs_aggregation::ShopifyStorefrontD
 void ShopifyStoreDtoArrayToShopifyStoreInfoArray(
     const std::vector<chs_aggregation::ShopifyStorefrontDto>& StoreDtos, csp::common::Array<csp::systems::ShopifyStoreInfo>& Stores)
 {
-    for (int i = 0; i < StoreDtos.size(); i++)
+    for (size_t i = 0; i < StoreDtos.size(); i++)
     {
         const chs_aggregation::ShopifyStorefrontDto& StoreDto = StoreDtos[i];
         csp::systems::ShopifyStoreInfo& Store = Stores[i];

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -206,7 +206,7 @@ void ECommerceSystem::UpdateCartInformation(const CartInfo& CartInformation, Car
         auto CartLinesUpdate = std::vector<std::shared_ptr<chs::ShopifyCartLineDto>>();
         auto CartLinesAdditions = std::vector<std::shared_ptr<chs::ShopifyCartLineDto>>();
 
-        for (int i = 0; i < CartInformation.CartLines.Size(); ++i)
+        for (size_t i = 0; i < CartInformation.CartLines.Size(); ++i)
         {
 
             csp::common::String CartLineId = CartInformation.CartLines[i].CartLineId;

--- a/Library/src/Systems/EventTicketing/EventTicketing.cpp
+++ b/Library/src/Systems/EventTicketing/EventTicketing.cpp
@@ -274,7 +274,7 @@ void TicketedEventVendorAuthInfoResult::OnResponse(const csp::services::ApiRespo
 
 bool SpaceIsTicketedResult::GetIsTicketedEvent() { return SpaceIsTicketed; }
 
-const bool SpaceIsTicketedResult::GetIsTicketedEvent() const { return SpaceIsTicketed; }
+bool SpaceIsTicketedResult::GetIsTicketedEvent() const { return SpaceIsTicketed; }
 
 void SpaceIsTicketedResult::OnResponse(const csp::services::ApiResponseBase* ApiResponse)
 {

--- a/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
+++ b/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
@@ -101,7 +101,7 @@ void EventTicketingSystem::GetTicketedEvents(const csp::common::Array<csp::commo
     std::vector<csp::common::String> RequestSpaceIds;
     RequestSpaceIds.reserve(SpaceIds.Size());
 
-    for (auto i = 0; i < SpaceIds.Size(); ++i)
+    for (size_t i = 0; i < SpaceIds.Size(); ++i)
     {
         RequestSpaceIds.push_back(SpaceIds[i]);
     }

--- a/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
+++ b/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
@@ -269,7 +269,7 @@ HotspotSequenceSystem::~HotspotSequenceSystem()
 
 void HotspotSequenceSystem::RemoveItemFromGroups(const csp::common::String& ItemName, csp::systems::NullResultCallback /*Callback*/)
 {
-    systems::SpaceSystem* SpaceSystem = systems::SystemsManager::Get().GetSpaceSystem();
+    systems::SpaceSystem* MySpaceSystem = systems::SystemsManager::Get().GetSpaceSystem();
     // This uses multiple async calls, so ensure this variable exists within this function
     csp::common::String ItemCopy = ItemName;
 
@@ -310,7 +310,7 @@ void HotspotSequenceSystem::RemoveItemFromGroups(const csp::common::String& Item
     };
 
     // Find all sequences containing this name
-    SequenceSystem->GetAllSequencesContainingItems({ ItemCopy }, "GroupId", { SpaceSystem->GetCurrentSpace().Id }, GetSequencesCallback);
+    SequenceSystem->GetAllSequencesContainingItems({ ItemCopy }, "GroupId", { MySpaceSystem->GetCurrentSpace().Id }, GetSequencesCallback);
 }
 
 HotspotSequenceSystem::HotspotSequenceSystem()

--- a/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
+++ b/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
@@ -267,7 +267,7 @@ HotspotSequenceSystem::~HotspotSequenceSystem()
     DeregisterSystemCallback();
 }
 
-void HotspotSequenceSystem::RemoveItemFromGroups(const csp::common::String& ItemName, csp::systems::NullResultCallback Callback)
+void HotspotSequenceSystem::RemoveItemFromGroups(const csp::common::String& ItemName, csp::systems::NullResultCallback /*Callback*/)
 {
     systems::SpaceSystem* SpaceSystem = systems::SystemsManager::Get().GetSpaceSystem();
     // This uses multiple async calls, so ensure this variable exists within this function
@@ -301,7 +301,7 @@ void HotspotSequenceSystem::RemoveItemFromGroups(const csp::common::String& Item
             }
         }
 
-        auto CB = [](const systems::NullResult& Res) {
+        auto CB = [](const systems::NullResult& /*Res*/) {
 
         };
 

--- a/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
+++ b/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
@@ -45,7 +45,7 @@ namespace
             DeletionKeys[i] = Sequences[i].Key;
         }
 
-        auto DeleteCallback = [Callback, SequenceSystem](const csp::systems::NullResult& DeleteResult)
+        auto DeleteCallback = [Callback](const csp::systems::NullResult& DeleteResult)
         {
             if (DeleteResult.GetResultCode() == systems::EResultCode::InProgress)
             {
@@ -145,7 +145,7 @@ void HotspotSequenceSystem::RenameHotspotGroup(
             return;
         }
 
-        auto UpdateCB = [Callback, SQ, NewKey](const SequenceResult& Result)
+        auto UpdateCB = [Callback](const SequenceResult& Result)
         {
             if (Result.GetResultCode() == csp::systems::EResultCode::InProgress)
             {
@@ -273,7 +273,7 @@ void HotspotSequenceSystem::RemoveItemFromGroups(const csp::common::String& Item
     // This uses multiple async calls, so ensure this variable exists within this function
     csp::common::String ItemCopy = ItemName;
 
-    auto GetSequencesCallback = [this, Callback, ItemCopy](const systems::SequencesResult& SequencesResult)
+    auto GetSequencesCallback = [ItemCopy](const systems::SequencesResult& SequencesResult)
     {
         if (SequencesResult.GetResultCode() == systems::EResultCode::InProgress)
         {

--- a/Library/src/Systems/Quota/Quota.cpp
+++ b/Library/src/Systems/Quota/Quota.cpp
@@ -270,8 +270,7 @@ const csp::common::String TierFeatureEnumToString(const TierFeatures& Value)
     // return a default/invalid value if no matching feature was found
     return "Invalid";
 }
-
-const TierNames StringToTierNameEnum(const csp::common::String& Value)
+TierNames StringToTierNameEnum(const csp::common::String& Value)
 {
     if (Value == "basic")
     {
@@ -297,7 +296,7 @@ const TierNames StringToTierNameEnum(const csp::common::String& Value)
     return TierNames::Invalid;
 }
 
-const TierFeatures StringToTierFeatureEnum(const csp::common::String& Value)
+TierFeatures StringToTierFeatureEnum(const csp::common::String& Value)
 {
     if (Value == "Agora")
     {

--- a/Library/src/Systems/Quota/Quota.cpp
+++ b/Library/src/Systems/Quota/Quota.cpp
@@ -24,7 +24,7 @@ namespace chs = csp::services::generated::trackingservice;
 
 namespace csp::systems
 {
-FeatureQuotaInfo::FeatureQuotaInfo(TierFeatures FeatureNameIn, TierNames TierNameIn, int32_t LimitIn, PeriodEnum PeriodIn, bool AllowReductionsIn)
+FeatureQuotaInfo::FeatureQuotaInfo(TierFeatures FeatureNameIn, TierNames TierNameIn, int32_t LimitIn, PeriodEnum PeriodIn, bool /*AllowReductionsIn*/)
     : FeatureName(FeatureNameIn)
     , TierName(TierNameIn)
     , Limit(LimitIn)

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -86,7 +86,7 @@ void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFea
     std::vector<csp::common::String> FeatureNamesList;
     FeatureNamesList.reserve(FeatureNames.Size());
 
-    for (auto idx = 0; idx < FeatureNames.Size(); ++idx)
+    for (size_t idx = 0; idx < FeatureNames.Size(); ++idx)
     {
         FeatureNamesList.push_back(TierFeatureEnumToString(FeatureNames[idx]));
     }
@@ -105,7 +105,7 @@ void QuotaSystem::GetTierFeatureProgressForSpace(
     std::vector<csp::common::String> FeatureNamesList;
     FeatureNamesList.reserve(FeatureNames.Size());
 
-    for (auto idx = 0; idx < FeatureNames.Size(); ++idx)
+    for (size_t idx = 0; idx < FeatureNames.Size(); ++idx)
     {
         FeatureNamesList.push_back(TierFeatureEnumToString(FeatureNames[idx]));
     }

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -158,7 +158,7 @@ void SequenceSystem::RenameSequence(const String& OldSequenceKey, const String& 
 
 void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys, const Optional<String>& InKeyRegex,
     const Optional<String>& InReferenceType, const Array<String>& InReferenceIds,
-    const csp::common::Map<csp::common::String, csp::common::String>& MetaData, SequencesResultCallback Callback)
+    const csp::common::Map<csp::common::String, csp::common::String>& /*MetaData*/, SequencesResultCallback Callback)
 {
     Array<String> EncodedSequenceKeys(InSequenceKeys.Size());
     for (size_t i = 0; i < InSequenceKeys.Size(); i++)

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -263,7 +263,7 @@ void SettingsSystem::AddBlockedSpace(const String InSpaceID, NullResultCallback 
         const auto& BlockedSpacesArray = Result.GetValue();
 
         // Ignore if space already blocked
-        for (int i = 0; i < BlockedSpacesArray.Size(); ++i)
+        for (size_t i = 0; i < BlockedSpacesArray.Size(); ++i)
         {
             if (BlockedSpacesArray[i] == InSpaceID)
             {
@@ -301,7 +301,7 @@ void SettingsSystem::RemoveBlockedSpace(const String InSpaceID, NullResultCallba
         auto FoundSpace = false;
 
         // Ignore if space not blocked
-        for (int i = 0; i < BlockedSpacesArray.Size(); ++i)
+        for (size_t i = 0; i < BlockedSpacesArray.Size(); ++i)
         {
             if (BlockedSpacesArray[i] == InSpaceID)
             {

--- a/Library/src/Systems/Spaces/Space.cpp
+++ b/Library/src/Systems/Spaces/Space.cpp
@@ -270,7 +270,7 @@ void PendingInvitesResult::OnResponse(const csp::services::ApiResponseBase* ApiR
         std::vector<chs_users::GroupInviteDto>& PendingInvitesArray = PendingInvitesResponse->GetArray();
         PendingInvitesEmailAddresses = Array<String>(PendingInvitesArray.size());
 
-        for (auto idx = 0; idx < PendingInvitesArray.size(); ++idx)
+        for (size_t idx = 0; idx < PendingInvitesArray.size(); ++idx)
         {
             PendingInvitesEmailAddresses[idx] = PendingInvitesArray[idx].GetEmail();
         }
@@ -297,7 +297,7 @@ void AcceptedInvitesResult::OnResponse(const csp::services::ApiResponseBase* Api
         std::vector<chs_users::GroupInviteDto>& AcceptedInvitesArray = AcceptedInvitesResponse->GetArray();
         AcceptedInvitesUserIds = Array<String>(AcceptedInvitesArray.size());
 
-        for (auto idx = 0; idx < AcceptedInvitesArray.size(); ++idx)
+        for (size_t idx = 0; idx < AcceptedInvitesArray.size(); ++idx)
         {
             if (AcceptedInvitesArray[idx].HasId())
             {
@@ -336,7 +336,7 @@ void PointOfInterestDtoToSpaceGeoLocation(chs_spatial::PointOfInterestDto& Dto, 
         const auto& GeoFence = Dto.GetGeofence();
         GeoLocation.GeoFence = csp::common::Array<csp::systems::GeoLocation>(GeoFence.size());
 
-        for (int idx = 0; idx < GeoFence.size(); ++idx)
+        for (size_t idx = 0; idx < GeoFence.size(); ++idx)
         {
             csp::systems::GeoLocation GeoFenceLocation;
             GeoFenceLocation.Latitude = GeoFence[idx]->GetLatitude();
@@ -381,7 +381,7 @@ void SpaceGeoLocationCollectionResult::OnResponse(const csp::services::ApiRespon
         std::vector<chs_spatial::PointOfInterestDto>& POIDtos = GeoLocationPOIsResponse->GetArray();
         GeoLocations = Array<SpaceGeoLocation>(POIDtos.size());
 
-        for (auto idx = 0; idx < POIDtos.size(); ++idx)
+        for (size_t idx = 0; idx < POIDtos.size(); ++idx)
         {
             SpaceGeoLocation GeoLocation;
             GeoLocation.Id = POIDtos[idx].GetId();

--- a/Library/src/Systems/Spaces/Space.cpp
+++ b/Library/src/Systems/Spaces/Space.cpp
@@ -315,7 +315,7 @@ void SpacesMetadataResult::SetMetadata(const Map<String, Map<String, String>>& I
 
 void SpacesMetadataResult::SetTags(const Map<String, Array<String>>& InTags) { Tags = InTags; }
 
-const bool SpaceGeoLocationResult::HasSpaceGeoLocation() const { return HasGeoLocation; }
+bool SpaceGeoLocationResult::HasSpaceGeoLocation() const { return HasGeoLocation; }
 
 const SpaceGeoLocation& SpaceGeoLocationResult::GetSpaceGeoLocation() const { return GeoLocation; }
 

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -687,7 +687,7 @@ void SpaceSystem::GetSpacesByIds(const Array<String>& RequestedSpaceIDs, SpacesR
     std::vector<String> SpaceIds;
     SpaceIds.reserve(RequestedSpaceIDs.Size());
 
-    for (auto idx = 0; idx < RequestedSpaceIDs.Size(); ++idx)
+    for (size_t idx = 0; idx < RequestedSpaceIDs.Size(); ++idx)
     {
         SpaceIds.push_back(RequestedSpaceIDs[idx]);
     }
@@ -1009,7 +1009,7 @@ void SpaceSystem::GetSpacesMetadata(const Array<String>& SpaceIds, SpacesMetadat
             Map<String, Array<String>> SpacesTags;
             const auto& AssetCollections = Result.GetAssetCollections();
 
-            for (int i = 0; i < AssetCollections.Size(); ++i)
+            for (size_t i = 0; i < AssetCollections.Size(); ++i)
             {
                 const auto& AssetCollection = AssetCollections[i];
 
@@ -1275,7 +1275,7 @@ void SpaceSystem::GetMetadataAssetCollections(const Array<csp::common::String>& 
     auto* AssetSystem = SystemsManager::Get().GetAssetSystem();
     Array<String> PrototypeNames(SpaceIds.Size());
 
-    for (auto item = 0; item < SpaceIds.Size(); ++item)
+    for (size_t item = 0; item < SpaceIds.Size(); ++item)
     {
         PrototypeNames[item] = SpaceSystemHelpers::GetSpaceMetadataAssetCollectionName(SpaceIds[item]);
     }
@@ -1841,7 +1841,7 @@ void SpaceSystem::DuplicateSpace(const String& SpaceId, const String& NewName, S
         std::vector<String> GroupIds;
         GroupIds.reserve(MemberGroupIds->Size());
 
-        for (int i = 0; i < MemberGroupIds->Size(); ++i)
+        for (size_t i = 0; i < MemberGroupIds->Size(); ++i)
         {
             GroupIds.push_back(MemberGroupIds->operator[](i));
         }

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -111,7 +111,7 @@ void SpaceSystem::RefreshMultiplayerConnectionToEnactScopeChange(
     // Unfortunately we have to stop listening in order for our scope change to take effect, then start again once done.
     // This hopefully will change in a future version when CHS support it.
     MultiplayerConnection->StopListening(
-        [this, MultiplayerConnection, SpaceId, RefreshMultiplayerContinuationEvent](csp::multiplayer::ErrorCode Error)
+        [MultiplayerConnection, SpaceId, RefreshMultiplayerContinuationEvent](csp::multiplayer::ErrorCode Error)
         {
             if (Error != csp::multiplayer::ErrorCode::None)
             {
@@ -121,7 +121,7 @@ void SpaceSystem::RefreshMultiplayerConnectionToEnactScopeChange(
 
             CSP_LOG_MSG(csp::systems::LogLevel::Log, " MultiplayerConnection->StopListening success");
             MultiplayerConnection->SetScopes(SpaceId,
-                [this, MultiplayerConnection, RefreshMultiplayerContinuationEvent](csp::multiplayer::ErrorCode Error)
+                [MultiplayerConnection, RefreshMultiplayerContinuationEvent](csp::multiplayer::ErrorCode Error)
                 {
                     CSP_LOG_MSG(csp::systems::LogLevel::Verbose, "SetScopes callback");
                     if (Error != csp::multiplayer::ErrorCode::None)
@@ -136,7 +136,7 @@ void SpaceSystem::RefreshMultiplayerConnectionToEnactScopeChange(
 
                     MultiplayerConnection->StartListening()()
                         .then(async::inline_scheduler(),
-                            [this, RefreshMultiplayerContinuationEvent]()
+                            [RefreshMultiplayerContinuationEvent]()
                             {
                                 CSP_LOG_MSG(csp::systems::LogLevel::Log, " MultiplayerConnection->StartListening success");
 
@@ -1599,7 +1599,7 @@ void SpaceSystem::RemoveSpaceThumbnail(const csp::common::String& SpaceId, NullR
                     return;
                 }
 
-                NullResultCallback DeleteAssetCollCallback = [Callback, DeleteAssetResult, AssetSystem](const NullResult& DeleteAssetCollResult)
+                NullResultCallback DeleteAssetCollCallback = [Callback, DeleteAssetResult](const NullResult& DeleteAssetCollResult)
                 {
                     if (DeleteAssetCollResult.GetResultCode() == EResultCode::InProgress)
                     {

--- a/Library/src/Systems/Spaces/SpaceSystemHelpers.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystemHelpers.cpp
@@ -131,7 +131,7 @@ namespace SpaceSystemHelpers
     {
         bool IdFound = false;
 
-        for (int i = 0; i < Ids.Size(); ++i)
+        for (size_t i = 0; i < Ids.Size(); ++i)
         {
             if (Ids[i] == UserId)
             {
@@ -175,7 +175,7 @@ namespace SpaceSystemHelpers
         std::vector<std::shared_ptr<chs::GroupInviteDto>> GroupInvites;
         GroupInvites.reserve(InviteUsers.Size());
 
-        for (auto i = 0; i < InviteUsers.Size(); ++i)
+        for (size_t i = 0; i < InviteUsers.Size(); ++i)
         {
             auto InviteUser = InviteUsers[i];
 

--- a/Library/src/Systems/Spaces/UserRoles.cpp
+++ b/Library/src/Systems/Spaces/UserRoles.cpp
@@ -35,7 +35,7 @@ namespace UserRolesHelpers
             return true;
         }
 
-        for (auto idx = 0; idx < Space.ModeratorIds.Size(); ++idx)
+        for (size_t idx = 0; idx < Space.ModeratorIds.Size(); ++idx)
         {
             if (UserId == Space.ModeratorIds[idx])
             {
@@ -44,7 +44,7 @@ namespace UserRolesHelpers
             }
         }
 
-        for (auto idx = 0; idx < Space.UserIds.Size(); ++idx)
+        for (size_t idx = 0; idx < Space.UserIds.Size(); ++idx)
         {
             if (UserId == Space.UserIds[idx])
             {
@@ -68,7 +68,7 @@ void UserRoleCollectionResult::FillUsersRoles(const Space& Space, const csp::com
 
     UserRoles = csp::common::Array<UserRoleInfo>(RequestedUserIds.Size());
 
-    for (auto idx = 0; idx < RequestedUserIds.Size(); ++idx)
+    for (size_t idx = 0; idx < RequestedUserIds.Size(); ++idx)
     {
         auto& currentUserId = RequestedUserIds[idx];
         UserRoleInfo currentRoleInfo;

--- a/Library/src/Systems/Spatial/AnchorSystem.cpp
+++ b/Library/src/Systems/Spatial/AnchorSystem.cpp
@@ -85,7 +85,7 @@ void AnchorSystem::CreateAnchor(csp::systems::AnchorProvider ThirdPartyAnchorPro
     {
         auto* Keys = SpatialKeyValue->Keys();
 
-        for (auto idx = 0; idx < Keys->Size(); ++idx)
+        for (size_t idx = 0; idx < Keys->Size(); ++idx)
         {
             auto Key = Keys->operator[](idx);
             auto Value = SpatialKeyValue->operator[](Key);
@@ -162,7 +162,7 @@ void AnchorSystem::CreateAnchorInSpace(csp::systems::AnchorProvider ThirdPartyAn
     {
         auto* Keys = SpatialKeyValue->Keys();
 
-        for (auto idx = 0; idx < Keys->Size(); ++idx)
+        for (size_t idx = 0; idx < Keys->Size(); ++idx)
         {
             auto Key = Keys->operator[](idx);
             auto Value = SpatialKeyValue->operator[](Key);

--- a/Library/src/Systems/Spatial/PointOfInterest.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterest.cpp
@@ -56,7 +56,7 @@ void PointOfInterestDtoToPointOfInterest(const chs::PointOfInterestDto& Dto, csp
         const auto& Tags = Dto.GetTags();
         POI.Tags = csp::common::Array<csp::common::String>(Tags.size());
 
-        for (int idx = 0; idx < Tags.size(); ++idx)
+        for (size_t idx = 0; idx < Tags.size(); ++idx)
         {
             POI.Tags[idx] = Tags[idx];
         }

--- a/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
@@ -72,7 +72,7 @@ CSP_ASYNC_RESULT void PointOfInterestSystem::CreatePOI(const csp::common::String
         std::vector<csp::common::String> DTOTags;
         DTOTags.reserve(Tags->Size());
 
-        for (int idx = 0; idx < Tags->Size(); idx++)
+        for (size_t idx = 0; idx < Tags->Size(); idx++)
         {
             DTOTags.push_back((*Tags)[idx]);
         }

--- a/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
@@ -46,7 +46,7 @@ PointOfInterestSystem::PointOfInterestSystem(csp::web::WebClient* InWebClient)
 PointOfInterestSystem::~PointOfInterestSystem() { CSP_DELETE(POIApiPtr); }
 
 CSP_ASYNC_RESULT void PointOfInterestSystem::CreatePOI(const csp::common::String& Title, const csp::common::String& Description,
-    const csp::common::String& Name, const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags, EPointOfInterestType Type,
+    const csp::common::String& Name, const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags, EPointOfInterestType /*Type*/,
     const csp::common::String& Owner, const csp::systems::GeoLocation& Location, const AssetCollection& AssetCollection, POIResultCallback Callback)
 {
     auto POIInfo = std::make_shared<chs::PointOfInterestDto>();

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -233,23 +233,23 @@ void AgoraUserTokenResult::OnResponse(const services::ApiResponseBase* ApiRespon
     if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
     {
         AuthResponse->FromJson(Response->GetPayload().GetContent());
-        std::shared_ptr<rapidjson::Document> Result = AuthResponse->GetOperationResult();
+        std::shared_ptr<rapidjson::Document> OperationResult = AuthResponse->GetOperationResult();
 
-        if (!Result)
+        if (!OperationResult)
         {
             CSP_LOG_MSG(LogLevel::Error, "AgoraUserTokenResult invalid");
 
             return;
         }
 
-        if (!Result->HasMember("token"))
+        if (!OperationResult->HasMember("token"))
         {
             CSP_LOG_MSG(LogLevel::Error, "AgoraUserTokenResult doesn't contain expected member: token");
 
             return;
         }
 
-        SetValue(Result->operator[]("token").GetString());
+        SetValue(OperationResult->operator[]("token").GetString());
     }
 }
 
@@ -263,23 +263,23 @@ void PostServiceProxyResult::OnResponse(const services::ApiResponseBase* ApiResp
     if (ApiResponse->GetResponseCode() == services::EResponseCode::ResponseSuccess)
     {
         AuthResponse->FromJson(Response->GetPayload().GetContent());
-        std::shared_ptr<rapidjson::Document> Result = AuthResponse->GetOperationResult();
+        std::shared_ptr<rapidjson::Document> OperationResult = AuthResponse->GetOperationResult();
 
-        if (!Result)
+        if (!OperationResult)
         {
             CSP_LOG_MSG(LogLevel::Error, "PostServiceProxyResult invalid");
 
             return;
         }
 
-        if (!Result->HasMember("token"))
+        if (!OperationResult->HasMember("token"))
         {
             CSP_LOG_MSG(LogLevel::Error, "PostServiceProxyResult doesn't contain expected member: token");
 
             return;
         }
 
-        SetValue(Result->operator[]("token").GetString());
+        SetValue(OperationResult->operator[]("token").GetString());
     }
 }
 

--- a/Library/src/Systems/Users/Profile.cpp
+++ b/Library/src/Systems/Users/Profile.cpp
@@ -78,7 +78,7 @@ void ProfileDtoToProfile(const chs::ProfileDto& Dto, csp::systems::Profile& Prof
         auto ResponseRoles = Dto.GetRoles();
         Profile.Roles = csp::common::Array<csp::common::String>(ResponseRoles.size());
 
-        for (int i = 0; i < ResponseRoles.size(); ++i)
+        for (size_t i = 0; i < ResponseRoles.size(); ++i)
         {
             Profile.Roles[i] = ResponseRoles[i];
         }

--- a/Library/src/Systems/Voip/VoipSystem.cpp
+++ b/Library/src/Systems/Voip/VoipSystem.cpp
@@ -22,7 +22,7 @@ VoipSystem::VoipSystem() { }
 
 VoipSystem::~VoipSystem() { }
 
-void VoipSystem::MuteLocalUser(bool IsMuted)
+void VoipSystem::MuteLocalUser(bool /*IsMuted*/)
 {
     // Not implemented
 }

--- a/Library/src/Systems/WebService.cpp
+++ b/Library/src/Systems/WebService.cpp
@@ -87,9 +87,9 @@ void ResultBase::OnResponse(const services::ApiResponseBase* ApiResponse)
     }
 }
 
-const EResultCode ResultBase::GetResultCode() const { return Result; }
+EResultCode ResultBase::GetResultCode() const { return Result; }
 
-const uint16_t ResultBase::GetHttpResultCode() const { return HttpResponseCode; }
+uint16_t ResultBase::GetHttpResultCode() const { return HttpResponseCode; }
 
 const csp::common::String& ResultBase::GetResponseBody() const { return ResponseBody; }
 

--- a/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
+++ b/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
@@ -120,20 +120,20 @@ EmscriptenWebClient::EmscriptenWebClient(const Port InPort, const ETransferProto
     std::srand(std::time(nullptr));
 }
 
-std::string EmscriptenWebClient::MD5Hash(const void* Data, const size_t Size)
+std::string EmscriptenWebClient::MD5Hash(const void* /*Data*/, const size_t /*Size*/)
 {
     assert(false && "Not implemented!");
     return "MD5Hash Not Implemented";
 }
 
 void EmscriptenWebClient::SetFileUploadContentFromFile(
-    HttpPayload* Payload, const char* FilePath, const char* Version, const csp::common::String& MediaType)
+    HttpPayload* /*Payload*/, const char* /*FilePath*/, const char* /*Version*/, const csp::common::String& /*MediaType*/)
 {
     assert(false && "Not implemented!");
 }
 
 void EmscriptenWebClient::SetFileUploadContentFromString(HttpPayload* Payload, const csp::common::String& StringSource,
-    const csp::common::String& FileName, const char* Version, const csp::common::String& MediaType)
+    const csp::common::String& FileName, const char* /*Version*/, const csp::common::String& MediaType)
 {
     std::ostringstream strm;
     strm << "MIME_boundary_" << std::rand();
@@ -151,7 +151,7 @@ void EmscriptenWebClient::SetFileUploadContentFromString(HttpPayload* Payload, c
 
 // This function is deliberately written this way to reduce the number of allocations and string copying. Do not change it!
 void EmscriptenWebClient::SetFileUploadContentFromBuffer(HttpPayload* Payload, const char* Buffer, size_t BufferLength,
-    const csp::common::String& FileName, const char* Version, const csp::common::String& MediaType)
+    const csp::common::String& FileName, const char* /*Version*/, const csp::common::String& MediaType)
 {
     constexpr const char Boundary[] = "MIME_boundary_FileFromBuffer";
     constexpr size_t BoundaryLen = CStringLength(Boundary);

--- a/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
+++ b/Library/src/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
@@ -67,7 +67,7 @@ void OnFetchSuccessOrError(emscripten_fetch_t* Fetch)
     auto& Payload = Response.GetMutablePayload();
     auto* Keys = Headers.Keys();
 
-    for (int i = 0; i < Keys->Size(); ++i)
+    for (rapidjson::SizeType i = 0; i < Keys->Size(); ++i)
     {
         auto Key = Keys->operator[](i).ToLower();
         auto Value = Headers[Key].ToLower();

--- a/Library/src/Web/HttpPayload.cpp
+++ b/Library/src/Web/HttpPayload.cpp
@@ -163,7 +163,7 @@ void HttpPayload::Reset()
     Headers.clear();
 }
 
-void HttpPayload::AddFormParam(const char* Name, const std::shared_ptr<csp::web::HttpPayload>& formFile)
+void HttpPayload::AddFormParam(const char* /*Name*/, const std::shared_ptr<csp::web::HttpPayload>& formFile)
 {
     // Set Multipart type and some boundary value
     std::string BoundaryText = "multipart/form-data; boundary=" + std::string(formFile->Boundary.c_str());

--- a/Library/src/Web/HttpRequest.cpp
+++ b/Library/src/Web/HttpRequest.cpp
@@ -87,9 +87,9 @@ void HttpRequest::WriteResponseData(size_t Offset, const char* Data, size_t Data
     Response.GetMutablePayload().WriteContent(Offset, Data, DataLength);
 }
 
-void HttpRequest::SetResponseProgress(float Progress)
+void HttpRequest::SetResponseProgress(float ReponseProgress)
 {
-    Response.GetProgress().SetProgressPercentage(Progress);
+    Response.GetProgress().SetProgressPercentage(ReponseProgress);
 
     if (Callback)
     {

--- a/Library/src/Web/HttpRequest.cpp
+++ b/Library/src/Web/HttpRequest.cpp
@@ -60,7 +60,7 @@ HttpRequest::~HttpRequest()
     }
 }
 
-const ERequestVerb HttpRequest::GetVerb() const { return Verb; }
+ERequestVerb HttpRequest::GetVerb() const { return Verb; }
 
 const csp::web::Uri& HttpRequest::GetUri() const { return Uri; }
 
@@ -176,7 +176,7 @@ uint32_t HttpRequest::GetRetryCount() const { return RetryCount; }
 
 void HttpRequest::SetSendDelay(const std::chrono::milliseconds InSendDelay) { SendDelay = InSendDelay; }
 
-const std::chrono::milliseconds HttpRequest::GetSendDelay() { return SendDelay; }
+std::chrono::milliseconds HttpRequest::GetSendDelay() { return SendDelay; }
 
 void HttpRequest::EnableAutoRetry(bool Enable) { IsAutoRetryEnabled = Enable; }
 

--- a/Library/src/Web/HttpRequest.h
+++ b/Library/src/Web/HttpRequest.h
@@ -65,7 +65,7 @@ public:
         csp::common::CancellationToken& CancellationToken, bool CallbackIsAsync = true);
     ~HttpRequest();
 
-    const ERequestVerb GetVerb() const;
+    ERequestVerb GetVerb() const;
     const csp::web::Uri& GetUri() const;
     HttpPayload& GetMutablePayload();
     const HttpPayload& GetPayload() const;
@@ -97,7 +97,7 @@ public:
     uint32_t GetRetryCount() const;
 
     void SetSendDelay(const std::chrono::milliseconds InSendDelay);
-    const std::chrono::milliseconds GetSendDelay();
+    std::chrono::milliseconds GetSendDelay();
 
     void Cancel();
     bool Cancelled();

--- a/Library/src/Web/HttpResponse.h
+++ b/Library/src/Web/HttpResponse.h
@@ -27,7 +27,7 @@ class HttpResponse;
 
 struct IHttpResponseHandler
 {
-    virtual void OnHttpProgress(HttpRequest& Request) {};
+    virtual void OnHttpProgress(HttpRequest& /*Request*/) {};
     virtual void OnHttpResponse(HttpResponse& Response) = 0;
     virtual bool ShouldDelete() const { return false; }
 

--- a/Library/src/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Web/POCOWebClient/POCOWebClient.cpp
@@ -396,7 +396,7 @@ void POCOWebClient::ProcessResponseAsync(
 }
 
 void POCOWebClient::ProcessRequestAsync(
-    Poco::Net::HTTPClientSession& ClientSession, Poco::Net::HTTPRequest& PocoRequest, std::ostream& RequestStream, HttpRequest& Request)
+    Poco::Net::HTTPClientSession& ClientSession, Poco::Net::HTTPRequest& /*PocoRequest*/, std::ostream& RequestStream, HttpRequest& Request)
 {
     CSP_PROFILE_SCOPED();
 
@@ -469,7 +469,7 @@ void POCOWebClient::SetFileUploadContentFromString(HttpPayload* Payload, const c
 
 // This function is deliberately written this way to reduce the number of allocations and string copying. Do not change it!
 void POCOWebClient::SetFileUploadContentFromBuffer(HttpPayload* Payload, const char* Buffer, size_t BufferLength, const csp::common::String& FileName,
-    const char* Version, const csp::common::String& MediaType)
+    const char* /*Version*/, const csp::common::String& MediaType)
 {
     constexpr const char Boundary[] = "MIME_boundary_FileFromBuffer";
     constexpr size_t BoundaryLen = CStringLength(Boundary);

--- a/Library/src/Web/POCOWebClient/POCOWebClient.h
+++ b/Library/src/Web/POCOWebClient/POCOWebClient.h
@@ -47,7 +47,7 @@ public:
     {
     }
 
-    virtual void onPrivateKeyRequested(const void* pSender, std::string& privateKey) override { }
+    virtual void onPrivateKeyRequested(const void* /*pSender*/, std::string& /*privateKey*/) override { }
 };
 
 class POCOWebClient : public WebClient

--- a/Library/src/Web/Uri.h
+++ b/Library/src/Web/Uri.h
@@ -47,7 +47,7 @@ private:
 };
 
 template <class T>
-[[deprecated("Unsupported type for URI param, please add support for it")]] inline void Uri::AddQueryParams(const char* ParamName, T Param)
+[[deprecated("Unsupported type for URI param, please add support for it")]] inline void Uri::AddQueryParams(const char* /*ParamName*/, T /*Param*/)
 {
     assert(false && "Unknown param type in Api binding");
 }

--- a/Library/src/Web/WebClient.cpp
+++ b/Library/src/Web/WebClient.cpp
@@ -458,7 +458,7 @@ void WebClient::PrintClientErrorResponseMessages(const HttpResponse& Response)
     }
     else
     {
-        for (auto i = 0; i < Errors.Size(); ++i)
+        for (size_t i = 0; i < Errors.Size(); ++i)
         {
             CSP_LOG_ERROR_FORMAT("Services request %s %s has returned a failed response (%i) with payload/error message: %s", Verb.c_str(),
                 Response.GetRequest()->GetUri().GetAsString(), ResponseCode, Errors[i].c_str());

--- a/Library/src/Web/WebClient.cpp
+++ b/Library/src/Web/WebClient.cpp
@@ -29,7 +29,7 @@ using namespace std::chrono_literals;
 namespace csp::web
 {
 
-WebClient::WebClient(const Port InPort, const ETransferProtocol Tp, bool AutoRefresh)
+WebClient::WebClient(const Port InPort, const ETransferProtocol /*Tp*/, bool AutoRefresh)
     : RootPort(InPort)
     , UserSystem(nullptr)
     , LoginState(nullptr)
@@ -187,7 +187,7 @@ void WebClient::SendRequest(ERequestVerb Verb, const csp::web::Uri& InUri, HttpP
 #endif
 }
 
-void WebClient::AddRequest(HttpRequest* Request, std::chrono::milliseconds SendDelay)
+void WebClient::AddRequest(HttpRequest* Request, [[maybe_unused]] std::chrono::milliseconds SendDelay)
 {
     RefreshIfExpired();
 

--- a/MultiplayerTestRunner/src/LoginRAII.cpp
+++ b/MultiplayerTestRunner/src/LoginRAII.cpp
@@ -28,7 +28,7 @@ namespace
 {
 /* Login to CHS. Return the userID on success */
 csp::common::String LogIn(csp::systems::UserSystem& UserSystem, const csp::common::String& Email, const csp::common::String& Password,
-    bool AgeVerified, csp::systems::EResultCode ExpectedResultCode, csp::systems::ERequestFailureReason ExpectedResultFailureCode)
+    bool AgeVerified, csp::systems::EResultCode /*ExpectedResultCode*/, csp::systems::ERequestFailureReason /*ExpectedResultFailureCode*/)
 {
     std::promise<csp::systems::LoginStateResult> ResultPromise;
     std::future<csp::systems::LoginStateResult> ResultFuture = ResultPromise.get_future();

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -56,6 +56,8 @@ void RunTest()
     EntitySystem.CreateAvatar(UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode,
         [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
 
+    ResultFuture.get();
+
     EntitySystem.ProcessPendingEntityOperations();
 
     // This is a hail mary attempt to get this to stop being flaky on CI. CHS is known to sometimes have a processing delay, which is unfortunate.

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -34,14 +34,11 @@ void RunTest()
     csp::systems::Space Space;
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
-    auto& SpaceSystem = *SystemsManager.GetSpaceSystem();
     auto& EntitySystem = *SystemsManager.GetSpaceEntitySystem();
 
     UUIDv4::UUIDGenerator<std::mt19937_64> uuidGenerator;
     const UUIDv4::UUID uuid = uuidGenerator.getUUID();
     std::string UniqueSpaceName = "MultiplayerTestRunnerSpace" + std::string("-") + uuid.str();
-
-    constexpr const char* TestSpaceDescription = "Test space from the CSP multiplayer test runner";
 
     // Create avater
     csp::common::String UserName = "Player 1";
@@ -58,8 +55,6 @@ void RunTest()
 
     EntitySystem.CreateAvatar(UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode,
         [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
-
-    csp::multiplayer::SpaceEntity* Avatar = ResultFuture.get();
 
     EntitySystem.ProcessPendingEntityOperations();
 

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -51,7 +51,7 @@ void RunTest()
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    EntitySystem.SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem.SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     std::promise<csp::multiplayer::SpaceEntity*> ResultPromise;
     std::future<csp::multiplayer::SpaceEntity*> ResultFuture = ResultPromise.get_future();

--- a/MultiplayerTestRunner/src/RunnableTests/CreateConversation.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateConversation.cpp
@@ -39,7 +39,6 @@ This scenario would fail if events arent correctly stored, and then flushed when
 void RunTest()
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
-    auto& SpaceSystem = *SystemsManager.GetSpaceSystem();
     auto& EntitySystem = *SystemsManager.GetSpaceEntitySystem();
 
     std::promise<csp::multiplayer::SpaceEntity*> CreateObjectResultPromise;

--- a/MultiplayerTestRunner/src/SpaceRAII.cpp
+++ b/MultiplayerTestRunner/src/SpaceRAII.cpp
@@ -100,20 +100,20 @@ SpaceRAII::~SpaceRAII()
 
     if (CreatedThisSpace)
     {
-        std::promise<csp::systems::NullResult> ResultPromise;
-        std::future<csp::systems::NullResult> ResultFuture = ResultPromise.get_future();
+        std::promise<csp::systems::NullResult> ResultPromise2;
+        std::future<csp::systems::NullResult> ResultFuture2 = ResultPromise2.get_future();
 
         SpaceSystem.DeleteSpace(SpaceId.c_str(),
-            [&ResultPromise](csp::systems::NullResult Result)
+            [&ResultPromise2](csp::systems::NullResult Result)
             {
                 // Callbacks are called both in progress and at the end, guard against double promise sets
                 if (Result.GetResultCode() == csp::systems::EResultCode::Success || Result.GetResultCode() == csp::systems::EResultCode::Failed)
                 {
-                    ResultPromise.set_value(Result);
+                    ResultPromise2.set_value(Result);
                 }
             });
 
-        csp::systems::NullResult DeleteSpaceResult = ResultFuture.get();
+        csp::systems::NullResult DeleteSpaceResult = ResultFuture2.get();
 
         if (DeleteSpaceResult.GetResultCode() == csp::systems::EResultCode::Success)
         {

--- a/MultiplayerTestRunner/src/Utils.cpp
+++ b/MultiplayerTestRunner/src/Utils.cpp
@@ -39,8 +39,8 @@ std::string Utils::GetUniqueString()
 }
 
 /* Create a new user. Return the profile on success */
-csp::systems::Profile Utils::CreateTestUser(bool AgeVerified /* = true */, csp::systems::EResultCode ExpectedResultCode /* = Success */,
-    csp::systems::ERequestFailureReason ExpectedResultFailureCode /* = None */)
+csp::systems::Profile Utils::CreateTestUser(bool AgeVerified /* = true */, csp::systems::EResultCode /*ExpectedResultCode*/ /* = Success */,
+    csp::systems::ERequestFailureReason /*ExpectedResultFailureCode*/ /* = None */)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto& UserSystem = *SystemsManager.GetUserSystem();

--- a/Tests/src/InternalTests/CommonTypeTests/Array.cpp
+++ b/Tests/src/InternalTests/CommonTypeTests/Array.cpp
@@ -225,7 +225,7 @@ CSP_INTERNAL_TEST(CSPEngine, CommonArrayTests, ArrayToListTest)
         EXPECT_EQ(ConvertedList.Size(), Instance.Size());
 
         // All elements should match those in the array, but should not have the same address
-        for (int i = 0; i < Instance.Size(); ++i)
+        for (size_t i = 0; i < Instance.Size(); ++i)
         {
             EXPECT_EQ(ConvertedList[i], Instance[i]);
             EXPECT_NE(&ConvertedList[i], &Instance[i]);

--- a/Tests/src/InternalTests/JsonTests.cpp
+++ b/Tests/src/InternalTests/JsonTests.cpp
@@ -30,7 +30,6 @@ struct TestObjectProps
     float FloatMember = 0.f;
     float DoubleMember = 0.0;
     csp::common::String StringMember = "";
-    const char* CharPtrMember = "";
 };
 
 void ToJson(JsonSerializer& Serializer, const TestObjectProps& Obj)
@@ -42,7 +41,6 @@ void ToJson(JsonSerializer& Serializer, const TestObjectProps& Obj)
     Serializer.SerializeMember("floatMember", Obj.FloatMember);
     Serializer.SerializeMember("doubleMember", Obj.DoubleMember);
     Serializer.SerializeMember("stringMember", Obj.StringMember);
-    Serializer.SerializeMember("charPtrMember", Obj.CharPtrMember);
 }
 
 void FromJson(const JsonDeserializer& Deserializer, TestObjectProps& Obj)
@@ -54,7 +52,6 @@ void FromJson(const JsonDeserializer& Deserializer, TestObjectProps& Obj)
     Deserializer.DeserializeMember("floatMember", Obj.FloatMember);
     Deserializer.DeserializeMember("doubleMember", Obj.DoubleMember);
     Deserializer.DeserializeMember("stringMember", Obj.StringMember);
-    Deserializer.DeserializeMember("charPtrMember", Obj.CharPtrMember);
 }
 
 struct TestOptionalPropObject
@@ -148,7 +145,6 @@ CSP_INTERNAL_TEST(CSPEngine, JsonTests, JsonPropertiesTest)
     Obj.FloatMember = 5.f;
     Obj.DoubleMember = 6.0;
     Obj.StringMember = "Test";
-    Obj.CharPtrMember = "Test2";
 
     const csp::common::String result = JsonSerializer::Serialize(Obj);
 
@@ -162,7 +158,6 @@ CSP_INTERNAL_TEST(CSPEngine, JsonTests, JsonPropertiesTest)
     EXPECT_EQ(Obj.FloatMember, Obj2.FloatMember);
     EXPECT_EQ(Obj.DoubleMember, Obj2.DoubleMember);
     EXPECT_EQ(Obj.StringMember, Obj2.StringMember);
-    EXPECT_TRUE(strcmp(Obj.CharPtrMember, Obj2.CharPtrMember));
 }
 
 CSP_INTERNAL_TEST(CSPEngine, JsonTests, JsonOptionalPropertyTest)

--- a/Tests/src/InternalTests/PlatformTestUtils.cpp
+++ b/Tests/src/InternalTests/PlatformTestUtils.cpp
@@ -131,7 +131,7 @@ void WebSocketSendReceive(csp::multiplayer::IWebSocketClient* WebSocketClient)
 {
     bool finished2 = false;
 
-    auto Fn2 = [&](const std::string& S, bool result)
+    auto Fn2 = [&](const std::string& /*S*/, bool result)
     {
         finished2 = true;
         EXPECT_TRUE(result);

--- a/Tests/src/InternalTests/SerialisationTests.cpp
+++ b/Tests/src/InternalTests/SerialisationTests.cpp
@@ -109,24 +109,24 @@ CSP_INTERNAL_TEST(CSPEngine, SerialisationTests, SpaceEntityUserSignalRSerialisa
         {
             EXPECT_TRUE(ComponentValue.is_array() && ComponentValue.as_array()[0].is_double());
 
-            auto& Array = ComponentValue.as_array();
+            auto& FloatArray = ComponentValue.as_array();
 
             if (Key == COMPONENT_KEY_VIEW_POSITION)
             {
 
-                EXPECT_TRUE(Array.size() == 3 && Array[0].as_double() == User->Transform.Position.X
-                    && Array[1].as_double() == User->Transform.Position.Y && Array[2].as_double() == User->Transform.Position.Z);
+                EXPECT_TRUE(FloatArray.size() == 3 && FloatArray[0].as_double() == User->Transform.Position.X
+                    && FloatArray[1].as_double() == User->Transform.Position.Y && FloatArray[2].as_double() == User->Transform.Position.Z);
             }
             else if (Key == COMPONENT_KEY_VIEW_ROTATION)
             {
-                EXPECT_TRUE(Array.size() == 4 && Array[0].as_double() == User->Transform.Rotation.X
-                    && Array[1].as_double() == User->Transform.Rotation.Y && Array[2].as_double() == User->Transform.Rotation.Z
-                    && Array[3].as_double() == User->Transform.Rotation.W);
+                EXPECT_TRUE(FloatArray.size() == 4 && FloatArray[0].as_double() == User->Transform.Rotation.X
+                    && FloatArray[1].as_double() == User->Transform.Rotation.Y && FloatArray[2].as_double() == User->Transform.Rotation.Z
+                    && FloatArray[3].as_double() == User->Transform.Rotation.W);
             }
             else if (Key == COMPONENT_KEY_VIEW_SCALE)
             {
-                EXPECT_TRUE(Array.size() == 3 && Array[0].as_double() == User->Transform.Scale.X && Array[1].as_double() == User->Transform.Scale.Y
-                    && Array[2].as_double() == User->Transform.Scale.Z);
+                EXPECT_TRUE(FloatArray.size() == 3 && FloatArray[0].as_double() == User->Transform.Scale.X
+                    && FloatArray[1].as_double() == User->Transform.Scale.Y && FloatArray[2].as_double() == User->Transform.Scale.Z);
             }
             else
             {
@@ -292,24 +292,24 @@ CSP_INTERNAL_TEST(CSPEngine, SerialisationTests, SpaceEntityObjectSignalRSeriali
         {
             EXPECT_TRUE(ComponentValue.is_array() && ComponentValue.as_array()[0].is_double());
 
-            auto& Array = ComponentValue.as_array();
+            auto& FloatArray = ComponentValue.as_array();
 
             if (Key == COMPONENT_KEY_VIEW_POSITION)
             {
 
-                EXPECT_TRUE(Array.size() == 3 && Array[0].as_double() == Object->Transform.Position.X
-                    && Array[1].as_double() == Object->Transform.Position.Y && Array[2].as_double() == Object->Transform.Position.Z);
+                EXPECT_TRUE(FloatArray.size() == 3 && FloatArray[0].as_double() == Object->Transform.Position.X
+                    && FloatArray[1].as_double() == Object->Transform.Position.Y && FloatArray[2].as_double() == Object->Transform.Position.Z);
             }
             else if (Key == COMPONENT_KEY_VIEW_ROTATION)
             {
-                EXPECT_TRUE(Array.size() == 4 && Array[0].as_double() == Object->Transform.Rotation.X
-                    && Array[1].as_double() == Object->Transform.Rotation.Y && Array[2].as_double() == Object->Transform.Rotation.Z
-                    && Array[3].as_double() == Object->Transform.Rotation.W);
+                EXPECT_TRUE(FloatArray.size() == 4 && FloatArray[0].as_double() == Object->Transform.Rotation.X
+                    && FloatArray[1].as_double() == Object->Transform.Rotation.Y && FloatArray[2].as_double() == Object->Transform.Rotation.Z
+                    && FloatArray[3].as_double() == Object->Transform.Rotation.W);
             }
             else if (Key == COMPONENT_KEY_VIEW_SCALE)
             {
-                EXPECT_TRUE(Array.size() == 3 && Array[0].as_double() == Object->Transform.Scale.X
-                    && Array[1].as_double() == Object->Transform.Scale.Y && Array[2].as_double() == Object->Transform.Scale.Z);
+                EXPECT_TRUE(FloatArray.size() == 3 && FloatArray[0].as_double() == Object->Transform.Scale.X
+                    && FloatArray[1].as_double() == Object->Transform.Scale.Y && FloatArray[2].as_double() == Object->Transform.Scale.Z);
             }
             else
             {

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -42,9 +42,6 @@ using namespace csp::multiplayer;
 namespace
 {
 
-MultiplayerConnection* Connection;
-SpaceEntitySystem* EntitySystem;
-
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
 void CreateAvatarForLeaderElection(csp::multiplayer::SpaceEntitySystem* EntitySystem)
@@ -84,7 +81,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalPositionTest
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -224,7 +220,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalRotationTest
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -364,7 +359,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalScaleTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -504,7 +498,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityParentIdTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -643,7 +636,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, RemoveSpaceEntityParentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -780,7 +772,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, GetRootHierarchyEntitiesTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -116,7 +116,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalPositionTest
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetScriptSystemReadyCallback(ScriptSystemReadyCallback);
 
@@ -256,7 +256,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalRotationTest
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetScriptSystemReadyCallback(ScriptSystemReadyCallback);
 
@@ -396,7 +396,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalScaleTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetScriptSystemReadyCallback(ScriptSystemReadyCallback);
 
@@ -536,7 +536,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityParentIdTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetScriptSystemReadyCallback(ScriptSystemReadyCallback);
 
@@ -675,7 +675,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, RemoveSpaceEntityParentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetScriptSystemReadyCallback(ScriptSystemReadyCallback);
 
@@ -812,7 +812,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, GetRootHierarchyEntitiesTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetScriptSystemReadyCallback(ScriptSystemReadyCallback);
 

--- a/Tests/src/MultiplayerTestRunnerProcess.cpp
+++ b/Tests/src/MultiplayerTestRunnerProcess.cpp
@@ -95,33 +95,33 @@ MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::operator=(Multiplaye
     return *this;
 }
 
-MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetLoginEmail(std::string LoginEmail)
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetLoginEmail(std::string SetLoginEmail)
 {
-    this->LoginEmail = std::move(LoginEmail);
+    this->LoginEmail = std::move(SetLoginEmail);
     return *this;
 }
 
-MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetPassword(std::string Password)
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetPassword(std::string SetPassword)
 {
-    this->Password = std::move(Password);
+    this->Password = std::move(SetPassword);
     return *this;
 }
 
-MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetSpaceId(std::string SpaceId)
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetSpaceId(std::string SetSpaceId)
 {
-    this->SpaceId = std::move(SpaceId);
+    this->SpaceId = std::move(SetSpaceId);
     return *this;
 }
 
-MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetTimeoutInSeconds(int TimeoutInSeconds)
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetTimeoutInSeconds(int SetTimeoutInSeconds)
 {
-    this->TimeoutInSeconds = TimeoutInSeconds;
+    this->TimeoutInSeconds = SetTimeoutInSeconds;
     return *this;
 }
 
-MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetEndpoint(std::string Endpoint)
+MultiplayerTestRunnerProcess& MultiplayerTestRunnerProcess::SetEndpoint(std::string SetEndpoint)
 {
-    this->Endpoint = std::move(Endpoint);
+    this->Endpoint = std::move(SetEndpoint);
     return *this;
 }
 

--- a/Tests/src/PublicAPITests/AnchorSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnchorSystemTests.cpp
@@ -147,11 +147,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSET-COLLECTION-REWIND";
 
     char UniqueAssetCollectionName[256];
@@ -187,7 +184,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorInSpaceTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -248,7 +244,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, DeleteMultipleAnchorsTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -327,7 +322,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -456,7 +450,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInSpaceTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -540,7 +533,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsByAssetCollectionIdTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     char UniqueSpaceName[256];
@@ -602,7 +594,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorResolutionTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/AnchorSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnchorSystemTests.cpp
@@ -210,7 +210,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorInSpaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
@@ -273,7 +273,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, DeleteMultipleAnchorsTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
@@ -352,7 +352,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
@@ -481,7 +481,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInSpaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
@@ -625,7 +625,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorResolutionTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };

--- a/Tests/src/PublicAPITests/AnchorSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnchorSystemTests.cpp
@@ -103,7 +103,7 @@ void DeleteAnchors(csp::systems::AnchorSystem* AnchorSystem, const csp::common::
 
     if (Result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        for (int idx = 0; idx < AnchorIDs.Size(); idx++)
+        for (size_t idx = 0; idx < AnchorIDs.Size(); idx++)
         {
             std::cerr << "Anchor Deleted: "
                       << "Id=" << AnchorIDs[idx] << std::endl;
@@ -391,7 +391,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
         const auto& ResultAnchors = Result.GetAnchors();
         AnchorCollection = csp::common::Array<csp::systems::Anchor>(ResultAnchors.Size());
 
-        for (int idx = 0; idx < ResultAnchors.Size(); ++idx)
+        for (size_t idx = 0; idx < ResultAnchors.Size(); ++idx)
         {
             AnchorCollection[idx] = ResultAnchors[idx];
         }
@@ -573,7 +573,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsByAssetCollectionIdTest)
 
         bool Found1 = false, Found2 = false;
 
-        for (auto i = 0; i < Anchors.Size(); ++i)
+        for (size_t i = 0; i < Anchors.Size(); ++i)
         {
             if (Anchors[i].Id == Anchor1.Id)
             {

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -403,7 +403,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetCollectionsByIdsTest)
 
     bool Found1 = false, Found2 = false;
 
-    for (int i = 0; i < AssetCollections.Size(); ++i)
+    for (size_t i = 0; i < AssetCollections.Size(); ++i)
     {
         auto& AssetCollection = AssetCollections[i];
 
@@ -689,7 +689,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsByCollectionIdsTest)
 
     bool Found1 = false, Found2 = false, Found3 = false;
 
-    for (int i = 0; i < Assets.Size(); ++i)
+    for (size_t i = 0; i < Assets.Size(); ++i)
     {
         auto& Asset = Assets[i];
 
@@ -825,7 +825,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, FindAssetCollectionsTest)
 
         const auto& RetrievedAssetCollections = Result.GetAssetCollections();
 
-        for (int idx = 0; idx < RetrievedAssetCollections.Size(); ++idx)
+        for (size_t idx = 0; idx < RetrievedAssetCollections.Size(); ++idx)
         {
             auto& CurrentAsset = RetrievedAssetCollections[idx];
 
@@ -941,7 +941,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, GetAssetsByDifferentCriteriaTest)
 
         const auto& RetrievedAssets = Result.GetAssets();
 
-        for (int idx = 0; idx < RetrievedAssets.Size(); ++idx)
+        for (size_t idx = 0; idx < RetrievedAssets.Size(); ++idx)
         {
             auto& CurrentAsset = RetrievedAssets[idx];
 

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -184,7 +184,7 @@ void DeleteAsset(csp::systems::AssetSystem* AssetSystem, csp::systems::AssetColl
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 }
 
-void UpdateAsset(csp::systems::AssetSystem* AssetSystem, csp::systems::AssetCollection& AssetCollection, csp::systems::Asset& Asset)
+void UpdateAsset(csp::systems::AssetSystem* AssetSystem, csp::systems::AssetCollection& /*AssetCollection*/, csp::systems::Asset& Asset)
 {
     auto [Result] = Awaitable(&csp::systems::AssetSystem::UpdateAsset, AssetSystem, Asset).Await(RequestPredicate);
 
@@ -2004,7 +2004,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Setup Asset callback
     bool AssetDetailBlobChangedCallbackCalled = false;
@@ -2091,7 +2091,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessGracefulFailureCallback
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Setup Asset callback
     bool AssetDetailBlobChangedCallbackCalled = false;

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -39,8 +39,6 @@ using namespace csp::multiplayer;
 
 namespace
 {
-MultiplayerConnection* Connection;
-SpaceEntitySystem* EntitySystem;
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
@@ -327,7 +325,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetCollectionNoSpaceTest)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
@@ -443,7 +440,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetTest)
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
     const char* TestAssetName = "OLY-UNITTEST-ASSET-REWIND";
-    const char* TestThirdPartyReferenceId = "OLY-UNITTEST-ASSET-THIRDPARTY";
 
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -504,12 +500,10 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, CreateAssetNoSpaceTest)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
     const char* TestAssetName = "OLY-UNITTEST-ASSET-REWIND";
-    const char* TestThirdPartyReferenceId = "OLY-UNITTEST-ASSET-THIRDPARTY";
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -566,7 +560,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateExternalUriAssetTest)
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
     const char* TestAssetName = "OLY-UNITTEST-ASSET-REWIND";
-    const char* TestThirdPartyReferenceId = "OLY-UNITTEST-ASSET-THIRDPARTY";
     const char* TestExternalUri = "https://github.com/KhronosGroup/glTF-Sample-Models/raw/master/2.0/Duck/glTF-Binary/Duck.glb";
     const char* TestExternalMimeType = "model/gltf-binary";
     char UniqueSpaceName[256];
@@ -1230,7 +1223,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsIncorrectFileTest)
     auto FilePath = std::filesystem::absolute("assets/Incorrect_File.jpg");
     csp::systems::FileAssetDataSource Source;
     Source.FilePath = FilePath.u8string().c_str();
-    const csp::common::String& FileMimeType = "image/jpeg";
 
     // Upload data
     auto [Result] = AWAIT_PRE(AssetSystem, UploadAssetData, RequestPredicateWithProgress, AssetCollection, Asset, Source);
@@ -1774,7 +1766,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetCollectionMetadataTest)
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-    const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
     const char* TestAssetName = "OLY-UNITTEST-ASSET-REWIND";
 
     csp::common::Array<csp::common::String> Tags = { "tag-test" };
@@ -1972,8 +1963,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
-    auto* EventBus = SystemsManager.GetEventBus();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -71,7 +71,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         csp::common::String ObjectName = "Object 1";
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
@@ -195,7 +195,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the fog
     csp::common::String ObjectName = "Object 1";
@@ -279,7 +279,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceT
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
         auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -48,7 +48,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
@@ -173,7 +172,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -254,7 +252,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceT
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";

--- a/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
@@ -43,7 +43,6 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -142,7 +141,6 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
@@ -65,7 +65,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";
@@ -164,7 +164,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -136,7 +135,6 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -209,7 +207,6 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -72,7 +72,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the Camera
     csp::common::String ObjectName = "Object 1";
@@ -158,7 +158,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the Camera
     csp::common::String ObjectName = "Object 1";
@@ -231,7 +231,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the CinematicCamera
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
@@ -69,7 +69,7 @@ CSP_PUBLIC_TEST(CSPEngine, CollisionTests, CollisionComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
@@ -47,7 +47,6 @@ CSP_PUBLIC_TEST(CSPEngine, CollisionTests, CollisionComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -228,7 +228,7 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the custom
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -206,7 +206,6 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -625,7 +625,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetNumberOfRe
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
 
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
@@ -640,7 +639,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetNumberOfRe
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the conversation
     csp::common::String ObjectName = "Object 1";
@@ -739,7 +738,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetMessagesFr
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
 
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
@@ -754,7 +752,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetMessagesFr
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the conversation
     csp::common::String ObjectName = "Object 1";
@@ -945,7 +943,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentDeleteTest)
                 CallbackCalled = true;
             });
 
-        CreatedObject->Destroy([](bool Success) {});
+        CreatedObject->Destroy([](bool /*Success*/) {});
 
         CreatedObject->QueueUpdate();
         EntitySystem->ProcessPendingEntityOperations();
@@ -1416,7 +1414,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTe
         auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
         EXPECT_EQ(EnterResult2.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         bool EntitiesRetrieved = false;
 
@@ -1850,7 +1848,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationEve
         // However, we still need this callback to flush the original creation event
         bool CallbackCalled = false;
 
-        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled = true; };
+        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled = true; };
         ConversationComponent->SetConversationUpdateCallback(Callback);
 
         const auto [Result] = AWAIT(ConversationComponent, CreateConversation, ConversationMessage);
@@ -1943,7 +1941,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationEve
     {
         bool CallbackCalled = false;
 
-        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled = true; };
+        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled = true; };
 
         ConversationComponent->SetConversationUpdateCallback(Callback);
 

--- a/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
@@ -99,7 +99,7 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         // Create object to represent the Custom fields
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };

--- a/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
@@ -63,14 +63,12 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
 
     const char* TestSpaceName2 = "OLY-UNITTEST-SPACE-REWIND-2";
-    const char* TestSpaceDescription2 = "OLY-UNITTEST-SPACEDESC-REWIND";
 
     const csp::common::String ObjectName = "Object 1";
     const csp::common::String ApplicationOrigin = "Application Origin 1";

--- a/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
@@ -70,7 +70,7 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the ECommerce
     csp::common::String ObjectName = "Object 1";
@@ -132,7 +132,7 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the ECommerce
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
@@ -48,7 +48,6 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -110,7 +109,6 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -52,7 +52,6 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -79,7 +78,6 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-    bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
@@ -167,7 +165,6 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -77,7 +77,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
@@ -189,7 +189,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the image
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -137,7 +136,6 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -72,7 +72,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the fog
     csp::common::String ObjectName = "Object 1";
@@ -159,7 +159,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the fog
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -75,7 +75,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
@@ -164,7 +164,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the image
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -51,8 +51,6 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -77,7 +75,6 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
 
     EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-    bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
@@ -142,7 +139,6 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -49,7 +49,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -147,7 +146,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -71,7 +71,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
@@ -169,7 +169,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -77,7 +77,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
@@ -196,7 +196,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the image
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -52,7 +52,6 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -79,7 +78,6 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
 
     EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-    bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
@@ -174,7 +172,6 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
@@ -75,7 +75,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
@@ -215,7 +215,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;

--- a/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -77,7 +76,6 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
 
     EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-    bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
@@ -189,14 +187,10 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-    const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-    const char* TestAssetName = "OLY-UNITTEST-ASSET-REWIND";
 
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -217,7 +211,6 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
 
     EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-    bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -49,14 +49,10 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    const char* TestSpaceName2 = "OLY-UNITTEST-SPACE-REWIND-2";
-    const char* TestSpaceDescription2 = "OLY-UNITTEST-SPACEDESC-REWIND";
 
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -75,7 +75,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         csp::common::String ObjectName = "Object 1";
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -49,7 +49,6 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -139,8 +138,6 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalThumbnailTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -221,7 +218,6 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -90,7 +90,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
@@ -117,7 +117,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
@@ -166,7 +166,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalThumbnailTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the portal
     csp::common::String ObjectName = "Object 1";
@@ -243,7 +243,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the portal
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -77,7 +76,6 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
 
     EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-    bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
@@ -75,7 +75,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;

--- a/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
@@ -48,7 +48,6 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, UseSplineTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -68,9 +67,7 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, UseSplineTest)
 
     const csp::common::String UserName = "Player 1";
     const SpaceTransform UserTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    const AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String UserAvatarId = "MyCoolAvatar";
-    const AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
     {
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -142,7 +139,6 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, SplineScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
@@ -77,7 +77,7 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, UseSplineTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         // Ensure we're in the first space
         EXPECT_EQ(SpaceSystem->GetCurrentSpace().Id, Space.Id);
@@ -164,7 +164,7 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, SplineScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the spline
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -71,7 +71,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         csp::common::String ObjectName = "Object 1";
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
@@ -183,7 +183,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the fog
     csp::common::String ObjectName = "Object 1";
@@ -261,7 +261,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
         auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -48,7 +48,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
@@ -161,7 +160,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -236,7 +234,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -71,7 +71,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the text
     csp::common::String ObjectName = "Object 1";
@@ -185,7 +185,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the text
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -49,7 +49,6 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -163,7 +162,6 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -47,7 +47,6 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -95,7 +94,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     EXPECT_EQ(VideoComponent->GetIsVisible(), true);
     EXPECT_EQ(VideoComponent->GetIsEnabled(), true);
 
-    auto* ModelComponent = static_cast<VideoPlayerSpaceComponent*>(CreatedObject->AddComponent(ComponentType::AnimatedModel));
+    CreatedObject->AddComponent(ComponentType::AnimatedModel);
 
     CreatedObject->QueueUpdate();
     EntitySystem->ProcessPendingEntityOperations();

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -69,7 +69,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/ConversationSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ConversationSystemTests.cpp
@@ -45,8 +45,6 @@ void OnDelete();
 std::atomic_bool IsTestComplete;
 std::atomic_bool IsDisconnected;
 std::atomic_bool IsReadyForUpdate;
-MultiplayerConnection* Connection;
-SpaceEntitySystem* EntitySystem;
 SpaceEntity* TestUser;
 SpaceEntity* TestObject;
 
@@ -55,7 +53,6 @@ const int WaitForTestTimeoutLimit = 20000;
 const int NumberOfEntityUpdateTicks = 5;
 int ReceivedEntityUpdatesCount;
 
-bool EventSent = false;
 bool EventReceived = false;
 
 ReplicatedValue ObjectFloatProperty;
@@ -107,8 +104,8 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventTest)
         bool CallbackCalled1 = false;
         bool CallbackCalled2 = false;
 
-        auto Callback1 = [&CallbackCalled1](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled1 = true; };
-        auto Callback2 = [&CallbackCalled2](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled2 = true; };
+        auto Callback1 = [&CallbackCalled1](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled1 = true; };
+        auto Callback2 = [&CallbackCalled2](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled2 = true; };
 
         ConversationComponent1->SetConversationUpdateCallback(Callback1);
         ConversationComponent2->SetConversationUpdateCallback(Callback2);
@@ -141,8 +138,8 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventTest)
         bool CallbackCalled1 = false;
         bool CallbackCalled2 = false;
 
-        const auto Callback1 = [&CallbackCalled1](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled1 = true; };
-        const auto Callback2 = [&CallbackCalled2](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled2 = true; };
+        const auto Callback1 = [&CallbackCalled1](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled1 = true; };
+        const auto Callback2 = [&CallbackCalled2](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled2 = true; };
 
         ConversationComponent1->SetConversationUpdateCallback(Callback1);
         ConversationComponent2->SetConversationUpdateCallback(Callback2);
@@ -229,7 +226,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventDelay
     {
         bool CallbackCalled = false;
 
-        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled = true; };
+        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled = true; };
 
         ConversationComponent->SetConversationUpdateCallback(Callback);
 
@@ -241,7 +238,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventDelay
     {
         bool CallbackCalled = false;
 
-        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& Params) { CallbackCalled = true; };
+        const auto Callback = [&CallbackCalled](const csp::multiplayer::ConversationEventParams& /*Params*/) { CallbackCalled = true; };
 
         ConversationComponent->SetConversationUpdateCallback(Callback);
 

--- a/Tests/src/PublicAPITests/ECommerceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ECommerceSystemTests.cpp
@@ -118,7 +118,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationT
 
     EXPECT_EQ(Result.GetProductInfo().Media.Size(), MediaSize);
 
-    for (int i = 0; i < Result.GetProductInfo().Media.Size(); ++i)
+    for (size_t i = 0; i < Result.GetProductInfo().Media.Size(); ++i)
     {
         EXPECT_EQ(Result.GetProductInfo().Media[i].MediaContentType, ImageMediaContentType);
         EXPECT_EQ(Result.GetProductInfo().Media[i].Url, ImageUrl);
@@ -128,7 +128,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationT
     }
     EXPECT_EQ(Result.GetProductInfo().Variants.Size(), VariantSize);
 
-    for (int i = 0; i < Result.GetProductInfo().Variants.Size(); ++i)
+    for (size_t i = 0; i < Result.GetProductInfo().Variants.Size(); ++i)
     {
         EXPECT_EQ(Result.GetProductInfo().Variants[i].Id, VariantIds[i]);
         EXPECT_EQ(Result.GetProductInfo().Variants[i].Title, VariantTitleAndOptionValue[i]);
@@ -141,7 +141,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationT
 
         EXPECT_EQ(Result.GetProductInfo().Variants[i].Options.Size(), OptionsSize);
 
-        for (int n = 0; n < Result.GetProductInfo().Variants[i].Options.Size(); ++n)
+        for (size_t n = 0; n < Result.GetProductInfo().Variants[i].Options.Size(); ++n)
         {
             EXPECT_EQ(Result.GetProductInfo().Variants[i].Options[n].Name, OptionsName);
             EXPECT_EQ(Result.GetProductInfo().Variants[i].Options[n].Value, VariantTitleAndOptionValue[i]);
@@ -212,7 +212,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationB
 
     EXPECT_EQ(Result.GetProducts()[0].Media.Size(), MediaSize);
 
-    for (int i = 0; i < Result.GetProducts()[0].Media.Size(); ++i)
+    for (size_t i = 0; i < Result.GetProducts()[0].Media.Size(); ++i)
     {
         EXPECT_EQ(Result.GetProducts()[0].Media[i].MediaContentType, ImageMediaContentType);
         EXPECT_EQ(Result.GetProducts()[0].Media[i].Url, ImageUrl);
@@ -222,7 +222,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationB
     }
     EXPECT_EQ(Result.GetProducts()[0].Variants.Size(), VariantSize);
 
-    for (int i = 0; i < Result.GetProducts()[0].Variants.Size(); ++i)
+    for (size_t i = 0; i < Result.GetProducts()[0].Variants.Size(); ++i)
     {
         auto& Variant = Result.GetProducts()[0].Variants[i];
         EXPECT_EQ(Variant.Id, VariantIds[i]);
@@ -238,7 +238,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, GetProductInformationB
 
         EXPECT_EQ(Variant.Options.Size(), OptionsSize);
 
-        for (int n = 0; n < Variant.Options.Size(); ++n)
+        for (size_t n = 0; n < Variant.Options.Size(); ++n)
         {
             EXPECT_EQ(Variant.Options[n].Name, OptionsName);
             EXPECT_EQ(Variant.Options[n].Value, VariantTitleAndOptionValue[i]);
@@ -455,7 +455,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, AddCartLinesTest)
     auto CartLines = csp::common::Array<csp::systems::CartLine>(VariantIds.Size());
 
     // Add local cart lines
-    for (int i = 0; i < VariantIds.Size(); ++i)
+    for (size_t i = 0; i < VariantIds.Size(); ++i)
     {
         auto CartLine = csp::systems::CartLine();
         CartLine.Quantity = 1;
@@ -485,7 +485,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, AddCartLinesTest)
     EXPECT_EQ(AddCartLinesCart.CartLines.Size(), 4);
     EXPECT_EQ(AddCartLinesCart.TotalQuantity, 4);
 
-    for (int i = 0; i < CartLines.Size(); ++i)
+    for (size_t i = 0; i < CartLines.Size(); ++i)
     {
         EXPECT_EQ(AddCartLinesCart.CartLines[i].ProductVariantId, CartLines[i].ProductVariantId);
         EXPECT_NE(AddCartLinesCart.CartLines[i].CartLineId, "");
@@ -568,7 +568,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, UpdateCartLinesTest)
     EXPECT_EQ(AddCartLinesCart.CartLines.Size(), 1);
     EXPECT_EQ(AddCartLinesCart.TotalQuantity, 1);
 
-    for (int i = 0; i < CartLines.Size(); ++i)
+    for (size_t i = 0; i < CartLines.Size(); ++i)
     {
         EXPECT_EQ(AddCartLinesCart.CartLines[i].ProductVariantId, CartLines[i].ProductVariantId);
         EXPECT_NE(AddCartLinesCart.CartLines[i].CartLineId, "");
@@ -604,7 +604,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, UpdateCartLinesTest)
     EXPECT_EQ(UpdateCartLinesCart.CartLines.Size(), 1);
     EXPECT_EQ(UpdateCartLinesCart.TotalQuantity, 2);
 
-    for (int i = 0; i < CartLines.Size(); ++i)
+    for (size_t i = 0; i < CartLines.Size(); ++i)
     {
         EXPECT_EQ(UpdateCartLinesCart.CartLines[i].ProductVariantId, CartLines[i].ProductVariantId);
         EXPECT_NE(UpdateCartLinesCart.CartLines[i].CartLineId, "");
@@ -687,7 +687,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ECommerceSystemTests, DeleteCartLinesTest)
     EXPECT_EQ(AddCartLinesCart.CartLines.Size(), 1);
     EXPECT_EQ(AddCartLinesCart.TotalQuantity, 1);
 
-    for (int i = 0; i < CartLines.Size(); ++i)
+    for (size_t i = 0; i < CartLines.Size(); ++i)
     {
         EXPECT_EQ(AddCartLinesCart.CartLines[i].ProductVariantId, CartLines[i].ProductVariantId);
         EXPECT_NE(AddCartLinesCart.CartLines[i].CartLineId, CartLines[i].CartLineId);

--- a/Tests/src/PublicAPITests/EventBusTests.cpp
+++ b/Tests/src/PublicAPITests/EventBusTests.cpp
@@ -298,7 +298,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventMultiTypeTest)
 
             std::cerr << "Multi Type Event Received " << ok << "  Payload: " << std::endl;
 
-            for (int i = 0; i < Data.Size(); ++i)
+            for (size_t i = 0; i < Data.Size(); ++i)
             {
                 if (Data[i].GetReplicatedValueType() == ReplicatedValueType::Boolean)
                 {

--- a/Tests/src/PublicAPITests/EventBusTests.cpp
+++ b/Tests/src/PublicAPITests/EventBusTests.cpp
@@ -165,7 +165,6 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventEmptyTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EventBus = SystemsManager.GetEventBus();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
@@ -257,7 +256,6 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventMultiTypeTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EventBus = SystemsManager.GetEventBus();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();

--- a/Tests/src/PublicAPITests/EventBusTests.cpp
+++ b/Tests/src/PublicAPITests/EventBusTests.cpp
@@ -195,7 +195,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventEmptyTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     EventBus->ListenNetworkEvent("TestEvent",
         [](bool ok, csp::common::Array<ReplicatedValue> Data)
@@ -289,7 +289,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventMultiTypeTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     EventBus->ListenNetworkEvent("MultiTypeEvent",
         [](bool ok, csp::common::Array<ReplicatedValue> Data)
@@ -400,7 +400,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventBusTests, EventCallbacksSystemsTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Set up Log callback
     LogSystem.SetLogCallback([&](csp::common::String InMessage) { LogConfirmed = InMessage == TestMsg; });
@@ -410,7 +410,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventBusTests, EventCallbacksSystemsTest)
     int TestCallbackId = 0;
 
     csp::multiplayer::EventBus::ParameterisedCallbackHandler TestCallback1
-        = [&TestCallback1Called, &TestCallbackId](bool ok, const csp::common::Array<csp::multiplayer::ReplicatedValue>& Params)
+        = [&TestCallback1Called, &TestCallbackId](bool ok, const csp::common::Array<csp::multiplayer::ReplicatedValue>& /*Params*/)
     {
         EXPECT_TRUE(ok);
 
@@ -424,7 +424,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventBusTests, EventCallbacksSystemsTest)
     };
 
     csp::multiplayer::EventBus::ParameterisedCallbackHandler TestCallback2
-        = [&TestCallback2Called, &TestCallbackId](bool ok, const csp::common::Array<csp::multiplayer::ReplicatedValue>& Params)
+        = [&TestCallback2Called, &TestCallbackId](bool ok, const csp::common::Array<csp::multiplayer::ReplicatedValue>& /*Params*/)
     {
         EXPECT_TRUE(ok);
 
@@ -616,7 +616,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SetCallbackBeforeConnectedTest)
     int TestCallbackId = 0;
 
     csp::multiplayer::EventBus::ParameterisedCallbackHandler TestCallback1
-        = [&TestCallback1Called, &TestCallbackId](bool ok, const csp::common::Array<csp::multiplayer::ReplicatedValue>& Params)
+        = [&TestCallback1Called, &TestCallbackId](bool ok, const csp::common::Array<csp::multiplayer::ReplicatedValue>& /*Params*/)
     {
         EXPECT_TRUE(ok);
 
@@ -655,7 +655,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SetCallbackBeforeConnectedTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Check system callback was called
     EventBus->SendNetworkEventToClient("TestEvent", {}, Connection->GetClientId(), ErrorCallback);

--- a/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
+++ b/Tests/src/PublicAPITests/EventTicketingSystemTests.cpp
@@ -506,7 +506,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEvents
     bool FoundSecond = false;
     bool FoundUnexpected = false;
 
-    for (auto i = 0; i < Events.Size(); ++i)
+    for (size_t i = 0; i < Events.Size(); ++i)
     {
         auto Event = Result.GetTicketedEvents()[i];
 
@@ -590,7 +590,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventTicketingSystemTests, GetTicketedEventsTwoEvents
     bool FoundSecond = false;
     bool FoundUnexpected = false;
 
-    for (auto i = 0; i < Events.Size(); ++i)
+    for (size_t i = 0; i < Events.Size(); ++i)
     {
         auto Event = Result.GetTicketedEvents()[i];
 

--- a/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
+++ b/Tests/src/PublicAPITests/GraphQLSystemTests.cpp
@@ -86,7 +86,6 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunQueryBadInputTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto GraphQLSystem = SystemsManager.GetGraphQLSystem();
     auto UserSystem = SystemsManager.GetUserSystem();
-    auto SpaceSystem = SystemsManager.GetSpaceSystem();
 
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
@@ -103,7 +102,6 @@ CSP_PUBLIC_TEST(CSPEngine, GraphQLSystemTests, RunRequestBadInputTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto GraphQLSystem = SystemsManager.GetGraphQLSystem();
     auto UserSystem = SystemsManager.GetUserSystem();
-    auto SpaceSystem = SystemsManager.GetSpaceSystem();
 
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -52,7 +52,7 @@ void CreateHotspotgroup(csp::systems::HotspotSequenceSystem* HotspotSequenceSyst
         EXPECT_EQ(group.Name, GroupName);
         EXPECT_EQ(group.Items.Size(), Items.Size());
 
-        for (int i = 0; i < group.Items.Size(); ++i)
+        for (size_t i = 0; i < group.Items.Size(); ++i)
         {
             EXPECT_EQ(group.Items[i], Items[i]);
         }
@@ -104,7 +104,7 @@ void UpdateHotspotGroup(csp::systems::HotspotSequenceSystem* HotspotSequenceSyst
         EXPECT_EQ(group.Name, GroupName);
         EXPECT_EQ(group.Items.Size(), Items.Size());
 
-        for (int i = 0; i < group.Items.Size(); ++i)
+        for (size_t i = 0; i < group.Items.Size(); ++i)
         {
             EXPECT_EQ(group.Items[i], Items[i]);
         }
@@ -152,7 +152,7 @@ void CompareGroups(const csp::systems::HotspotGroup& S1, const csp::systems::Hot
     EXPECT_EQ(S1.Items.Size(), S2.Items.Size());
     if (S1.Items.Size() == S2.Items.Size())
     {
-        for (int i = 0; i < S1.Items.Size(); ++i)
+        for (size_t i = 0; i < S1.Items.Size(); ++i)
         {
             EXPECT_EQ(S1.Items[i], S2.Items[i]);
         }

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -159,9 +159,6 @@ void CompareGroups(const csp::systems::HotspotGroup& S1, const csp::systems::Hot
     }
 }
 
-static constexpr const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-static constexpr const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
 CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
 {
     SetRandSeed();
@@ -193,7 +190,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
 
     // Validate sequence creation events.
     bool CallbackCalled = false;
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     HotspotSystem->SetHotspotSequenceChangedCallback(
         [&CallbackCalled, &Space, &TestGroupName](const csp::multiplayer::SequenceHotspotChangedParams& Params)
         {
@@ -242,6 +238,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotGroupTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
+
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 
     // Log in
     csp::common::String UserId;
@@ -310,8 +308,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, UpdateHotspotGroupTest)
     csp::common::Array<csp::common::String> NewItems { "Hotspot3" };
     csp::common::String TestGroupName = "CSP-UNITTEST-SEQUENCE-MAG";
 
-    const char* TestSequenceReferenceID = "CSP-UNITTEST-ReferenceID-MAG";
-
     csp::systems::HotspotGroup HotspotGroup1;
     csp::systems::HotspotGroup HotspotGroup2;
 
@@ -364,8 +360,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameHotspotGroupTest)
     csp::common::String OldTestGroupName = "CSP-UNITTEST-SEQUENCE-MAG1";
     csp::common::String NewTestGroupName = "CSP-UNITTEST-SEQUENCE-MAG2";
 
-    const char* TestSequenceReferenceID = "CSP-UNITTEST-ReferenceID-MAG";
-
     csp::systems::HotspotGroup HotspotGroup;
 
     CreateHotspotgroup(HotspotSystem, OldTestGroupName, SequenceItems, HotspotGroup);
@@ -373,8 +367,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameHotspotGroupTest)
 
     bool ReceivedUpdateCallback = false;
     bool ReceivedRenameCallback = false;
-
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     HotspotSystem->SetHotspotSequenceChangedCallback(
         [&ReceivedUpdateCallback, &ReceivedRenameCallback, &Space, &OldTestGroupName, &NewTestGroupName](
@@ -442,8 +434,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameFailHotspotGroupTest)
     csp::common::String OldTestGroupName = "CSP-UNITTEST-SEQUENCE-MAG1";
     csp::common::String NewTestGroupName = "CSP-UNITTEST-SEQUENCE-MAG2";
 
-    const char* TestSequenceReferenceID = "CSP-UNITTEST-ReferenceID-MAG";
-
     csp::systems::HotspotGroup HotspotGroup;
 
     csp::common::String expectedName = SpaceSystem->GetCurrentSpace().Id + ":" + NewTestGroupName;
@@ -468,6 +458,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotNoGroupTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
+
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 
     // Log in
     csp::common::String UserId;
@@ -508,6 +500,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotsGroupsTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
+
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 
     // Log in
     csp::common::String UserId;
@@ -573,6 +567,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotNoGroupTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
 
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
+
     // Log in
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
@@ -607,6 +603,8 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GenerateSequenceKeyTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
+
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 
     // Log in
     csp::common::String UserId;
@@ -648,8 +646,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
-    auto* EventBus = SystemsManager.GetEventBus();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
 
@@ -792,8 +788,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteEntityWithHotspotComponen
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
-    auto* EventBus = SystemsManager.GetEventBus();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
 
@@ -934,8 +928,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
-    auto* EventBus = SystemsManager.GetEventBus();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
 

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -133,7 +133,7 @@ void RenameHotspotGroup(csp::systems::HotspotSequenceSystem* HotspotSequenceSyst
     }
 }
 
-void GetHotspotGroups(csp::systems::HotspotSequenceSystem* HotspotSequenceSystem, const csp::common::Array<csp::common::String>& GroupNames,
+void GetHotspotGroups(csp::systems::HotspotSequenceSystem* HotspotSequenceSystem, const csp::common::Array<csp::common::String>& /*GroupNames*/,
     csp::common::Array<csp::systems::HotspotGroup>& Groups, csp::systems::EResultCode ExpectedResultCode = csp::systems::EResultCode::Success,
     csp::systems::ERequestFailureReason ExpectedResultFailureCode = csp::systems::ERequestFailureReason::None)
 {
@@ -672,7 +672,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
@@ -682,7 +682,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
     bool ComponentAdded = false;
 
     CreatedObject->SetUpdateCallback(
-        [&ComponentAdded, ObjectName](csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::SpaceEntityUpdateFlags Flags,
+        [&ComponentAdded, ObjectName](csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::SpaceEntityUpdateFlags /*Flags*/,
             csp::common::Array<csp::multiplayer::ComponentUpdateInfo>& UpdateInfo)
         {
             if (Entity->GetName() == ObjectName)
@@ -816,7 +816,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteEntityWithHotspotComponen
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
@@ -826,7 +826,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteEntityWithHotspotComponen
     bool ComponentAdded = false;
 
     CreatedObject->SetUpdateCallback(
-        [&ComponentAdded, ObjectName](csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::SpaceEntityUpdateFlags Flags,
+        [&ComponentAdded, ObjectName](csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::SpaceEntityUpdateFlags /*Flags*/,
             csp::common::Array<csp::multiplayer::ComponentUpdateInfo>& UpdateInfo)
         {
             if (Entity->GetName() == ObjectName)
@@ -898,7 +898,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteEntityWithHotspotComponen
 
         HotspotSystem->SetHotspotSequenceChangedCallback(CB);
 
-        CreatedObject->Destroy([](bool Success) {});
+        CreatedObject->Destroy([](bool /*Success*/) {});
 
         WaitForCallbackWithUpdate(SequencesUpdated, EntitySystem);
     }
@@ -958,7 +958,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
@@ -968,7 +968,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
     bool ComponentAdded = false;
 
     CreatedObject->SetUpdateCallback(
-        [&ComponentAdded, ObjectName](csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::SpaceEntityUpdateFlags Flags,
+        [&ComponentAdded, ObjectName](csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::SpaceEntityUpdateFlags /*Flags*/,
             csp::common::Array<csp::multiplayer::ComponentUpdateInfo>& UpdateInfo)
         {
             if (Entity->GetName() == ObjectName)

--- a/Tests/src/PublicAPITests/LogSystemTests.cpp
+++ b/Tests/src/PublicAPITests/LogSystemTests.cpp
@@ -622,6 +622,7 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, ProfileTest)
             std::cout << InMessage << std::endl;
         });
 
+#if CSP_PROFILING_ENABLED
     const int TestValue = 12345;
 
     CSP_PROFILE_SCOPED_TAG(TestTag);
@@ -637,7 +638,6 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, ProfileTest)
     CSP_PROFILE_EVENT_TAG(TestEvent);
     CSP_PROFILE_EVENT_FORMAT("Event %d", TestValue)
 
-#if CSP_PROFILING_ENABLED
     EXPECT_TRUE(BeginConfirmed);
     EXPECT_TRUE(EndConfirmed);
     EXPECT_TRUE(EventConfirmed);

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -400,7 +400,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, GetMultipleMaterialsTest)
         CreatedMaterial4->GetMaterialId(),
     };
 
-    for (int i = 0; i < FoundMaterials.Size(); ++i)
+    for (size_t i = 0; i < FoundMaterials.Size(); ++i)
     {
 // Guarding use of dynamic_cast to avoid having to enable RTTI for WASM.
 #if defined CSP_WINDOWS

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -114,7 +114,7 @@ void GetMaterials(AssetSystem* AssetSystem, const csp::common::String& SpaceId, 
 
 void GetMaterial(AssetSystem* AssetSystem, const csp::common::String& AssetCollectionId, const csp::common::String& AssetId, Material** OutMaterial,
     csp::systems::EResultCode ExpectedResultCode = csp::systems::EResultCode::Success,
-    csp::systems::ERequestFailureReason ExpectedResultFailureCode = csp::systems::ERequestFailureReason::None)
+    csp::systems::ERequestFailureReason /*ExpectedResultFailureCode*/ = csp::systems::ERequestFailureReason::None)
 {
     auto [Result] = AWAIT_PRE(AssetSystem, GetMaterial, RequestPredicate, AssetCollectionId, AssetId);
     EXPECT_EQ(Result.GetResultCode(), ExpectedResultCode);

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -709,7 +709,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // Log in
     csp::common::String UserId;
@@ -809,7 +808,6 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     const char* TestAssetCollectionName = "CSP-UNITTEST-ASSETCOLLECTION";
     const char* TestAssetName = "CSP-UNITTEST-ASSET";

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -3188,7 +3188,7 @@ void RunEntityLockTest(bool Local)
 
             CreatedEntity->SetUpdateCallback(
                 [&EntityUpdated, CreatedEntity](
-                    SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                    SpaceEntity* /*Entity*/, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
                 {
                     if (Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_LOCK_TYPE)
                     {
@@ -3219,7 +3219,7 @@ void RunEntityLockTest(bool Local)
 
             CreatedEntity->SetUpdateCallback(
                 [&EntityUpdated, CreatedEntity](
-                    SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                    SpaceEntity* /*Entity*/, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
                 {
                     if (Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_LOCK_TYPE)
                     {

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -282,7 +282,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
@@ -344,7 +343,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
@@ -396,8 +394,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -452,8 +448,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -532,7 +526,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
@@ -631,7 +624,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -705,7 +697,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -786,7 +777,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -874,7 +864,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -942,8 +931,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1004,7 +991,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1105,7 +1091,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1203,7 +1188,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpa
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1331,7 +1315,6 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
@@ -1413,7 +1396,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1445,17 +1427,17 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
     auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
-    auto* ImageComponent = (ImageSpaceComponent*)CreatedObject->AddComponent(ComponentType::Image);
+    CreatedObject->AddComponent(ComponentType::Image);
     CreatedObject->QueueUpdate();
 
     // Create object 2
     auto [CreatedObject2] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
-    auto* ImageComponent2 = (ImageSpaceComponent*)CreatedObject2->AddComponent(ComponentType::Image);
+    CreatedObject2->AddComponent(ComponentType::Image);
     CreatedObject2->QueueUpdate();
 
     // Create object 3
     auto [CreatedObject3] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
-    auto* ImageComponent3 = (ImageSpaceComponent*)CreatedObject3->AddComponent(ComponentType::Image);
+    CreatedObject3->AddComponent(ComponentType::Image);
     CreatedObject3->QueueUpdate();
 
     // Destroy Entites
@@ -1481,7 +1463,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1564,14 +1545,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-    const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-    const char* TestAssetName = "OLY-UNITTEST-ASSET-REWIND";
 
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -1660,14 +1637,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-    const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-    const char* TestAssetName = "OLY-UNITTEST-ASSET-REWIND";
 
     char UniqueSpaceName[256];
     SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -1689,7 +1662,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
 
     EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-    bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
@@ -1699,7 +1671,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
 
     const csp::common::String ModelAssetId = "NotARealId";
 
-    auto* LightSpaceComponentInstance = (LightSpaceComponent*)Object->AddComponent(ComponentType::Invalid);
+    Object->AddComponent(ComponentType::Invalid);
 
     // Process component creation
     Object->QueueUpdate();
@@ -1951,8 +1923,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
@@ -2046,8 +2016,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
@@ -2141,8 +2109,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
@@ -2239,8 +2205,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
@@ -2329,8 +2293,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTe
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
@@ -2634,8 +2596,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateObjectParentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -191,7 +191,7 @@ void OnUserCreated(SpaceEntity* InUser, SpaceEntitySystem* EntitySystem)
 
             if (InUpdateFlags & SpaceEntityUpdateFlags::UPDATE_FLAGS_COMPONENTS)
             {
-                for (int i = 0; i < InComponentUpdateInfoArray.Size(); ++i)
+                for (size_t i = 0; i < InComponentUpdateInfoArray.Size(); ++i)
                 {
                     uint16_t ComponentID = InComponentUpdateInfoArray[i].ComponentId;
 
@@ -202,7 +202,7 @@ void OnUserCreated(SpaceEntity* InUser, SpaceEntitySystem* EntitySystem)
                         const csp::common::Map<uint32_t, ReplicatedValue>& Properties = *UpdatedUser->GetComponent(ComponentID)->GetProperties();
                         const csp::common::Array<uint32_t>* PropertyKeys = Properties.Keys();
 
-                        for (int j = 0; j < PropertyKeys->Size(); ++j)
+                        for (size_t j = 0; j < PropertyKeys->Size(); ++j)
                         {
                             if (j >= 3) // We only randomise the first 3 properties, so we don't really need to print any more
                             {

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -298,7 +298,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
 
     bool CallbackCalled = false;
 
-    Connection->SetConnectionCallback([&CallbackCalled](const csp::common::String& Message) { CallbackCalled = true; });
+    Connection->SetConnectionCallback([&CallbackCalled](const csp::common::String& /*Message*/) { CallbackCalled = true; });
 
     csp::common::String UserId;
 
@@ -319,7 +319,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
     SpaceTransform ObjectTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
 
@@ -378,7 +378,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
@@ -425,7 +425,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     WaitForTestTimeoutCountMs = 0;
     int KeepAliveInterval = 200;
@@ -483,7 +483,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     OnConnect(EntitySystem);
 
@@ -569,7 +569,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
         SpaceTransform ObjectTransform
             = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
 
-        EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
         auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
 
@@ -585,7 +585,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
         bool EntityUpdated = false;
 
         CreatedObject->SetUpdateCallback(
-            [&EntityUpdated](SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+            [&EntityUpdated](SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == "Object 1")
                 {
@@ -655,7 +655,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
@@ -729,7 +729,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     const csp::common::String& UserName = "Creator 1";
     const SpaceTransform& UserTransform
@@ -898,7 +898,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
@@ -973,7 +973,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform
@@ -1028,7 +1028,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     const csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
@@ -1036,7 +1036,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
     auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
 
     bool PatchPending = true;
-    Object->SetPatchSentCallback([&PatchPending](bool ok) { PatchPending = false; });
+    Object->SetPatchSentCallback([&PatchPending](bool /*ok*/) { PatchPending = false; });
 
     const csp::common::String ModelAssetId = "NotARealId";
 
@@ -1129,7 +1129,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     const csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
@@ -1137,7 +1137,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
     auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
 
     bool PatchPending = true;
-    Object->SetPatchSentCallback([&PatchPending](bool ok) { PatchPending = false; });
+    Object->SetPatchSentCallback([&PatchPending](bool /*ok*/) { PatchPending = false; });
 
     const csp::common::String ModelAssetId = "NotARealId";
 
@@ -1233,7 +1233,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpa
     auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
 
     bool PatchPending = true;
-    Object->SetPatchSentCallback([&PatchPending](bool ok) { PatchPending = false; });
+    Object->SetPatchSentCallback([&PatchPending](bool /*ok*/) { PatchPending = false; });
 
     auto* ComponentToKeep = (StaticModelSpaceComponent*)Object->AddComponent(ComponentType::StaticModel);
     ComponentToKeep->SetComponentName("ComponentNameKeep");
@@ -1369,7 +1369,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [Avatar]
         = Awaitable(&SpaceEntitySystem::CreateAvatar, EntitySystem, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode)
@@ -1436,7 +1436,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create 3 seperate objects to ensure there is too many updates for the rate limiter to process in one tick
 
@@ -1505,7 +1505,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
@@ -1687,7 +1687,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     bool AssetDetailBlobChangedCallbackCalled = false;
     csp::common::String CallbackAssetId;
@@ -1753,7 +1753,7 @@ void RunParentEntityReplicationTest(bool Local)
     SpaceTransform ObjectTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransform);
     auto [CreatedChildEntity1] = AWAIT(EntitySystem, CreateObject, ChildEntityName1, ObjectTransform);
@@ -1771,7 +1771,7 @@ void RunParentEntityReplicationTest(bool Local)
 
         CreatedChildEntity1->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName1](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName1 && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
                 {
@@ -1814,7 +1814,7 @@ void RunParentEntityReplicationTest(bool Local)
 
         CreatedChildEntity2->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName2](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName2 && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
                 {
@@ -1851,7 +1851,7 @@ void RunParentEntityReplicationTest(bool Local)
 
         CreatedChildEntity1->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName1](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName1 && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
                 {
@@ -1886,7 +1886,7 @@ void RunParentEntityReplicationTest(bool Local)
 
         CreatedChildEntity2->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName2](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName2 && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
                 {
@@ -1984,18 +1984,16 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
     SpaceTransform ObjectTransformExpected
         = { csp::common::Vector3 { 2, 1, 1 }, csp::common::Vector4 { 0, 0, 0, 1 }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransformParent);
     auto [CreatedChildEntity] = AWAIT(EntitySystem, CreateObject, ChildEntityName, ObjectTransformChild);
 
-    uint64_t ParentEntityId = CreatedParentEntity->GetId();
-    uint64_t ChildEntityId = CreatedChildEntity->GetId();
-
     bool ChildEntityUpdated = false;
 
     CreatedChildEntity->SetUpdateCallback(
-        [&ChildEntityUpdated, ChildEntityName](SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+        [&ChildEntityUpdated, ChildEntityName](
+            SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
         {
             if (Entity->GetName() == ChildEntityName && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
             {
@@ -2030,7 +2028,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
     // When performing quaternion operations, W can be negative, so no point checking
     EXPECT_EQ(ObjectTransformExpected.Scale == GlobalScale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result) {});
+    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
 
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);
@@ -2081,18 +2079,16 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
     SpaceTransform ObjectTransformExpected
         = { csp::common::Vector3 { 0, 0, 1 }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransformParent);
     auto [CreatedChildEntity] = AWAIT(EntitySystem, CreateObject, ChildEntityName, ObjectTransformChild);
 
-    uint64_t ParentEntityId = CreatedParentEntity->GetId();
-    uint64_t ChildEntityId = CreatedChildEntity->GetId();
-
     bool ChildEntityUpdated = false;
 
     CreatedChildEntity->SetUpdateCallback(
-        [&ChildEntityUpdated, ChildEntityName](SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+        [&ChildEntityUpdated, ChildEntityName](
+            SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
         {
             if (Entity->GetName() == ChildEntityName && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
             {
@@ -2127,7 +2123,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
     EXPECT_EQ(ObjectTransformExpected.Rotation.Z == GlobalRotation.Z, true);
     EXPECT_EQ(ObjectTransformExpected.Scale == GlobalScale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result) {});
+    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
 
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);
@@ -2181,18 +2177,16 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
     SpaceTransform ObjectTransformExpected = { csp::common::Vector3 { 0, 0, -0.5f }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f },
         csp::common::Vector3 { -0.5f, 0.5f, 0.5f } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransformParent);
     auto [CreatedChildEntity] = AWAIT(EntitySystem, CreateObject, ChildEntityName, ObjectTransformChild);
 
-    uint64_t ParentEntityId = CreatedParentEntity->GetId();
-    uint64_t ChildEntityId = CreatedChildEntity->GetId();
-
     bool ChildEntityUpdated = false;
 
     CreatedChildEntity->SetUpdateCallback(
-        [&ChildEntityUpdated, ChildEntityName](SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+        [&ChildEntityUpdated, ChildEntityName](
+            SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
         {
             if (Entity->GetName() == ChildEntityName && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
             {
@@ -2227,7 +2221,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
     EXPECT_EQ(ObjectTransformExpected.Rotation.Z == GlobalRotation.Z, true);
     EXPECT_EQ(ObjectTransformExpected.Scale == GlobalScale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result) {});
+    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
 
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);
@@ -2278,18 +2272,16 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     SpaceTransform ObjectTransformExpected
         = { csp::common::Vector3 { 0, 0, 1 }, csp::common::Vector4 { 0, -0.7071081f, 0, 0.7071055f }, csp::common::Vector3 { 0.5f, 0.5f, 0.5f } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransformParent);
     auto [CreatedChildEntity] = AWAIT(EntitySystem, CreateObject, ChildEntityName, ObjectTransformChild);
 
-    uint64_t ParentEntityId = CreatedParentEntity->GetId();
-    uint64_t ChildEntityId = CreatedChildEntity->GetId();
-
     bool ChildEntityUpdated = false;
 
     CreatedChildEntity->SetUpdateCallback(
-        [&ChildEntityUpdated, ChildEntityName](SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+        [&ChildEntityUpdated, ChildEntityName](
+            SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
         {
             if (Entity->GetName() == ChildEntityName && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
             {
@@ -2319,7 +2311,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     EXPECT_EQ(ObjectTransformExpected.Rotation.Z == ObjectTransformActual.Rotation.Z, true);
     EXPECT_EQ(ObjectTransformExpected.Scale == ObjectTransformActual.Scale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& Result) {});
+    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
 
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);
@@ -2368,7 +2360,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTe
     SpaceTransform ObjectTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransform);
     auto [CreatedChildEntity] = AWAIT(EntitySystem, CreateObject, ChildEntityName, ObjectTransform);
@@ -2387,7 +2379,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTe
     bool ChildEntityUpdated = false;
 
     CreatedChildEntity->SetUpdateCallback(
-        [&ChildEntityUpdated, ChildEntityName](SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+        [&ChildEntityUpdated, ChildEntityName](
+            SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
         {
             if (Entity->GetName() == ChildEntityName && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
             {
@@ -2496,7 +2489,7 @@ void RunParentChildDeletionTest(bool Local)
     SpaceTransform ObjectTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransform);
     auto [CreatedChildEntity1] = AWAIT(EntitySystem, CreateObject, ChildEntityName1, ObjectTransform);
@@ -2508,7 +2501,7 @@ void RunParentChildDeletionTest(bool Local)
 
         CreatedChildEntity1->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName1](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName1 && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
                 {
@@ -2541,7 +2534,7 @@ void RunParentChildDeletionTest(bool Local)
 
         CreatedChildEntity2->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName2](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName2 && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
                 {
@@ -2671,7 +2664,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateObjectParentTest)
     SpaceTransform ObjectTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransform);
     auto [CreatedChildEntity] = AWAIT(CreatedParentEntity, CreateChildEntity, ChildEntityName, ObjectTransform);
@@ -2730,7 +2723,7 @@ void RunParentDeletionTest(bool Local)
     SpaceTransform ObjectTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
 
-    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     auto [CreatedParentEntity] = AWAIT(EntitySystem, CreateObject, ParentEntityName, ObjectTransform);
     auto [CreatedChildEntity1] = AWAIT(EntitySystem, CreateObject, ChildEntityName1, ObjectTransform);
@@ -2742,7 +2735,7 @@ void RunParentDeletionTest(bool Local)
 
         CreatedChildEntity1->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName1](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName1 && (Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT))
                 {
@@ -2771,7 +2764,7 @@ void RunParentDeletionTest(bool Local)
 
         CreatedChildEntity2->SetUpdateCallback(
             [&ChildEntityUpdated, ChildEntityName2](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (Entity->GetName() == ChildEntityName2 && Flags & SpaceEntityUpdateFlags::UPDATE_FLAGS_PARENT)
                 {
@@ -2796,7 +2789,7 @@ void RunParentDeletionTest(bool Local)
 
         CreatedChildEntity1->SetUpdateCallback(
             [&ChildEntityUpdated, &LocalDestroyCalled, &EntityDestroyCalled, ChildEntityName1](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (ChildEntityUpdated)
                 {
@@ -2815,7 +2808,7 @@ void RunParentDeletionTest(bool Local)
 
         CreatedChildEntity2->SetUpdateCallback(
             [&ChildEntityUpdated2, &LocalDestroyCalled, &EntityDestroyCalled, ChildEntityName2](
-                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& UpdateInfo)
+                SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& /*UpdateInfo*/)
             {
                 if (ChildEntityUpdated2)
                 {
@@ -2992,7 +2985,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
 
     // Invoke function for delete objects errors
     EXPECT_CALL(*SignalRMock, Invoke)
-        .WillOnce([](const std::string& DeleteObjectsMethodName, const signalr::value& DeleteEntityMessage,
+        .WillOnce([](const std::string& /*DeleteObjectsMethodName*/, const signalr::value& /*DeleteEntityMessage*/,
                       std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             { Callback(signalr::value("Irrelevant value from DeleteObjects"), std::make_exception_ptr(std::runtime_error("mock exception"))); });
 
@@ -3023,7 +3016,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
 
     EXPECT_CALL(*SignalRMock, Invoke)
         .WillRepeatedly(
-            [](const std::string& HubMethodName, const signalr::value& Message,
+            [](const std::string& HubMethodName, const signalr::value& /*Message*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
                 if (HubMethodName == "DeleteObjects")
@@ -3065,7 +3058,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
 
     EXPECT_CALL(*SignalRMock, Invoke)
         .WillRepeatedly(
-            [](const std::string& HubMethodName, const signalr::value& Message,
+            [](const std::string& HubMethodName, const signalr::value& /*Message*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
                 if (HubMethodName == "DeleteObjects")
@@ -3111,7 +3104,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
 
     EXPECT_CALL(*SignalRMock, Invoke)
         .WillRepeatedly(
-            [](const std::string& HubMethodName, const signalr::value& Message,
+            [](const std::string& HubMethodName, const signalr::value& /*Message*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
                 if (HubMethodName == "DeleteObjects")

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -315,7 +315,6 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 
     const char* TestSpaceName = "CSP-TEST-SPACE";
     const char* TestSpaceDescription = "CSP-TEST-SPACEDESC";
-    const char* TestAssetCollectionName = "CSP-TEST-ASSETCOLLECTION";
 
     // The default POI we will be using during the test.
     csp::systems::PointOfInterest DefaultPOI;

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -226,7 +226,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaT
         const auto& ResultPOIs = Result.GetPOIs();
         POICollection = csp::common::Array<csp::systems::PointOfInterest>(ResultPOIs.Size());
 
-        for (int idx = 0; idx < ResultPOIs.Size(); ++idx)
+        for (size_t idx = 0; idx < ResultPOIs.Size(); ++idx)
         {
             POICollection[idx] = ResultPOIs[idx];
         }
@@ -237,7 +237,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaT
 
     bool POIFound = false;
 
-    for (int idx = 0; idx < POICollection.Size(); ++idx)
+    for (size_t idx = 0; idx < POICollection.Size(); ++idx)
     {
         if (POICollection[idx].Name == PointOfInterest.Name)
         {

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -244,7 +244,6 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetConcurrentUsersInSpace)
     auto UserSystem = SystemsManager.GetUserSystem();
     auto QuotaSystem = SystemsManager.GetQuotaSystem();
     auto SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     csp::common::Array<TierFeatures> TierFeaturesArray = { TierFeatures::SpaceOwner, TierFeatures::ObjectCaptureUpload,
         TierFeatures::AudioVideoUpload, TierFeatures::OpenAI, TierFeatures::TicketedSpace };

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -127,7 +127,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForUser)
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
     EXPECT_EQ(Result.GetFeaturesLimitInfo().Size(), TierFeaturesArray.Size());
 
-    for (int i = 0; i < TierFeaturesArray.Size(); i++)
+    for (size_t i = 0; i < TierFeaturesArray.Size(); i++)
     {
         EXPECT_EQ(Result.GetFeaturesLimitInfo()[i].FeatureName, TierFeaturesArray[i]);
         EXPECT_EQ(Result.GetFeaturesLimitInfo()[i].Limit, -1);
@@ -165,7 +165,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeatureProgressForSpace)
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
     EXPECT_EQ(Result.GetFeaturesLimitInfo().Size(), TierFeaturesArray.Size());
 
-    for (int i = 0; i < TierFeaturesArray.Size(); i++)
+    for (size_t i = 0; i < TierFeaturesArray.Size(); i++)
     {
         EXPECT_EQ(Result.GetFeaturesLimitInfo()[i].FeatureName, TierFeaturesArray[i]);
         EXPECT_EQ(Result.GetFeaturesLimitInfo()[i].Limit, -1);
@@ -229,7 +229,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTierFeaturesQuota)
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
     EXPECT_EQ(Result.GetFeaturesQuotaInfo().Size(), ExpectedInfoArray.Size());
 
-    for (int i = 0; i < Result.GetFeaturesQuotaInfo().Size(); i++)
+    for (size_t i = 0; i < Result.GetFeaturesQuotaInfo().Size(); i++)
     {
         EXPECT_EQ(Result.GetFeaturesQuotaInfo()[i].FeatureName, ExpectedInfoArray[i].FeatureName);
         EXPECT_EQ(Result.GetFeaturesQuotaInfo()[i].TierName, ExpectedInfoArray[i].TierName);

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -39,9 +39,6 @@
 
 using namespace csp::multiplayer;
 
-MultiplayerConnection* Connection;
-SpaceEntitySystem* EntitySystem;
-
 void OnUserCreated(SpaceEntity* InUser);
 
 namespace
@@ -82,7 +79,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptBindingTest)
 
     ScriptSystem.CreateContext(ContextId);
 
-    qjs::Context* Context = (qjs::Context*)ScriptSystem.GetContext(ContextId);
     qjs::Context::Module* Module = (qjs::Context::Module*)ScriptSystem.GetModule(ContextId, "CSPTest");
 
     Module->function("RunFunction", Fn);
@@ -119,7 +115,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CreateScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -200,7 +195,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -334,7 +328,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AvatarScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -429,7 +422,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptLogTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -504,7 +496,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -612,7 +603,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteAndChangeComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -719,7 +709,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -878,7 +867,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptDeltaTimeTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -973,7 +961,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubs
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1104,7 +1091,6 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
@@ -1156,8 +1142,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
     auto [SpaceEntity] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
 
     // Attempt to add 2 script components
-    auto Comp1 = SpaceEntity->AddComponent(csp::multiplayer::ComponentType::ScriptData);
-    auto Comp2 = SpaceEntity->AddComponent(csp::multiplayer::ComponentType::ScriptData);
+    SpaceEntity->AddComponent(csp::multiplayer::ComponentType::ScriptData);
+    SpaceEntity->AddComponent(csp::multiplayer::ComponentType::ScriptData);
 
     SpaceEntity->QueueUpdate();
     EntitySystem->ProcessPendingEntityOperations();
@@ -1181,6 +1167,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ScriptSystemTests, ModifyExistingScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -142,7 +142,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CreateScriptTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // we'll be using this in a few places below as part of the test, so we declare it upfront
     const std::string ScriptText = R"xx(
@@ -221,7 +221,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
 
     std::atomic_bool ScriptSystemReady = false;
 
-    auto EntityCreatedCallback = [](SpaceEntity* Entity) { std::cerr << "EntityCreatedCallback called" << std::endl; };
+    auto EntityCreatedCallback = [](SpaceEntity* /*Entity*/) { std::cerr << "EntityCreatedCallback called" << std::endl; };
 
     auto EntitiesReadyCallback = [](bool Ok)
     {
@@ -240,7 +240,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetEntityCreatedCallback(EntityCreatedCallback);
     EntitySystem->SetInitialEntitiesRetrievedCallback(EntitiesReadyCallback);
@@ -292,7 +292,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
 
     // Create an AnimatedModelComponent and have the script update it's position
     {
-        EntitySystem->SetEntityCreatedCallback([](SpaceEntity* Entity) {});
+        EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
         const csp::common::String ObjectName = "Object 1";
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
@@ -357,7 +357,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AvatarScriptTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
@@ -452,7 +452,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptLogTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
@@ -526,7 +526,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteScriptTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
@@ -634,7 +634,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteAndChangeComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
@@ -739,7 +739,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
 
     std::atomic_bool ScriptSystemReady = false;
 
-    auto EntityCreatedCallback = [](SpaceEntity* Entity) { std::cerr << "EntityCreatedCallback called" << std::endl; };
+    auto EntityCreatedCallback = [](SpaceEntity* /*Entity*/) { std::cerr << "EntityCreatedCallback called" << std::endl; };
 
     auto EntitiesReadyCallback = [](bool Ok)
     {
@@ -758,7 +758,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetEntityCreatedCallback(EntityCreatedCallback);
     EntitySystem->SetInitialEntitiesRetrievedCallback(EntitiesReadyCallback);
@@ -813,7 +813,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
     auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
 
     bool PatchPending = true;
-    CreatedObject->SetPatchSentCallback([&PatchPending](bool ok) { PatchPending = false; });
+    CreatedObject->SetPatchSentCallback([&PatchPending](bool /*ok*/) { PatchPending = false; });
 
     // Create script
     auto* ScriptComponent = static_cast<ScriptSpaceComponent*>(CreatedObject->AddComponent(ComponentType::ScriptData));
@@ -901,7 +901,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptDeltaTimeTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
@@ -993,7 +993,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubs
 
     std::atomic_bool ScriptSystemReady = false;
 
-    auto EntityCreatedCallback = [](SpaceEntity* Entity) { std::cerr << "EntityCreatedCallback called" << std::endl; };
+    auto EntityCreatedCallback = [](SpaceEntity* /*Entity*/) { std::cerr << "EntityCreatedCallback called" << std::endl; };
 
     auto EntitiesReadyCallback = [](bool Ok)
     {
@@ -1012,7 +1012,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubs
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     EntitySystem->SetEntityCreatedCallback(EntityCreatedCallback);
     EntitySystem->SetInitialEntitiesRetrievedCallback(EntitiesReadyCallback);
@@ -1128,7 +1128,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* Entity) {});
+    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
@@ -1240,7 +1240,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ScriptSystemTests, ModifyExistingScriptTest)
 
     bool EntityHasBeenRecreated = false;
     // we're gonna wanna wait till the entity is created before we can do our test
-    EntitySystem->SetEntityCreatedCallback([&EntityHasBeenRecreated](csp::multiplayer::SpaceEntity* Object) { EntityHasBeenRecreated = true; });
+    EntitySystem->SetEntityCreatedCallback([&EntityHasBeenRecreated](csp::multiplayer::SpaceEntity* /*Object*/) { EntityHasBeenRecreated = true; });
 
     // spin till we recreate the entity from phase 1 locally, having received it back from CHS
     while (EntityHasBeenRecreated == false)

--- a/Tests/src/PublicAPITests/SequenceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceSystemTests.cpp
@@ -55,7 +55,7 @@ void CreateSequence(csp::systems::SequenceSystem* SequenceSystem, const csp::com
             EXPECT_EQ(Sequence.MetaData[(*Keys)[i]], MetaData[(*Keys)[i]]);
         }
 
-        for (int i = 0; i < Sequence.Items.Size(); ++i)
+        for (size_t i = 0; i < Sequence.Items.Size(); ++i)
         {
             EXPECT_EQ(Sequence.Items[i], Items[i]);
         }
@@ -120,7 +120,7 @@ void UpdateSequence(csp::systems::SequenceSystem* SequenceSystem, const csp::com
         EXPECT_EQ(Sequence.ReferenceId, ReferenceId);
         EXPECT_EQ(Sequence.Items.Size(), Items.Size());
 
-        for (int i = 0; i < Sequence.Items.Size(); ++i)
+        for (size_t i = 0; i < Sequence.Items.Size(); ++i)
         {
             EXPECT_EQ(Sequence.Items[i], Items[i]);
         }
@@ -225,7 +225,7 @@ void CompareSequences(const csp::systems::Sequence& S1, const csp::systems::Sequ
     EXPECT_EQ(S1.ReferenceId, S2.ReferenceId);
     EXPECT_EQ(S1.Items.Size(), S2.Items.Size());
 
-    for (int i = 0; i < S1.Items.Size(); ++i)
+    for (size_t i = 0; i < S1.Items.Size(); ++i)
     {
         EXPECT_EQ(S1.Items[i], S2.Items[i]);
     }

--- a/Tests/src/PublicAPITests/SequenceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceSystemTests.cpp
@@ -232,9 +232,6 @@ void CompareSequences(const csp::systems::Sequence& S1, const csp::systems::Sequ
 }
 } // namespace
 
-static constexpr const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-static constexpr const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
 CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceTest)
 {
     SetRandSeed();
@@ -297,8 +294,6 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceInvalidKeyTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* SequenceSystem = SystemsManager.GetSequenceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
-    auto* EventBus = SystemsManager.GetEventBus();
 
     // Log in
     csp::common::String UserId;
@@ -348,8 +343,6 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoItemsTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* SequenceSystem = SystemsManager.GetSequenceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
-    auto* EventBus = SystemsManager.GetEventBus();
 
     // Log in
     csp::common::String UserId;
@@ -391,7 +384,6 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, CreateSequenceNoSpaceTest)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* SequenceSystem = SystemsManager.GetSequenceSystem();
 
     // Log in
@@ -424,6 +416,8 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* SequenceSystem = SystemsManager.GetSequenceSystem();
+
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 
     // Log in
     csp::common::String UserId;
@@ -475,6 +469,8 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, GetSequenceInvalidKeyTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* SequenceSystem = SystemsManager.GetSequenceSystem();
+
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 
     // Log in
     csp::common::String UserId;
@@ -901,8 +897,8 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RegisterSequenceUpdatedTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* SequenceSystem = SystemsManager.GetSequenceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
-    auto* EventBus = SystemsManager.GetEventBus();
+
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
 
     // Log in
     csp::common::String UserId;

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -189,7 +189,7 @@ void GetSpaceSites(::SpaceSystem* SpaceSystem, const String& SpaceId, Array<Site
     const auto& ResultSites = Result.GetSites();
     OutSites = Array<Site>(ResultSites.Size());
 
-    for (int idx = 0; idx < ResultSites.Size(); ++idx)
+    for (size_t idx = 0; idx < ResultSites.Size(); ++idx)
     {
         OutSites[idx] = ResultSites[idx];
     }
@@ -230,7 +230,7 @@ void GetUsersRoles(::SpaceSystem* SpaceSystem, const String& SpaceId, const Arra
     const auto& ReturnedRolesInfo = Result.GetUsersRoles();
     OutUsersRoles = Array<UserRoleInfo>(ReturnedRolesInfo.Size());
 
-    for (int idx = 0; idx < ReturnedRolesInfo.Size(); ++idx)
+    for (size_t idx = 0; idx < ReturnedRolesInfo.Size(); ++idx)
     {
         OutUsersRoles[idx] = ReturnedRolesInfo[idx];
     }
@@ -401,7 +401,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBulkInviteTest)
     auto& PendingInvites = GetInvitesResult.GetPendingInvitesEmails();
     EXPECT_EQ(PendingInvites.Size(), InviteUsers.InviteUserRoleInfos.Size());
 
-    for (auto idx = 0; idx < PendingInvites.Size(); ++idx)
+    for (size_t idx = 0; idx < PendingInvites.Size(); ++idx)
     {
         std::cerr << "Pending space invite for email: " << PendingInvites[idx] << std::endl;
     }
@@ -506,7 +506,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBufferWithBulkInvite
     auto& PendingInvites = GetInvitesResult.GetPendingInvitesEmails();
     EXPECT_EQ(PendingInvites.Size(), InviteUsers.InviteUserRoleInfos.Size());
 
-    for (auto idx = 0; idx < PendingInvites.Size(); ++idx)
+    for (size_t idx = 0; idx < PendingInvites.Size(); ++idx)
     {
         std::cerr << "Pending space invite for email: " << PendingInvites[idx] << std::endl;
     }
@@ -648,7 +648,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesTest)
 
     bool SpaceFound = false;
 
-    for (int i = 0; i < ResultSpaces.Size(); ++i)
+    for (size_t i = 0; i < ResultSpaces.Size(); ++i)
     {
         if (ResultSpaces[i].Name == UniqueSpaceName)
         {
@@ -740,7 +740,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpacesByIdsTest)
     bool PrivateSpaceFound = false;
     bool PublicSpaceFound = false;
 
-    for (int i = 0; i < ResultSpaces.Size(); ++i)
+    for (size_t i = 0; i < ResultSpaces.Size(); ++i)
     {
         if (ResultSpaces[i].Name == UniquePrivateSpaceName)
         {
@@ -786,7 +786,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesAsGuestTest)
 
     String SpaceId[SPACE_COUNT];
 
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         char UniqueSpaceName[256];
         SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -810,7 +810,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesAsGuestTest)
     EXPECT_GE(ResultSpaces.Size(), SPACE_COUNT);
 
     // Make sure that all returned spaces are public
-    for (int i = 0; i < ResultSpaces.Size(); ++i)
+    for (size_t i = 0; i < ResultSpaces.Size(); ++i)
     {
         const auto& Space = ResultSpaces[i];
 
@@ -824,7 +824,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesAsGuestTest)
     // Clean up
     LogIn(UserSystem, UserId, SpaceCreatorUser.Email, GeneratedTestAccountPassword);
 
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         DeleteSpace(SpaceSystem, SpaceId[i]);
     }
@@ -853,7 +853,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesTest)
 
     String SpaceId[SPACE_COUNT];
 
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         char UniqueSpaceName[256];
         SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -871,7 +871,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesTest)
     EXPECT_GE(ResultSpaces.Size(), SPACE_COUNT);
 
     // Make sure that all returned spaces are public
-    for (int i = 0; i < ResultSpaces.Size(); ++i)
+    for (size_t i = 0; i < ResultSpaces.Size(); ++i)
     {
         const auto& Space = ResultSpaces[i];
 
@@ -880,7 +880,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpacesTest)
     }
 
     // Clean up
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         DeleteSpace(SpaceSystem, SpaceId[i]);
     }
@@ -909,7 +909,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPrivateSpacesTest)
 
     String SpaceId[SPACE_COUNT];
 
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         char UniqueSpaceName[256];
         SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -927,7 +927,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPrivateSpacesTest)
     EXPECT_GE(ResultSpaces.Size(), SPACE_COUNT);
 
     // Make sure that all returned spaces are public
-    for (int i = 0; i < ResultSpaces.Size(); ++i)
+    for (size_t i = 0; i < ResultSpaces.Size(); ++i)
     {
         const auto& Space = ResultSpaces[i];
 
@@ -936,7 +936,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPrivateSpacesTest)
     }
 
     // Clean up
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         DeleteSpace(SpaceSystem, SpaceId[i]);
     }
@@ -965,7 +965,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPaginatedPrivateSpacesTest)
 
     String SpaceId[SPACE_COUNT];
 
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         char UniqueSpaceName[256];
         SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
@@ -992,7 +992,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPaginatedPrivateSpacesTest)
     }
 
     // Clean up
-    for (int i = 0; i < SPACE_COUNT; ++i)
+    for (size_t i = 0; i < SPACE_COUNT; ++i)
     {
         DeleteSpace(SpaceSystem, SpaceId[i]);
     }
@@ -1043,7 +1043,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, JoinPublicSpaceTest)
 
     EXPECT_EQ(RetrievedUserRoles.Size(), 2);
 
-    for (auto idx = 0; idx < RetrievedUserRoles.Size(); ++idx)
+    for (size_t idx = 0; idx < RetrievedUserRoles.Size(); ++idx)
     {
         if (RetrievedUserRoles[idx].UserId == SpaceOwnerUserId)
         {
@@ -1132,7 +1132,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSiteInfoTest)
     bool Site1Found = false;
     bool Site2Found = false;
 
-    for (int idx = 0; idx < SpaceSites.Size(); ++idx)
+    for (size_t idx = 0; idx < SpaceSites.Size(); ++idx)
     {
         if (SpaceSites[idx].Name == SiteInfo1.Name)
         {
@@ -1237,7 +1237,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateUserRolesTest)
 
     EXPECT_EQ(RetrievedUserRoles.Size(), 2);
 
-    for (auto idx = 0; idx < RetrievedUserRoles.Size(); ++idx)
+    for (size_t idx = 0; idx < RetrievedUserRoles.Size(); ++idx)
     {
         if (RetrievedUserRoles[idx].UserId == DefaultUserId)
         {
@@ -1778,7 +1778,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPendingUserInvitesTest)
     EXPECT_EQ(GetInvitesResult.GetResultCode(), csp::systems::EResultCode::Success);
     auto& PendingInvites = GetInvitesResult.GetPendingInvitesEmails();
     EXPECT_EQ(PendingInvites.Size(), 1);
-    for (auto idx = 0; idx < PendingInvites.Size(); ++idx)
+    for (size_t idx = 0; idx < PendingInvites.Size(); ++idx)
     {
         std::cerr << "Pending space invite for email: " << PendingInvites[idx] << std::endl;
     }
@@ -1859,7 +1859,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetAcceptedUserInvitesTest)
     EXPECT_EQ(GetAcceptedInvitesResult.GetResultCode(), csp::systems::EResultCode::Success);
     auto& AcceptedInvites = GetAcceptedInvitesResult.GetAcceptedInvitesUserIds();
     EXPECT_EQ(AcceptedInvites.Size(), 2);
-    for (auto idx = 0; idx < AcceptedInvites.Size(); ++idx)
+    for (size_t idx = 0; idx < AcceptedInvites.Size(); ++idx)
     {
         std::cerr << "Accepted space invite for user id: " << AcceptedInvites[idx] << std::endl;
     }
@@ -1904,7 +1904,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, BulkInvitetoSpaceTest)
 
     EXPECT_EQ(PendingInvites.Size(), 4);
 
-    for (auto idx = 0; idx < PendingInvites.Size(); ++idx)
+    for (size_t idx = 0; idx < PendingInvites.Size(); ++idx)
     {
         std::cerr << "Pending space invite for email: " << PendingInvites[idx] << std::endl;
     }
@@ -2435,7 +2435,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationTest)
     EXPECT_DOUBLE_EQ(AddGeoResult.GetSpaceGeoLocation().Location.Longitude, InitialGeoLocation.Longitude);
     EXPECT_DOUBLE_EQ(AddGeoResult.GetSpaceGeoLocation().Orientation, InitialOrientation);
 
-    for (auto i = 0; i < AddGeoResult.GetSpaceGeoLocation().GeoFence.Size(); ++i)
+    for (size_t i = 0; i < AddGeoResult.GetSpaceGeoLocation().GeoFence.Size(); ++i)
     {
         EXPECT_DOUBLE_EQ(AddGeoResult.GetSpaceGeoLocation().GeoFence[i].Latitude, InitialGeoFence[i].Latitude);
         EXPECT_DOUBLE_EQ(AddGeoResult.GetSpaceGeoLocation().GeoFence[i].Longitude, InitialGeoFence[i].Longitude);
@@ -2476,7 +2476,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationTest)
     EXPECT_DOUBLE_EQ(UpdateGeoResult.GetSpaceGeoLocation().Location.Longitude, SecondGeoLocation.Longitude);
     EXPECT_DOUBLE_EQ(UpdateGeoResult.GetSpaceGeoLocation().Orientation, SecondOrientation);
 
-    for (auto i = 0; i < UpdateGeoResult.GetSpaceGeoLocation().GeoFence.Size(); ++i)
+    for (size_t i = 0; i < UpdateGeoResult.GetSpaceGeoLocation().GeoFence.Size(); ++i)
     {
         EXPECT_DOUBLE_EQ(UpdateGeoResult.GetSpaceGeoLocation().GeoFence[i].Latitude, SecondGeoFence[i].Latitude);
         EXPECT_DOUBLE_EQ(UpdateGeoResult.GetSpaceGeoLocation().GeoFence[i].Longitude, SecondGeoFence[i].Longitude);
@@ -2490,7 +2490,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GeoLocationTest)
     EXPECT_DOUBLE_EQ(GetUpdatedGeoResult.GetSpaceGeoLocation().Location.Longitude, SecondGeoLocation.Longitude);
     EXPECT_DOUBLE_EQ(GetUpdatedGeoResult.GetSpaceGeoLocation().Orientation, SecondOrientation);
 
-    for (auto i = 0; i < GetUpdatedGeoResult.GetSpaceGeoLocation().GeoFence.Size(); ++i)
+    for (size_t i = 0; i < GetUpdatedGeoResult.GetSpaceGeoLocation().GeoFence.Size(); ++i)
     {
         EXPECT_DOUBLE_EQ(GetUpdatedGeoResult.GetSpaceGeoLocation().GeoFence[i].Latitude, SecondGeoFence[i].Latitude);
         EXPECT_DOUBLE_EQ(GetUpdatedGeoResult.GetSpaceGeoLocation().GeoFence[i].Longitude, SecondGeoFence[i].Longitude);

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1163,7 +1163,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateUserRolesTest)
     auto& SystemsManager = ::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // Get alt account user ID
     String AltUserId;
@@ -1921,7 +1920,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
     auto& SystemsManager = ::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
@@ -2233,7 +2231,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
     auto& SystemsManager = ::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
@@ -2289,7 +2286,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsNonModeratorTest)
     auto& SystemsManager = ::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
@@ -2332,7 +2328,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsModeratorTest)
     auto& SystemsManager = ::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
     const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1958,11 +1958,11 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
     // Exit and re-enter space to verify its OK to always add self to public space
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     {
-        auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        auto [Result2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
 
-        EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+        EXPECT_EQ(Result2.GetResultCode(), csp::systems::EResultCode::Success);
 
-        auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+        auto [ExitSpaceResult2] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
 
     // Log back in with default user so space can be deleted

--- a/Tests/src/PublicAPITests/SystemResultTests.cpp
+++ b/Tests/src/PublicAPITests/SystemResultTests.cpp
@@ -129,9 +129,9 @@ CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, BaseResultTest)
     ResponseReceiver Receiver;
 
     // Synthesise a response to feed to ApiResponseBase
-    csp::web::HttpPayload* MyHttpPayload = CSP_NEW csp::web::HttpPayload(MyTestPayload);
+    csp::web::HttpPayload MyHttpPayload(MyTestPayload);
     csp::web::HttpRequest MyTestRequest = csp::web::HttpRequest(
-        WebClient, csp::web::ERequestVerb::GET, csp::web::Uri(), *MyHttpPayload, &Receiver, csp::common::CancellationToken::Dummy());
+        WebClient, csp::web::ERequestVerb::GET, csp::web::Uri(), MyHttpPayload, &Receiver, csp::common::CancellationToken::Dummy());
     MyTestRequest.SetRequestProgress(1.0f);
     MyTestRequest.SetResponseCode(MyTestResponseCode);
 
@@ -148,6 +148,4 @@ CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, BaseResultTest)
     csp::web::HttpRequest* MyRequest = ResponseBase.GetResponse()->GetRequest();
     EXPECT_EQ(MyRequest->GetPayload().GetContent(), "1234");
     EXPECT_EQ(ResponseBase.GetResponseCode(), csp::services::EResponseCode::ResponseSuccess);
-
-    CSP_DELETE(MyHttpPayload);
 }

--- a/Tests/src/PublicAPITests/SystemResultTests.cpp
+++ b/Tests/src/PublicAPITests/SystemResultTests.cpp
@@ -129,8 +129,9 @@ CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, BaseResultTest)
     ResponseReceiver Receiver;
 
     // Synthesise a response to feed to ApiResponseBase
-    csp::web::HttpRequest MyTestRequest = csp::web::HttpRequest(WebClient, csp::web::ERequestVerb::GET, csp::web::Uri(),
-        csp::web::HttpPayload(MyTestPayload), &Receiver, csp::common::CancellationToken::Dummy());
+    csp::web::HttpPayload* MyHttpPayload = CSP_NEW csp::web::HttpPayload(MyTestPayload);
+    csp::web::HttpRequest MyTestRequest = csp::web::HttpRequest(
+        WebClient, csp::web::ERequestVerb::GET, csp::web::Uri(), *MyHttpPayload, &Receiver, csp::common::CancellationToken::Dummy());
     MyTestRequest.SetRequestProgress(1.0f);
     MyTestRequest.SetResponseCode(MyTestResponseCode);
 
@@ -147,4 +148,6 @@ CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, BaseResultTest)
     csp::web::HttpRequest* MyRequest = ResponseBase.GetResponse()->GetRequest();
     EXPECT_EQ(MyRequest->GetPayload().GetContent(), "1234");
     EXPECT_EQ(ResponseBase.GetResponseCode(), csp::services::EResponseCode::ResponseSuccess);
+
+    CSP_DELETE(MyHttpPayload);
 }

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -712,7 +712,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetThirdPartySupportedProvidersTest)
     bool FoundGoogle = false;
     bool FoundDiscord = false;
     bool FoundApple = false;
-    for (auto idx = 0; idx < SupportedProviders.Size(); ++idx)
+    for (size_t idx = 0; idx < SupportedProviders.Size(); ++idx)
     {
         if (SupportedProviders[idx] == csp::systems::EThirdPartyAuthenticationProviders::Google)
         {

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -565,7 +565,6 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserTest)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SettingsSystem = SystemsManager.GetSettingsSystem();
 
     const char* TestUserName = "CSP-TEST-NAME";
     const char* TestDisplayName = "CSP-TEST-DISPLAY";
@@ -619,10 +618,8 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DeleteUserTest)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SettingsSystem = SystemsManager.GetSettingsSystem();
 
     const char* TestUserName = "CSP-TEST-NAME";
-    const char* TestDisplayName = "CSP-TEST-DISPLAY";
 
     char UniqueUserName[256];
     SPRINTF(UniqueUserName, "%s-%s-%s", TestUserName, GetUniqueString().c_str(), GetUniqueString().c_str());
@@ -667,8 +664,6 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, CreateUserEmptyUsernameDisplaynameTe
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
-
-    const char* TestUserName = "CSP-TEST-NAME";
 
     char UniqueEmail[256];
     SPRINTF(UniqueEmail, GeneratedTestAccountEmailFormat, GetUniqueString().c_str());

--- a/Tests/src/TestHelpers.h
+++ b/Tests/src/TestHelpers.h
@@ -142,7 +142,7 @@ inline void PrintProgress(float Progress)
     char ProgressString[256];
     SPRINTF(ProgressString, "Progress=%d%%\n", ProgressPercent);
 
-    for (int i = 0; i < strlen(ProgressString); ++i)
+    for (size_t i = 0; i < strlen(ProgressString); ++i)
         std::cerr << "\b";
 
     std::cerr << ProgressString;

--- a/ThirdParty/quickjs/include/quickjspp.hpp
+++ b/ThirdParty/quickjs/include/quickjspp.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#pragma warning(disable : 4702)
 
 #include "quickjs.h"
 

--- a/premake5_helpers.lua
+++ b/premake5_helpers.lua
@@ -84,6 +84,7 @@ if not CSP then
         cppdialect "C++17"
 		
 		flags {"FatalWarnings"}
+		warnings "Extra" -- corresponds to level /W4
 		externalwarnings "Off"
 			
         -- Standard debug/release config settings


### PR DESCRIPTION
Note that a few warnings had to be suppressed in externals or in the
wrapper generator:
- "unreachable code" (4702) was suppressed in quickjs
- "'const' qualifier on return type has no effect" (5266) was suppressed
  in the wrapper generator for the MacOS and WASM builds
- "missing field initializer" was suppressed in the wrapper generator for
  the MacOS and WASM builds

Given its size, it is a good idea to review this PR commit by commit. The first commit contains the build changes, and every subsequent commit contains all the fixes for a given warning. The very last commit is actually a bug fix: removing the const char* serializer/deserializer because it never worked and the test gave a false positive.