### PR TITLE
[OB-4404] fix: Fix crash when deserializing invalid component types

### DIFF
--- a/Library/src/Multiplayer/MCS/MCSTypes.cpp
+++ b/Library/src/Multiplayer/MCS/MCSTypes.cpp
@@ -109,6 +109,38 @@ namespace
             throw std::invalid_argument("Trying to deserialize unsupported ItemComponentDataType");
         }
     }
+
+    void DeserializeComponents(SignalRDeserializer& Deserializer, std::optional<std::map<PropertyKeyType, ItemComponentData>>& Components)
+    {
+        if (Deserializer.NextValueIsNull() == false)
+        {
+            Components = std::map<PropertyKeyType, ItemComponentData> {};
+
+            size_t ComponentsSize = 0;
+            Deserializer.StartReadUintMap(ComponentsSize);
+
+            for (size_t i = 0; i < ComponentsSize; ++i)
+            {
+                try
+                {
+                    std::pair<PropertyKeyType, ItemComponentData> ComponentKeyValue;
+                    Deserializer.ReadKeyValue(ComponentKeyValue);
+
+                    (*Components)[ComponentKeyValue.first] = ComponentKeyValue.second;
+                }
+                catch (const std::exception&)
+                {
+                }
+            }
+
+            Deserializer.EndReadUintMap();
+        }
+        else
+        {
+            Components = std::nullopt;
+            Deserializer.Skip();
+        }
+    }
 }
 
 ItemComponentData::ItemComponentData(const ItemComponentDataVariant& Value)
@@ -207,35 +239,7 @@ void ObjectMessage::Deserialize(SignalRDeserializer& Deserializer)
         Deserializer.ReadValue(IsPersistent);
         Deserializer.ReadValue(OwnerId);
         Deserializer.ReadValue(ParentId);
-
-        // Deserialize components
-        if (Deserializer.NextValueIsNull() == false)
-        {
-            Components = std::map<PropertyKeyType, ItemComponentData> {};
-
-            size_t ComponentsSize = 0;
-            Deserializer.StartReadUintMap(ComponentsSize);
-
-            for (size_t i = 0; i < ComponentsSize; ++i)
-            {
-                try
-                {
-                    std::pair<PropertyKeyType, ItemComponentData> ComponentKeyValue;
-                    Deserializer.ReadKeyValue(ComponentKeyValue);
-
-                    (*Components)[ComponentKeyValue.first] = ComponentKeyValue.second;
-                }
-                catch (const std::exception&)
-                {
-                }
-            }
-
-            Deserializer.EndReadUintMap();
-        }
-        else
-        {
-            Deserializer.Skip();
-        }
+        DeserializeComponents(Deserializer, Components);
     }
     Deserializer.EndReadArray();
 }
@@ -313,34 +317,7 @@ void ObjectPatch::Deserialize(SignalRDeserializer& Deserializer)
             Deserializer.EndReadArray();
         }
 
-        // Deserialize components
-        if (Deserializer.NextValueIsNull() == false)
-        {
-            Components = std::map<PropertyKeyType, ItemComponentData> {};
-
-            size_t ComponentsSize = 0;
-            Deserializer.StartReadUintMap(ComponentsSize);
-
-            for (size_t i = 0; i < ComponentsSize; ++i)
-            {
-                try
-                {
-                    std::pair<PropertyKeyType, ItemComponentData> ComponentKeyValue;
-                    Deserializer.ReadKeyValue(ComponentKeyValue);
-
-                    (*Components)[ComponentKeyValue.first] = ComponentKeyValue.second;
-                }
-                catch (const std::exception&)
-                {
-                }
-            }
-
-            Deserializer.EndReadUintMap();
-        }
-        else
-        {
-            Deserializer.Skip();
-        }
+        DeserializeComponents(Deserializer, Components);
     }
     Deserializer.EndReadArray();
 }


### PR DESCRIPTION
- Added exception catching when deserializing components
- Currently haven't added logging, as we are changing how this is going to be done in the multiplayer refactor
- We will still receive logs from the exceptions, even though they are caught.