### PR TITLE
[OF-1633] chore: remove friends from SpaceEntity et al.

### DIFF
--- a/Library/include/CSP/Multiplayer/EventBus.h
+++ b/Library/include/CSP/Multiplayer/EventBus.h
@@ -51,12 +51,6 @@ enum class ErrorCode;
 class CSP_API EventBus
 {
 public:
-    /** @cond DO_NOT_DOCUMENT */
-    friend class csp::systems::SpaceSystem;
-    friend class csp::systems::SystemsManager;
-    friend class MultiplayerConnection;
-    /** @endcond */
-
     typedef std::function<void(csp::multiplayer::ErrorCode)> ErrorCodeCallbackHandler;
 
     // The callback used to register to listen to events.
@@ -98,11 +92,13 @@ public:
     /// @brief Instructs the event bus to start listening to messages
     void StartEventMessageListening();
 
+    /// @brief EventBus constructor
+    /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the event bus with
+    CSP_NO_EXPORT EventBus(MultiplayerConnection* InMultiplayerConnection);
+
 private:
     EventBus();
     ~EventBus();
-
-    EventBus(MultiplayerConnection* InMultiplayerConnection);
 
     class MultiplayerConnection* MultiplayerConnectionInst;
 

--- a/Library/include/CSP/Multiplayer/EventBus.h
+++ b/Library/include/CSP/Multiplayer/EventBus.h
@@ -96,9 +96,11 @@ public:
     /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the event bus with
     CSP_NO_EXPORT EventBus(MultiplayerConnection* InMultiplayerConnection);
 
+    /// @brief EventBus destructor
+    CSP_NO_EXPORT ~EventBus();
+
 private:
     EventBus();
-    ~EventBus();
 
     class MultiplayerConnection* MultiplayerConnectionInst;
 

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -194,13 +194,14 @@ public:
     /// @brief MultiplayerConnection constructor
     CSP_NO_EXPORT MultiplayerConnection();
 
+    /// @brief MultiplayerConnection destructor
+    CSP_NO_EXPORT ~MultiplayerConnection();
+
     /// @brief End the multiplayer connection.
     /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
     CSP_NO_EXPORT void Disconnect(ErrorCodeCallbackHandler Callback);
 
 private:
-    ~MultiplayerConnection();
-
     MultiplayerConnection(const MultiplayerConnection& InBoundConnection);
 
     typedef std::function<void(std::exception_ptr)> ExceptionCallbackHandler;
@@ -222,7 +223,7 @@ private:
     class csp::multiplayer::ISignalRConnection* Connection;
     class csp::multiplayer::IWebSocketClient* WebSocketClient;
     class NetworkEventManagerImpl* NetworkEventManager;
-    EventBus* EventBusPtr;
+    class EventBus* EventBusPtr;
 
     uint64_t ClientId;
 

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -56,6 +56,7 @@ class ReplicatedValue;
 class SpaceEntitySystem;
 class ClientElectionManager;
 class ISignalRConnection;
+class NetworkEventManagerImpl;
 class IWebSocketClient;
 class EventBus;
 
@@ -84,14 +85,6 @@ class CSP_API MultiplayerConnection
 {
 public:
     /** @cond DO_NOT_DOCUMENT */
-    friend class csp::systems::SpaceSystem;
-    friend class csp::systems::SystemsManager;
-    friend class csp::systems::UserSystem;
-    friend class SpaceEntityEventHandler;
-    friend class SpaceEntitySystem;
-    friend class ClientElectionManager;
-    friend class ClientElectionEventHandler;
-    friend class EventBus;
     friend class ::CSPEngine_MultiplayerTests_SignalRConnectionTest_Test;
     /** @endcond */
 
@@ -129,7 +122,7 @@ public:
     ConnectionState GetConnectionState() const;
 
     /// @brief Sets the Self Messaging flag for this client.
-    /// This allows a client to declare that it wishes to recieve every patch and object message it sends.
+    /// This allows a client to declare that it wishes to receive every patch and object message it sends.
     /// @warning Don't use this function if you aren't sure of the consequences, it's very unlikely that a client would want to use this!
     /// @param AllowSelfMessaging bool : True to allow and false to disallow.
     /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
@@ -160,8 +153,52 @@ public:
     /// ownership of this pointer.
     CSP_NO_EXPORT void Connect(ErrorCodeCallbackHandler Callback, ISignalRConnection* SignalRConnection);
 
+    /// @brief Indicates whether the multiplayer connection is established
+    /// @return bool : true if connected, false otherwise
+    CSP_NO_EXPORT bool IsConnected() const { return Connected; }
+
+    /// @brief Getter for the signalR connection
+    /// @return ISignalRConnection* : pointer to the signalR connection
+    CSP_NO_EXPORT csp::multiplayer::ISignalRConnection* GetSignalRConnection() { return Connection; };
+
+    /// @brief Getter for the NetworkEventManager
+    /// @return NetworkEventManagerImpl* : pointer to the NetworkEventManager
+    CSP_NO_EXPORT csp::multiplayer::NetworkEventManagerImpl* GetNetworkEventManager() { return NetworkEventManager; }
+
+    /// @brief Getter for the EventBus
+    /// @return EventBus* : pointer to the EventBus
+    CSP_NO_EXPORT EventBus* GetEventBusPtr() { return EventBusPtr; }
+
+    /// @brief Disconnect the multiplayer and provide a reason
+    /// @param Reason csp::common::String& : the reason to disconnect
+    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state
+    CSP_NO_EXPORT void DisconnectWithReason(const csp::common::String& Reason, ErrorCodeCallbackHandler Callback);
+
+    CSP_START_IGNORE
+    // Invoke "StartListening" on already created Connection
+    CSP_NO_EXPORT std::function<async::task<void>()> StartListening();
+    CSP_END_IGNORE
+
+    /// @brief Subscribes the connected user to the specified space's scope.
+    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
+    CSP_NO_EXPORT void SetScopes(csp::common::String InSpaceId, ErrorCodeCallbackHandler Callback);
+
+    /// @brief Stop listening to the multiplayer
+    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
+    CSP_NO_EXPORT void StopListening(ErrorCodeCallbackHandler Callback);
+
+    /// @brief Clears the connected user's subscription to their current set of scopes.
+    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
+    CSP_NO_EXPORT void ResetScopes(ErrorCodeCallbackHandler Callback);
+
+    /// @brief MultiplayerConnection constructor
+    CSP_NO_EXPORT MultiplayerConnection();
+
+    /// @brief End the multiplayer connection.
+    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
+    CSP_NO_EXPORT void Disconnect(ErrorCodeCallbackHandler Callback);
+
 private:
-    MultiplayerConnection();
     ~MultiplayerConnection();
 
     MultiplayerConnection(const MultiplayerConnection& InBoundConnection);
@@ -178,25 +215,9 @@ private:
     auto DeleteEntities(uint64_t EntityId) const;
     // Get the client ID and return it (does not set it locally)
     auto RequestClientId();
-    // Invoke "StartListening" on already created Connection
-    std::function<async::task<void>()> StartListening();
     CSP_END_IGNORE
 
-    /// @brief End the multiplayer connection.
-    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-    void Disconnect(ErrorCodeCallbackHandler Callback);
     void Stop(ExceptionCallbackHandler Callback) const;
-    void StopListening(ErrorCodeCallbackHandler Callback);
-
-    /// @brief Subscribes the connected user to the specified space's scope.
-    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-    void SetScopes(csp::common::String InSpaceId, ErrorCodeCallbackHandler Callback);
-
-    /// @brief Clears the connected user's subscription to their current set of scopes.
-    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-    void ResetScopes(ErrorCodeCallbackHandler Callback);
-
-    void DisconnectWithReason(const csp::common::String& Reason, ErrorCodeCallbackHandler Callback);
 
     class csp::multiplayer::ISignalRConnection* Connection;
     class csp::multiplayer::IWebSocketClient* WebSocketClient;

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -114,6 +114,8 @@ class CSP_API SpaceEntity
 {
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
+    friend class SpaceEntitySystem;
+
 #ifdef CSP_TESTS
     friend class ::CSPEngine_MultiplayerTests_LockPrerequisitesTest_Test;
 #endif
@@ -408,10 +410,6 @@ public:
     /// @return SpaceEntity*
     CSP_NO_EXPORT SpaceEntity* GetParent();
 
-    /// @brief Setter for the parent entity
-    /// @param InParent SpaceEntity : the parent entity to set
-    CSP_NO_EXPORT void SetParent(SpaceEntity* InParent);
-
     /// @brief Getter for the parent id
     /// @return csp::common::Optional<uint64_t>
     CSP_NO_EXPORT csp::common::Optional<uint64_t> GetParentId();
@@ -420,23 +418,9 @@ public:
     /// @return std::chrono::milliseconds
     CSP_NO_EXPORT std::chrono::milliseconds GetTimeOfLastPatch();
 
-    /// @brief Setter for the time of the last patch
-    /// @param NewTime std::chrono::milliseconds : the time to set
-    CSP_NO_EXPORT void SetTimeOfLastPatch(std::chrono::milliseconds NewTime);
-
-    /// @brief Setter for the owner ID
-    /// @param InOwnerId uint64_t : the owner ID to set
-    CSP_NO_EXPORT void SetOwnerId(const uint64_t InOwnerId);
-
-    /// @brief Remove child entities from parent
-    CSP_NO_EXPORT void RemoveChildEntities();
-
     /// @brief Remove the parent from the specified child entity
     /// @param Index size_t : the index of the child entity
     CSP_NO_EXPORT void RemoveParentFromChildEntity(size_t Index);
-
-    /// @brief Set ParentId to nullptr
-    CSP_NO_EXPORT void RemoveParentId();
 
     /// @brief Mark for update
     CSP_NO_EXPORT void MarkForUpdate();
@@ -454,13 +438,6 @@ public:
 
     /// @brief Resolve the relationship between the parent and the child
     CSP_NO_EXPORT void ResolveParentChildRelationship();
-
-    // Do NOT call directly, always call either Select() Deselect() or SpaceEntitySystem::InternalSetSelectionStateOfEntity()
-    /// @brief Internal version of the selected state of the entity setter
-    /// @param SelectedState bool : the selected state to set
-    /// @param ClientID uint64_t : the client ID of the entity for which to set the selected state
-    /// @return bool : the selection state of the entity
-    CSP_NO_EXPORT bool InternalSetSelectionStateOfEntity(const bool SelectedState, uint64_t ClientID);
 
 private:
     class DirtyComponent
@@ -546,6 +523,31 @@ private:
     csp::common::List<uint16_t> TransientDeletionComponentIds;
 
     std::chrono::milliseconds TimeOfLastPatch;
+
+    /// @brief Setter for the parent entity
+    /// @param InParent SpaceEntity : the parent entity to set
+    void SetParent(SpaceEntity* InParent);
+
+    /// @brief Setter for the time of the last patch
+    /// @param NewTime std::chrono::milliseconds : the time to set
+    void SetTimeOfLastPatch(std::chrono::milliseconds NewTime);
+
+    /// @brief Setter for the owner ID
+    /// @param InOwnerId uint64_t : the owner ID to set
+    void SetOwnerId(const uint64_t InOwnerId);
+
+    /// @brief Remove child entities from parent
+    void RemoveChildEntities();
+
+    /// @brief Set ParentId to nullptr
+    void RemoveParentId();
+
+    // Do NOT call directly, always call either Select() Deselect() or SpaceEntitySystem::InternalSetSelectionStateOfEntity()
+    /// @brief Internal version of the selected state of the entity setter
+    /// @param SelectedState bool : the selected state to set
+    /// @param ClientID uint64_t : the client ID of the entity for which to set the selected state
+    /// @return bool : the selection state of the entity
+    bool InternalSetSelectionStateOfEntity(const bool SelectedState, uint64_t ClientID);
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -39,7 +39,6 @@ CSP_END_IGNORE
 
 namespace csp::multiplayer
 {
-class SpaceEntitySystem;
 class EntityScriptInterface;
 
 CSP_START_IGNORE
@@ -66,7 +65,7 @@ enum class SpaceEntityType
 /// Add means the component is newly added, clients should ensure that this triggers appropriate instantiation of wrapping objects.
 /// All properties for the component should be included.
 /// Delete means the component has been marked for deletion. It is likely that some other clients will not have the component at the point this is
-/// recieved. Any wrapping data objects should be deleted when this is recieved, and clients should cease updating this component as any call would
+/// received. Any wrapping data objects should be deleted when this is received, and clients should cease updating this component as any call would
 /// fail. The CSP representation of the component has been removed at this point.
 enum class ComponentUpdateType
 {
@@ -115,12 +114,6 @@ class CSP_API SpaceEntity
 {
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
-    friend class SpaceEntitySystem;
-    friend class EntityScript;
-    friend class EntityScriptInterface;
-    friend class EntitySystemScriptInterface;
-    friend class ComponentBase;
-    friend class ComponentScriptInterface;
 #ifdef CSP_TESTS
     friend class ::CSPEngine_MultiplayerTests_LockPrerequisitesTest_Test;
 #endif
@@ -148,8 +141,8 @@ public:
 
     /// Internal constructor to explicitly create a SpaceEntity in a specified state.
     /// Initially implemented for use in SpaceEntitySystem::CreateAvatar
-    CSP_NO_EXPORT SpaceEntity(SpaceEntitySystem* EntitySystem, uint64_t Id, const csp::common::String& Name, const SpaceTransform& Transform,
-        uint64_t OwnerId, bool IsTransferable, bool IsPersistant);
+    CSP_NO_EXPORT SpaceEntity(SpaceEntitySystem* EntitySystem, SpaceEntityType Type, uint64_t Id, const csp::common::String& Name,
+        const SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistant);
 
     /// @brief Destroys the SpaceEntity instance.
     ~SpaceEntity();
@@ -217,8 +210,8 @@ public:
     /// @param Value csp::common::Vector3 : The scale to set.
     void SetScale(const csp::common::Vector3& Value);
 
-    /// @brief Get whether the space is transient or persistant.
-    /// @return returns True if the space is transient and false if it is marked as persistant.
+    /// @brief Get whether the space is transient or persistent.
+    /// @return returns True if the space is transient and false if it is marked as persistent.
     bool GetIsTransient() const;
 
     /// @brief Get the third party reference of this entity.
@@ -286,7 +279,7 @@ public:
     /// @brief Set a callback to be executed when a patch message is received for this Entity. Only one callback can be set.
     /// @param Callback UpdateCallback : Contains the SpaceEntity that updated, a set of flags to tell which parts updated
     /// and an array of information to tell which components updated.
-    /// When this callback is recieved, the flags and arrays should be used to determine which properties have updated data.
+    /// When this callback is received, the flags and arrays should be used to determine which properties have updated data.
     CSP_EVENT void SetUpdateCallback(UpdateCallback Callback);
 
     /// @brief Set a callback to be executed when a patch message with a destroy flag is received for this Entity. Only one callback can be set.
@@ -368,6 +361,107 @@ public:
     /// @return bool
     bool IsLocked() const;
 
+    /// @brief Getter for the EntityUpdateCallback
+    /// @return: UpdateCallback
+    CSP_NO_EXPORT UpdateCallback GetEntityUpdateCallback();
+
+    /// @brief Setter for the parameters of the EntityUpdateCallback
+    /// @param Entity SpaceEntity* : the entity for which the callback is set
+    /// @param Flags SpaceEntityUpdateFlags : the flags to set
+    /// @param Info csp::common::Array<ComponentUpdateInfo>& : the array of component update info to set
+    CSP_NO_EXPORT void SetEntityUpdateCallbackParams(
+        SpaceEntity* Entity, SpaceEntityUpdateFlags Flags, csp::common::Array<ComponentUpdateInfo>& Info);
+
+    /// @brief Getter for the EntityDestroyCallback
+    /// @return: DestroyCallback
+    CSP_NO_EXPORT DestroyCallback GetEntityDestroyCallback();
+
+    /// @brief Setter for the parameters of the EntityDestroyCallbackParams
+    /// @param bool : the boolean to set
+    CSP_NO_EXPORT void SetEntityDestroyCallbackParams(const bool Boolean);
+
+    /// @brief Getter for the EntityPatchSentCallback
+    /// @return: CallbackHandler
+    CSP_NO_EXPORT CallbackHandler GetEntityPatchSentCallback();
+
+    /// @brief Setter for the parameters of the EntityPatchSentCallbackParams
+    /// @param bool : the boolean to set
+    CSP_NO_EXPORT void SetEntityPatchSentCallbackParams(const bool Boolean);
+
+    /// @brief Getter for the dirty properties
+    /// @return csp::common::Map<uint16_t, ReplicatedValue>
+    CSP_NO_EXPORT csp::common::Map<uint16_t, ReplicatedValue> GetDirtyProperties();
+
+    /// @brief Getter for the transient deletion component IDs
+    /// @return csp::common::List<uint16_t>
+    CSP_NO_EXPORT csp::common::List<uint16_t> GetTransientDeletionComponentIds();
+
+    /// @brief Getter for the ShouldUpdateParent boolean
+    /// @return bool
+    CSP_NO_EXPORT bool GetShouldUpdateParent();
+
+    /// @brief Setter for the ShouldUpdateParent boolean
+    /// @param Boolean bool : the boolean value to set ShouldUpdateParent to
+    CSP_NO_EXPORT void SetShouldUpdateParent(const bool Boolean);
+
+    /// @brief Getter for the parent entity
+    /// @return SpaceEntity*
+    CSP_NO_EXPORT SpaceEntity* GetParent();
+
+    /// @brief Setter for the parent entity
+    /// @param InParent SpaceEntity : the parent entity to set
+    CSP_NO_EXPORT void SetParent(SpaceEntity* InParent);
+
+    /// @brief Getter for the parent id
+    /// @return csp::common::Optional<uint64_t>
+    CSP_NO_EXPORT csp::common::Optional<uint64_t> GetParentId();
+
+    /// @brief Getter for the time of the last patch
+    /// @return std::chrono::milliseconds
+    CSP_NO_EXPORT std::chrono::milliseconds GetTimeOfLastPatch();
+
+    /// @brief Setter for the time of the last patch
+    /// @param NewTime std::chrono::milliseconds : the time to set
+    CSP_NO_EXPORT void SetTimeOfLastPatch(std::chrono::milliseconds NewTime);
+
+    /// @brief Setter for the owner ID
+    /// @param InOwnerId uint64_t : the owner ID to set
+    CSP_NO_EXPORT void SetOwnerId(const uint64_t InOwnerId);
+
+    /// @brief Remove child entities from parent
+    CSP_NO_EXPORT void RemoveChildEntities();
+
+    /// @brief Remove the parent from the specified child entity
+    /// @param Index size_t : the index of the child entity
+    CSP_NO_EXPORT void RemoveParentFromChildEntity(size_t Index);
+
+    /// @brief Set ParentId to nullptr
+    CSP_NO_EXPORT void RemoveParentId();
+
+    /// @brief Mark for update
+    CSP_NO_EXPORT void MarkForUpdate();
+
+    /// @brief Getter for the script interface
+    /// @return EntityScriptInterface*
+    CSP_NO_EXPORT EntityScriptInterface* GetScriptInterface();
+
+    /// @brief Claim script ownership
+    CSP_NO_EXPORT void ClaimScriptOwnership();
+
+    /// @brief Apply a local patch
+    /// @param InvokeUpdateCallback bool : whether to invoke the update callback (default: true)
+    CSP_NO_EXPORT void ApplyLocalPatch(bool InvokeUpdateCallback = true);
+
+    /// @brief Resolve the relationship between the parent and the child
+    CSP_NO_EXPORT void ResolveParentChildRelationship();
+
+    // Do NOT call directly, always call either Select() Deselect() or SpaceEntitySystem::InternalSetSelectionStateOfEntity()
+    /// @brief Internal version of the selected state of the entity setter
+    /// @param SelectedState bool : the selected state to set
+    /// @param ClientID uint64_t : the client ID of the entity for which to set the selected state
+    /// @return bool : the selection state of the entity
+    CSP_NO_EXPORT bool InternalSetSelectionStateOfEntity(const bool SelectedState, uint64_t ClientID);
+
 private:
     class DirtyComponent
     {
@@ -376,27 +470,29 @@ private:
         ComponentUpdateType UpdateType;
     };
 
-    void ApplyLocalPatch(bool InvokeUpdateCallback = true);
+public:
+    /// @brief Getter for the dirty components
+    /// @return csp::common::Map<uint16_t, DirtyComponent>
+    CSP_NO_EXPORT csp::common::Map<uint16_t, DirtyComponent> GetDirtyComponents();
+
+    /// @brief Add specified dirty component to space entity
+    /// @param DirtyComponent ComponentBase* : the dirty component to add
+    CSP_NO_EXPORT void AddDirtyComponent(ComponentBase* DirtyComponent);
+
+    /// @brief Update after the property of a component was changed
+    /// @param DirtyComponent ComponentBase* : the dirty component to update
+    /// @param PropertyKey int32_t : the key of the property to update
+    CSP_NO_EXPORT void OnPropertyChanged(ComponentBase* DirtyComponent, int32_t PropertyKey);
+
+private:
     uint16_t GenerateComponentId();
     ComponentBase* InstantiateComponent(uint16_t Id, ComponentType Type);
-    void AddDirtyComponent(ComponentBase* DirtyComponent);
-
-    void OnPropertyChanged(ComponentBase* DirtyComponent, int32_t PropertyKey);
-    EntityScriptInterface* GetScriptInterface();
-
-    void ClaimScriptOwnership();
-    void MarkForUpdate();
-
-    // Do NOT call directly, always call either Select() Deselect() or SpaceEntitySystem::InternalSetSelectionStateOfEntity()
-    bool InternalSetSelectionStateOfEntity(const bool SelectedState, uint64_t ClientID);
 
     void DestroyComponent(uint16_t Key);
 
     ComponentBase* FindFirstComponentOfType(ComponentType Type, bool SearchDirtyComponents = false) const;
 
-    void AddChildEntitiy(SpaceEntity* ChildEntity);
-
-    void ResolveParentChildRelationship();
+    void AddChildEntity(SpaceEntity* ChildEntity);
 
     csp::multiplayer::mcs::ObjectMessage CreateObjectMessage();
     csp::multiplayer::mcs::ObjectPatch CreateObjectPatch();

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -349,6 +349,8 @@ protected:
     std::recursive_mutex* EntitiesLock;
 
 private:
+    SpaceEntitySystem(); // needed for the wrapper generator
+
     MultiplayerConnection* MultiplayerConnectionInst;
     csp::multiplayer::ISignalRConnection* Connection;
 

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -326,7 +326,10 @@ public:
 
     /// @brief SpaceEntitySystem constructor
     /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the SpaceEntitySystem with
-    SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection);
+    CSP_NO_EXPORT SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection);
+
+    /// @brief SpaceEntitySystem destructor
+    CSP_NO_EXPORT ~SpaceEntitySystem();
 
     /// @brief Getter for the pending adds
     /// @return: SpaceEntityQueue*
@@ -346,8 +349,6 @@ protected:
     std::recursive_mutex* EntitiesLock;
 
 private:
-    ~SpaceEntitySystem();
-
     MultiplayerConnection* MultiplayerConnectionInst;
     csp::multiplayer::ISignalRConnection* Connection;
 

--- a/Library/src/Multiplayer/Election/ClientElectionManager.cpp
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.cpp
@@ -473,7 +473,7 @@ bool ClientElectionManager::IsConnected() const
         return false;
     }
 
-    return Connection->Connected;
+    return Connection->IsConnected();
 }
 
 void ClientElectionManager::BindNetworkEvents()

--- a/Library/src/Multiplayer/EventBus.cpp
+++ b/Library/src/Multiplayer/EventBus.cpp
@@ -121,7 +121,7 @@ void EventBus::StopListenNetworkEvent(const csp::common::String& EventName)
 
 void EventBus::StartEventMessageListening()
 {
-    if (MultiplayerConnectionInst->Connection == nullptr)
+    if (MultiplayerConnectionInst->GetSignalRConnection() == nullptr)
     {
         CSP_LOG_ERROR_MSG("Error : Multiplayer connection is unavailable, EventBus cannot start listening to events.");
         return;
@@ -165,7 +165,7 @@ void EventBus::StartEventMessageListening()
         }
     };
 
-    MultiplayerConnectionInst->Connection->On("OnEventMessage", LocalCallback);
+    MultiplayerConnectionInst->GetSignalRConnection()->On("OnEventMessage", LocalCallback);
 }
 
 void EventBus::SendNetworkEvent(
@@ -199,7 +199,7 @@ async::task<std::optional<csp::multiplayer::ErrorCode>> EventBus::SendNetworkEve
 void EventBus::SendNetworkEventToClient(
     const csp::common::String& EventName, const csp::common::Array<ReplicatedValue>& Args, uint64_t TargetClientId, ErrorCodeCallbackHandler Callback)
 {
-    MultiplayerConnectionInst->NetworkEventManager->SendNetworkEvent(EventName, Args, TargetClientId, Callback);
+    MultiplayerConnectionInst->GetNetworkEventManager()->SendNetworkEvent(EventName, Args, TargetClientId, Callback);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -472,6 +472,19 @@ void SpaceEntity::RemoveComponent(uint16_t Key)
     }
 }
 
+void SpaceEntity::RemoveChildEntities() { GetParentEntity()->ChildEntities.RemoveItem(this); }
+
+void SpaceEntity::RemoveParentFromChildEntity(size_t Index)
+{
+    if (Index < ChildEntities.Size())
+    {
+        ChildEntities[Index]->RemoveParentEntity();
+        ChildEntities[Index]->Parent = nullptr;
+    }
+}
+
+void SpaceEntity::RemoveParentId() { ParentId = nullptr; }
+
 void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback)
 {
     /// If we're sending patches to ourselves, don't apply local patches, as we'll be directly deserialising the data instead.

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -261,8 +261,8 @@ namespace
         const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistant,
         const csp::common::String& AvatarId, csp::multiplayer::AvatarState AvatarState, csp::multiplayer::AvatarPlayMode AvatarPlayMode)
     {
-        auto NewAvatar = std::unique_ptr<csp::multiplayer::SpaceEntity>(
-            new csp::multiplayer::SpaceEntity(&SpaceEntitySystem, NetworkId, Name, Transform, OwnerId, IsTransferable, IsPersistant));
+        auto NewAvatar = std::unique_ptr<csp::multiplayer::SpaceEntity>(new csp::multiplayer::SpaceEntity(
+            &SpaceEntitySystem, SpaceEntityType::Avatar, NetworkId, Name, Transform, OwnerId, IsTransferable, IsPersistant));
 
         auto* AvatarComponent = static_cast<AvatarSpaceComponent*>(NewAvatar->AddComponent(ComponentType::AvatarData));
         AvatarComponent->SetAvatarId(AvatarId);
@@ -1428,9 +1428,9 @@ void SpaceEntitySystem::CreateObjectInternal(const csp::common::String& InName, 
             Callback(nullptr);
         }
 
-        auto* NewObject = new SpaceEntity(this);
-        NewObject->Type = SpaceEntityType::Object;
         auto ID = ParseGenerateObjectIDsResult(Result);
+        auto* NewObject
+            = new SpaceEntity(this, SpaceEntityType::Object, ID, InName, InSpaceTransform, MultiplayerConnectionInst->GetClientId(), true, true);
 
         if (InParent.HasValue())
         {

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -122,14 +122,14 @@ SpaceEntityEventHandler::SpaceEntityEventHandler(SpaceEntitySystem* EntitySystem
 
 void SpaceEntityEventHandler::OnEvent(const csp::events::Event& InEvent)
 {
-    if (InEvent.GetId() == csp::events::FOUNDATION_TICK_EVENT_ID && EntitySystem->MultiplayerConnectionInst != nullptr
-        && EntitySystem->MultiplayerConnectionInst->Connected)
+    if (InEvent.GetId() == csp::events::FOUNDATION_TICK_EVENT_ID && EntitySystem->GetMultiplayerConnectionInstance() != nullptr
+        && EntitySystem->GetMultiplayerConnectionInstance()->IsConnected())
     {
         EntitySystem->TickEntities();
     }
     else if (InEvent.GetId() == csp::events::MULTIPLAYERSYSTEM_DISCONNECT_EVENT_ID)
     {
-        auto Connection = EntitySystem->MultiplayerConnectionInst;
+        auto Connection = EntitySystem->GetMultiplayerConnectionInstance();
         csp::common::String Reason(InEvent.GetString("Reason"));
 
         auto Done = false;
@@ -250,6 +250,10 @@ void SpaceEntitySystem::Shutdown()
     IsInitialised = false;
 }
 
+SpaceEntitySystem::SpaceEntityQueue* SpaceEntitySystem::GetPendingAdds() { return PendingAdds; }
+
+MultiplayerConnection* SpaceEntitySystem::GetMultiplayerConnectionInstance() { return MultiplayerConnectionInst; }
+
 namespace
 {
     std::unique_ptr<csp::multiplayer::SpaceEntity> BuildNewAvatar(csp::systems::UserSystem& UserSystem,
@@ -259,6 +263,7 @@ namespace
     {
         auto NewAvatar = std::unique_ptr<csp::multiplayer::SpaceEntity>(
             new csp::multiplayer::SpaceEntity(&SpaceEntitySystem, NetworkId, Name, Transform, OwnerId, IsTransferable, IsPersistant));
+
         auto* AvatarComponent = static_cast<AvatarSpaceComponent*>(NewAvatar->AddComponent(ComponentType::AvatarData));
         AvatarComponent->SetAvatarId(AvatarId);
         AvatarComponent->SetState(AvatarState);
@@ -384,7 +389,7 @@ void SpaceEntitySystem::CreateObject(const csp::common::String& InName, const Sp
 
 void SpaceEntitySystem::DestroyEntity(SpaceEntity* Entity, CallbackHandler Callback)
 {
-    const auto& Children = Entity->ChildEntities;
+    const auto& Children = Entity->GetChildEntities()->ToArray();
 
     const std::function LocalCallback = [Callback](const signalr::value& /*EntityMessage*/, const std::exception_ptr& Except)
     {
@@ -449,12 +454,12 @@ void SpaceEntitySystem::DestroyEntity(SpaceEntity* Entity, CallbackHandler Callb
 
     for (size_t i = 0; i < ChildrenToUpdate.Size(); ++i)
     {
-        ChildrenToUpdate[i]->ParentId = nullptr;
+        ChildrenToUpdate[i]->RemoveParentId();
         ResolveEntityHierarchy(ChildrenToUpdate[i]);
 
-        if (ChildrenToUpdate[i]->EntityUpdateCallback)
+        if (ChildrenToUpdate[i]->GetEntityUpdateCallback())
         {
-            ChildrenToUpdate[i]->EntityUpdateCallback(ChildrenToUpdate[i], UPDATE_FLAGS_PARENT, Info);
+            ChildrenToUpdate[i]->SetEntityUpdateCallbackParams(ChildrenToUpdate[i], UPDATE_FLAGS_PARENT, Info);
         }
     }
 
@@ -472,9 +477,9 @@ void SpaceEntitySystem::LocalDestroyEntity(SpaceEntity* Entity)
 {
     if (Entity != nullptr)
     {
-        if (Entity->EntityDestroyCallback != nullptr)
+        if (Entity->GetEntityDestroyCallback() != nullptr)
         {
-            Entity->EntityDestroyCallback(true);
+            Entity->SetEntityDestroyCallbackParams(true);
         }
 
         RemoveEntity(Entity);
@@ -796,8 +801,8 @@ void SpaceEntitySystem::LocalDestroyAllEntities()
 void SpaceEntitySystem::QueueEntityUpdate(SpaceEntity* EntityToUpdate)
 {
     // If we have nothing to update, don't allow a patch to be sent.
-    if (EntityToUpdate->DirtyComponents.Size() == 0 && EntityToUpdate->DirtyProperties.Size() == 0
-        && EntityToUpdate->TransientDeletionComponentIds.Size() == 0 && EntityToUpdate->ShouldUpdateParent == false)
+    if (EntityToUpdate->GetDirtyComponents().Size() == 0 && EntityToUpdate->GetDirtyProperties().Size() == 0
+        && EntityToUpdate->GetTransientDeletionComponentIds().Size() == 0 && EntityToUpdate->GetShouldUpdateParent() == false)
     {
         // TODO: consider making this a callback that informs the user what the status of the request is 'Success, SignalRException, NoChanges',
         // etc. CSP_LOG_MSG(csp::systems::LogLevel::Log, "Skipped patch message send as no data changed");
@@ -934,20 +939,19 @@ void SpaceEntitySystem::ResolveParentChildForDeletion(SpaceEntity* Deletion)
 {
     if (Deletion->GetParentEntity())
     {
-        Deletion->GetParentEntity()->ChildEntities.RemoveItem(Deletion);
+        Deletion->RemoveChildEntities();
     }
 
-    for (size_t i = 0; i < Deletion->ChildEntities.Size(); ++i)
+    for (size_t i = 0; i < Deletion->GetChildEntities()->Size(); ++i)
     {
-        Deletion->ChildEntities[i]->RemoveParentEntity();
-        Deletion->ChildEntities[i]->Parent = nullptr;
-        ResolveEntityHierarchy(Deletion->ChildEntities[i]);
+        Deletion->RemoveParentFromChildEntity(i);
+        ResolveEntityHierarchy(Deletion->GetChildEntities()->ToArray()[i]);
     }
 }
 
 void SpaceEntitySystem::ResolveEntityHierarchy(SpaceEntity* Entity)
 {
-    if (Entity->ParentId.HasValue())
+    if (Entity->GetParentId().HasValue())
     {
         for (size_t i = 0; i < RootHierarchyEntities.Size(); ++i)
         {
@@ -1251,7 +1255,7 @@ void SpaceEntitySystem::ProcessPendingEntityOperations()
 
             const milliseconds CurrentTime = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
 
-            if (CurrentTime - PendingEntity->TimeOfLastPatch >= EntityPatchRate || !EntityPatchRateLimitEnabled)
+            if (CurrentTime - PendingEntity->GetTimeOfLastPatch() >= EntityPatchRate || !EntityPatchRateLimitEnabled)
             {
                 // If the entity is not owned by us, and not a transferable entity, it is not allowed to modify the entity.
                 if (!PendingEntity->IsModifiable())
@@ -1265,17 +1269,17 @@ void SpaceEntitySystem::ProcessPendingEntityOperations()
                 }
 
                 // since we are aiming to mutate the data for this entity remotely, we need to claim ownership over it
-                PendingEntity->OwnerId = MultiplayerConnectionInst->GetClientId();
+                PendingEntity->SetOwnerId(MultiplayerConnectionInst->GetClientId());
                 ClaimScriptOwnership(PendingEntity);
 
                 PendingEntities.Append(PendingEntity);
 
-                if (PendingEntity->EntityPatchSentCallback != nullptr)
+                if (PendingEntity->GetEntityPatchSentCallback() != nullptr)
                 {
-                    PendingEntity->EntityPatchSentCallback(true);
+                    PendingEntity->SetEntityPatchSentCallbackParams(true);
                 }
 
-                PendingEntity->TimeOfLastPatch = CurrentTime;
+                PendingEntity->SetTimeOfLastPatch(CurrentTime);
                 it = PendingOutgoingUpdateUniqueSet->erase(it);
             }
             else
@@ -1427,11 +1431,6 @@ void SpaceEntitySystem::CreateObjectInternal(const csp::common::String& InName, 
         auto* NewObject = new SpaceEntity(this);
         NewObject->Type = SpaceEntityType::Object;
         auto ID = ParseGenerateObjectIDsResult(Result);
-        NewObject->Id = ID;
-        NewObject->Name = InName;
-        NewObject->Transform = InSpaceTransform;
-        NewObject->OwnerId = MultiplayerConnectionInst->GetClientId();
-        NewObject->IsTransferable = true;
 
         if (InParent.HasValue())
         {

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -139,7 +139,7 @@ void SystemsManager::CreateSystems()
     ScriptSystem->Initialise();
 
     MultiplayerConnection = new csp::multiplayer::MultiplayerConnection();
-    EventBus = MultiplayerConnection->EventBusPtr;
+    EventBus = MultiplayerConnection->GetEventBusPtr();
 
     AnalyticsSystem = new csp::systems::AnalyticsSystem();
     UserSystem = new csp::systems::UserSystem(WebClient, EventBus);


### PR DESCRIPTION
Remove friends from SpaceEntity, SpaceEntitySystem, EventBus and MultiplayerConnection.

Create new getters and setters where private members were used directly, and make necessary private methods public (using CSP_NO_EXPORT, to avoid unnecessary exports).

Add docstrings on every new or changed function.