### PR TITLE
[NT-0] fix!: fix IsPersistant typo

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -144,7 +144,7 @@ public:
     /// Internal constructor to explicitly create a SpaceEntity in a specified state.
     /// Initially implemented for use in SpaceEntitySystem::CreateAvatar
     CSP_NO_EXPORT SpaceEntity(SpaceEntitySystem* EntitySystem, SpaceEntityType Type, uint64_t Id, const csp::common::String& Name,
-        const SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistant);
+        const SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistent);
 
     /// @brief Destroys the SpaceEntity instance.
     ~SpaceEntity();
@@ -486,7 +486,7 @@ private:
     SpaceEntityType Type;
     uint64_t Id;
     bool IsTransferable;
-    bool IsPersistant;
+    bool IsPersistent;
     uint64_t OwnerId;
     csp::common::Optional<uint64_t> ParentId;
     bool ShouldUpdateParent;

--- a/Library/src/Multiplayer/MCS/MCSTypes.cpp
+++ b/Library/src/Multiplayer/MCS/MCSTypes.cpp
@@ -169,12 +169,12 @@ const ItemComponentDataVariant& ItemComponentData::GetValue() const { return Val
 
 bool ItemComponentData::operator==(const ItemComponentData& Other) const { return Value == Other.Value; }
 
-ObjectMessage::ObjectMessage(uint64_t Id, uint64_t Type, bool IsTransferable, bool IsPersistant, uint64_t OwnerId, std::optional<uint64_t> ParentId,
+ObjectMessage::ObjectMessage(uint64_t Id, uint64_t Type, bool IsTransferable, bool IsPersistent, uint64_t OwnerId, std::optional<uint64_t> ParentId,
     const std::map<PropertyKeyType, ItemComponentData>& Components)
     : Id { Id }
     , Type { Type }
     , IsTransferable { IsTransferable }
-    , IsPersistant { IsPersistant }
+    , IsPersistent { IsPersistent }
     , OwnerId { OwnerId }
     , ParentId { ParentId }
     , Components { Components }
@@ -188,7 +188,7 @@ void ObjectMessage::Serialize(SignalRSerializer& Serializer) const
         Serializer.WriteValue(Id);
         Serializer.WriteValue(Type);
         Serializer.WriteValue(IsTransferable);
-        Serializer.WriteValue(IsPersistant);
+        Serializer.WriteValue(IsPersistent);
         Serializer.WriteValue(OwnerId);
         Serializer.WriteValue(ParentId);
         Serializer.WriteValue(Components);
@@ -204,7 +204,7 @@ void ObjectMessage::Deserialize(SignalRDeserializer& Deserializer)
         Deserializer.ReadValue(Id);
         Deserializer.ReadValue(Type);
         Deserializer.ReadValue(IsTransferable);
-        Deserializer.ReadValue(IsPersistant);
+        Deserializer.ReadValue(IsPersistent);
         Deserializer.ReadValue(OwnerId);
         Deserializer.ReadValue(ParentId);
         Deserializer.ReadValue(Components);
@@ -214,7 +214,7 @@ void ObjectMessage::Deserialize(SignalRDeserializer& Deserializer)
 
 bool ObjectMessage::operator==(const ObjectMessage& Other) const
 {
-    return Id == Other.Id && Type == Other.Type && IsTransferable == Other.IsTransferable && IsPersistant == Other.IsPersistant
+    return Id == Other.Id && Type == Other.Type && IsTransferable == Other.IsTransferable && IsPersistent == Other.IsPersistent
         && OwnerId == Other.OwnerId && ParentId == Other.ParentId && Components == Other.Components;
 }
 
@@ -224,7 +224,7 @@ uint64_t ObjectMessage::GetType() const { return Type; }
 
 bool ObjectMessage::GetIsTransferable() const { return IsTransferable; }
 
-bool ObjectMessage::GetIsPersistant() const { return IsPersistant; }
+bool ObjectMessage::GetIsPersistent() const { return IsPersistent; }
 
 uint64_t ObjectMessage::GetOwnerId() const { return OwnerId; }
 

--- a/Library/src/Multiplayer/MCS/MCSTypes.h
+++ b/Library/src/Multiplayer/MCS/MCSTypes.h
@@ -139,7 +139,7 @@ class ObjectMessage : public ISignalRSerializable, public ISignalRDeserializable
 {
 public:
     ObjectMessage() = default;
-    ObjectMessage(uint64_t Id, uint64_t Type, bool IsTransferable, bool IsPersistant, uint64_t OwnerId, std::optional<uint64_t> ParentId,
+    ObjectMessage(uint64_t Id, uint64_t Type, bool IsTransferable, bool IsPersistent, uint64_t OwnerId, std::optional<uint64_t> ParentId,
         const std::map<PropertyKeyType, ItemComponentData>& Components);
 
     void Serialize(SignalRSerializer& Serializer) const override;
@@ -150,7 +150,7 @@ public:
     uint64_t GetId() const;
     uint64_t GetType() const;
     bool GetIsTransferable() const;
-    bool GetIsPersistant() const;
+    bool GetIsPersistent() const;
     uint64_t GetOwnerId() const;
     std::optional<uint64_t> GetParentId() const;
     const std::optional<std::map<PropertyKeyType, ItemComponentData>>& GetComponents() const;
@@ -159,7 +159,7 @@ private:
     uint64_t Id = 0;
     uint64_t Type = 0;
     bool IsTransferable = false;
-    bool IsPersistant = false;
+    bool IsPersistent = false;
     uint64_t OwnerId = 0;
     std::optional<uint64_t> ParentId;
     std::optional<std::map<PropertyKeyType, ItemComponentData>> Components;

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -89,7 +89,7 @@ SpaceEntity::SpaceEntity()
     , Type(SpaceEntityType::Avatar)
     , Id(0)
     , IsTransferable(true)
-    , IsPersistant(true)
+    , IsPersistent(true)
     , OwnerId(0)
     , ParentId(nullptr)
     , ShouldUpdateParent(false)
@@ -111,7 +111,7 @@ SpaceEntity::SpaceEntity(SpaceEntitySystem* InEntitySystem)
     , Type(SpaceEntityType::Avatar)
     , Id(0)
     , IsTransferable(true)
-    , IsPersistant(true)
+    , IsPersistent(true)
     , OwnerId(0)
     , ParentId(nullptr)
     , ShouldUpdateParent(false)
@@ -129,7 +129,7 @@ SpaceEntity::SpaceEntity(SpaceEntitySystem* InEntitySystem)
 }
 
 SpaceEntity::SpaceEntity(SpaceEntitySystem* EntitySystem, SpaceEntityType Type, uint64_t Id, const csp::common::String& Name,
-    const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistant)
+    const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistent)
     : SpaceEntity(EntitySystem)
 {
     this->Id = Id;
@@ -138,7 +138,7 @@ SpaceEntity::SpaceEntity(SpaceEntitySystem* EntitySystem, SpaceEntityType Type, 
     this->Transform = Transform;
     this->OwnerId = OwnerId;
     this->IsTransferable = IsTransferable;
-    this->IsPersistant = IsPersistant;
+    this->IsPersistent = IsPersistent;
 }
 
 SpaceEntity::~SpaceEntity()
@@ -295,7 +295,7 @@ void SpaceEntity::SetScale(const csp::common::Vector3& Value)
     }
 }
 
-bool SpaceEntity::GetIsTransient() const { return !IsPersistant; }
+bool SpaceEntity::GetIsTransient() const { return !IsPersistent; }
 
 const csp::common::String& SpaceEntity::GetThirdPartyRef() const { return ThirdPartyRef; }
 
@@ -1046,7 +1046,7 @@ mcs::ObjectMessage SpaceEntity::CreateObjectMessage()
     }
 
     // 3. Create the object message using the reqired properties and our created components.
