### PR TITLE
[NT-0] fix: Seed true randomness in username/email generation

### DIFF
--- a/Tests/src/TestHelpers.h
+++ b/Tests/src/TestHelpers.h
@@ -172,7 +172,9 @@ inline double RandomRangeDouble(double Min, double Max)
 // This function creates a unique string by randomly selecting a values from a epoch time stamp and random values from a string
 inline std::string GetUniqueString()
 {
-    UUIDv4::UUIDGenerator<std::mt19937_64> uuidGenerator;
+    std::random_device rd;
+    std::mt19937_64 rng(rd());
+    UUIDv4::UUIDGenerator<std::mt19937_64> uuidGenerator(rng);
     const UUIDv4::UUID uuid = uuidGenerator.getUUID();
 
     return uuid.str();


### PR DESCRIPTION
We were getting some [name collision errors from MCS](https://magnopus.teamcity.com/buildConfiguration/Olympus_Foundation_X64_FunctionalTests/287383?showLog=287383_3581_103.3634.3638&logFilter=debug&logView=flowAware) in some of our tests. It may or may not be because of us not setting an actual random seed here, but it's a good idea to do anyway, and low risk.
