### PR TITLE
Revert "Prevent referencing native nullptrs"

### DIFF
--- a/Library/CSharpWrapper/src/NativeClassWrapper.cs
+++ b/Library/CSharpWrapper/src/NativeClassWrapper.cs
@@ -45,18 +45,12 @@ namespace Csp
 
         internal virtual string _safeTypeName { get; }
 
-        [Obsolete("NativeClassWrapper instances are now guaranteed to be valid")]
         public bool PointerIsValid => _ptr != IntPtr.Zero;
 
         public NativeClassWrapper() { }
 
         internal NativeClassWrapper(NativePointer ptr)
         {
-            if (ptr.Pointer == IntPtr.Zero)
-            {
-                throw new ArgumentException("NativePointer cannot be zero.", nameof(ptr));
-            }
-
             _ptr = ptr.Pointer;
             _ownsPtr = ptr.OwnsOwnData;
         }

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/TaskMethod.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/TaskMethod.mustache
@@ -20,18 +20,7 @@ static void {{ delegate.name }}Function(
     var tcs = (TaskCompletionSource<{{# has_multiple_results }}({{/ has_multiple_results }}{{# results }}{{# type }}{{> Type }}{{/ type }}{{> Comma }}{{/ results }}{{# has_multiple_results }}){{/ has_multiple_results }}>)_handle.Target;
     var _this = ({{ class_name }})tcs.Task.AsyncState;
 
-    var task_result = 
-        {{# has_multiple_results }}({{/ has_multiple_results }}
-        {{# results }}
-            {{# type.is_pointer_or_reference }}
-                _{{ name }}.Pointer == IntPtr.Zero ? null : new {{# type }}{{> Type }}{{/ type }}(_{{ name }})
-            {{/ type.is_pointer_or_reference }}
-            {{^ type.is_pointer_or_reference }}
-                _{{ name }}
-            {{/ type.is_pointer_or_reference }}
-            {{> Comma }}
-        {{/ results }}
-        {{# has_multiple_results }}){{/ has_multiple_results }};
+    var task_result = {{# has_multiple_results }}({{/ has_multiple_results }}{{# results }}{{# type.is_pointer_or_reference }}new {{# type }}{{> Type }}{{/ type }}({{/ type.is_pointer_or_reference }}_{{ name }}{{# type.is_pointer_or_reference }}){{/ type.is_pointer_or_reference }}{{> Comma }}{{/ results }}{{# has_multiple_results }}){{/ has_multiple_results }};
     {{# results }}{{# type.is_result_base }}
     if (task_result.GetResultCode() == Csp.Systems.EResultCode.InProgress)
     {


### PR DESCRIPTION
Reverts magnopus-opensource/connected-spaces-platform#702

While we agree this is a good change, it breaks some behaviour in Array<> that relies on being able to create null instances.

See [this conversation on Slack](https://magnopus.slack.com/archives/C02TKEGRJE6/p1749727816407889).