### PR TITLE
Prevent referencing native nullptrs

### DIFF
--- a/Library/CSharpWrapper/src/NativeClassWrapper.cs
+++ b/Library/CSharpWrapper/src/NativeClassWrapper.cs
@@ -45,7 +45,7 @@ namespace Csp
 
         internal virtual string _safeTypeName { get; }
 
-        [Deprecated("NativeClassWrapper instances are now guaranteed to be valid")]
+        [Obsolete("NativeClassWrapper instances are now guaranteed to be valid")]
         public bool PointerIsValid => _ptr != IntPtr.Zero;
 
         public NativeClassWrapper() { }

--- a/Library/CSharpWrapper/src/NativeClassWrapper.cs
+++ b/Library/CSharpWrapper/src/NativeClassWrapper.cs
@@ -45,12 +45,18 @@ namespace Csp
 
         internal virtual string _safeTypeName { get; }
 
+        [Deprecated("NativeClassWrapper instances are now guaranteed to be valid")]
         public bool PointerIsValid => _ptr != IntPtr.Zero;
 
         public NativeClassWrapper() { }
 
         internal NativeClassWrapper(NativePointer ptr)
         {
+            if (ptr.Pointer == IntPtr.Zero)
+            {
+                throw new ArgumentException("NativePointer cannot be zero.", nameof(ptr));
+            }
+
             _ptr = ptr.Pointer;
             _ownsPtr = ptr.OwnsOwnData;
         }

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/TaskMethod.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/TaskMethod.mustache
@@ -20,7 +20,18 @@ static void {{ delegate.name }}Function(
     var tcs = (TaskCompletionSource<{{# has_multiple_results }}({{/ has_multiple_results }}{{# results }}{{# type }}{{> Type }}{{/ type }}{{> Comma }}{{/ results }}{{# has_multiple_results }}){{/ has_multiple_results }}>)_handle.Target;
     var _this = ({{ class_name }})tcs.Task.AsyncState;
 
-    var task_result = {{# has_multiple_results }}({{/ has_multiple_results }}{{# results }}{{# type.is_pointer_or_reference }}new {{# type }}{{> Type }}{{/ type }}({{/ type.is_pointer_or_reference }}_{{ name }}{{# type.is_pointer_or_reference }}){{/ type.is_pointer_or_reference }}{{> Comma }}{{/ results }}{{# has_multiple_results }}){{/ has_multiple_results }};
+    var task_result = 
+        {{# has_multiple_results }}({{/ has_multiple_results }}
+        {{# results }}
+            {{# type.is_pointer_or_reference }}
+                _{{ name }}.Pointer == IntPtr.Zero ? null : new {{# type }}{{> Type }}{{/ type }}(_{{ name }})
+            {{/ type.is_pointer_or_reference }}
+            {{^ type.is_pointer_or_reference }}
+                _{{ name }}
+            {{/ type.is_pointer_or_reference }}
+            {{> Comma }}
+        {{/ results }}
+        {{# has_multiple_results }}){{/ has_multiple_results }};
     {{# results }}{{# type.is_result_base }}
     if (task_result.GetResultCode() == Csp.Systems.EResultCode.InProgress)
     {


### PR DESCRIPTION
In some cases, the C++ layer will use `nullptr` in callbacks or return values to indicate failure or a missing object. The C# wrapper generator currently wraps these in a managed object instance; calling any function or property on this object will result in a segfault.

The expected behavior in C# is that objects are valid or `null`.

This PR will:

* Ensure that invalid `NativeClassWrapper` instances cannot be created
* Return a C# `null` any time a native `nullptr` is produced