### PR TITLE
[OF-1623] build: Add ability to compile optionally with or without nodeJS for WASM

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -292,17 +292,16 @@ if not Project then
                 --"-sUSE_ES6_IMPORT_META=0"                                       -- disable use of import.meta as it is not yet supported everywhere
             }
             
-            -- Compile with or without node support. Node support is used for headless testing.
-            -- In thoery, applications should be able to consume emscripten libraries with node compiled in no problem, but it hasn't worked out that way in practice.
-            filter { "options:wasm_with_node" }
-                linkoptions {"-sENVIRONMENT='web,worker,node'" }   
-            filter { "not options:wasm_with_node" }
-                linkoptions { "-sENVIRONMENT='web,worker'" }   
-            filter{}
-
             links {
                 "websocket.js"
             }
+        -- Compile with or without node support. Node support is used for headless testing.
+        -- In thoery, applications should be able to consume emscripten libraries with node compiled in no problem, but it hasn't worked out that way in practice.
+        filter { "platforms:wasm", "options:wasm_with_node" }
+            linkoptions {"-sENVIRONMENT='web,worker,node'" }   
+        filter { "platforms:wasm", "not options:wasm_with_node" }
+            linkoptions { "-sENVIRONMENT='web,worker'" }   
+
         filter { "platforms:wasm", "configurations:*Debug*" }
             buildoptions {
                 "-gdwarf-5",

--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -296,7 +296,7 @@ if not Project then
                 "websocket.js"
             }
         -- Compile with or without node support. Node support is used for headless testing.
-        -- In thoery, applications should be able to consume emscripten libraries with node compiled in no problem, but it hasn't worked out that way in practice.
+        -- In theory, applications should be able to consume emscripten libraries with node compiled in no problem, but it hasn't worked out that way in practice.
         filter { "platforms:wasm", "options:wasm_with_node" }
             linkoptions {"-sENVIRONMENT='web,worker,node'" }   
         filter { "platforms:wasm", "not options:wasm_with_node" }

--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -268,7 +268,6 @@ if not Project then
                 "-sFETCH",                                                      -- enable Emscripten's Fetch API (needed for making REST calls to CHS)
                 "-sALLOW_TABLE_GROWTH=1",                                       -- needed for registering callbacks that are passed to Connected Spaces Platform
                 "-sWASM_BIGINT",                                                -- enable support for JavaScript's bigint (needed for 64-bit integer support)
-                "-sENVIRONMENT='web,worker,node'",                              -- compile for web, worker and node (worker is required for multi-threading, node for running headless tests)
                 "-sALLOW_MEMORY_GROWTH=1",                                      -- we don't know how much memory we'll need, so allow WASM to dynamically allocate more memory
                 "-sINITIAL_MEMORY=33554432",
                 "-sMAXIMUM_MEMORY=1073741824",                                  -- set an upper memory allocation bound to prevent Emscripten from trying to allocate too much memory
@@ -292,6 +291,14 @@ if not Project then
                 "]",
                 --"-sUSE_ES6_IMPORT_META=0"                                       -- disable use of import.meta as it is not yet supported everywhere
             }
+            
+            -- Compile with or without node support. Node support is used for headless testing.
+            -- In thoery, applications should be able to consume emscripten libraries with node compiled in no problem, but it hasn't worked out that way in practice.
+            filter { "options:wasm_with_node" }
+                linkoptions {"-sENVIRONMENT='web,worker,node'" }   
+            filter { "not options:wasm_with_node" }
+                linkoptions { "-sENVIRONMENT='web,worker'" }   
+            filter{}
 
             links {
                 "websocket.js"

--- a/Tools/Emscripten/EmscriptenFullBuildAndConfigure.bat
+++ b/Tools/Emscripten/EmscriptenFullBuildAndConfigure.bat
@@ -2,6 +2,7 @@
 
 REM *** Command Line Arguments *** 
 REM [1] - Configuration - release || debug
+REM [1] - Optional, append withNode to build with Node support, example ./EmscriptenFullBuildAnd
 
 git config core.hooksPath .githooks
 git config commit.template .githooks/commit-template.txt
@@ -29,7 +30,7 @@ del Makefile
 if "%~1"=="" (goto ArgNone) else (goto ArgCheck)
 
 :ArgNone
-echo No configuration name provided
+echo No configuration name provided, please provide "debug" or "release" after ./EmscriptenFullBuildAndConfigure
 exit /b 1
 
 :ArgCheck
@@ -38,7 +39,17 @@ echo Unsupported configuration "%~1". Supported configurations are "debug" and "
 exit /b 1
 
 :ArgOk
-"modules/premake/bin/release/premake5" gmake2 --generate_wasm
+REM withNode is an optional arg
+set "WITH_NODE=0"
+if /i "%~2"=="withNode" set "WITH_NODE=1"
+
+if "%WITH_NODE%"=="1" (
+    echo Building with Node.js support
+    "modules/premake/bin/release/premake5" gmake2 --generate_wasm --wasm_with_node
+) else (
+    echo Building without Node.js support
+    "modules/premake/bin/release/premake5" gmake2 --generate_wasm
+)
 goto Wasm
 
 :Wasm

--- a/Tools/Emscripten/EmscriptenFullBuildAndConfigure.bat
+++ b/Tools/Emscripten/EmscriptenFullBuildAndConfigure.bat
@@ -2,7 +2,7 @@
 
 REM *** Command Line Arguments *** 
 REM [1] - Configuration - release || debug
-REM [1] - Optional, append withNode to build with Node support, example ./EmscriptenFullBuildAnd
+REM [2] - Optional, append withNode to build with Node support, example ./EmscriptenFullBuildAndConfigure debug withNode
 
 git config core.hooksPath .githooks
 git config commit.template .githooks/commit-template.txt

--- a/Tools/Emscripten/EmscriptenFullBuildAndConfigure.sh
+++ b/Tools/Emscripten/EmscriptenFullBuildAndConfigure.sh
@@ -1,6 +1,8 @@
 git config core.hooksPath .githooks
 git config commit.template .githooks/commit-template.txt
 
+# Example usage, ./EmscriptenFullBuildAndConfigure debug withNode
+
 if ! test -f "../../modules/premake/README.md"; then
     git submodule update --recursive
 fi
@@ -27,6 +29,19 @@ if [ "$1" != "debug" ] && [ "$1" != "release" ]
   then
     echo Unsupported configuration "$1". Supported configurations are "debug" and "release". Please try again.
     exit
+fi
+
+WITH_NODE=0
+if [ "$2" = "withNode" ]; then
+    WITH_NODE=1
+fi
+
+if [ "$WITH_NODE" -eq 1 ]; then
+    echo "Building with Node.js support"
+    "premake5" gmake2 --generate_wasm --wasm_with_node
+else
+    echo "Building without Node.js support"
+    "premake5" gmake2 --generate_wasm
 fi
 
 "premake5" gmake2 --generate_wasm

--- a/premake5.lua
+++ b/premake5.lua
@@ -15,6 +15,11 @@ newoption {
     description = "Generate the project for building WebAssembly. This option should only be used with the gmake2 action"
 }
 
+newoption {
+   trigger = "wasm_with_node",
+   description = "Compile nodeJS support into the wasm build"
+}
+
 solution( "ConnectedSpacesPlatform" )
     -- Build configurations
     if CSP.HasCommandLineArgument("DLLOnly") then


### PR DESCRIPTION
In theory, compiling in node should be fine, its the emscripten default, it's meant to check which environment it is in by design. However, web clients couldn't consume it without making modifications. Therefore we'll branch for now.

Makes the default build mode without node, as it has always been.