### PR TITLE
[OB-4284] fix: Prevent SpaceEntity::ComponentsLock from doubling locking

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -516,7 +516,7 @@ private:
 
     CSP_START_IGNORE
     mutable std::mutex EntityMutexLock;
-    mutable std::mutex ComponentsLock;
+    mutable std::recursive_mutex ComponentsLock;
     mutable std::mutex PropertiesLock;
     CSP_END_IGNORE
 

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -1526,6 +1526,7 @@ void SpaceEntitySystem::ApplyIncomingPatch(const signalr::value* EntityMessage)
             if (Entities[i]->GetId() == Patch.GetId())
             {
                 Entities[i]->FromObjectPatch(Patch);
+                EntityFound = true;
             }
         }
 


### PR DESCRIPTION
In the following circumstance, we can cause SpaceEntity::ComponentsLock to be locked twice in the same code path, causing the program to lock up:

- A script exists that modifies a component property when executed
- The script source is then updated
- This causes a patch to be sent, changing the script source
- A patch is received by another client, which locks the ComponentsLock mutex
- ScriptSpaceComponent overrides SetPropertyFromPatch to get them to re-run the script when changed
- This causes the script to run, and the script modifies a property
- Modifying this property calls SpaceEntity::AddDirtyComponent, which also locks ComponentsLock
- The program then freezes

We have currently fixed this by introducing a recursive_mutex, which isn't the best way forward. Ideally, we want to understand our threading and locking model, so we can redesign a better system where we fully understand all of our codepaths, and find a safer way of fixing this without introducing a large amount of locks for each component update.

I unfortunately couldn't create a reliable test for this, as double locking is undefined behaviour. I did manual testing to ensure this bug is fixed.

I also fixed the following bugs introduced by the Serialization refactor:
    - Readded mutex logs for serialzation/deserialization
    - An error log will fire when receiving a patch update stating that the entity could not be found
    - SpaceEntity::UpdateCallback will not fire if only components have changed, and not entity properties