### PR TITLE
[OF-1671] feat!: promote restful service api uri version information to csp foundation

### DIFF
--- a/Library/docs/source/learn/overview/mcs.md
+++ b/Library/docs/source/learn/overview/mcs.md
@@ -157,7 +157,7 @@ Consider the method GetAssetCollectionById in the AssetSystem class, which demon
 void AssetSystem::GetAssetCollectionById(const String& AssetCollectionId, AssetCollectionResultCallback Callback)
 {
     services::ResponseHandlerPtr ResponseHandler = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdGet(AssetCollectionId, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdGet(AssetCollectionId, ResponseHandler);
 }
 ```
 

--- a/Library/docs/source/learn/users/authentication.md
+++ b/Library/docs/source/learn/users/authentication.md
@@ -67,7 +67,7 @@ void UserSystem::Login(const String& UserName, const csp::common::String& Email,
 		}
 		
 		// Make the login call and handle response
-		static_cast<AuthenticationApi*>(AuthenticationAPI)->apiV1UsersLoginPost(Request, ResponseHandler);
+		static_cast<AuthenticationApi*>(AuthenticationAPI)->usersLoginPost(Request, ResponseHandler);
 	}
 }
 ```
@@ -159,7 +159,7 @@ if (UserHasVerifiedAge.HasValue()) {
 }
 	
 // Make the call to log in as guest
-static_cast<AuthenticationApi*>(AuthenticationAPI)->apiV1UsersLoginAsGuestPost(Request, ResponseHandler);
+static_cast<AuthenticationApi*>(AuthenticationAPI)->usersLoginAsGuestPost(Request, ResponseHandler);
 ```
 
 ### Key Points
@@ -238,7 +238,7 @@ void UserSystem::Logout(NullResultCallback Callback) {
         MultiplayerConnection->Disconnect(ErrorCallback);
         
         // Handle logout response
-        static_cast<AuthenticationApi*>(AuthenticationAPI)->apiV1UsersLogoutPost(Request, ResponseHandler);
+        static_cast<AuthenticationApi*>(AuthenticationAPI)->usersLogoutPost(Request, ResponseHandler);
 	}
 }
 ```

--- a/Library/docs/source/learn/users/management.md
+++ b/Library/docs/source/learn/users/management.md
@@ -100,7 +100,7 @@ Request->SetInitialSettings({InitialSettings});
 * Finally, CSP will invoke the services endpoint to create the user profile, passing the `CreateUserRequest` object, and a callback to handle the response.
 
 ```
-static_cast<ProfileApi*>(ProfileAPI)->apiV1UsersPost(Request, ResponseHandler);
+static_cast<ProfileApi*>(ProfileAPI)->usersPost(Request, ResponseHandler);
 ```
 
 Here is a simplified example of the CreateUser method in action:
@@ -131,7 +131,7 @@ void UserSystem::CreateUser(const Optional<String>& UserName,
 	InitialSettings->SetSettings({{"Newsletter", ReceiveNewsletter ? "true" : "false"}});
 	Request->SetInitialSettings({InitialSettings});
 
-	static_cast<ProfileApi*>(ProfileAPI)->apiV1UsersPost(Request, ResponseHandler);
+	static_cast<ProfileApi*>(ProfileAPI)->usersPost(Request, ResponseHandler);
 }
 ```
 
@@ -228,7 +228,7 @@ void UserSystem::UpdateUserDisplayName(const String& UserId,
                                 void, chs_user::ProfileDto>(Callback, nullptr,
                                 csp::web::EResponseCodes::ResponseOk);
 
-   static_cast<ProfileApi*>(ProfileAPI)->apiV1UsersDisplayNamePatch(Request, ResponseHandler);
+   static_cast<ProfileApi*>(ProfileAPI)->usersDisplayNamePatch(Request, ResponseHandler);
 }
 ```
 

--- a/Library/include/CSP/CSPFoundation.h
+++ b/Library/include/CSP/CSPFoundation.h
@@ -18,20 +18,58 @@
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/String.h"
 
+#include <string>
+
 namespace csp
 {
+
+class CSP_API MCSServiceDefinition
+{
+public:
+    MCSServiceDefinition()
+        : URI("")
+        , Version(0)
+    {
+    }
+
+    MCSServiceDefinition(const csp::common::String& InURI, const uint32_t InVersion)
+        : URI(InURI)
+        , Version(InVersion)
+    {
+    }
+
+    /// @brief Gets the root URI for the service endpoint.
+    /// @return csp::common::String : The root URI of the service endpoint.
+    const csp::common::String GetURI() const { return URI; }
+    /// @brief Sets the URI for the service endpoint.
+    /// @param InURI csp::common::String : URI for service endpoint.
+    void SetURI(const csp::common::String& InURI) { URI = InURI; }
+
+    /// @brief Gets the current version of the service endpoint.
+    /// @return int32_t : Representing the current version of the service endpoint.
+    const int32_t GetVersion() const { return Version; }
+    /// @brief Sets the current Version for the service endpoint.
+    /// @param InVersion uint32_t : Version for service endpoint.
+    CSP_NO_EXPORT void SetVersion(const uint32_t InVersion) { Version = InVersion; }
+
+private:
+    csp::common::String URI;
+    uint32_t Version;
+};
 
 /// @brief Holds supported endpoint uris used by Foundation.
 class CSP_API EndpointURIs
 {
 public:
-    csp::common::String UserServiceURI;
-    csp::common::String PrototypeServiceURI;
-    csp::common::String SpatialDataServiceURI;
-    csp::common::String MultiplayerServiceURI;
-    csp::common::String AggregationServiceURI;
-    csp::common::String TrackingServiceURI;
-    csp::common::String MaintenanceWindowURI;
+    MCSServiceDefinition UserService;
+    MCSServiceDefinition PrototypeService;
+    MCSServiceDefinition SpatialDataService;
+    MCSServiceDefinition MultiplayerService;
+    MCSServiceDefinition AggregationService;
+    MCSServiceDefinition TrackingService;
+    MCSServiceDefinition MaintenanceWindow;
+
+private:
 };
 
 /// @brief Holds client data used in requests for all Magnopus Serives.

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -282,12 +282,12 @@ EndpointURIs CSPFoundation::CreateEndpointsFromRoot(const csp::common::String& E
     const std::string MultiplayerServiceURI = TranslateEndpointRootURIToMultiplayerServiceUri(RootURI);
 
     EndpointURIs EndpointsURI;
-    EndpointsURI.UserServiceURI = CSP_TEXT(UserServiceURI.c_str());
-    EndpointsURI.PrototypeServiceURI = CSP_TEXT(PrototypeServiceURI.c_str());
-    EndpointsURI.SpatialDataServiceURI = CSP_TEXT(SpatialDataServiceURI.c_str());
-    EndpointsURI.MultiplayerServiceURI = CSP_TEXT(MultiplayerServiceURI.c_str());
-    EndpointsURI.AggregationServiceURI = CSP_TEXT(AggregationServiceURI.c_str());
-    EndpointsURI.TrackingServiceURI = CSP_TEXT(TrackingServiceURI.c_str());
+    EndpointsURI.UserService = MCSServiceDefinition(CSP_TEXT(UserServiceURI.c_str()), 1U);
+    EndpointsURI.PrototypeService = MCSServiceDefinition(CSP_TEXT(PrototypeServiceURI.c_str()), 1U);
+    EndpointsURI.SpatialDataService = MCSServiceDefinition(CSP_TEXT(SpatialDataServiceURI.c_str()), 1U);
+    EndpointsURI.AggregationService = MCSServiceDefinition(CSP_TEXT(AggregationServiceURI.c_str()), 1U);
+    EndpointsURI.TrackingService = MCSServiceDefinition(CSP_TEXT(TrackingServiceURI.c_str()), 1U);
+    EndpointsURI.MultiplayerService = MCSServiceDefinition(CSP_TEXT(MultiplayerServiceURI.c_str()), 1U);
 
     return EndpointsURI;
 }

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -149,7 +149,7 @@ namespace
 
 ISignalRConnection* MultiplayerConnection::MakeSignalRConnection()
 {
-    return new csp::multiplayer::SignalRConnection(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str(), KEEP_ALIVE_INTERVAL,
+    return new csp::multiplayer::SignalRConnection(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI().c_str(), KEEP_ALIVE_INTERVAL,
         std::make_shared<csp::multiplayer::CSPWebsocketClient>());
 }
 

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -75,7 +75,7 @@ void CSPWebSocketClientPOCO::Start(const std::string& /*Url*/, CallbackHandler C
     try
     {
         CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint
-            = ParseMultiplayerServiceUriEndPoint(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI.c_str());
+            = ParseMultiplayerServiceUriEndPoint(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI().c_str());
 
         auto domain = ParsedEndpoint.Domain;
         auto protocol = ParsedEndpoint.Protocol;

--- a/Library/src/Services/ApiBase/ApiBase.h
+++ b/Library/src/Services/ApiBase/ApiBase.h
@@ -218,9 +218,9 @@ using ResponseHandlerPtr = ApiResponseHandlerBase*;
 class ApiBase
 {
 public:
-    ApiBase(csp::web::WebClient* InWebClient, const csp::common::String* InRootUri)
+    ApiBase(csp::web::WebClient* InWebClient, const csp::MCSServiceDefinition* InServiceDefinition)
         : WebClient(InWebClient)
-        , RootUri(InRootUri)
+        , ServiceDefinition(InServiceDefinition)
     {
     }
 
@@ -238,7 +238,7 @@ public:
     }
 
     csp::web::WebClient* WebClient;
-    const csp::common::String* RootUri;
+    const MCSServiceDefinition* ServiceDefinition;
 };
 
 //

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -394,7 +394,7 @@ void AssetSystem::DeleteAssetCollectionById(const csp::common::String& AssetColl
     services::ResponseHandlerPtr ResponseHandler = PrototypeAPI->CreateHandler<NullResultCallback, NullResult, void, services::NullDto>(
         Callback, nullptr, web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdDelete(PrototypeId, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdDelete(PrototypeId, ResponseHandler);
 }
 
 void AssetSystem::DeleteAssetById(const csp::common::String& AsseCollectiontId, const csp::common::String& AssetId, NullResultCallback Callback)
@@ -403,7 +403,7 @@ void AssetSystem::DeleteAssetById(const csp::common::String& AsseCollectiontId, 
         Callback, nullptr, web::EResponseCodes::ResponseNoContent);
 
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdDelete(AsseCollectiontId, AssetId, ResponseHandler);
+        ->prototypesPrototypeIdAssetDetailsAssetDetailIdDelete(AsseCollectiontId, AssetId, ResponseHandler);
 }
 
 void AssetSystem::CreateAssetCollection(const Optional<String>& InSpaceId, const Optional<String>& ParentAssetCollectionId,
@@ -423,7 +423,7 @@ void AssetSystem::CreateAssetCollection(const Optional<String>& InSpaceId, const
         = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(
             Callback, nullptr, web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesPost(PrototypeInfo, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesPost(PrototypeInfo, ResponseHandler);
 }
 
 async::task<AssetCollectionResult> AssetSystem::CreateAssetCollection(const csp::common::Optional<csp::common::String>& InSpaceId,
@@ -447,7 +447,7 @@ async::task<AssetCollectionResult> AssetSystem::CreateAssetCollection(const csp:
         = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(
             [](const AssetCollectionResult&) {}, nullptr, web::EResponseCodes::ResponseCreated, std::move(OnCompleteEvent));
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesPost(PrototypeInfo, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesPost(PrototypeInfo, ResponseHandler);
 
     return OnCompleteTask;
 }
@@ -468,7 +468,7 @@ void AssetSystem::DeleteAssetCollection(const AssetCollection& AssetCollection, 
     services::ResponseHandlerPtr ResponseHandler = PrototypeAPI->CreateHandler<NullResultCallback, NullResult, void, services::NullDto>(
         Callback, nullptr, web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdDelete(PrototypeId, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdDelete(PrototypeId, ResponseHandler);
 }
 
 async::task<NullResult> AssetSystem::DeleteAssetCollection(const AssetCollection& AssetCollection)
@@ -489,7 +489,7 @@ async::task<NullResult> AssetSystem::DeleteAssetCollection(const AssetCollection
     services::ResponseHandlerPtr ResponseHandler = PrototypeAPI->CreateHandler<NullResultCallback, NullResult, void, services::NullDto>(
         [](const NullResult& /*s*/) {}, nullptr, web::EResponseCodes::ResponseNoContent, std::move(OnCompleteEvent));
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdDelete(PrototypeId, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdDelete(PrototypeId, ResponseHandler);
 
     return OnCompleteTask;
 }
@@ -522,8 +522,7 @@ void AssetSystem::DeleteMultipleAssetCollections(csp::common::Array<AssetCollect
     csp::services::ResponseHandlerPtr ResponseHandler
         = PrototypeAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::DtoArray<chs::PrototypeDto>>(Callback, nullptr);
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)
-        ->apiV1PrototypesDelete(AssetCollectionIds, ResponseHandler, csp::common::CancellationToken::Dummy());
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesDelete(AssetCollectionIds, ResponseHandler, csp::common::CancellationToken::Dummy());
 }
 
 void AssetSystem::CopyAssetCollectionsToSpace(csp::common::Array<AssetCollection>& SourceAssetCollections, const csp::common::String& DestSpaceId,
@@ -573,7 +572,7 @@ void AssetSystem::CopyAssetCollectionsToSpace(csp::common::Array<AssetCollection
 
     // Use `GET /api/v1/prototypes` and only pass asset collection IDs
     static_cast<chs::PrototypeApi*>(PrototypeAPI)
-        ->apiV1PrototypesGroupOwnedOriginalGroupIdDuplicateNewGroupIdPost(std::nullopt, // Tags
+        ->prototypesGroupOwnedOriginalGroupIdDuplicateNewGroupIdPost(std::nullopt, // Tags
             std::nullopt, // ExcludedTags
             std::nullopt, // TagsAll
             AssetCollectionIds, // const std::optional<std::vector<utility::string_t>>& Ids
@@ -606,7 +605,7 @@ void AssetSystem::GetAssetCollectionById(const String& AssetCollectionId, AssetC
     services::ResponseHandlerPtr ResponseHandler
         = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdGet(AssetCollectionId, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdGet(AssetCollectionId, ResponseHandler);
 }
 
 async::task<AssetCollectionResult> AssetSystem::GetAssetCollectionById(const csp::common::String& AssetCollectionId)
@@ -618,7 +617,7 @@ async::task<AssetCollectionResult> AssetSystem::GetAssetCollectionById(const csp
         = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(
             [](const AssetCollectionResult&) {}, nullptr, web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdGet(AssetCollectionId, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdGet(AssetCollectionId, ResponseHandler);
 
     return OnCompleteTask;
 }
@@ -628,7 +627,7 @@ void AssetSystem::GetAssetCollectionByName(const String& AssetCollectionName, As
     services::ResponseHandlerPtr ResponseHandler
         = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesNameNameGet(AssetCollectionName, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesNameNameGet(AssetCollectionName, ResponseHandler);
 }
 
 void AssetSystem::FindAssetCollections(const Optional<Array<String>>& Ids, const Optional<String>& ParentId, const Optional<Array<String>>& Names,
@@ -666,7 +665,7 @@ void AssetSystem::FindAssetCollections(const Optional<Array<String>>& Ids, const
             Callback, nullptr);
 
     static_cast<chs::PrototypeApi*>(PrototypeAPI)
-        ->apiV1PrototypesGet(PrototypeTags, // Tags
+        ->prototypesGet(PrototypeTags, // Tags
             std::nullopt, // ExcludedTags
             std::nullopt, // TagsAll
             PrototypeIds, // Ids
@@ -732,7 +731,7 @@ async::task<AssetCollectionsResult> AssetSystem::FindAssetCollections(const csp:
             [](const AssetCollectionsResult&) {}, nullptr, web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
 
     static_cast<chs::PrototypeApi*>(PrototypeAPI)
-        ->apiV1PrototypesGet(PrototypeTags, // Tags
+        ->prototypesGet(PrototypeTags, // Tags
             std::nullopt, // ExcludedTags
             std::nullopt, // TagsAll
             PrototypeIds, // Ids
@@ -768,7 +767,7 @@ void AssetSystem::UpdateAssetCollectionMetadata(const AssetCollection& AssetColl
     services::ResponseHandlerPtr ResponseHandler
         = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(Callback, nullptr);
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdPut(AssetCollection.Id, PrototypeInfo, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdPut(AssetCollection.Id, PrototypeInfo, ResponseHandler);
 }
 
 async::task<AssetCollectionResult> AssetSystem::UpdateAssetCollectionMetadata(const AssetCollection& AssetCollection,
@@ -785,7 +784,7 @@ async::task<AssetCollectionResult> AssetSystem::UpdateAssetCollectionMetadata(co
         = PrototypeAPI->CreateHandler<AssetCollectionResultCallback, AssetCollectionResult, void, chs::PrototypeDto>(
             [](const AssetCollectionResult&) {}, nullptr, web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
 
-    static_cast<chs::PrototypeApi*>(PrototypeAPI)->apiV1PrototypesIdPut(AssetCollection.Id, PrototypeInfo, ResponseHandler);
+    static_cast<chs::PrototypeApi*>(PrototypeAPI)->prototypesIdPut(AssetCollection.Id, PrototypeInfo, ResponseHandler);
 
     return OnCompleteTask;
 }
@@ -820,7 +819,7 @@ void AssetSystem::GetAssetCollectionCount(const csp::common::Optional<csp::commo
         csp::systems::AssetCollectionCountResult, void, services::DtoArray<chs::PrototypeDto>>(Callback, nullptr);
 
     static_cast<chs::PrototypeApi*>(PrototypeAPI)
-        ->apiV1PrototypesCountGet(PrototypeTags, // Tags
+        ->prototypesCountGet(PrototypeTags, // Tags
             std::nullopt, // ExcludedTags
             std::nullopt, // TagsAll
             PrototypeIds, // Ids
@@ -884,7 +883,7 @@ void AssetSystem::CreateAsset(const AssetCollection& AssetCollection, const Stri
     services::ResponseHandlerPtr ResponseHandler = AssetDetailAPI->CreateHandler<AssetResultCallback, AssetResult, void, chs::AssetDetailDto>(
         Callback, nullptr, web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::AssetDetailApi*>(AssetDetailAPI)->apiV1PrototypesPrototypeIdAssetDetailsPost(AssetCollection.Id, AssetInfo, ResponseHandler);
+    static_cast<chs::AssetDetailApi*>(AssetDetailAPI)->prototypesPrototypeIdAssetDetailsPost(AssetCollection.Id, AssetInfo, ResponseHandler);
 }
 
 async::task<AssetResult> AssetSystem::CreateAsset(const AssetCollection& AssetCollection, const csp::common::String& Name,
@@ -934,7 +933,7 @@ async::task<AssetResult> AssetSystem::CreateAsset(const AssetCollection& AssetCo
     services::ResponseHandlerPtr ResponseHandler = AssetDetailAPI->CreateHandler<AssetResultCallback, AssetResult, void, chs::AssetDetailDto>(
         [](const AssetResult&) {}, nullptr, web::EResponseCodes::ResponseCreated, std::move(OnCompleteEvent));
 
-    static_cast<chs::AssetDetailApi*>(AssetDetailAPI)->apiV1PrototypesPrototypeIdAssetDetailsPost(AssetCollection.Id, AssetInfo, ResponseHandler);
+    static_cast<chs::AssetDetailApi*>(AssetDetailAPI)->prototypesPrototypeIdAssetDetailsPost(AssetCollection.Id, AssetInfo, ResponseHandler);
 
     return OnCompleteTask;
 }
@@ -965,7 +964,7 @@ void AssetSystem::UpdateAsset(const Asset& Asset, AssetResultCallback Callback)
     services::ResponseHandlerPtr ResponseHandler = AssetDetailAPI->CreateHandler<AssetResultCallback, AssetResult, void, chs::AssetDetailDto>(
         Callback, nullptr, web::EResponseCodes::ResponseCreated);
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdPut(Asset.AssetCollectionId, Asset.Id, AssetInfo, ResponseHandler);
+        ->prototypesPrototypeIdAssetDetailsAssetDetailIdPut(Asset.AssetCollectionId, Asset.Id, AssetInfo, ResponseHandler);
 }
 
 void AssetSystem::DeleteAsset(const AssetCollection& AssetCollection, const Asset& Asset, NullResultCallback Callback)
@@ -998,7 +997,7 @@ void AssetSystem::GetAssetsInCollection(const AssetCollection& AssetCollection, 
         = AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
 
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesAssetDetailsGet(std::nullopt, // Ids
+        ->prototypesAssetDetailsGet(std::nullopt, // Ids
             std::nullopt, // SupportedPlatforms
             std::nullopt, // AssetTypes
             std::nullopt, // Styles
@@ -1018,8 +1017,7 @@ void AssetSystem::GetAssetById(const String& AssetCollectionId, const String& As
     services::ResponseHandlerPtr ResponseHandler
         = AssetDetailAPI->CreateHandler<AssetResultCallback, AssetResult, void, chs::AssetDetailDto>(Callback, nullptr);
 
-    static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdGet(AssetCollectionId, AssetId, ResponseHandler);
+    static_cast<chs::AssetDetailApi*>(AssetDetailAPI)->prototypesPrototypeIdAssetDetailsAssetDetailIdGet(AssetCollectionId, AssetId, ResponseHandler);
 }
 
 void AssetSystem::GetAssetsByCriteria(const Array<String>& AssetCollectionIds, const Optional<Array<String>>& AssetIds,
@@ -1085,7 +1083,7 @@ void AssetSystem::GetAssetsByCriteria(const Array<String>& AssetCollectionIds, c
         = AssetDetailAPI->CreateHandler<AssetsResultCallback, AssetsResult, void, services::DtoArray<chs::AssetDetailDto>>(Callback, nullptr);
 
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesAssetDetailsGet(AssetDetailIds, // Ids
+        ->prototypesAssetDetailsGet(AssetDetailIds, // Ids
             std::nullopt, // SupportedPlatforms
             AssetDetailTypes, // AssetTypes
             std::nullopt, // Styles
@@ -1168,7 +1166,7 @@ async::task<AssetsResult> AssetSystem::GetAssetsByCriteria(const csp::common::Ar
             [](const AssetsResult&) {}, nullptr, web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
 
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesAssetDetailsGet(AssetDetailIds, // Ids
+        ->prototypesAssetDetailsGet(AssetDetailIds, // Ids
             std::nullopt, // SupportedPlatforms
             AssetDetailTypes, // AssetTypes
             std::nullopt, // Styles
@@ -1208,7 +1206,7 @@ void AssetSystem::GetAssetsByCollectionIds(const Array<String>& AssetCollectionI
 
     // Use `GET /api/v1/prototypes/asset-details` and only pass asset collection IDs
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesAssetDetailsGet(std::nullopt, // Ids
+        ->prototypesAssetDetailsGet(std::nullopt, // Ids
             std::nullopt, // SupportedPlatforms
             std::nullopt, // AssetTypes
             std::nullopt, // Styles
@@ -1256,7 +1254,7 @@ void AssetSystem::UploadAssetDataEx(const AssetCollection& AssetCollection, cons
         InternalCallback, nullptr, web::EResponseCodes::ResponseOK);
 
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdBlobPost(
+        ->prototypesPrototypeIdAssetDetailsAssetDetailIdBlobPost(
             AssetCollection.Id, Asset.Id, std::nullopt, FormFile, ResponseHandler, CancellationToken);
 }
 
@@ -1281,7 +1279,7 @@ async::task<UriResult> AssetSystem::UploadAssetDataEx(const AssetCollection& Ass
         [](const UriResult&) {}, nullptr, web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
 
     static_cast<chs::AssetDetailApi*>(AssetDetailAPI)
-        ->apiV1PrototypesPrototypeIdAssetDetailsAssetDetailIdBlobPost(
+        ->prototypesPrototypeIdAssetDetailsAssetDetailIdBlobPost(
             AssetCollection.Id, Asset.Id, std::nullopt, FormFile, ResponseHandler, CancellationToken);
 
     return OnCompleteTask;

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -73,7 +73,7 @@ void ECommerceSystem::GetProductInformation(const common::String& SpaceId, const
         = ShopifyAPI->CreateHandler<ProductInfoResultCallback, ProductInfoResult, void, chs::ShopifyProductDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyProductsProductIdGet(SpaceId, ProductId, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->spacesSpaceIdVendorsShopifyProductsProductIdGet(SpaceId, ProductId, ResponseHandler);
 }
 
 void ECommerceSystem::GetProductInfoCollectionByVariantIds(
@@ -84,7 +84,7 @@ void ECommerceSystem::GetProductInfoCollectionByVariantIds(
 
     const std::vector<common::String> VariantIds = common::Convert(InVariantIds);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyProductsVariantsGet(SpaceId, VariantIds, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->spacesSpaceIdVendorsShopifyProductsVariantsGet(SpaceId, VariantIds, ResponseHandler);
 }
 
 void ECommerceSystem::GetCheckoutInformation(const common::String& SpaceId, const common::String& CartId, CheckoutInfoResultCallback Callback)
@@ -103,7 +103,7 @@ void ECommerceSystem::GetCheckoutInformation(const common::String& SpaceId, cons
         = ShopifyAPI->CreateHandler<CheckoutInfoResultCallback, CheckoutInfoResult, void, chs::ShopifyCheckoutDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyCartsCartIdCheckoutInfoGet(SpaceId, CartId, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->spacesSpaceIdVendorsShopifyCartsCartIdCheckoutInfoGet(SpaceId, CartId, ResponseHandler);
 }
 
 void ECommerceSystem::CreateCart(const common::String& SpaceId, CartInfoResultCallback Callback)
@@ -111,7 +111,7 @@ void ECommerceSystem::CreateCart(const common::String& SpaceId, CartInfoResultCa
     csp::services::ResponseHandlerPtr ResponseHandler = ShopifyAPI->CreateHandler<CartInfoResultCallback, CartInfoResult, void, chs::ShopifyCartDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyCartsPost(SpaceId, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->spacesSpaceIdVendorsShopifyCartsPost(SpaceId, ResponseHandler);
 }
 
 void ECommerceSystem::GetCart(const common::String& SpaceId, const common::String& CartId, CartInfoResultCallback Callback)
@@ -119,7 +119,7 @@ void ECommerceSystem::GetCart(const common::String& SpaceId, const common::Strin
     csp::services::ResponseHandlerPtr ResponseHandler = ShopifyAPI->CreateHandler<CartInfoResultCallback, CartInfoResult, void, chs::ShopifyCartDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyCartsCartIdGet(SpaceId, CartId, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->spacesSpaceIdVendorsShopifyCartsCartIdGet(SpaceId, CartId, ResponseHandler);
 }
 
 void ECommerceSystem::GetShopifyStores(const csp::common::Optional<bool>& IsActive, GetShopifyStoresResultCallback Callback)
@@ -141,7 +141,7 @@ void ECommerceSystem::GetShopifyStores(const csp::common::Optional<bool>& IsActi
     const auto& UserId = UserSystem->GetLoginState().UserId;
 
     static_cast<chs::ShopifyApi*>(ShopifyAPI)
-        ->apiV1VendorsShopifyUsersUserIdStorefrontsGet(UserId, ActiveParam, std::nullopt, std::nullopt, ResponseHandler);
+        ->vendorsShopifyUsersUserIdStorefrontsGet(UserId, ActiveParam, std::nullopt, std::nullopt, ResponseHandler);
 }
 
 void ECommerceSystem::AddShopifyStore(const common::String& StoreName, const common::String& SpaceId, const bool IsEcommerceActive,
@@ -156,7 +156,7 @@ void ECommerceSystem::AddShopifyStore(const common::String& StoreName, const com
         = ShopifyAPI->CreateHandler<AddShopifyStoreResultCallback, AddShopifyStoreResult, void, chs::ShopifyStorefrontDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyPut(SpaceId, ShopifyStorefrontInfo, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->spacesSpaceIdVendorsShopifyPut(SpaceId, ShopifyStorefrontInfo, ResponseHandler);
 }
 
 void ECommerceSystem::SetECommerceActiveInSpace(
@@ -170,7 +170,7 @@ void ECommerceSystem::SetECommerceActiveInSpace(
         = ShopifyAPI->CreateHandler<SetECommerceActiveResultCallback, AddShopifyStoreResult, void, chs::ShopifyStorefrontDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1SpacesSpaceIdVendorsShopifyPut(SpaceId, ShopifyStorefrontInfo, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->spacesSpaceIdVendorsShopifyPut(SpaceId, ShopifyStorefrontInfo, ResponseHandler);
 }
 
 void ECommerceSystem::ValidateShopifyStore(
@@ -184,7 +184,7 @@ void ECommerceSystem::ValidateShopifyStore(
         = ShopifyAPI->CreateHandler<ValidateShopifyStoreResultCallback, ValidateShopifyStoreResult, void, chs::ShopifyStorefrontValidationRequest>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::ShopifyApi*>(ShopifyAPI)->apiV1VendorsShopifyValidatePut(ShopifyStorefrontValidationInfo, ResponseHandler);
+    static_cast<chs::ShopifyApi*>(ShopifyAPI)->vendorsShopifyValidatePut(ShopifyStorefrontValidationInfo, ResponseHandler);
 }
 
 void ECommerceSystem::UpdateCartInformation(const CartInfo& CartInformation, CartInfoResultCallback Callback)
@@ -253,7 +253,7 @@ void ECommerceSystem::UpdateCartInformation(const CartInfo& CartInformation, Car
     csp::services::ResponseHandlerPtr ResponseHandler = ShopifyAPI->CreateHandler<CartInfoResultCallback, CartInfoResult, void, chs::ShopifyCartDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
     static_cast<chs::ShopifyApi*>(ShopifyAPI)
-        ->apiV1SpacesSpaceIdVendorsShopifyCartsCartIdPut(CartInformation.SpaceId, CartInformation.CartId, CartUpdateInfo, ResponseHandler);
+        ->spacesSpaceIdVendorsShopifyCartsCartIdPut(CartInformation.SpaceId, CartInformation.CartId, CartUpdateInfo, ResponseHandler);
 }
 
 } // namespace csp::systems

--- a/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
+++ b/Library/src/Systems/EventTicketing/EventTicketingSystem.cpp
@@ -58,7 +58,7 @@ void EventTicketingSystem::CreateTicketedEvent(const csp::common::String& SpaceI
         = EventTicketingAPI->CreateHandler<TicketedEventResultCallback, TicketedEventResult, void, chs::SpaceEventDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->apiV1SpacesSpaceIdEventsPost(SpaceId, Request, ResponseHandler);
+    static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->spacesSpaceIdEventsPost(SpaceId, Request, ResponseHandler);
 }
 
 void EventTicketingSystem::UpdateTicketedEvent(const csp::common::String& SpaceId, const csp::common::String& EventId,
@@ -92,7 +92,7 @@ void EventTicketingSystem::UpdateTicketedEvent(const csp::common::String& SpaceI
         = EventTicketingAPI->CreateHandler<TicketedEventResultCallback, TicketedEventResult, void, chs::SpaceEventDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->apiV1SpacesSpaceIdEventsEventIdPut(SpaceId, EventId, Request, ResponseHandler);
+    static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->spacesSpaceIdEventsEventIdPut(SpaceId, EventId, Request, ResponseHandler);
 }
 
 void EventTicketingSystem::GetTicketedEvents(const csp::common::Array<csp::common::String>& SpaceIds, const csp::common::Optional<int>& Skip,
@@ -114,7 +114,7 @@ void EventTicketingSystem::GetTicketedEvents(const csp::common::Array<csp::commo
     const auto RequestLimit = Limit.HasValue() ? *Limit : std::optional<int>(std::nullopt);
 
     static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)
-        ->apiV1SpacesEventsGet(std::nullopt, // VendorEventIds
+        ->spacesEventsGet(std::nullopt, // VendorEventIds
             std::nullopt, // VendorName
             RequestSpaceIds, // SpaceIds
             std::nullopt, // UserIds
@@ -139,7 +139,7 @@ void EventTicketingSystem::SubmitEventTicket(const csp::common::String& SpaceId,
     }
 
     static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)
-        ->apiV1SpacesSpaceIdVendorsVendorNameEventsVendorEventIdTicketsVendorTicketIdPut(
+        ->spacesSpaceIdVendorsVendorNameEventsVendorEventIdTicketsVendorTicketIdPut(
             SpaceId, GetVendorNameString(Vendor), VendorEventId, VendorTicketId, RequestOnBehalfOfUserId, ResponseHandler);
 }
 
@@ -150,7 +150,7 @@ void EventTicketingSystem::GetVendorAuthorizeInfo(
         TicketedEventVendorAuthInfoResult, void, chs::VendorProviderInfo>(Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
     static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)
-        ->apiV1VendorsVendorNameUsersUserIdProviderInfoGet(GetVendorNameString(Vendor), UserId, std::nullopt, ResponseHandler);
+        ->vendorsVendorNameUsersUserIdProviderInfoGet(GetVendorNameString(Vendor), UserId, std::nullopt, ResponseHandler);
 }
 
 void EventTicketingSystem::GetIsSpaceTicketed(const csp::common::String& SpaceId, SpaceIsTicketedResultCallback Callback)
@@ -163,7 +163,7 @@ void EventTicketingSystem::GetIsSpaceTicketed(const csp::common::String& SpaceId
     std::vector<csp::common::String> RequestSpaceId;
     RequestSpaceId.push_back(SpaceId);
 
-    static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->apiV1SpacesTicketedGet(RequestSpaceId, ResponseHandler);
+    static_cast<chs::TicketedSpaceApi*>(EventTicketingAPI)->spacesTicketedGet(RequestSpaceId, ResponseHandler);
 }
 
 } // namespace csp::systems

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -54,8 +54,7 @@ void QuotaSystem::GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback)
         csp::services::DtoArray<chs::QuotaFeatureLimitProgressDto>>(Callback, nullptr);
 
     static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)
-        ->apiV1UsersUserIdQuotaProgressGet(
-            csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, FeatureNamesList, ResponseHandler);
+        ->usersUserIdQuotaProgressGet(csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, FeatureNamesList, ResponseHandler);
 }
 
 void QuotaSystem::GetConcurrentUsersInSpace(const csp::common::String& SpaceId, FeatureLimitCallback Callback)
@@ -65,7 +64,7 @@ void QuotaSystem::GetConcurrentUsersInSpace(const csp::common::String& SpaceId, 
     csp::services::ResponseHandlerPtr ResponseHandler = QuotaManagementAPI->CreateHandler<FeatureLimitCallback, FeatureLimitResult, void,
         csp::services::DtoArray<chs::QuotaFeatureLimitProgressDto>>(Callback, nullptr);
 
-    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->apiV1GroupsGroupIdQuotaProgressGet(SpaceId.c_str(), FeatureNamesList, ResponseHandler);
+    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->groupsGroupIdQuotaProgressGet(SpaceId.c_str(), FeatureNamesList, ResponseHandler);
 }
 
 void QuotaSystem::GetTotalSpaceSizeInKilobytes(const csp::common::String& SpaceId, FeatureLimitCallback Callback)
@@ -75,7 +74,7 @@ void QuotaSystem::GetTotalSpaceSizeInKilobytes(const csp::common::String& SpaceI
     csp::services::ResponseHandlerPtr ResponseHandler = QuotaManagementAPI->CreateHandler<FeatureLimitCallback, FeatureLimitResult, void,
         csp::services::DtoArray<chs::QuotaFeatureLimitProgressDto>>(Callback, nullptr);
 
-    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->apiV1GroupsGroupIdQuotaProgressGet(SpaceId, FeatureNamesList, ResponseHandler);
+    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->groupsGroupIdQuotaProgressGet(SpaceId, FeatureNamesList, ResponseHandler);
 }
 
 void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFeatures>& FeatureNames, FeaturesLimitCallback Callback)
@@ -92,8 +91,7 @@ void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFea
     }
 
     static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)
-        ->apiV1UsersUserIdQuotaProgressGet(
-            csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, FeatureNamesList, ResponseHandler);
+        ->usersUserIdQuotaProgressGet(csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, FeatureNamesList, ResponseHandler);
 }
 
 void QuotaSystem::GetTierFeatureProgressForSpace(
@@ -110,7 +108,7 @@ void QuotaSystem::GetTierFeatureProgressForSpace(
         FeatureNamesList.push_back(TierFeatureEnumToString(FeatureNames[idx]));
     }
 
-    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->apiV1GroupsGroupIdQuotaProgressGet(SpaceId, FeatureNamesList, ResponseHandler);
+    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->groupsGroupIdQuotaProgressGet(SpaceId, FeatureNamesList, ResponseHandler);
 }
 
 void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
@@ -119,7 +117,7 @@ void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
         = QuotaTierAssignmentAPI->CreateHandler<UserTierCallback, UserTierResult, void, chs::QuotaTierAssignmentDto>(Callback, nullptr);
 
     static_cast<chs::QuotaTierAssignmentApi*>(QuotaTierAssignmentAPI)
-        ->apiV1UsersUserIdTierAssignmentGet(csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, ResponseHandler);
+        ->usersUserIdTierAssignmentGet(csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, ResponseHandler);
 }
 
 void QuotaSystem::GetTierFeatureQuota(TierNames TierName, TierFeatures FeatureName, FeatureQuotaCallback Callback)
@@ -128,7 +126,7 @@ void QuotaSystem::GetTierFeatureQuota(TierNames TierName, TierFeatures FeatureNa
         = QuotaManagementAPI->CreateHandler<FeatureQuotaCallback, FeatureQuotaResult, void, chs::QuotaFeatureTierDto>(Callback, nullptr);
 
     static_cast<chs::QuotaManagementApi*>(QuotaManagementAPI)
-        ->apiV1TiersTierNameFeaturesFeatureNameQuotaGet(TierNameEnumToString(TierName), TierFeatureEnumToString(FeatureName), ResponseHandler);
+        ->tiersTierNameFeaturesFeatureNameQuotaGet(TierNameEnumToString(TierName), TierFeatureEnumToString(FeatureName), ResponseHandler);
 }
 
 void QuotaSystem::GetTierFeaturesQuota(TierNames TierName, FeaturesQuotaCallback Callback)
@@ -137,6 +135,6 @@ void QuotaSystem::GetTierFeaturesQuota(TierNames TierName, FeaturesQuotaCallback
         = QuotaManagementAPI->CreateHandler<FeaturesQuotaCallback, FeaturesQuotaResult, void, csp::services::DtoArray<chs::QuotaFeatureTierDto>>(
             Callback, nullptr);
 
-    static_cast<chs::QuotaManagementApi*>(QuotaManagementAPI)->apiV1TiersTierNameQuotasGet(TierNameEnumToString(TierName), ResponseHandler);
+    static_cast<chs::QuotaManagementApi*>(QuotaManagementAPI)->tiersTierNameQuotasGet(TierNameEnumToString(TierName), ResponseHandler);
 }
 } // namespace csp::systems

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -83,7 +83,7 @@ void SequenceSystem::CreateSequence(const String& SequenceKey, const String& Ref
         = SequenceAPI->CreateHandler<SequenceResultCallback, SequenceResult, void, chs::SequenceDto>(Callback, nullptr);
 
     static_cast<chs::SequenceApi*>(SequenceAPI)
-        ->apiV1SequencesPut(std::nullopt, // NewKey
+        ->sequencesPut(std::nullopt, // NewKey
             SequenceInfo, // Dto
             ResponseHandler, // ResponseHandler
             CancellationToken::Dummy() // CancellationToken
@@ -107,7 +107,7 @@ void SequenceSystem::UpdateSequence(const String& SequenceKey, const String& Ref
         = SequenceAPI->CreateHandler<SequenceResultCallback, SequenceResult, void, chs::SequenceDto>(Callback, nullptr);
 
     static_cast<chs::SequenceApi*>(SequenceAPI)
-        ->apiV1SequencesPut(csp::common::Encode::URI(SequenceKey), // NewKey
+        ->sequencesPut(csp::common::Encode::URI(SequenceKey), // NewKey
             SequenceInfo, // Dto
             ResponseHandler, // ResponseHandler
             CancellationToken::Dummy() // CancellationToken
@@ -146,7 +146,7 @@ void SequenceSystem::RenameSequence(const String& OldSequenceKey, const String& 
         const auto SequenceInfo = CreateSequenceDto(Sequence.Key, Sequence.ReferenceType, Sequence.ReferenceId, Sequence.Items, Sequence.MetaData);
 
         static_cast<chs::SequenceApi*>(SequenceAPI)
-            ->apiV1SequencesPut(csp::common::Encode::URI(NewSequenceKey), // NewKey
+            ->sequencesPut(csp::common::Encode::URI(NewSequenceKey), // NewKey
                 SequenceInfo, // Dto
                 ResponseHandler, // ResponseHandler
                 CancellationToken::Dummy() // CancellationToken
@@ -198,7 +198,7 @@ void SequenceSystem::GetSequencesByCriteria(const Array<String>& InSequenceKeys,
         = SequenceAPI->CreateHandler<SequencesResultCallback, SequencesResult, void, csp::services::DtoArray<chs::SequenceDto>>(Callback, nullptr);
 
     static_cast<chs::SequenceApi*>(SequenceAPI)
-        ->apiV1SequencesGet(SequenceKeys, // Keys
+        ->sequencesGet(SequenceKeys, // Keys
             KeyRegex, // Regex
             ReferenceType, // ReferenceType
             ReferenceIds, // ReferenceIds
@@ -222,7 +222,7 @@ void SequenceSystem::GetAllSequencesContainingItems(
         = SequenceAPI->CreateHandler<SequencesResultCallback, SequencesResult, void, csp::services::DtoArray<chs::SequenceDto>>(Callback, nullptr);
 
     static_cast<chs::SequenceApi*>(SequenceAPI)
-        ->apiV1SequencesGet(std::nullopt, // Keys
+        ->sequencesGet(std::nullopt, // Keys
             std::nullopt, // Regex
             ReferenceType, // ReferenceType
             ReferenceIds, // ReferenceIds
@@ -248,7 +248,7 @@ void SequenceSystem::GetSequence(const String& SequenceKey, SequenceResultCallba
         = SequenceAPI->CreateHandler<SequenceResultCallback, SequenceResult, void, chs::SequenceDto>(Callback, nullptr);
 
     static_cast<chs::SequenceApi*>(SequenceAPI)
-        ->apiV1SequencesKeysKeyGet(csp::common::Encode::URI(SequenceKey, true), // Key
+        ->sequencesKeysKeyGet(csp::common::Encode::URI(SequenceKey, true), // Key
             ResponseHandler, // ResponseHandler
             CancellationToken::Dummy() // CancellationToken
         );
@@ -276,7 +276,7 @@ void SequenceSystem::DeleteSequences(const Array<String>& InSequenceKeys, NullRe
 
     std::vector<String> SequenceKeys = Convert(EncodedSequenceKeys);
     static_cast<chs::SequenceApi*>(SequenceAPI)
-        ->apiV1SequencesKeysDelete(SequenceKeys, // Keys
+        ->sequencesKeysDelete(SequenceKeys, // Keys
             ResponseHandler, // ResponseHandler
             CancellationToken::Dummy() // CancellationToken)
         );

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -85,7 +85,7 @@ void SettingsSystem::SetSettingValue(const String& InContext, const String& InKe
         = SettingsAPI->CreateHandler<SettingsResultCallback, SettingsCollectionResult, void, chs::SettingsDto>(
             InternalCallback, nullptr, web::EResponseCodes::ResponseOK);
 
-    static_cast<chs::SettingsApi*>(SettingsAPI)->apiV1UsersUserIdSettingsContextPut(UserId, InContext, InSettings, SettingsResponseHandler);
+    static_cast<chs::SettingsApi*>(SettingsAPI)->usersUserIdSettingsContextPut(UserId, InContext, InSettings, SettingsResponseHandler);
 }
 
 void SettingsSystem::GetSettingValue(const String& InContext, const String& InKey, StringResultCallback Callback) const
@@ -133,7 +133,7 @@ void SettingsSystem::GetSettingValue(const String& InContext, const String& InKe
         = SettingsAPI->CreateHandler<SettingsResultCallback, SettingsCollectionResult, void, chs::SettingsDto>(
             InternalCallback, nullptr, web::EResponseCodes::ResponseOK);
 
-    static_cast<chs::SettingsApi*>(SettingsAPI)->apiV1UsersUserIdSettingsContextGet(UserId, InContext, MyKey, SettingsResponseHandler);
+    static_cast<chs::SettingsApi*>(SettingsAPI)->usersUserIdSettingsContextGet(UserId, InContext, MyKey, SettingsResponseHandler);
 }
 
 void SettingsSystem::SetNDAStatus(bool InValue, NullResultCallback Callback)

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -100,7 +100,7 @@ async::task<SpaceResult> SpaceSystem::CreateSpaceGroupInfo(
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(
         [](const SpaceResult&) {}, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(*OnCompleteEvent.get()));
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsPost(GroupInfo, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsPost(GroupInfo, ResponseHandler);
 
     return OnCompleteTask;
 }
@@ -578,7 +578,7 @@ void SpaceSystem::UpdateSpace(const String& SpaceId, const Optional<String>& Nam
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<BasicSpaceResultCallback, BasicSpaceResult, void, chs::GroupLiteDto>(Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdLitePut(SpaceId, LiteGroupInfo, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdLitePut(SpaceId, LiteGroupInfo, ResponseHandler);
 }
 
 void SpaceSystem::DeleteSpace(const csp::common::String& SpaceId, NullResultCallback Callback)
@@ -588,7 +588,7 @@ void SpaceSystem::DeleteSpace(const csp::common::String& SpaceId, NullResultCall
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chsaggregation::SpaceApi*>(SpaceAPI)->apiV1SpacesSpaceIdDelete(SpaceId, ResponseHandler);
+    static_cast<chsaggregation::SpaceApi*>(SpaceAPI)->spacesSpaceIdDelete(SpaceId, ResponseHandler);
 }
 
 void SpaceSystem::GetSpaces(SpacesResultCallback Callback)
@@ -599,7 +599,7 @@ void SpaceSystem::GetSpaces(SpacesResultCallback Callback)
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<SpacesResultCallback, SpacesResult, void, csp::services::DtoArray<chs::GroupDto>>(Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1UsersUserIdGroupsGet(InUserId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->usersUserIdGroupsGet(InUserId, ResponseHandler);
 }
 
 void SpaceSystem::GetSpacesByAttributes(const Optional<bool>& InIsDiscoverable, const Optional<bool>& InIsArchived,
@@ -628,7 +628,7 @@ void SpaceSystem::GetSpacesByAttributes(const Optional<bool>& InIsDiscoverable, 
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<BasicSpacesResultCallback, BasicSpacesResult, void, csp::services::DtoArray<chs::GroupLiteDto>>(Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsLiteGet(std::nullopt, // Ids
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsLiteGet(std::nullopt, // Ids
         std::nullopt, // GroupTypes
         std::nullopt, // Names
         std::nullopt, // PartialName
@@ -671,7 +671,7 @@ void SpaceSystem::GetSpacesByIds(const Array<String>& RequestedSpaceIDs, SpacesR
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<SpacesResultCallback, SpacesResult, void, csp::services::DtoArray<chs::GroupDto>>(Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGet(SpaceIds, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGet(SpaceIds, ResponseHandler);
 }
 
 void SpaceSystem::GetSpacesForUserId(const String& UserId, SpacesResultCallback Callback)
@@ -681,7 +681,7 @@ void SpaceSystem::GetSpacesForUserId(const String& UserId, SpacesResultCallback 
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<SpacesResultCallback, SpacesResult, void, csp::services::DtoArray<chs::GroupDto>>(Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1UsersUserIdGroupsGet(UserId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->usersUserIdGroupsGet(UserId, ResponseHandler);
 }
 
 void SpaceSystem::GetSpace(const String& SpaceId, SpaceResultCallback Callback)
@@ -696,7 +696,7 @@ void SpaceSystem::GetSpace(const String& SpaceId, SpaceResultCallback Callback)
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(Callback, nullptr, csp::web::EResponseCodes::ResponseOK);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdGet(SpaceId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdGet(SpaceId, ResponseHandler);
 }
 
 async::task<SpaceResult> SpaceSystem::GetSpace(const String& SpaceId)
@@ -714,7 +714,7 @@ async::task<SpaceResult> SpaceSystem::GetSpace(const String& SpaceId)
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(
         [](const SpaceResult&) {}, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdGet(SpaceId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdGet(SpaceId, ResponseHandler);
 
     return OnCompleteTask;
 }
@@ -736,7 +736,7 @@ void SpaceSystem::InviteToSpace(const csp::common::String& SpaceId, const String
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdEmailInvitesPost(
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdEmailInvitesPost(
         SpaceId, std::nullopt, EmailLinkUrlParam, SignupUrlParam, GroupInviteInfo, ResponseHandler);
 }
 
@@ -751,7 +751,7 @@ void SpaceSystem::BulkInviteToSpace(const String& SpaceId, const InviteUserRoleI
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdEmailInvitesBulkPost(
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdEmailInvitesBulkPost(
         SpaceId, std::nullopt, EmailLinkUrlParam, SignupUrlParam, GroupInvites, ResponseHandler);
 }
 
@@ -769,7 +769,7 @@ async::task<NullResult> SpaceSystem::BulkInviteToSpace(const csp::common::String
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         [](const NullResult&) {}, nullptr, csp::web::EResponseCodes::ResponseNoContent, std::move(OnCompleteEvent));
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdEmailInvitesBulkPost(
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdEmailInvitesBulkPost(
         SpaceId, std::nullopt, EmailLinkUrlParam, SignupUrlParam, GroupInvites, ResponseHandler);
 
     return OnCompleteTask;
@@ -781,7 +781,7 @@ void SpaceSystem::GetPendingUserInvites(const String& SpaceId, PendingInvitesRes
         = GroupAPI->CreateHandler<PendingInvitesResultCallback, PendingInvitesResult, void, csp::services::DtoArray<chs::GroupInviteDto>>(
             Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdEmailInvitesGet(SpaceId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdEmailInvitesGet(SpaceId, ResponseHandler);
 }
 
 void SpaceSystem::GetAcceptedUserInvites(const String& SpaceId, AcceptedInvitesResultCallback Callback)
@@ -790,7 +790,7 @@ void SpaceSystem::GetAcceptedUserInvites(const String& SpaceId, AcceptedInvitesR
         = GroupAPI->CreateHandler<AcceptedInvitesResultCallback, AcceptedInvitesResult, void, csp::services::DtoArray<chs::GroupInviteDto>>(
             Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdEmailInvitesAcceptedGet(SpaceId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdEmailInvitesAcceptedGet(SpaceId, ResponseHandler);
 }
 
 void SpaceSystem::AddUserToSpace(const csp::common::String& SpaceId, const String& UserId, SpaceResultCallback Callback)
@@ -820,7 +820,7 @@ void SpaceSystem::AddUserToSpace(const csp::common::String& SpaceId, const Strin
             csp::services::ResponseHandlerPtr ResponseHandler
                 = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(Callback, nullptr);
 
-            static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupCodesGroupCodeUsersUserIdPut(SpaceCode, UserId, ResponseHandler);
+            static_cast<chs::GroupApi*>(GroupAPI)->groupCodesGroupCodeUsersUserIdPut(SpaceCode, UserId, ResponseHandler);
         });
 }
 
@@ -845,7 +845,7 @@ async::task<SpaceResult> SpaceSystem::AddUserToSpace(const csp::common::String& 
             csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(
                 [](const SpaceResult&) {}, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(*OnCompleteEvent.get()));
 
-            static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupCodesGroupCodeUsersUserIdPut(SpaceCode, UserId, ResponseHandler);
+            static_cast<chs::GroupApi*>(GroupAPI)->groupCodesGroupCodeUsersUserIdPut(SpaceCode, UserId, ResponseHandler);
         });
 
     return OnCompleteTask;
@@ -856,7 +856,7 @@ void SpaceSystem::RemoveUserFromSpace(const String& SpaceId, const String& UserI
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdUsersUserIdDelete(SpaceId, UserId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdUsersUserIdDelete(SpaceId, UserId, ResponseHandler);
 }
 
 void SpaceSystem::AddSiteInfo(const String& SpaceId, Site& SiteInfo, SiteResultCallback Callback)
@@ -895,14 +895,14 @@ void SpaceSystem::UpdateUserRole(const String& SpaceId, const UserRoleInfo& NewU
         csp::services::ResponseHandlerPtr ResponseHandler
             = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback, nullptr);
 
-        static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdOwnerNewGroupOwnerIdPut(SpaceId, UserId, ResponseHandler);
+        static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdOwnerNewGroupOwnerIdPut(SpaceId, UserId, ResponseHandler);
     }
     else if (NewUserRole == SpaceUserRole::Moderator)
     {
         csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-        static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdModeratorsUserIdPut(SpaceId, UserId, ResponseHandler);
+        static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdModeratorsUserIdPut(SpaceId, UserId, ResponseHandler);
     }
     else if (NewUserRole == SpaceUserRole::User)
     {
@@ -919,7 +919,7 @@ void SpaceSystem::UpdateUserRole(const String& SpaceId, const UserRoleInfo& NewU
         csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-        static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdModeratorsUserIdDelete(SpaceId, UserId, ResponseHandler);
+        static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdModeratorsUserIdDelete(SpaceId, UserId, ResponseHandler);
     }
     else
     {
@@ -1248,14 +1248,14 @@ void SpaceSystem::AddUserToSpaceBanList(const String& SpaceId, const String& Req
 {
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback, nullptr);
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdBannedUsersUserIdPut(SpaceId, RequestedUserId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdBannedUsersUserIdPut(SpaceId, RequestedUserId, ResponseHandler);
 }
 
 void SpaceSystem::DeleteUserFromSpaceBanList(const String& SpaceId, const String& RequestedUserId, NullResultCallback Callback)
 {
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback, nullptr);
-    static_cast<chs::GroupApi*>(GroupAPI)->apiV1GroupsGroupIdBannedUsersUserIdDelete(SpaceId, RequestedUserId, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdBannedUsersUserIdDelete(SpaceId, RequestedUserId, ResponseHandler);
 }
 
 void SpaceSystem::GetMetadataAssetCollection(const String& SpaceId, AssetCollectionResultCallback Callback)
@@ -1835,7 +1835,7 @@ void SpaceSystem::DuplicateSpace(const String& SpaceId, const String& NewName, S
     csp::services::ResponseHandlerPtr ResponseHandler
         = SpaceAPI->CreateHandler<csp::systems::SpaceResultCallback, csp::systems::SpaceResult, void, chs::GroupDto>(Callback, nullptr);
 
-    static_cast<chsaggregation::SpaceApi*>(SpaceAPI)->apiV1SpacesSpaceIdDuplicatePost(SpaceId, // spaceId
+    static_cast<chsaggregation::SpaceApi*>(SpaceAPI)->spacesSpaceIdDuplicatePost(SpaceId, // spaceId
         false, // asyncCall
         Request, // RequestBody
         ResponseHandler // ResponseHandler

--- a/Library/src/Systems/Spatial/AnchorSystem.cpp
+++ b/Library/src/Systems/Spatial/AnchorSystem.cpp
@@ -111,7 +111,7 @@ void AnchorSystem::CreateAnchor(csp::systems::AnchorProvider ThirdPartyAnchorPro
     csp::services::ResponseHandlerPtr ResponseHandler = AnchorsAPI->CreateHandler<AnchorResultCallback, AnchorResult, void, chs::AnchorDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::AnchorsApi*>(AnchorsAPI)->apiV1AnchorsPost(AnchorInfo, ResponseHandler);
+    static_cast<chs::AnchorsApi*>(AnchorsAPI)->anchorsPost(AnchorInfo, ResponseHandler);
 }
 
 void AnchorSystem::CreateAnchorInSpace(csp::systems::AnchorProvider ThirdPartyAnchorProvider, const csp::common::String& ThirdPartyAnchorId,
@@ -188,7 +188,7 @@ void AnchorSystem::CreateAnchorInSpace(csp::systems::AnchorProvider ThirdPartyAn
     csp::services::ResponseHandlerPtr ResponseHandler = AnchorsAPI->CreateHandler<AnchorResultCallback, AnchorResult, void, chs::AnchorDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::AnchorsApi*>(AnchorsAPI)->apiV1AnchorsPost(AnchorInfo, ResponseHandler);
+    static_cast<chs::AnchorsApi*>(AnchorsAPI)->anchorsPost(AnchorInfo, ResponseHandler);
 }
 
 void AnchorSystem::DeleteAnchors(const csp::common::Array<csp::common::String>& AnchorIds, NullResultCallback Callback)
@@ -204,7 +204,7 @@ void AnchorSystem::DeleteAnchors(const csp::common::Array<csp::common::String>& 
     csp::services::ResponseHandlerPtr ResponseHandler = AnchorsAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs::AnchorsApi*>(AnchorsAPI)->apiV1AnchorsDelete(IdsToBeDeleted, ResponseHandler);
+    static_cast<chs::AnchorsApi*>(AnchorsAPI)->anchorsDelete(IdsToBeDeleted, ResponseHandler);
 }
 
 void AnchorSystem::GetAnchorsInArea(const csp::systems::GeoLocation& OriginLocation, const double AreaRadius,
@@ -275,8 +275,8 @@ void AnchorSystem::GetAnchorsInArea(const csp::systems::GeoLocation& OriginLocat
     auto AnchorSkip = Skip.HasValue() ? *Skip : std::optional<int>(std::nullopt);
 
     static_cast<chs::AnchorsApi*>(AnchorsAPI)
-        ->apiV1AnchorsGet(AnchorSpatialKeys, AnchorSpatialValues, OriginLocation.Longitude, OriginLocation.Latitude, AreaRadius, AnchorTags,
-            AnchorTagsAll, std::nullopt, std::nullopt, ReferenceIds, std::nullopt, AnchorSkip, AnchorLimit, ResponseHandler,
+        ->anchorsGet(AnchorSpatialKeys, AnchorSpatialValues, OriginLocation.Longitude, OriginLocation.Latitude, AreaRadius, AnchorTags, AnchorTagsAll,
+            std::nullopt, std::nullopt, ReferenceIds, std::nullopt, AnchorSkip, AnchorLimit, ResponseHandler,
             csp::common::CancellationToken::Dummy());
 }
 
@@ -294,8 +294,8 @@ void AnchorSystem::GetAnchorsInSpace(const csp::common::String& SpaceId, const c
     auto AnchorSkip = Skip.HasValue() ? *Skip : std::optional<int>(std::nullopt);
 
     static_cast<chs::AnchorsApi*>(AnchorsAPI)
-        ->apiV1AnchorsGet(std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-            std::nullopt, ReferenceIds, std::nullopt, AnchorSkip, AnchorLimit, ResponseHandler, csp::common::CancellationToken::Dummy());
+        ->anchorsGet(std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+            ReferenceIds, std::nullopt, AnchorSkip, AnchorLimit, ResponseHandler, csp::common::CancellationToken::Dummy());
 }
 
 void AnchorSystem::GetAnchorsByAssetCollectionId(const csp::common::String& AssetCollectionId, const csp::common::Optional<int>& Skip,
@@ -312,8 +312,8 @@ void AnchorSystem::GetAnchorsByAssetCollectionId(const csp::common::String& Asse
     auto AnchorSkip = Skip.HasValue() ? *Skip : std::optional<int>(std::nullopt);
 
     static_cast<chs::AnchorsApi*>(AnchorsAPI)
-        ->apiV1AnchorsGet(std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-            std::nullopt, std::nullopt, AssetCollectionIds, AnchorSkip, AnchorLimit, ResponseHandler, csp::common::CancellationToken::Dummy());
+        ->anchorsGet(std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+            std::nullopt, AssetCollectionIds, AnchorSkip, AnchorLimit, ResponseHandler, csp::common::CancellationToken::Dummy());
 }
 
 void AnchorSystem::CreateAnchorResolution(const csp::common::String& AnchorId, bool SuccessfullyResolved, int ResolveAttempted, double ResolveTime,
@@ -330,7 +330,7 @@ void AnchorSystem::CreateAnchorResolution(const csp::common::String& AnchorId, b
     csp::services::ResponseHandlerPtr ResponseHandler = AnchorsAPI->CreateHandler<csp::systems::AnchorResolutionResultCallback,
         csp::systems::AnchorResolutionResult, void, chs::AnchorResolutionDto>(Callback, nullptr);
 
-    static_cast<chs::AnchorsApi*>(AnchorsAPI)->apiV1AnchorResolutionsPost(AnchorResolutionInfo, ResponseHandler);
+    static_cast<chs::AnchorsApi*>(AnchorsAPI)->anchorResolutionsPost(AnchorResolutionInfo, ResponseHandler);
 }
 
 } // namespace csp::systems

--- a/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
+++ b/Library/src/Systems/Spatial/PointOfInterestSystem.cpp
@@ -95,7 +95,7 @@ CSP_ASYNC_RESULT void PointOfInterestSystem::CreatePOI(const csp::common::String
     csp::services::ResponseHandlerPtr ResponseHandler = POIApiPtr->CreateHandler<POIResultCallback, POIResult, void, chs::PointOfInterestDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiPost(POIInfo, ResponseHandler);
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiPost(POIInfo, ResponseHandler);
 }
 
 void PointOfInterestSystem::DeletePOI(const PointOfInterest& POI, NullResultCallback Callback)
@@ -120,7 +120,7 @@ void PointOfInterestSystem::GetPOIsInArea(const csp::systems::GeoLocation& Origi
         TypeOption = PointOfInterestHelpers::TypeToString(*Type).c_str();
     }
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiGet(std::nullopt, std::nullopt, TypeOption, std::nullopt, std::nullopt, std::nullopt,
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiGet(std::nullopt, std::nullopt, TypeOption, std::nullopt, std::nullopt, std::nullopt,
         OriginLocation.Longitude, OriginLocation.Latitude, AreaRadius, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, ResponseHandler);
@@ -167,7 +167,7 @@ CSP_ASYNC_RESULT void PointOfInterestSystem::CreateSite(const Site& Site, SiteRe
     csp::services::ResponseHandlerPtr ResponseHandler = POIApiPtr->CreateHandler<SiteResultCallback, SiteResult, void, chs::PointOfInterestDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiPost(POIInfo, ResponseHandler);
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiPost(POIInfo, ResponseHandler);
 }
 
 void PointOfInterestSystem::DeleteSite(const Site& Site, NullResultCallback Callback) { DeletePOIInternal(Site.Id, Callback); }
@@ -180,7 +180,7 @@ void PointOfInterestSystem::GetSites(const csp::common::String& SpaceId, SitesCo
 
     std::vector<csp::common::String> SpaceID({ SpaceId });
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiGet(std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiGet(std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, SpaceID, std::nullopt, std::nullopt, ResponseHandler);
 }
@@ -190,7 +190,7 @@ void PointOfInterestSystem::DeletePOIInternal(const csp::common::String POIId, N
     csp::services::ResponseHandlerPtr ResponseHandler = POIApiPtr->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiIdDelete(POIId, ResponseHandler);
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiIdDelete(POIId, ResponseHandler);
 }
 
 void PointOfInterestSystem::AddSpaceGeoLocation(const csp::common::String& SpaceId, const csp::common::Optional<GeoLocation>& Location,
@@ -298,7 +298,7 @@ void PointOfInterestSystem::AddSpaceGeoLocation(const csp::common::String& Space
         = POIApiPtr->CreateHandler<SpaceGeoLocationResultCallback, SpaceGeoLocationResult, void, chs::PointOfInterestDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiPost(POIInfo, ResponseHandler);
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiPost(POIInfo, ResponseHandler);
 }
 
 void PointOfInterestSystem::UpdateSpaceGeoLocation(const csp::common::String& SpaceId, const csp::common::String& SpaceGeoLocationId,
@@ -407,7 +407,7 @@ void PointOfInterestSystem::UpdateSpaceGeoLocation(const csp::common::String& Sp
         = POIApiPtr->CreateHandler<SpaceGeoLocationResultCallback, SpaceGeoLocationResult, void, chs::PointOfInterestDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseOK);
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiIdPut(SpaceGeoLocationId, POIInfo, ResponseHandler);
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiIdPut(SpaceGeoLocationId, POIInfo, ResponseHandler);
 }
 
 void PointOfInterestSystem::GetSpaceGeoLocation(const csp::common::String& SpaceId, SpaceGeoLocationResultCallback Callback)
@@ -440,7 +440,7 @@ void PointOfInterestSystem::GetSpaceGeoLocation(const csp::common::String& Space
         = POIApiPtr->CreateHandler<SpaceGeoLocationCollectionResultCallback, SpaceGeoLocationCollectionResult, void,
             csp::services::DtoArray<chs::PointOfInterestDto>>(CollectionCallback, nullptr, csp::web::EResponseCodes::ResponseOK);
 
-    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->apiV1PoiGet(std::nullopt, std::nullopt, SpacePOIType, std::nullopt, std::nullopt, std::nullopt,
+    static_cast<chs::PointOfInterestApi*>(POIApiPtr)->poiGet(std::nullopt, std::nullopt, SpacePOIType, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, SpaceIds, std::nullopt, Limit, ResponseHandler);
 }

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -184,7 +184,7 @@ void UserSystem::Login(const csp::common::String& UserName, const csp::common::S
             = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginState, chs_user::AuthDto>(
                 LoginStateResCallback, &CurrentLoginState);
 
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->apiV1UsersLoginPost(Request, ResponseHandler);
+        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost(Request, ResponseHandler);
     }
     else
     {
@@ -243,7 +243,7 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
             = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginState, chs_user::AuthDto>(
                 LoginStateResCallback, &CurrentLoginState);
 
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->apiV1UsersRefreshPost(Request, ResponseHandler);
+        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost(Request, ResponseHandler);
     }
     else
     {
@@ -281,7 +281,7 @@ void UserSystem::RefreshSession(const csp::common::String& UserId, const csp::co
             = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginState, chs_user::AuthDto>(
                 LoginStateResCallback, &CurrentLoginState);
 
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->apiV1UsersRefreshPost(Request, ResponseHandler);
+        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost(Request, ResponseHandler);
     }
 }
 
@@ -331,7 +331,7 @@ void UserSystem::LoginAsGuest(const csp::common::Optional<bool>& UserHasVerified
             = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginState, chs_user::AuthDto>(
                 LoginStateResCallback, &CurrentLoginState);
 
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->apiV1UsersLoginPost(Request, ResponseHandler);
+        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost(Request, ResponseHandler);
     }
     else
     {
@@ -395,7 +395,7 @@ void UserSystem::GetThirdPartyProviderAuthoriseURL(
     CurrentLoginState.State = ELoginState::LoginThirdPartyProviderDetailsRequested;
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)
-        ->apiV1SocialProvidersProviderGet(ConvertExternalAuthProvidersToString(AuthProvider), csp::CSPFoundation::GetTenant(), ResponseHandler);
+        ->socialProvidersProviderGet(ConvertExternalAuthProvidersToString(AuthProvider), csp::CSPFoundation::GetTenant(), ResponseHandler);
 }
 
 void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken, const csp::common::String& ThirdPartyStateId,
@@ -470,7 +470,7 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
         = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginState, chs_user::AuthDto>(
             LoginStateResCallback, &CurrentLoginState);
 
-    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->apiV1UsersLoginSocialPost(Request, ResponseHandler);
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginSocialPost(Request, ResponseHandler);
 }
 
 void UserSystem::Logout(NullResultCallback Callback)
@@ -495,7 +495,7 @@ void UserSystem::Logout(NullResultCallback Callback)
                 = AuthenticationAPI->CreateHandler<NullResultCallback, LogoutResult, LoginState, csp::services::NullDto>(
                     Callback, &CurrentLoginState, csp::web::EResponseCodes::ResponseNoContent);
 
-            static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->apiV1UsersLogoutPost(Request, ResponseHandler);
+            static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogoutPost(Request, ResponseHandler);
         };
 
         auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
@@ -550,7 +550,7 @@ void UserSystem::CreateUser(const csp::common::Optional<csp::common::String>& Us
         = ProfileAPI->CreateHandler<ProfileResultCallback, ProfileResult, void, chs_user::ProfileDto>(
             Callback, nullptr, csp::web::EResponseCodes::ResponseCreated);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersPost(Request, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersPost(Request, ResponseHandler);
 }
 
 void UserSystem::UpgradeGuestAccount(const csp::common::String& UserName, const csp::common::String& DisplayName, const csp::common::String& Email,
@@ -569,7 +569,7 @@ void UserSystem::UpgradeGuestAccount(const csp::common::String& UserName, const 
     const csp::services::ResponseHandlerPtr ResponseHandler
         = ProfileAPI->CreateHandler<ProfileResultCallback, ProfileResult, void, chs_user::ProfileDto>(Callback, nullptr);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersUserIdUpgradeGuestPost(UserId, Request, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersUserIdUpgradeGuestPost(UserId, Request, ResponseHandler);
 }
 
 void UserSystem::ConfirmUserEmail(NullResultCallback Callback)
@@ -579,7 +579,7 @@ void UserSystem::ConfirmUserEmail(NullResultCallback Callback)
     csp::services::ResponseHandlerPtr ResponseHandler = ProfileAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersUserIdConfirmEmailPost(UserId, nullptr, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersUserIdConfirmEmailPost(UserId, nullptr, ResponseHandler);
 }
 
 void UserSystem::ResetUserPassword(
@@ -594,7 +594,7 @@ void UserSystem::ResetUserPassword(
     csp::services::ResponseHandlerPtr ResponseHandler = ProfileAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersUserIdTokenChangePasswordPost(UserId, Request, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersUserIdTokenChangePasswordPost(UserId, Request, ResponseHandler);
 }
 
 void UserSystem::UpdateUserDisplayName(const csp::common::String& UserId, const csp::common::String& NewUserDisplayName, NullResultCallback Callback)
@@ -602,7 +602,7 @@ void UserSystem::UpdateUserDisplayName(const csp::common::String& UserId, const 
     const csp::services::ResponseHandlerPtr ResponseHandler
         = ProfileAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback, nullptr);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersUserIdDisplayNamePut(UserId, NewUserDisplayName, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersUserIdDisplayNamePut(UserId, NewUserDisplayName, ResponseHandler);
 }
 
 void UserSystem::DeleteUser(const csp::common::String& UserId, NullResultCallback Callback)
@@ -610,7 +610,7 @@ void UserSystem::DeleteUser(const csp::common::String& UserId, NullResultCallbac
     csp::services::ResponseHandlerPtr ResponseHandler = ProfileAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersUserIdDelete(UserId, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersUserIdDelete(UserId, ResponseHandler);
 }
 
 bool UserSystem::EmailCheck(const std::string& Email) const { return Email.find("@") != std::string::npos; }
@@ -641,7 +641,7 @@ void UserSystem::ForgotPassword(const csp::common::String& Email, const csp::com
             Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
 
         static_cast<chs_user::ProfileApi*>(ProfileAPI)
-            ->apiV1UsersForgotPasswordPost(RedirectUrlValue, UseTokenChangePasswordUrl, EmailLinkUrlValue, Request, ResponseHandler);
+            ->usersForgotPasswordPost(RedirectUrlValue, UseTokenChangePasswordUrl, EmailLinkUrlValue, Request, ResponseHandler);
     }
     else
     {
@@ -656,7 +656,7 @@ void UserSystem::GetProfileByUserId(const csp::common::String& InUserId, Profile
     csp::services::ResponseHandlerPtr ResponseHandler
         = ProfileAPI->CreateHandler<ProfileResultCallback, ProfileResult, void, chs_user::ProfileDto>(Callback, nullptr);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersUserIdGet(UserId, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersUserIdGet(UserId, ResponseHandler);
 }
 
 void UserSystem::GetProfilesByUserId(const csp::common::Array<csp::common::String>& InUserIds, BasicProfilesResultCallback Callback)
@@ -667,7 +667,7 @@ void UserSystem::GetProfilesByUserId(const csp::common::Array<csp::common::Strin
         = ProfileAPI->CreateHandler<BasicProfilesResultCallback, BasicProfilesResult, void, csp::services::DtoArray<chs_user::ProfileLiteDto>>(
             Callback, nullptr);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersLiteGet(UserIds, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersLiteGet(UserIds, ResponseHandler);
 }
 
 void UserSystem::GetBasicProfilesByUserId(const csp::common::Array<csp::common::String>& InUserIds, BasicProfilesResultCallback Callback)
@@ -678,7 +678,7 @@ void UserSystem::GetBasicProfilesByUserId(const csp::common::Array<csp::common::
         = ProfileAPI->CreateHandler<BasicProfilesResultCallback, BasicProfilesResult, void, csp::services::DtoArray<chs_user::ProfileLiteDto>>(
             Callback, nullptr);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersLiteGet(UserIds, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersLiteGet(UserIds, ResponseHandler);
 }
 
 void UserSystem::Ping(NullResultCallback Callback)
@@ -741,7 +741,7 @@ void UserSystem::ResendVerificationEmail(
     csp::services::ResponseHandlerPtr ResponseHandler
         = ProfileAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback, nullptr);
 
-    static_cast<chs_user::ProfileApi*>(ProfileAPI)->apiV1UsersEmailsEmailConfirmEmailReSendPost(InEmail, Tenant, RedirectUrl, ResponseHandler);
+    static_cast<chs_user::ProfileApi*>(ProfileAPI)->usersEmailsEmailConfirmEmailReSendPost(InEmail, Tenant, RedirectUrl, ResponseHandler);
 }
 
 void UserSystem::GetCustomerPortalUrl(const csp::common::String& UserId, StringResultCallback Callback)
@@ -749,7 +749,7 @@ void UserSystem::GetCustomerPortalUrl(const csp::common::String& UserId, StringR
     csp::services::ResponseHandlerPtr ResponseHandler
         = StripeAPI->CreateHandler<StringResultCallback, CustomerPortalUrlResult, void, chs_user::StripeCustomerPortalDto>(Callback, nullptr);
 
-    static_cast<chs_user::StripeApi*>(StripeAPI)->apiV1VendorsStripeCustomerPortalsUserIdGet(UserId, ResponseHandler);
+    static_cast<chs_user::StripeApi*>(StripeAPI)->vendorsStripeCustomerPortalsUserIdGet(UserId, ResponseHandler);
 };
 
 void UserSystem::GetCheckoutSessionUrl(TierNames Tier, StringResultCallback Callback)
@@ -761,7 +761,7 @@ void UserSystem::GetCheckoutSessionUrl(TierNames Tier, StringResultCallback Call
     csp::services::ResponseHandlerPtr ResponseHandler
         = StripeAPI->CreateHandler<StringResultCallback, CheckoutSessionUrlResult, void, chs_user::StripeCheckoutSessionDto>(Callback, nullptr);
 
-    static_cast<chs_user::StripeApi*>(StripeAPI)->apiV1VendorsStripeCheckoutSessionsPost(CheckoutSessionInfo, ResponseHandler);
+    static_cast<chs_user::StripeApi*>(StripeAPI)->vendorsStripeCheckoutSessionsPost(CheckoutSessionInfo, ResponseHandler);
 };
 
 void UserSystem::NotifyRefreshTokenHasChanged()

--- a/Library/src/Web/GraphQLApi/GraphQLApi.cpp
+++ b/Library/src/Web/GraphQLApi/GraphQLApi.cpp
@@ -24,7 +24,7 @@ namespace csp::systems::graphqlservice
 {
 
 GraphQLApi::GraphQLApi(csp::web::WebClient* InWebClient)
-    : ApiBase(InWebClient, &csp::CSPFoundation::GetEndpoints().AggregationServiceURI)
+    : ApiBase(InWebClient, &csp::CSPFoundation::GetEndpoints().AggregationService)
 {
 }
 
@@ -33,7 +33,7 @@ GraphQLApi::~GraphQLApi() { }
 void GraphQLApi::Query(
     csp::common::String QueryText, csp::services::ApiResponseHandlerBase* ResponseHandler, csp::common::CancellationToken& CancellationToken) const
 {
-    csp::web::Uri Uri(*RootUri + "/graphql");
+    csp::web::Uri Uri((ServiceDefinition->GetURI() + "/graphql").c_str());
     csp::web::HttpPayload Payload;
     Payload.AddHeader(CSP_TEXT("Content-Type"), CSP_TEXT("application/json"));
     Payload.SetContent(QueryText);

--- a/Library/src/Web/MaintenanceApi/MaintenanceApi.cpp
+++ b/Library/src/Web/MaintenanceApi/MaintenanceApi.cpp
@@ -23,7 +23,7 @@
 namespace csp::systems::maintenanceservice
 {
 MaintenanceApi::MaintenanceApi(csp::web::WebClient* InWebClient)
-    : ApiBase(InWebClient, &csp::CSPFoundation::GetEndpoints().AggregationServiceURI)
+    : ApiBase(InWebClient, &csp::CSPFoundation::GetEndpoints().AggregationService)
 {
 }
 

--- a/Tests/src/InternalTests/WebSocketClientTests.cpp
+++ b/Tests/src/InternalTests/WebSocketClientTests.cpp
@@ -42,7 +42,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientStartStopTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI);
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI());
 
     // Stop
     WebSocketStop(WebSocket);
@@ -64,7 +64,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI);
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI());
 
     // Send
     WebSocketSend(WebSocket, "test");
@@ -89,7 +89,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerServiceURI);
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI());
 
     // Receive
     WebSocketSendReceive(WebSocket);
@@ -110,10 +110,10 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, RegularMultiplayerServiceURI)
 {
     const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://ogs-internal.magnopus-dev.cloud");
-    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://ogs-multiplayer-internal.magnopus-dev.cloud/mag-multiplayer/hubs/v1/multiplayer");
+    ASSERT_EQ(Endpoints.MultiplayerService.GetURI(), "https://ogs-multiplayer-internal.magnopus-dev.cloud/mag-multiplayer/hubs/v1/multiplayer");
 
     CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
-        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerService.GetURI().c_str());
 
     EXPECT_EQ(ParsedURI.Protocol, "https");
     EXPECT_EQ(ParsedURI.Domain, "ogs-multiplayer-internal.magnopus-dev.cloud");
@@ -125,10 +125,10 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, RegularMultiplayerServiceURI)
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURI)
 {
     const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://localhost:8081");
-    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://localhost:8081/mag-multiplayer/hubs/v1/multiplayer");
+    ASSERT_EQ(Endpoints.MultiplayerService.GetURI(), "https://localhost:8081/mag-multiplayer/hubs/v1/multiplayer");
 
     CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
-        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerService.GetURI().c_str());
 
     EXPECT_EQ(ParsedURI.Protocol, "https");
     EXPECT_EQ(ParsedURI.Domain, "localhost");
@@ -140,10 +140,10 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURI)
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURIHttp)
 {
     const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("http://localhost");
-    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "http://localhost/mag-multiplayer/hubs/v1/multiplayer");
+    ASSERT_EQ(Endpoints.MultiplayerService.GetURI(), "http://localhost/mag-multiplayer/hubs/v1/multiplayer");
 
     CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
-        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerService.GetURI().c_str());
 
     EXPECT_EQ(ParsedURI.Protocol, "http");
     EXPECT_EQ(ParsedURI.Domain, "localhost");
@@ -155,10 +155,10 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURIHtt
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalVariantMultiplayerServiceURI)
 {
     const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://127.0.0.1:8081");
-    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://127.0.0.1:8081/mag-multiplayer/hubs/v1/multiplayer");
+    ASSERT_EQ(Endpoints.MultiplayerService.GetURI(), "https://127.0.0.1:8081/mag-multiplayer/hubs/v1/multiplayer");
 
     CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
-        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerService.GetURI().c_str());
 
     EXPECT_EQ(ParsedURI.Protocol, "https");
     EXPECT_EQ(ParsedURI.Domain, "127.0.0.1");
@@ -170,18 +170,18 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalVariantMultiplayerServic
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMultiplayerServiceURINoScheme)
 {
     const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("localhost:8081");
-    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "localhost:8081/mag-multiplayer/hubs/v1/multiplayer");
+    ASSERT_EQ(Endpoints.MultiplayerService.GetURI(), "localhost:8081/mag-multiplayer/hubs/v1/multiplayer");
 
-    EXPECT_THROW(CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str()), std::runtime_error);
+    EXPECT_THROW(CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerService.GetURI().c_str()), std::runtime_error);
 }
 
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalNoPortMultiplayerServiceURI)
 {
     const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://localhost");
-    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://localhost/mag-multiplayer/hubs/v1/multiplayer");
+    ASSERT_EQ(Endpoints.MultiplayerService.GetURI(), "https://localhost/mag-multiplayer/hubs/v1/multiplayer");
 
     CSPWebSocketClientPOCO::ParsedURIInfo ParsedURI
-        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str());
+        = CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerService.GetURI().c_str());
 
     EXPECT_EQ(ParsedURI.Protocol, "https");
     EXPECT_EQ(ParsedURI.Domain, "localhost");
@@ -193,7 +193,7 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalNoPortMultiplayerService
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, LocalMalformedMultiplayerServiceURI)
 {
     const csp::EndpointURIs Endpoints = csp::CSPFoundation::CreateEndpointsFromRoot("https://localhost:notanumber");
-    ASSERT_EQ(Endpoints.MultiplayerServiceURI, "https://localhost:notanumber/mag-multiplayer/hubs/v1/multiplayer");
+    ASSERT_EQ(Endpoints.MultiplayerService.GetURI(), "https://localhost:notanumber/mag-multiplayer/hubs/v1/multiplayer");
 
-    EXPECT_THROW(CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerServiceURI.c_str()), Poco::SyntaxException);
+    EXPECT_THROW(CSPWebSocketClientPOCO::ParseMultiplayerServiceUriEndPoint(Endpoints.MultiplayerService.GetURI().c_str()), Poco::SyntaxException);
 }


### PR DESCRIPTION
This is the CSP portion of the [OF-1671] Promote RESTful Service API URI version information to CSPFoundation work.

The PR contains the following changes:

 - Introduce a new MCSServiceDefinition (Public API break)
 - Updated usage and reference to RESTful service URI. 
 -  Updated CSP to reference the new generated function names (version agnostic csp services generator files)

> [!IMPORTANT]
>
> I have updated the csp services submodule to reference the branch with the required changes. These changes should not be merged until both PR's are approved.

> [!WARNING]
>
> These changes do apply a break in the current public API, As a result, we should get some input from client teams to ensure that the transition is smooth ahead of the next release. 
