### PR TITLE
[OF-1586] refac: CreateAvatar Continuations

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -149,6 +149,11 @@ public:
     /// @brief Creates a SpaceEntity instance using the space entity system provided.
     SpaceEntity(SpaceEntitySystem* InEntitySystem);
 
+    /// Internal constructor to explicitly create a SpaceEntity in a specified state.
+    /// Initially implemented for use in SpaceEntitySystem::CreateAvatar
+    CSP_NO_EXPORT SpaceEntity(SpaceEntitySystem* EntitySystem, uint64_t Id, const csp::common::String& Name, const SpaceTransform& Transform,
+        uint64_t OwnerId, bool IsTransferable, bool IsPersistant);
+
     /// @brief Destroys the SpaceEntity instance.
     ~SpaceEntity();
 

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -29,11 +29,17 @@
 #include <mutex>
 #include <set>
 
+namespace async
+{
+CSP_START_IGNORE
+template <typename T> class task;
+template <typename T> class shared_task;
+CSP_END_IGNORE
+}
+
 namespace signalr
 {
-
 class value;
-
 } // namespace signalr
 
 namespace csp::memory
@@ -53,6 +59,12 @@ class SystemsManager;
 class SequenceSystem;
 
 } // namespace csp::systems
+
+class CSPEngine_SpaceEntitySystemTests_TestErrorInRemoteGenerateNewAvatarId_Test;
+class CSPEngine_SpaceEntitySystemTests_TestSuccessInRemoteGenerateNewAvatarId_Test;
+class CSPEngine_SpaceEntitySystemTests_TestErrorInSendNewAvatarObjectMessage_Test;
+class CSPEngine_SpaceEntitySystemTests_TestSuccessInSendNewAvatarObjectMessage_Test;
+class CSPEngine_SpaceEntitySystemTests_TestSuccessInCreateNewLocalAvatar_Test;
 
 /// @brief Namespace that encompasses everything in the multiplayer system
 namespace csp::multiplayer
@@ -82,6 +94,13 @@ class CSP_API SpaceEntitySystem
     friend class EntityScript;
     friend class SpaceEntity;
     friend void csp::memory::Delete<SpaceEntitySystem>(SpaceEntitySystem* Ptr);
+
+    // Tests
+    friend class CSPEngine_SpaceEntitySystemTests_TestErrorInRemoteGenerateNewAvatarId_Test;
+    friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInRemoteGenerateNewAvatarId_Test;
+    friend class CSPEngine_SpaceEntitySystemTests_TestErrorInSendNewAvatarObjectMessage_Test;
+    friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInSendNewAvatarObjectMessage_Test;
+    friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInCreateNewLocalAvatar_Test;
     /** @endcond */
     CSP_END_IGNORE
 
@@ -368,6 +387,16 @@ private:
 
     void CreateObjectInternal(const csp::common::String& InName, csp::common::Optional<uint64_t> InParent, const SpaceTransform& InSpaceTransform,
         EntityCreatedCallback Callback);
+
+    // CreateAvatar Continuations
+    CSP_START_IGNORE
+    async::shared_task<uint64_t> RemoteGenerateNewAvatarId();
+    std::function<async::task<std::tuple<signalr::value, std::exception_ptr>>(uint64_t)> SendNewAvatarObjectMessage(const csp::common::String& Name,
+        const SpaceTransform& Transform, const csp::common::String& AvatarId, AvatarState AvatarState, AvatarPlayMode AvatarPlayMode);
+    std::function<void(std::tuple<async::shared_task<uint64_t>, async::task<void>>)> CreateNewLocalAvatar(const csp::common::String& Name,
+        const SpaceTransform& Transform, const csp::common::String& AvatarId, AvatarState AvatarState, AvatarPlayMode AvatarPlayMode,
+        EntityCreatedCallback Callback);
+    CSP_END_IGNORE
 
     class EntityScriptBinding* ScriptBinding;
     class SpaceEntityEventHandler* EventHandler;

--- a/Library/src/Multiplayer/SignalR/ISignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/ISignalRConnection.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <async++.h>
 #include <exception>
 #include <functional>
 #include <map>
