### PR TITLE
[OB-4307] fix: remove no script component error handling

### DIFF
--- a/Library/src/Multiplayer/Script/EntityScript.cpp
+++ b/Library/src/Multiplayer/Script/EntityScript.cpp
@@ -26,7 +26,6 @@
 namespace csp::multiplayer
 {
 
-constexpr const char* SCRIPT_ERROR_NO_COMPONENT = "No script component";
 constexpr const char* SCRIPT_ERROR_EMPTY_SCRIPT = "Script is empty";
 
 EntityScript::EntityScript(SpaceEntity* InEntity, SpaceEntitySystem* InSpaceEntitySystem)
@@ -50,12 +49,7 @@ bool EntityScript::Invoke()
     HasLastError = false;
     LastError = "Unknown Error";
 
-    if (EntityScriptComponent == nullptr)
-    {
-        HasLastError = true;
-        LastError = SCRIPT_ERROR_NO_COMPONENT;
-    }
-    else
+    if (EntityScriptComponent != nullptr)
     {
         const csp::common::String& ScriptSource = EntityScriptComponent->GetScriptSource();
 


### PR DESCRIPTION
From Investigation: it seems the code in written in a manner that assumes the entities which are passed are assumed to contain a script component. However, this simply checks all components in the space resulting in an incorrect assumption. 

In a traditional ECS system the assumption would be true, but is not the case for CSP.  Looking at the timeline this was introduced in 20/06/2023 by MAG-pw, only receiving formatting changes.

The PR simplify Removes the assumption and reformatting the code to reflect this is all entities  and not a subset.