### PR TITLE
[NT-0] fix: removed redundant removal of thumbnail and metadata

### DIFF
--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -151,7 +151,7 @@ public:
         const csp::common::Optional<csp::common::String>& Description, const csp::common::Optional<SpaceAttributes>& Type,
         const csp::common::Optional<csp::common::Array<csp::common::String>>& Tags, BasicSpaceResultCallback Callback);
 
-    /// @brief Deletes a given space and the corresponding UserService group.
+    /// @brief Deletes a given space and the associated objects that belong to it. Including UserService group, Metadata, and Thumbnail.
     /// @param Space Space : space to delete
     /// @param Callback NullResultCallback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void DeleteSpace(const csp::common::String& SpaceId, NullResultCallback Callback);

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -531,14 +531,10 @@ void SpaceSystem::CreateSpace(const String& Name, const String& Description, Spa
         .then(csp::common::continuations::InvokeIfExceptionInChain(
             [this, CurrentSpaceResult, Callback](const std::exception& /*Except*/)
             {
-                const auto SpaceId = CurrentSpaceResult->GetSpace().Id;
-
                 auto NullResultCallback
                     = [](const csp::systems::NullResult& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; };
 
-                this->RemoveSpaceThumbnail(SpaceId, NullResultCallback);
-                this->RemoveMetadata(SpaceId, NullResultCallback);
-                this->DeleteSpace(SpaceId, NullResultCallback);
+                this->DeleteSpace(CurrentSpaceResult->GetSpace().Id, NullResultCallback);
 
                 Callback(MakeInvalid<SpaceResult>());
             }));
@@ -588,14 +584,10 @@ void SpaceSystem::CreateSpaceWithBuffer(const String& Name, const String& Descri
         .then(csp::common::continuations::InvokeIfExceptionInChain(
             [this, CurrentSpaceResult, Callback](const std::exception& /*Except*/)
             {
-                const auto SpaceId = CurrentSpaceResult->GetSpace().Id;
-
                 auto NullResultCallback
                     = [](const csp::systems::NullResult& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; };
 
-                this->RemoveSpaceThumbnail(SpaceId, NullResultCallback);
-                this->RemoveMetadata(SpaceId, NullResultCallback);
-                this->DeleteSpace(SpaceId, NullResultCallback);
+                this->DeleteSpace(CurrentSpaceResult->GetSpace().Id, NullResultCallback);
 
                 Callback(MakeInvalid<SpaceResult>());
             }));


### PR DESCRIPTION
On the CI we currently have two flaky test introduced by 021dffc5bbae6e298a5aac8a77197160a81c9b22

On review of the change it seems that behaviour has changed from a linear deletion process to non blocking async workflow. This resulted in a race condition where we are deleting the same resources, in the event these are executed in the wrong order would result in the tests crashing. 

The DELETE /api/v1/spaces/{SpaceId} endpoint will delete the thumbnail and metadata, which make the previous calls redundant, and removal prevent the race condition as only a single action will attempt to delete a resource. 

```
DELETE /api/v1/spaces/{SpaceId}
Locates the Space by its unique groupId represented here as spaceId and the associated objects that belong to it
and deletes it from the data store. This Function will search for items related to a spaceId even if the spaceId itself has already been deleted.
```