### PR TITLE
[OF-1608] Disable the tests that are problematic on local CHS

### DIFF
--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -1224,6 +1224,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
               .SetSpaceId(Space.Id.c_str())
               .SetLoginEmail(TestUser.Email.c_str())
               .SetPassword(GeneratedTestAccountPassword)
+              .SetEndpoint(EndpointBaseURI())
               .SetTimeoutInSeconds(60);
 
     std::future<void> ReadyForAssertionsFuture = CreateConversationRunner.ReadyForAssertionsFuture();

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -1193,7 +1193,7 @@ Tests that the CreateConversaiton event is correctly received and processed by o
 Due to multiplayer messages being received before the component has a valid component id, we need to ensure that the event is stored and processed
 correctly when receiving the component property from a patch, which has been created by the ConversationSpaceComponent::CreateConversation call.
 */
-CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientEventDelayTest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, ConversationTests, ConversationComponentSecondClientEventDelayTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
@@ -1338,7 +1338,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
 Tests that other clients can't Delete other clients messages, or edit other clients conversations or messages.
 Other clients can still delete other conversations, as components/entities dont have any restrictions.
 */
-CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, ConversationTests, ConversationComponentPermissionsTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -1188,6 +1188,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentEventTest)
     LogOut(UserSystem);
 }
 
+// This test is to be fixed as part of OF-1645.
 /*
 Tests that the CreateConversaiton event is correctly received and processed by other clients.
 Due to multiplayer messages being received before the component has a valid component id, we need to ensure that the event is stored and processed
@@ -1334,6 +1335,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ConversationTests, ConversationComponentSeco
     LogOut(UserSystem);
 }
 
+// This test is to be fixed as part of OF-1645.
 /*
 Tests that other clients can't Delete other clients messages, or edit other clients conversations or messages.
 Other clients can still delete other conversations, as components/entities dont have any restrictions.

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -800,6 +800,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     LogOut(UserSystem);
 }
 
+// This test is to be fixed as part of OF-1651.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, MaterialTests, MaterialAssetEventTest)
 {
     SetRandSeed();

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -800,7 +800,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     LogOut(UserSystem);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, MaterialTests, MaterialAssetEventTest)
 {
     SetRandSeed();
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2284,7 +2284,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     LogOut(UserSystem);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTest)
 {
     // Tests the SpaceEntitySystem::OnAllEntitiesCreated
     // for ParentId and ChildEntities

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2284,6 +2284,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     LogOut(UserSystem);
 }
 
+// This test is to be fixed as part of OF-1651.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTest)
 {
     // Tests the SpaceEntitySystem::OnAllEntitiesCreated

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -188,7 +188,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOIWithTagsTest)
     LogOut(UserSystem);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaTest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaTest)
 {
     SetRandSeed();
 
@@ -301,7 +301,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
     LogOut(UserSystem);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 {
     SetRandSeed();
 

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -188,6 +188,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOIWithTagsTest)
     LogOut(UserSystem);
 }
 
+// This test is to be fixed as part of OF-1649.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaTest)
 {
     SetRandSeed();
@@ -301,6 +302,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
     LogOut(UserSystem);
 }
 
+// This test is to be fixed as part of OF-1649.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 {
     SetRandSeed();

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -938,7 +938,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AppleLogInTest)
 }
 #endif
 
-CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
 {
     SetRandSeed();
 
@@ -1005,7 +1005,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
     LogOut(UserSystem);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, PostServiceProxyTest)
+CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, PostServiceProxyTest)
 {
     SetRandSeed();
 

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -938,6 +938,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AppleLogInTest)
 }
 #endif
 
+// This test is to be fixed as part of OF-1646.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
 {
     SetRandSeed();
@@ -1005,6 +1006,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
     LogOut(UserSystem);
 }
 
+// This test is to be fixed as part of OF-1646.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, PostServiceProxyTest)
 {
     SetRandSeed();


### PR DESCRIPTION
there are two parts to this PR. it is debatable whether the second part should stay in this PR (if it doesn't, it should go in the ticket that will fix the conversation tests). the obvious argument in favour of keeping this change in is that local CHS is ready to use in PR checks.

Part 1: disable the problematic tests. there are 8 of them. More info about the failures in the story. Will also add dedicated new stories, see links in the story.

Part 2: fix crash in local CHS (a conversation test was calling the hard-coded live endpoint, leading to a crash). this is the part that arguably should be moved to the conversation story.