### PR TITLE
[NT-0] fix: fix MaterialEventTest and MaterialAssetEventTest 

### DIFF
--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -727,24 +727,15 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     {
         bool CallbackCalled = false;
 
-        auto CB = [&CallbackCalled, &CreatedGLTFMaterial](const csp::multiplayer::MaterialChangedParams& Params)
-        {
-            const auto Start = std::chrono::steady_clock::now();
-            constexpr std::chrono::seconds Timeout = std::chrono::seconds(10);
-            while (!CreatedGLTFMaterial)
-            {
-                if ((std::chrono::steady_clock::now() - Start) >= Timeout)
-                {
-                    // Timeout reached
-                    FAIL() << "Busy wait timeout reached waiting for Material creation.";
-                }
-            }
+        csp::common::String MaterialCollectionId;
+        csp::common::String MaterialId;
 
-            EXPECT_EQ(Params.MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
-            EXPECT_EQ(Params.MaterialId, CreatedGLTFMaterial->GetMaterialId());
+        auto CB = [&CallbackCalled, &MaterialCollectionId, &MaterialId](const csp::multiplayer::MaterialChangedParams& Params)
+        {
+            MaterialCollectionId = Params.MaterialCollectionId;
+            MaterialId = Params.MaterialId;
 
             EXPECT_EQ(Params.ChangeType, csp::multiplayer::EAssetChangeType::Created);
-
             CallbackCalled = true;
         };
 
@@ -756,8 +747,11 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
         CreatedGLTFMaterial = static_cast<GLTFMaterial*>(CreatedMaterial);
 
         WaitForCallback(CallbackCalled);
-
         EXPECT_TRUE(CallbackCalled);
+
+        // Do the check here where we know it exists
+        EXPECT_EQ(MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
+        EXPECT_EQ(MaterialId, CreatedGLTFMaterial->GetMaterialId());
     }
 
     // Update material and listen for event
@@ -845,24 +839,15 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
     // Create material and listen for event
     bool CallbackCalled = false;
 
-    auto CB = [&CallbackCalled, &CreatedGLTFMaterial](const csp::multiplayer::MaterialChangedParams& Params)
-    {
-        const auto Start = std::chrono::steady_clock::now();
-        constexpr std::chrono::seconds Timeout = std::chrono::seconds(10);
-        while (!CreatedGLTFMaterial)
-        {
-            if ((std::chrono::steady_clock::now() - Start) >= Timeout)
-            {
-                // Timeout reached
-                FAIL() << "Busy wait time-out reached waiting for Material creation.";
-            }
-        }
+    csp::common::String MaterialCollectionId;
+    csp::common::String MaterialId;
 
-        EXPECT_EQ(Params.MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
-        EXPECT_EQ(Params.MaterialId, CreatedGLTFMaterial->GetMaterialId());
+    auto CB = [&CallbackCalled, &MaterialCollectionId, &MaterialId](const csp::multiplayer::MaterialChangedParams& Params)
+    {
+        MaterialCollectionId = Params.MaterialCollectionId;
+        MaterialId = Params.MaterialId;
 
         EXPECT_EQ(Params.ChangeType, csp::multiplayer::EAssetChangeType::Created);
-
         CallbackCalled = true;
     };
 
@@ -874,8 +859,11 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
     CreatedGLTFMaterial = static_cast<GLTFMaterial*>(CreatedMaterial);
 
     WaitForCallback(CallbackCalled);
-
     EXPECT_TRUE(CallbackCalled);
+
+    // Do the check here where we know it exists
+    EXPECT_EQ(MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
+    EXPECT_EQ(MaterialId, CreatedGLTFMaterial->GetMaterialId());
 
     // Cleanup
     DeleteSpace(SpaceSystem, Space.Id);

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -729,12 +729,15 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
 
         auto CB = [&CallbackCalled, &CreatedGLTFMaterial](const csp::multiplayer::MaterialChangedParams& Params)
         {
-            EXPECT_EQ(Params.MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
-            EXPECT_EQ(Params.MaterialId, CreatedGLTFMaterial->GetMaterialId());
+            if (CreatedGLTFMaterial)
+            {
+                EXPECT_EQ(Params.MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
+                EXPECT_EQ(Params.MaterialId, CreatedGLTFMaterial->GetMaterialId());
 
-            EXPECT_EQ(Params.ChangeType, csp::multiplayer::EAssetChangeType::Created);
+                EXPECT_EQ(Params.ChangeType, csp::multiplayer::EAssetChangeType::Created);
 
-            CallbackCalled = true;
+                CallbackCalled = true;
+            }
         };
 
         AssetSystem->SetMaterialChangedCallback(CB);

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -729,15 +729,23 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
 
         auto CB = [&CallbackCalled, &CreatedGLTFMaterial](const csp::multiplayer::MaterialChangedParams& Params)
         {
-            if (CreatedGLTFMaterial)
+            const auto Start = std::chrono::steady_clock::now();
+            constexpr std::chrono::seconds Timeout = std::chrono::seconds(10);
+            while (!CreatedGLTFMaterial)
             {
-                EXPECT_EQ(Params.MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
-                EXPECT_EQ(Params.MaterialId, CreatedGLTFMaterial->GetMaterialId());
-
-                EXPECT_EQ(Params.ChangeType, csp::multiplayer::EAssetChangeType::Created);
-
-                CallbackCalled = true;
+                if ((std::chrono::steady_clock::now() - Start) >= Timeout)
+                {
+                    // Timeout reached
+                    FAIL() << "Busy wait timeout reached waiting for Material creation.";
+                }
             }
+
+            EXPECT_EQ(Params.MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
+            EXPECT_EQ(Params.MaterialId, CreatedGLTFMaterial->GetMaterialId());
+
+            EXPECT_EQ(Params.ChangeType, csp::multiplayer::EAssetChangeType::Created);
+
+            CallbackCalled = true;
         };
 
         AssetSystem->SetMaterialChangedCallback(CB);
@@ -802,8 +810,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     LogOut(UserSystem);
 }
 
-// This test is to be fixed as part of OF-1651.
-CSP_PUBLIC_TEST(DISABLED_CSPEngine, MaterialTests, MaterialAssetEventTest)
+CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
 {
     SetRandSeed();
 
@@ -840,6 +847,17 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MaterialTests, MaterialAssetEventTest)
 
     auto CB = [&CallbackCalled, &CreatedGLTFMaterial](const csp::multiplayer::MaterialChangedParams& Params)
     {
+        const auto Start = std::chrono::steady_clock::now();
+        constexpr std::chrono::seconds Timeout = std::chrono::seconds(10);
+        while (!CreatedGLTFMaterial)
+        {
+            if ((std::chrono::steady_clock::now() - Start) >= Timeout)
+            {
+                // Timeout reached
+                FAIL() << "Busy wait time-out reached waiting for Material creation.";
+            }
+        }
+
         EXPECT_EQ(Params.MaterialCollectionId, CreatedGLTFMaterial->GetMaterialCollectionId());
         EXPECT_EQ(Params.MaterialId, CreatedGLTFMaterial->GetMaterialId());
 


### PR DESCRIPTION
Fix MaterialEventTest and MaterialAssetEventTest by shamelessly reusing the fix for https://github.com/magnopus-opensource/connected-spaces-platform/pull/688.

Note that this PR has been re-purposed, as when I opened it I only had a fix for the crash in MaterialEventTest (not for the test failure), but now I have a real fix, which happens to also fix a second test, MaterialAssetEventTest.

Therefore, if I haven't squashed yet, please ignore the first commit, as it has the crash fix and not the fix fix.

Reasons why I have reasonable grounds to think that the transient failure is fixed:
- have 1000 out of 1000 successful runs of each of the 2 aforementioned tests, on local CHS, on my local machine. Note that before the fix (this morning), it wouldn't go past 5 or 6 runs at most before encountering an error.
![image](https://github.com/user-attachments/assets/0edf6a80-8f70-4143-b714-fc3257185ca7)
- have 1 successful local CHS CI job that was green the first time around: https://magnopus.teamcity.com/buildConfiguration/Olympus_Foundation_X64_TestsLocalChsInstance/289172
- have 1 successful live CHS CI job that was green the first time around: https://magnopus.teamcity.com/buildConfiguration/Olympus_Foundation_X64_FunctionalTests/289185