-    return mcs::ObjectMessage { Id, static_cast<uint64_t>(Type), IsTransferable, IsPersistant, OwnerId, Convert(ParentId),
+    return mcs::ObjectMessage { Id, static_cast<uint64_t>(Type), IsTransferable, IsPersistent, OwnerId, Convert(ParentId),
         ComponentPacker.GetComponents() };
 }
 
@@ -1102,7 +1102,7 @@ void SpaceEntity::FromObjectMessage(const mcs::ObjectMessage& Message)
     Id = Message.GetId();
     Type = static_cast<SpaceEntityType>(Message.GetType());
     IsTransferable = Message.GetIsTransferable();
-    IsPersistant = Message.GetIsPersistant();
+    IsPersistent = Message.GetIsPersistent();
     OwnerId = Message.GetOwnerId();
     ParentId = common::Convert(Message.GetParentId());
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -258,11 +258,11 @@ namespace
 {
     std::unique_ptr<csp::multiplayer::SpaceEntity> BuildNewAvatar(csp::systems::UserSystem& UserSystem,
         csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, uint64_t NetworkId, const csp::common::String& Name,
-        const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistant,
+        const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistent,
         const csp::common::String& AvatarId, csp::multiplayer::AvatarState AvatarState, csp::multiplayer::AvatarPlayMode AvatarPlayMode)
     {
         auto NewAvatar = std::unique_ptr<csp::multiplayer::SpaceEntity>(new csp::multiplayer::SpaceEntity(
-            &SpaceEntitySystem, SpaceEntityType::Avatar, NetworkId, Name, Transform, OwnerId, IsTransferable, IsPersistant));
+            &SpaceEntitySystem, SpaceEntityType::Avatar, NetworkId, Name, Transform, OwnerId, IsTransferable, IsPersistent));
 
         auto* AvatarComponent = static_cast<AvatarSpaceComponent*>(NewAvatar->AddComponent(ComponentType::AvatarData));
         AvatarComponent->SetAvatarId(AvatarId);