@@ -48,7 +49,7 @@ public:
     virtual std::string GetConnectionId() const = 0;
     virtual void SetDisconnected(const std::function<void(std::exception_ptr)>& DisconnectedCallback) = 0;
     virtual void On(const std::string& EventName, const MethodInvokedHandler& Handler) = 0;
-    virtual void Invoke(
+    virtual async::task<std::tuple<signalr::value, std::exception_ptr>> Invoke(
         const std::string& MethodName, const signalr::value& Arguments,
         std::function<void(const signalr::value&, std::exception_ptr)> Callback = [](const signalr::value&, std::exception_ptr) {})
         = 0;

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.h
@@ -51,7 +51,7 @@ public:
 
     void On(const std::string& EventName, const MethodInvokedHandler& Handler) override;
 
-    void Invoke(
+    async::task<std::tuple<signalr::value, std::exception_ptr>> Invoke(
         const std::string& MethodName, const signalr::value& Arguments = signalr::value(),
         std::function<void(const signalr::value&, std::exception_ptr)> Callback = [](const signalr::value&, std::exception_ptr) {}) override;
 

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -126,6 +126,18 @@ SpaceEntity::SpaceEntity(SpaceEntitySystem* InEntitySystem)
 {
 }
 
+SpaceEntity::SpaceEntity(SpaceEntitySystem* EntitySystem, uint64_t Id, const csp::common::String& Name,
+    const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistant)
+    : SpaceEntity(EntitySystem)
+{
+    this->Id = Id;
+    this->Name = Name;
+    this->Transform = Transform;
+    this->OwnerId = OwnerId;
+    this->IsTransferable = IsTransferable;
+    this->IsPersistant = IsPersistant;
+}
+
 SpaceEntity::~SpaceEntity()
 {
     auto& Keys = *Components.Keys();
@@ -389,6 +401,10 @@ void SpaceEntity::MarkForUpdate()
 #else
         EntitySystem->QueueEntityUpdate(this);
 #endif
+    }
+    else
+    {
+        CSP_LOG_MSG(csp::systems::LogLevel::Warning, "Space Entity not marked for update, no local EntitySystem found.");
     }
 }
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -378,7 +378,7 @@ void SpaceEntitySystem::CreateAvatar(const csp::common::String& InName, const Sp
     async::when_all(GetAvatarNetworkIdChain, SerializeAndSendChain)
         .then(CreateNewLocalAvatar(InName, InSpaceTransform, InAvatarId, InState, InAvatarPlayMode, Callback))
         .then(csp::common::continuations::InvokeIfExceptionInChain(
-            [Callback, this](const std::exception& Except)
+            [Callback](const std::exception& Except)
             {
                 CSP_LOG_FORMAT(csp::systems::LogLevel::Error, "Failed to create Avatar. Exception: %s", Except.what());
                 Callback(nullptr);

--- a/Tests/src/Mocks/SignalRConnectionMock.h
+++ b/Tests/src/Mocks/SignalRConnectionMock.h
@@ -27,8 +27,8 @@ public:
     MOCK_METHOD(std::string, GetConnectionId, (), (const, override));
     MOCK_METHOD(void, SetDisconnected, (const std::function<void(std::exception_ptr)>&), (override));
     MOCK_METHOD(void, On, (const std::string&, const MethodInvokedHandler&), (override));
-    MOCK_METHOD(
-        void, Invoke, (const std::string&, const signalr::value&, std::function<void(const signalr::value&, std::exception_ptr)>), (override));
+    MOCK_METHOD((async::task<std::tuple<signalr::value, std::exception_ptr>>), Invoke,
+        (const std::string&, const signalr::value&, std::function<void(const signalr::value&, std::exception_ptr)>), (override));
     MOCK_METHOD(void, Send, (const std::string&, const signalr::value&, std::function<void(std::exception_ptr)>), (override));
     MOCK_METHOD((const std::map<std::string, std::string>&), HTTPHeaders, (), (const, override));
 };

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2946,7 +2946,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
     // Invoke function for delete objects errors
     EXPECT_CALL(*SignalRMock, Invoke)
         .WillOnce(
-            [](const std::string& DeleteObjectsMethodName, const signalr::value& DeleteEntityMessage,
+            [](const std::string& /*DeleteObjectsMethodName*/, const signalr::value& /*DeleteEntityMessage*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
                 auto Value = signalr::value("Irrelevant value from DeleteObjects");

--- a/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
@@ -58,7 +58,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInRemoteGenerateNe
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
     auto SignalRMock
@@ -102,7 +101,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorInRemoteGenerateNewA
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
     // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
@@ -147,7 +145,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInSendNewAvatarObj
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
     // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
@@ -190,7 +187,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorInSendNewAvatarObjec
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
     // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
@@ -242,7 +238,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInCreateNewLocalAv
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
     // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
@@ -302,7 +297,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorLoggedFromWholeCreat
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
-    auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
     auto SignalRMock

--- a/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "CSP/Multiplayer/MultiPlayerConnection.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "Debug/Logging.h"
+#include "Mocks/SignalRConnectionMock.h"
+#include "TestHelpers.h"
+#include <Memory/Memory.h>
+
+#include "signalrclient/signalr_value.h"
+#include "gtest/gtest.h"
+#include <memory>
+
+using namespace csp::multiplayer;
+
+namespace
+{
+class MockEntityCreatedCallback
+{
+public:
+    MOCK_METHOD(void, Call, (csp::multiplayer::SpaceEntity*), ());
+};
+
+/* We need to unset the mock logger before CSP shuts down,
+ * because you get interdependent memory errors in the "Foundation shutdown"
+ * log if you don't. (Another reason we don't want to be starting/stopping
+ * ALL of CSP in these tests really.)
+ */
+struct RAIIMockLogger
+{
+    RAIIMockLogger() { csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(MockLogCallback.AsStdFunction()); }
+    ~RAIIMockLogger() { csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback(nullptr); }
+    ::testing::MockFunction<void(const csp::common::String&)> MockLogCallback;
+};
+
+struct SignalRConnectionMockDeleter
+{
+    void operator()(SignalRConnectionMock* ptr) const noexcept { CSP_DELETE(ptr); }
+};
+
+}
+
+CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInRemoteGenerateNewAvatarId)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    auto SignalRMock
+        = std::unique_ptr<SignalRConnectionMock, SignalRConnectionMockDeleter>(CSP_NEW SignalRConnectionMock(), SignalRConnectionMockDeleter {});
+    SpaceEntitySystem->SetConnection(SignalRMock.get());
+
+    // SignalR populates a result and not an exception
+    EXPECT_CALL(*SignalRMock, Invoke("GenerateObjectIds", ::testing::_, ::testing::_))
+        .WillOnce(
+            [](const std::string& /**/, const signalr::value& /**/,
+                std::function<void(const signalr::value&, std::exception_ptr)> /**/) -> async::task<std::tuple<signalr::value, std::exception_ptr>>
+            {
+                // For some reason the ID value has to be an array :/
+                std::vector<signalr::value> ids;
+                ids.emplace_back(signalr::value(uint64_t(55)));
+                // Construct a signalr::value that holds an array of those IDs
+                signalr::value Value(ids);
+
+                return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
+            });
+
+    SpaceEntitySystem->RemoteGenerateNewAvatarId()
+        .then(async::inline_scheduler(),
+            [](async::shared_task<uint64_t> Result)
+            {
+                EXPECT_FALSE(Result.get_exception());
+                EXPECT_EQ(Result.get(), uint64_t(55));
+            })
+        .then(async::inline_scheduler(),
+            [](async::task<void> CheckForErrorsTask)
+            { EXPECT_FALSE(CheckForErrorsTask.get_exception()); }); // This is to be paranoid and guard against errors in writing the test, as async++
+                                                                    // will catch exceptions and convert to a friendly cancel if they occur.
+
+    // During destruction (test cleanup) CSP can access the connection.
+    // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.
+    SignalRConnectionMock* ThrowawaySignalRMock = CSP_NEW SignalRConnectionMock();
+    SpaceEntitySystem->SetConnection(ThrowawaySignalRMock);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorInRemoteGenerateNewAvatarId)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
+    auto SignalRMock
+        = std::unique_ptr<SignalRConnectionMock, SignalRConnectionMockDeleter>(CSP_NEW SignalRConnectionMock(), SignalRConnectionMockDeleter {});
+    SpaceEntitySystem->SetConnection(SignalRMock.get());
+
+    // SignalR populates an exception
+    EXPECT_CALL(*SignalRMock, Invoke("GenerateObjectIds", ::testing::_, ::testing::_))
+        .WillOnce(
+            [](const std::string& /**/, const signalr::value& /**/, std::function<void(const signalr::value&, std::exception_ptr)> /**/) {
+                return async::make_task(
+                    std::make_tuple(signalr::value("Irrelevant value"), std::make_exception_ptr(std::runtime_error("mock exception"))));
+            });
+
+    SpaceEntitySystem->RemoteGenerateNewAvatarId()
+        .then(
+            [](async::shared_task<uint64_t> Result)
+            {
+                EXPECT_TRUE(Result.get_exception());
+                try
+                {
+                    std::rethrow_exception(Result.get_exception());
+                }
+                catch (std::runtime_error error)
+                {
+                    EXPECT_EQ(std::string(error.what()), std::string("mock exception"));
+                }
+            })
+        .then(async::inline_scheduler(),
+            [](async::task<void> CheckForErrorsTask)
+            { EXPECT_FALSE(CheckForErrorsTask.get_exception()); }); // This is to be paranoid and guard against errors in writing the test, as async++
+                                                                    // will catch exceptions and convert to a friendly cancel if they occur.
+
+    // During destruction (test cleanup) CSP can access the connection.
+    // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.
+    SignalRConnectionMock* ThrowawaySignalRMock = CSP_NEW SignalRConnectionMock();
+    SpaceEntitySystem->SetConnection(ThrowawaySignalRMock);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInSendNewAvatarObjectMessage)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
+    auto SignalRMock
+        = std::unique_ptr<SignalRConnectionMock, SignalRConnectionMockDeleter>(CSP_NEW SignalRConnectionMock(), SignalRConnectionMockDeleter {});
+    SpaceEntitySystem->SetConnection(SignalRMock.get());
+
+    // SignalR populates a result and not an exception
+    EXPECT_CALL(*SignalRMock, Invoke("SendObjectMessage", ::testing::_, ::testing::_))
+        .WillOnce(
+            [](const std::string& /**/, const signalr::value& /**/,
+                std::function<void(const signalr::value&, std::exception_ptr)> /**/) -> async::task<std::tuple<signalr::value, std::exception_ptr>>
+            { return async::make_task(std::make_tuple(signalr::value(true), std::exception_ptr(nullptr))); });
+
+    const SpaceTransform& UserTransform
+        = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+
+    async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
+        .then(async::inline_scheduler(),
+            SpaceEntitySystem->SendNewAvatarObjectMessage("Username", UserTransform, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
+        .then(async::inline_scheduler(),
+            [](std::tuple<const signalr::value&, std::exception_ptr> Results)
+            {
+                auto [Result, Exception] = Results;
+                EXPECT_EQ(Result.as_bool(), true);
+                EXPECT_FALSE(Exception);
+            })
+        .then(async::inline_scheduler(),
+            [](async::task<void> CheckForErrorsTask)
+            { EXPECT_FALSE(CheckForErrorsTask.get_exception()); }); // This is to be paranoid and guard against errors in writing the test, as async++
+                                                                    // will catch exceptions and convert to a friendly cancel if they occur.
+
+    // During destruction (test cleanup) CSP can access the connection.
+    // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.
+    SignalRConnectionMock* ThrowawaySignalRMock = CSP_NEW SignalRConnectionMock();
+    SpaceEntitySystem->SetConnection(ThrowawaySignalRMock);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorInSendNewAvatarObjectMessage)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
+    auto SignalRMock
+        = std::unique_ptr<SignalRConnectionMock, SignalRConnectionMockDeleter>(CSP_NEW SignalRConnectionMock(), SignalRConnectionMockDeleter {});
+    SpaceEntitySystem->SetConnection(SignalRMock.get());
+
+    // SignalR populates an exception
+    EXPECT_CALL(*SignalRMock, Invoke("SendObjectMessage", ::testing::_, ::testing::_))
+        .WillOnce(
+            [](const std::string& /**/, const signalr::value& /**/,
+                std::function<void(const signalr::value&, std::exception_ptr)> /**/) -> async::task<std::tuple<signalr::value, std::exception_ptr>> {
+                return async::make_task(
+                    std::make_tuple(signalr::value("Irrelevent Value"), std::make_exception_ptr(std::runtime_error("mock exception"))));
+            });
+
+    const SpaceTransform& UserTransform
+        = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+
+    async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
+        .then(async::inline_scheduler(),
+            SpaceEntitySystem->SendNewAvatarObjectMessage("Username", UserTransform, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
+        .then(async::inline_scheduler(),
+            [](std::tuple<const signalr::value&, std::exception_ptr> Results)
+            {
+                auto [Result, Exception] = Results;
+                EXPECT_TRUE(Exception);
+                try
+                {
+                    std::rethrow_exception(Exception);
+                }
+                catch (std::runtime_error error)
+                {
+                    EXPECT_EQ(std::string(error.what()), std::string("mock exception"));
+                }
+            })
+        .then(async::inline_scheduler(),
+            [](async::task<void> CheckForErrorsTask)
+            { EXPECT_FALSE(CheckForErrorsTask.get_exception()); }); // This is to be paranoid and guard against errors in writing the test, as async++
+                                                                    // will catch exceptions and convert to a friendly cancel if they occur.
+
+    // During destruction (test cleanup) CSP can access the connection.
+    // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.
+    SignalRConnectionMock* ThrowawaySignalRMock = CSP_NEW SignalRConnectionMock();
+    SpaceEntitySystem->SetConnection(ThrowawaySignalRMock);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInCreateNewLocalAvatar)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    // SignalRConnectionMock* SignalRMock = CSP_NEW SignalRConnectionMock();
+    auto SignalRMock
+        = std::unique_ptr<SignalRConnectionMock, SignalRConnectionMockDeleter>(CSP_NEW SignalRConnectionMock(), SignalRConnectionMockDeleter {});
+    SpaceEntitySystem->SetConnection(SignalRMock.get());
+
+    using MockEntityCreatedCallback = testing::MockFunction<void(SpaceEntity*)>;
+    MockEntityCreatedCallback MockCallback;
+
+    const csp::common::String Username = "Username";
+    const csp::common::String AvatarId = "AvatarId";
+    AvatarState AvatarState = AvatarState::Flying;
+    AvatarPlayMode AvatarPlayMode = AvatarPlayMode::Creator;
+    const uint64_t Id = 55;
+    const SpaceTransform UserTransform
+        = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+
+    EXPECT_CALL(MockCallback, Call(::testing::_))
+        .WillOnce(::testing::Invoke(
+            [Id, &Username, &AvatarId, AvatarState, AvatarPlayMode, &UserTransform](SpaceEntity* CreatedSpaceEntity)
+            {
+                ASSERT_NE(CreatedSpaceEntity, nullptr);
+                ASSERT_EQ(CreatedSpaceEntity->GetId(), Id);
+                ASSERT_EQ(CreatedSpaceEntity->GetName(), Username);
+
+                ASSERT_EQ(CreatedSpaceEntity->GetComponents()->Size(), 1);
+
+                ComponentBase* AvatarComponentBase = CreatedSpaceEntity->GetComponent(0);
+                ASSERT_EQ(AvatarComponentBase->GetComponentType(), ComponentType::AvatarData);
+
+                AvatarSpaceComponent* AvatarComponent = dynamic_cast<AvatarSpaceComponent*>(AvatarComponentBase);
+                ASSERT_NE(AvatarComponent, nullptr);
+                ASSERT_EQ(AvatarComponent->GetAvatarId(), AvatarId);
+                ASSERT_EQ(AvatarComponent->GetAvatarPlayMode(), AvatarPlayMode);
+                ASSERT_EQ(AvatarComponent->GetState(), AvatarState);
+            }));
+
+    async::spawn(async::inline_scheduler(),
+        []()
+        {
+            return std::make_tuple(async::make_task(uint64_t { 55 }).share(), async::make_task());
+        }) // This continuation takes the ID (and another void return from a when_all branch) as its input
+        .then(async::inline_scheduler(),
+            SpaceEntitySystem->CreateNewLocalAvatar(Username, UserTransform, AvatarId, AvatarState, AvatarPlayMode, MockCallback.AsStdFunction()));
+
+    // During destruction (test cleanup) CSP can access the connection.
+    // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.
+    SignalRConnectionMock* ThrowawaySignalRMock = CSP_NEW SignalRConnectionMock();
+    SpaceEntitySystem->SetConnection(ThrowawaySignalRMock);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorLoggedFromWholeCreateAvatarChain)
+{
+    RAIIMockLogger MockLogger {};
+    csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(csp::systems::LogLevel::Log);
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* SpaceEntitySystem = SystemsManager.GetSpaceEntitySystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // As CSP deletes its owned pointers with CSP_DELETE, you must use CSP_NEW.
+    auto SignalRMock
+        = std::unique_ptr<SignalRConnectionMock, SignalRConnectionMockDeleter>(CSP_NEW SignalRConnectionMock(), SignalRConnectionMockDeleter {});
+    SpaceEntitySystem->SetConnection(SignalRMock.get());
+
+    // SignalR populates an exception
+    EXPECT_CALL(*SignalRMock, Invoke)
+        .WillOnce(
+            [](const std::string& /**/, const signalr::value& /**/, std::function<void(const signalr::value&, std::exception_ptr)> /**/) {
+                return async::make_task(
+                    std::make_tuple(signalr::value("Irrelevent Value"), std::make_exception_ptr(std::runtime_error("mock exception"))));
+            });
+
+    using MockEntityCreatedCallback = testing::MockFunction<void(SpaceEntity*)>;
+    MockEntityCreatedCallback MockCallback;
+
+    // Expect the callback gets nullptr (not the greatest error return...)
+    EXPECT_CALL(MockCallback, Call(nullptr));
+
+    // Expect that we log the error message
+    const csp::common::String ErrorMsg = "Failed to create Avatar. Exception: mock exception";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(ErrorMsg)).Times(1);
+
+    const SpaceTransform& UserTransform
+        = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+
+    SpaceEntitySystem->CreateAvatar("Username", UserTransform, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default, MockCallback.AsStdFunction());
+
+    // During destruction (test cleanup) CSP can access the connection.
+    // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.
+    SignalRConnectionMock* ThrowawaySignalRMock = CSP_NEW SignalRConnectionMock();
+    SpaceEntitySystem->SetConnection(ThrowawaySignalRMock);
+}


### PR DESCRIPTION
Refactor CreateAvatar to be linear.

This adds continuation capability to `SignalRConnection::Invoke`, which is the core of this ticket.

As this is an internal change and we're interested mostly in how it handles being interrupted, testing is performed on a continuation by continuation basis via mocks, mocking failures in the `SignalRConnection`.

A new continuation utility is added to unwrap types that come out of `Invoke` (and other SignalR methods I suspect). This utility introduces a `std::conditional` pattern using `if constexpr` to optionally forward or not forward the input arg to subsequent continuations.

You may be surprised by the double construct of the avatar. This _is_ unfortunate, but is explained in a large comment in the file.

> [!Warning]
> Do not review the [first commit](https://github.com/magnopus-opensource/connected-spaces-platform/commit/69d1a12072208e1e9f25bf102e71e1ff010c4065). This has been split into a seperate PR [here.](https://github.com/magnopus-opensource/connected-spaces-platform/pull/670) This PR is only slightly dependent on it, so if it gets rejected it'll be fine.

> [!Note]
> I have confirmed manually that a web build of this allows a user to enter an OKO web space and spawn in as an avatar (both creator an non-creator modes, not that it makes a difference)