### PR TITLE
[NT-0] fix: Correct script property declaration types for avatar component HandRotation and HeadRotation properties

### DIFF
--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
@@ -38,8 +38,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(std::string, CustomAvatarUrl);
     DECLARE_SCRIPT_PROPERTY(bool, IsHandIKEnabled);
     DECLARE_SCRIPT_PROPERTY(Vector3, TargetHandIKTargetLocation);
-    DECLARE_SCRIPT_PROPERTY(Vector3, HandRotation);
-    DECLARE_SCRIPT_PROPERTY(Vector3, HeadRotation);
+    DECLARE_SCRIPT_PROPERTY(Vector4, HandRotation);
+    DECLARE_SCRIPT_PROPERTY(Vector4, HeadRotation);
     DECLARE_SCRIPT_PROPERTY(float, WalkRunBlendPercentage);
     DECLARE_SCRIPT_PROPERTY(float, TorsoTwistAlpha);
     DECLARE_SCRIPT_PROPERTY(int32_t, AvatarPlayMode);


### PR DESCRIPTION
The avatar component `HandRotation` and `HeadRotation` were declared with the wrong types in the component script interface header. This PR updates the declaration to match the definition and component property types.