--- a/Tests/src/InternalTests/MCSTests.cpp
+++ b/Tests/src/InternalTests/MCSTests.cpp
@@ -27,18 +27,18 @@ CSP_INTERNAL_TEST(CSPEngine, MCSTests, ObjectMessageConstructorTest)
     const uint64_t TestId = 1;
     const uint64_t TestType = 2;
     const bool TestIsTransferable = false;
-    const bool TestIsPersistant = true;
+    const bool TestIsPersistent = true;
     const uint64_t TestOwnerId = 3;
     const std::optional<uint64_t> TestParentId = 4;
     std::map<mcs::PropertyKeyType, mcs::ItemComponentData> TestComponents;
     TestComponents[0] = mcs::ItemComponentData { { 0ll } };
 
-    mcs::ObjectMessage Object { TestId, TestType, TestIsTransferable, TestIsPersistant, TestOwnerId, TestParentId, TestComponents };
+    mcs::ObjectMessage Object { TestId, TestType, TestIsTransferable, TestIsPersistent, TestOwnerId, TestParentId, TestComponents };
 
     EXPECT_EQ(Object.GetId(), TestId);
     EXPECT_EQ(Object.GetType(), TestType);
     EXPECT_EQ(Object.GetIsTransferable(), TestIsTransferable);
-    EXPECT_EQ(Object.GetIsPersistant(), TestIsPersistant);
+    EXPECT_EQ(Object.GetIsPersistent(), TestIsPersistent);
     EXPECT_EQ(Object.GetOwnerId(), TestOwnerId);
     EXPECT_EQ(Object.GetParentId(), TestParentId);
     EXPECT_EQ(Object.GetComponents(), TestComponents);
@@ -71,13 +71,13 @@ CSP_INTERNAL_TEST(CSPEngine, MCSTests, ObjectMessageSerializeTest)
     const uint64_t TestId = 1;
     const uint64_t TestType = 2;
     const bool TestIsTransferable = true;
-    const bool TestIsPersistant = true;
+    const bool TestIsPersistent = true;
     const uint64_t TestOwnerId = 3;
     const std::optional<uint64_t> TestParentId = 4;
     std::map<mcs::PropertyKeyType, mcs::ItemComponentData> TestComponents;
     TestComponents[0] = mcs::ItemComponentData { { 0ll } };
 
-    mcs::ObjectMessage Object { TestId, TestType, TestIsTransferable, TestIsPersistant, TestOwnerId, TestParentId, TestComponents };
+    mcs::ObjectMessage Object { TestId, TestType, TestIsTransferable, TestIsPersistent, TestOwnerId, TestParentId, TestComponents };
 
     SignalRSerializer Serializer;
     Serializer.WriteValue(Object);


### PR DESCRIPTION
It is IsPersistent.

This typo has been present, and ignored, in the last 3 or 4 PRs that touched space entity. I got tired of seeing it.

Unfortunately, ObjectMessage::GetIsPersistent() is public (defined in MCSTypes.h), so I marked the change as breaking...