### PR TITLE
[OF-1686] feat!: Avatar Space visibility

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
@@ -22,6 +22,7 @@
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/String.h"
 #include "CSP/Multiplayer/ComponentBase.h"
+#include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
 
 namespace csp::multiplayer
 {
@@ -79,12 +80,14 @@ enum class AvatarComponentPropertyKeys
     AvatarPlayMode,
     MovementDirection,
     LocomotionModel,
+    IsVisible,
+    IsARVisible,
     Num
 };
 
 // @ingroup AvatarSpaceComponent
 /// @brief Data representation of an AvatarSpaceComponent.
-class CSP_API AvatarSpaceComponent : public ComponentBase
+class CSP_API AvatarSpaceComponent : public ComponentBase, public IVisibleComponent
 {
 public:
     /// @brief Constructs the avatar space component, and associates it with the specified Parent space entity.
@@ -268,6 +271,18 @@ public:
     /// @brief Sets which locomotion model this avatar component is using.
     /// @param Value The locomotion model used by this avatar component.
     void SetLocomotionModel(LocomotionModel Value);
+
+    /// \addtogroup IVisibleComponent
+    /// @{
+    /// @copydoc IVisibleComponent::GetIsVisible()
+    bool GetIsVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVisible()
+    void SetIsVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsARVisible()
+    bool GetIsARVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsARVisible()
+    void SetIsARVisible(bool InValue) override;
+    /// @}
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -93,12 +93,13 @@ public:
     /// @brief Creates a SpaceEntity with type Avatar, and relevant components and default states as specified.
     /// @param InName csp::common::String : The name to give the new SpaceEntity.
     /// @param InSpaceTransform SpaceTransform : The initial transform to set the SpaceEntity to.
+    /// @param IsVisible bool : The initial visibility of the Avatar.
     /// @param InState AvatarState : The initial Avatar State to set.
     /// @param InAvatarId csp::common::String : The Initial AvatarID to set.
     /// @param InAvatarPlayMode AvatarPlayMode : The Initial AvatarPlayMode to set.
     /// @param Callback EntityCreatedCallback A callback that executes when the creation is complete,
     /// which contains a pointer to the new SpaceEntity so that it can be used on the local client.
-    CSP_ASYNC_RESULT void CreateAvatar(const csp::common::String& InName, const SpaceTransform& InSpaceTransform, AvatarState InState,
+    CSP_ASYNC_RESULT void CreateAvatar(const csp::common::String& InName, const SpaceTransform& InSpaceTransform, bool IsVisible, AvatarState InState,
         const csp::common::String& InAvatarId, AvatarPlayMode InAvatarPlayMode, EntityCreatedCallback Callback);
 
     /// @brief Creates a SpaceEntity of type Object, and relevant default values.
@@ -416,9 +417,9 @@ private:
     CSP_START_IGNORE
     async::shared_task<uint64_t> RemoteGenerateNewAvatarId();
     std::function<async::task<std::tuple<signalr::value, std::exception_ptr>>(uint64_t)> SendNewAvatarObjectMessage(const csp::common::String& Name,
-        const SpaceTransform& Transform, const csp::common::String& AvatarId, AvatarState AvatarState, AvatarPlayMode AvatarPlayMode);
+        const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId, AvatarState AvatarState, AvatarPlayMode AvatarPlayMode);
     std::function<void(std::tuple<async::shared_task<uint64_t>, async::task<void>>)> CreateNewLocalAvatar(const csp::common::String& Name,
-        const SpaceTransform& Transform, const csp::common::String& AvatarId, AvatarState AvatarState, AvatarPlayMode AvatarPlayMode,
+        const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId, AvatarState AvatarState, AvatarPlayMode AvatarPlayMode,
         EntityCreatedCallback Callback);
     CSP_END_IGNORE
 

--- a/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
@@ -39,6 +39,8 @@ AvatarSpaceComponent::AvatarSpaceComponent(SpaceEntity* Parent)
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarPlayMode)] = static_cast<int64_t>(AvatarPlayMode::Default);
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::MovementDirection)] = csp::common::Vector3 { 0.0f, 0.0f, 0.0f };
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::LocomotionModel)] = static_cast<int64_t>(LocomotionModel::Grounded);
+    Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible)] = true;
+    Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible)] = true;
 
     SetScriptInterface(new AvatarSpaceComponentScriptInterface(this));
 }
@@ -189,5 +191,13 @@ void AvatarSpaceComponent::SetLocomotionModel(LocomotionModel Value)
 {
     SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::LocomotionModel), static_cast<int64_t>(Value));
 }
+
+bool AvatarSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible)); }
+
+void AvatarSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible), InValue); }
+
+bool AvatarSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible)); }
+
+void AvatarSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible), InValue); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
@@ -42,5 +42,8 @@ DEFINE_SCRIPT_PROPERTY_VEC4(AvatarSpaceComponent, HeadRotation);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, float, float, WalkRunBlendPercentage);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, float, float, TorsoTwistAlpha);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarPlayMode, int32_t, AvatarPlayMode);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::LocomotionModel, int32_t, LocomotionModel);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsARVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
@@ -43,6 +43,9 @@ public:
     DECLARE_SCRIPT_PROPERTY(float, WalkRunBlendPercentage);
     DECLARE_SCRIPT_PROPERTY(float, TorsoTwistAlpha);
     DECLARE_SCRIPT_PROPERTY(int32_t, AvatarPlayMode);
+    DECLARE_SCRIPT_PROPERTY(int32_t, LocomotionModel);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -346,7 +346,10 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AvatarSpaceComponent, HeadRotation, "headRotation")
         .PROPERTY_GET_SET(AvatarSpaceComponent, WalkRunBlendPercentage, "walkRunBlendPercentage")
         .PROPERTY_GET_SET(AvatarSpaceComponent, TorsoTwistAlpha, "torsoTwistAlpha")
-        .PROPERTY_GET_SET(AvatarSpaceComponent, AvatarPlayMode, "avatarPlayMode");
+        .PROPERTY_GET_SET(AvatarSpaceComponent, AvatarPlayMode, "avatarPlayMode")
+        .PROPERTY_GET_SET(AvatarSpaceComponent, LocomotionModel, "locomotionModel")
+        .PROPERTY_GET_SET(AvatarSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(AvatarSpaceComponent, IsARVisible, "isARVisible");
 
     Module->class_<ExternalLinkSpaceComponentScriptInterface>("ExternalLinkSpaceComponent")
         .constructor<>()

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -261,7 +261,7 @@ namespace
 {
     std::unique_ptr<csp::multiplayer::SpaceEntity> BuildNewAvatar(csp::systems::UserSystem& UserSystem,
         csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, uint64_t NetworkId, const csp::common::String& Name,
-        const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable, bool IsPersistent,
+        const csp::multiplayer::SpaceTransform& Transform, bool IsVisible, uint64_t OwnerId, bool IsTransferable, bool IsPersistent,
         const csp::common::String& AvatarId, csp::multiplayer::AvatarState AvatarState, csp::multiplayer::AvatarPlayMode AvatarPlayMode)
     {
         auto NewAvatar = std::unique_ptr<csp::multiplayer::SpaceEntity>(new csp::multiplayer::SpaceEntity(
@@ -272,6 +272,7 @@ namespace
         AvatarComponent->SetState(AvatarState);
         AvatarComponent->SetAvatarPlayMode(AvatarPlayMode);
         AvatarComponent->SetUserId(UserSystem.GetLoginState().UserId);
+        AvatarComponent->SetIsVisible(IsVisible);
 
         return NewAvatar;
     }
@@ -298,12 +299,12 @@ async::shared_task<uint64_t> SpaceEntitySystem::RemoteGenerateNewAvatarId()
 }
 
 std::function<async::task<std::tuple<signalr::value, std::exception_ptr>>(uint64_t)> SpaceEntitySystem::SendNewAvatarObjectMessage(
-    const csp::common::String& Name, const SpaceTransform& Transform, const csp::common::String& AvatarId, AvatarState AvatarState,
+    const csp::common::String& Name, const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId, AvatarState AvatarState,
     AvatarPlayMode AvatarPlayMode)
 {
-    return [Name, Transform, AvatarId, AvatarState, AvatarPlayMode, this](uint64_t NetworkId) // Serialize Avatar
+    return [Name, Transform, IsVisible, AvatarId, AvatarState, AvatarPlayMode, this](uint64_t NetworkId) // Serialize Avatar
     {
-        auto NewAvatar = BuildNewAvatar(*csp::systems::SystemsManager::Get().GetUserSystem(), *this, NetworkId, Name, Transform,
+        auto NewAvatar = BuildNewAvatar(*csp::systems::SystemsManager::Get().GetUserSystem(), *this, NetworkId, Name, Transform, IsVisible,
             MultiplayerConnectionInst->GetClientId(), false, false, AvatarId, AvatarState, AvatarPlayMode);
 
         mcs::ObjectMessage Message = NewAvatar->CreateObjectMessage();
@@ -317,10 +318,10 @@ std::function<async::task<std::tuple<signalr::value, std::exception_ptr>>(uint64
 }
 
 std::function<void(std::tuple<async::shared_task<uint64_t>, async::task<void>>)> SpaceEntitySystem::CreateNewLocalAvatar(
-    const csp::common::String& Name, const SpaceTransform& Transform, const csp::common::String& AvatarId, AvatarState AvatarState,
+    const csp::common::String& Name, const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId, AvatarState AvatarState,
     AvatarPlayMode AvatarPlayMode, EntityCreatedCallback Callback)
 {
-    return [Name, Transform, AvatarId, AvatarState, AvatarPlayMode, this, Callback](
+    return [Name, Transform, IsVisible, AvatarId, AvatarState, AvatarPlayMode, this, Callback](
                std::tuple<async::shared_task<uint64_t>, async::task<void>> NetworkIdFromChain)
     {
         uint64_t NetworkId = std::get<0>(NetworkIdFromChain).get();
@@ -344,7 +345,7 @@ std::function<void(std::tuple<async::shared_task<uint64_t>, async::task<void>>)>
          * (Stricter interface segregation for our serializers would also have solved this problem, but only in the local sense)
          */
         std::unique_ptr<csp::multiplayer::SpaceEntity> NewAvatar = BuildNewAvatar(*csp::systems::SystemsManager::Get().GetUserSystem(), *this,
-            NetworkId, Name, Transform, MultiplayerConnectionInst->GetClientId(), false, false, AvatarId, AvatarState, AvatarPlayMode);
+            NetworkId, Name, Transform, IsVisible, MultiplayerConnectionInst->GetClientId(), false, false, AvatarId, AvatarState, AvatarPlayMode);
 
         std::scoped_lock EntitiesLocker(*EntitiesLock);
         // Release to vague ownership. True ownership is blurry here. It could be shared between both Entities and Objects, or just owned by Entities.
@@ -361,7 +362,7 @@ std::function<void(std::tuple<async::shared_task<uint64_t>, async::task<void>>)>
     };
 }
 
-void SpaceEntitySystem::CreateAvatar(const csp::common::String& InName, const SpaceTransform& InSpaceTransform, AvatarState InState,
+void SpaceEntitySystem::CreateAvatar(const csp::common::String& InName, const SpaceTransform& InSpaceTransform, bool IsVisible, AvatarState InState,
     const csp::common::String& InAvatarId, AvatarPlayMode InAvatarPlayMode, EntityCreatedCallback Callback)
 {
 
@@ -370,13 +371,13 @@ void SpaceEntitySystem::CreateAvatar(const csp::common::String& InName, const Sp
 
     // Use the object ID to construct a serialized avatar and send it to the server, "SendObjectMessage"
     async::task<void> SerializeAndSendChain
-        = GetAvatarNetworkIdChain.then(SendNewAvatarObjectMessage(InName, InSpaceTransform, InAvatarId, InState, InAvatarPlayMode))
+        = GetAvatarNetworkIdChain.then(SendNewAvatarObjectMessage(InName, InSpaceTransform, IsVisible, InAvatarId, InState, InAvatarPlayMode))
               .then(multiplayer::continuations::UnwrapSignalRResultOrThrow<false>());
 
     // Once the server has acknowledged our new avatar, add it to local state and give it to the client.
     // Note: The when_all is so we can reuse the remote avatar ID without having to refetch it
     async::when_all(GetAvatarNetworkIdChain, SerializeAndSendChain)
-        .then(CreateNewLocalAvatar(InName, InSpaceTransform, InAvatarId, InState, InAvatarPlayMode, Callback))
+        .then(CreateNewLocalAvatar(InName, InSpaceTransform, IsVisible, InAvatarId, InState, InAvatarPlayMode, Callback))
         .then(csp::common::continuations::InvokeIfExceptionInChain(
             [Callback](const std::exception& Except)
             {

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -44,6 +44,7 @@ void RunTest()
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
@@ -53,7 +54,7 @@ void RunTest()
     std::promise<csp::multiplayer::SpaceEntity*> ResultPromise;
     std::future<csp::multiplayer::SpaceEntity*> ResultFuture = ResultPromise.get_future();
 
-    EntitySystem.CreateAvatar(UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode,
+    EntitySystem.CreateAvatar(UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode,
         [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
 
     ResultFuture.get();

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -48,11 +48,12 @@ void CreateAvatarForLeaderElection(csp::multiplayer::SpaceEntitySystem* EntitySy
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cout << "CreateAvatar Local Callback" << std::endl;

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -83,12 +83,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalPositionTest
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -96,8 +90,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalPositionTest
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     std::atomic_bool ScriptSystemReady = false;
 
@@ -222,12 +215,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalRotationTest
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -235,8 +222,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalRotationTest
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     std::atomic_bool ScriptSystemReady = false;
 
@@ -361,12 +347,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalScaleTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -374,8 +354,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalScaleTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     std::atomic_bool ScriptSystemReady = false;
 
@@ -500,12 +479,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityParentIdTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -513,8 +486,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityParentIdTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     std::atomic_bool ScriptSystemReady = false;
 
@@ -638,12 +610,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, RemoveSpaceEntityParentTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -651,8 +617,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, RemoveSpaceEntityParentTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     std::atomic_bool ScriptSystemReady = false;
 
@@ -774,12 +739,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, GetRootHierarchyEntitiesTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -787,8 +746,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, GetRootHierarchyEntitiesTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     std::atomic_bool ScriptSystemReady = false;
 

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../SpaceSystemTestHelpers.h"
+#include "../UserSystemTestHelpers.h"
+#include "Awaitable.h"
+#include "CSP/CSPFoundation.h"
+#include "CSP/Common/Optional.h"
+#include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
+#include "CSP/Multiplayer/MultiPlayerConnection.h"
+#include "CSP/Multiplayer/Script/EntityScript.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
+#include "TestHelpers.h"
+
+#include "gtest/gtest.h"
+#include <chrono>
+#include <thread>
+
+using namespace csp::multiplayer;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
+
+} // namespace
+
+/*
+    Tests that AvatarSpaceComponent default properties are correctly set on construction.
+    Tests properties are correctly updated via setters.
+*/
+CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
+
+    // Login
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Create space
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    // Enter space
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    // Define Avatar properties
+    const csp::common::String& UserName = "Creator 1";
+    const SpaceTransform& UserTransform
+        = { csp::common::Vector3 { 1.11f, 2.22f, 3.33f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = false;
+    AvatarState UserAvatarState = AvatarState::Idle;
+    const csp::common::String& UserAvatarId = "Creator1Avatar";
+    AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Creator;
+    LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
+
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    EXPECT_NE(Avatar, nullptr);
+
+    EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
+    EXPECT_EQ(Avatar->GetName(), UserName);
+    EXPECT_EQ(Avatar->GetPosition(), UserTransform.Position);
+    EXPECT_EQ(Avatar->GetRotation(), UserTransform.Rotation);
+
+    auto& Components = *Avatar->GetComponents();
+    EXPECT_EQ(Components.Size(), 1);
+
+    auto* Component = Components[0];
+    EXPECT_EQ(Component->GetComponentType(), ComponentType::AvatarData);
+
+    // Verify that the default AvatarSpaceComponent property values are correct
+    AvatarSpaceComponent* AvatarComponent = dynamic_cast<AvatarSpaceComponent*>(Component);
+    EXPECT_EQ(AvatarComponent->GetAvatarId(), UserAvatarId);
+    EXPECT_EQ(AvatarComponent->GetState(), UserAvatarState);
+    EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), UserAvatarPlayMode);
+    EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), AvatarPlayMode::Creator);
+    EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
+    EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
+    EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
+    EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
+    EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
+    EXPECT_EQ(AvatarComponent->GetIsHandIKEnabled(), false);
+    EXPECT_EQ(AvatarComponent->GetTargetHandIKTargetLocation(), csp::common::Vector3::Zero());
+    EXPECT_EQ(AvatarComponent->GetHandRotation(), csp::common::Vector4::Identity());
+    EXPECT_EQ(AvatarComponent->GetHeadRotation(), csp::common::Vector4::Identity());
+    EXPECT_EQ(AvatarComponent->GetWalkRunBlendPercentage(), 0.0f);
+    EXPECT_EQ(AvatarComponent->GetTorsoTwistAlpha(), 0.0f);
+    EXPECT_EQ(AvatarComponent->GetMovementDirection(), csp::common::Vector3::Zero());
+
+    // Set new AvatarSpaceComponent property values
+    constexpr const char* NewAvatarId = "TestAvatarId";
+    AvatarState NewAvatarState = AvatarState::Flying;
+    AvatarPlayMode NewAvatarPlayMode = AvatarPlayMode::VR;
+    LocomotionModel NewAvatarLocomotionModel = LocomotionModel::FreeCamera;
+    bool NewIsVisible = true;
+    bool NewIsARVisible = false;
+    int64_t NewAvatarMeshIndex = 42;
+    csp::common::String NewAgoraUserId = "AgoraUser123";
+    csp::common::String NewCustomAvatarUrl = "https://example.com/avatar.png";
+    bool NewIsHandIKEnabled = true;
+    csp::common::Vector3 NewTargetHandIKTargetLocation = { 0.1f, 0.2f, 0.3f };
+    csp::common::Vector4 NewHandRotation = { 0.1f, 0.2f, 0.3f, 1.0f };
+    csp::common::Vector4 NewHeadRotation = { 0.4f, 0.5f, 0.6f, 1.0f };
+    float NewWalkRunBlendPercentage = 0.75f;
+    float NewTorsoTwistAlpha = 0.5f;
+    csp::common::Vector3 NewMovementDirection = { 0.0f, 1.0f, 0.0f };
+
+    AvatarComponent->SetAvatarId(NewAvatarId);
+    AvatarComponent->SetState(NewAvatarState);
+    AvatarComponent->SetAvatarPlayMode(NewAvatarPlayMode);
+    AvatarComponent->SetLocomotionModel(NewAvatarLocomotionModel);
+    AvatarComponent->SetIsVisible(NewIsVisible);
+    AvatarComponent->SetIsARVisible(NewIsARVisible);
+    AvatarComponent->SetAvatarMeshIndex(NewAvatarMeshIndex);
+    AvatarComponent->SetAgoraUserId(NewAgoraUserId);
+    AvatarComponent->SetCustomAvatarUrl(NewCustomAvatarUrl);
+    AvatarComponent->SetIsHandIKEnabled(NewIsHandIKEnabled);
+    AvatarComponent->SetTargetHandIKTargetLocation(NewTargetHandIKTargetLocation);
+    AvatarComponent->SetHandRotation(NewHandRotation);
+    AvatarComponent->SetHeadRotation(NewHeadRotation);
+    AvatarComponent->SetWalkRunBlendPercentage(NewWalkRunBlendPercentage);
+    AvatarComponent->SetTorsoTwistAlpha(NewTorsoTwistAlpha);
+    AvatarComponent->SetMovementDirection(NewMovementDirection);
+
+    // Verify that the AvatarSpaceComponent property values are updated correctly
+    EXPECT_EQ(AvatarComponent->GetAvatarId(), NewAvatarId);
+    EXPECT_EQ(AvatarComponent->GetState(), NewAvatarState);
+    EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), NewAvatarPlayMode);
+    EXPECT_EQ(AvatarComponent->GetLocomotionModel(), NewAvatarLocomotionModel);
+    EXPECT_EQ(AvatarComponent->GetIsVisible(), NewIsVisible);
+    EXPECT_EQ(AvatarComponent->GetIsARVisible(), NewIsARVisible);
+    EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), NewAvatarMeshIndex);
+    EXPECT_EQ(AvatarComponent->GetAgoraUserId(), NewAgoraUserId);
+    EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), NewCustomAvatarUrl);
+    EXPECT_EQ(AvatarComponent->GetIsHandIKEnabled(), NewIsHandIKEnabled);
+    EXPECT_EQ(AvatarComponent->GetTargetHandIKTargetLocation(), NewTargetHandIKTargetLocation);
+    EXPECT_EQ(AvatarComponent->GetHandRotation(), NewHandRotation);
+    EXPECT_EQ(AvatarComponent->GetHeadRotation(), NewHeadRotation);
+    EXPECT_EQ(AvatarComponent->GetWalkRunBlendPercentage(), NewWalkRunBlendPercentage);
+    EXPECT_EQ(AvatarComponent->GetTorsoTwistAlpha(), NewTorsoTwistAlpha);
+    EXPECT_EQ(AvatarComponent->GetMovementDirection(), NewMovementDirection);
+
+    // Exit Space
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+    // Delete space
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+/*
+    Tests that AvatarSpaceComponents can be sucessfully modified by scripts
+*/
+CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
+
+    // Login
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Create space
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    // Enter space
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    // Define Avatar properties
+    const csp::common::String& UserName = "Creator 1";
+    const SpaceTransform& UserTransform
+        = { csp::common::Vector3 { 1.11f, 2.22f, 3.33f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = false;
+    AvatarState UserAvatarState = AvatarState::Idle;
+    const csp::common::String& UserAvatarId = "Creator1Avatar";
+    AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Creator;
+    LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
+
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    EXPECT_NE(Avatar, nullptr);
+
+    EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
+    EXPECT_EQ(Avatar->GetName(), UserName);
+    EXPECT_EQ(Avatar->GetPosition(), UserTransform.Position);
+    EXPECT_EQ(Avatar->GetRotation(), UserTransform.Rotation);
+
+    auto& Components = *Avatar->GetComponents();
+    EXPECT_EQ(Components.Size(), 1);
+
+    auto* Component = Components[0];
+    EXPECT_EQ(Component->GetComponentType(), ComponentType::AvatarData);
+
+    // Verify that the default AvatarSpaceComponent property values are correct
+    AvatarSpaceComponent* AvatarComponent = dynamic_cast<AvatarSpaceComponent*>(Component);
+    EXPECT_EQ(AvatarComponent->GetAvatarId(), UserAvatarId);
+    EXPECT_EQ(AvatarComponent->GetState(), UserAvatarState);
+    EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), UserAvatarPlayMode);
+    EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), AvatarPlayMode::Creator);
+    EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
+    EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
+    EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
+    EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
+    EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
+    EXPECT_EQ(AvatarComponent->GetIsHandIKEnabled(), false);
+    EXPECT_EQ(AvatarComponent->GetTargetHandIKTargetLocation(), csp::common::Vector3::Zero());
+    EXPECT_EQ(AvatarComponent->GetHandRotation(), csp::common::Vector4::Identity());
+    EXPECT_EQ(AvatarComponent->GetHeadRotation(), csp::common::Vector4::Identity());
+    EXPECT_EQ(AvatarComponent->GetWalkRunBlendPercentage(), 0.0f);
+    EXPECT_EQ(AvatarComponent->GetTorsoTwistAlpha(), 0.0f);
+    EXPECT_EQ(AvatarComponent->GetMovementDirection(), csp::common::Vector3::Zero());
+
+    Avatar->QueueUpdate();
+    EntitySystem->ProcessPendingEntityOperations();
+
+    // Setup script to set new properties
+    std::string AvatarComponentScriptText = R"xx(
+			var avatar = ThisEntity.getAvatarComponents()[0];
+			avatar.avatarId = "TestAvatarId";
+            avatar.state = 3; // Flying
+            avatar.avatarPlayMode = 2; // VR
+            avatar.locomotionModel = 1; // FreeCamera
+            avatar.avatarMeshIndex = 42;
+            avatar.agoraUserId = "AgoraUser123";
+            avatar.customAvatarUrl = "https://example.com/avatar.png";
+            avatar.isHandIKEnabled = true;
+            avatar.targetHandIKTargetLocation = [0.1, 0.2, 0.3];
+            avatar.handRotation = [0.1, 0.2, 0.3, 1.0];
+            avatar.headRotation = [0.4, 0.5, 0.6, 1.0];
+            avatar.walkRunBlendPercentage = 0.75;
+            avatar.torsoTwistAlpha = 0.5;
+            avatar.isVisible = true;
+            avatar.isARVisible = false;
+		)xx";
+
+    Avatar->GetScript().SetScriptSource(AvatarComponentScriptText.c_str());
+    Avatar->GetScript().Invoke();
+
+    EntitySystem->ProcessPendingEntityOperations();
+
+    // Test scripts sets new properties
+    EXPECT_EQ(AvatarComponent->GetAvatarId(), "TestAvatarId");
+    EXPECT_EQ(AvatarComponent->GetState(), AvatarState::Flying);
+    EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), AvatarPlayMode::VR);
+    EXPECT_EQ(AvatarComponent->GetLocomotionModel(), LocomotionModel::FreeCamera);
+    EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), 42);
+    EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "AgoraUser123");
+    EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "https://example.com/avatar.png");
+    EXPECT_EQ(AvatarComponent->GetIsHandIKEnabled(), true);
+    EXPECT_EQ(AvatarComponent->GetTargetHandIKTargetLocation(), csp::common::Vector3(0.1f, 0.2f, 0.3f));
+    EXPECT_EQ(AvatarComponent->GetHandRotation(), csp::common::Vector4(0.1f, 0.2f, 0.3f, 1.0f));
+    EXPECT_EQ(AvatarComponent->GetHeadRotation(), csp::common::Vector4(0.4f, 0.5f, 0.6f, 1.0f));
+    EXPECT_EQ(AvatarComponent->GetWalkRunBlendPercentage(), 0.75f);
+    EXPECT_EQ(AvatarComponent->GetTorsoTwistAlpha(), 0.5f);
+    EXPECT_EQ(AvatarComponent->GetIsVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetIsARVisible(), false);
+
+    // Exit space
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+    // Delete space
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    // Log out
+    LogOut(UserSystem);
+}

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -71,11 +71,11 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     const csp::common::String& UserName = "Creator 1";
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.11f, 2.22f, 3.33f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
-    bool IsVisible = false;
-    AvatarState UserAvatarState = AvatarState::Idle;
+    const bool IsVisible = false;
+    const AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "Creator1Avatar";
-    AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Creator;
-    LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
+    const AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Creator;
+    const LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
 
     auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
@@ -113,21 +113,21 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
 
     // Set new AvatarSpaceComponent property values
     constexpr const char* NewAvatarId = "TestAvatarId";
-    AvatarState NewAvatarState = AvatarState::Flying;
-    AvatarPlayMode NewAvatarPlayMode = AvatarPlayMode::VR;
-    LocomotionModel NewAvatarLocomotionModel = LocomotionModel::FreeCamera;
-    bool NewIsVisible = true;
-    bool NewIsARVisible = false;
-    int64_t NewAvatarMeshIndex = 42;
-    csp::common::String NewAgoraUserId = "AgoraUser123";
-    csp::common::String NewCustomAvatarUrl = "https://example.com/avatar.png";
-    bool NewIsHandIKEnabled = true;
-    csp::common::Vector3 NewTargetHandIKTargetLocation = { 0.1f, 0.2f, 0.3f };
-    csp::common::Vector4 NewHandRotation = { 0.1f, 0.2f, 0.3f, 1.0f };
-    csp::common::Vector4 NewHeadRotation = { 0.4f, 0.5f, 0.6f, 1.0f };
-    float NewWalkRunBlendPercentage = 0.75f;
-    float NewTorsoTwistAlpha = 0.5f;
-    csp::common::Vector3 NewMovementDirection = { 0.0f, 1.0f, 0.0f };
+    const AvatarState NewAvatarState = AvatarState::Flying;
+    const AvatarPlayMode NewAvatarPlayMode = AvatarPlayMode::VR;
+    const LocomotionModel NewAvatarLocomotionModel = LocomotionModel::FreeCamera;
+    const bool NewIsVisible = true;
+    const bool NewIsARVisible = false;
+    const int64_t NewAvatarMeshIndex = 42;
+    const csp::common::String NewAgoraUserId = "AgoraUser123";
+    const csp::common::String NewCustomAvatarUrl = "https://example.com/avatar.png";
+    const bool NewIsHandIKEnabled = true;
+    const csp::common::Vector3 NewTargetHandIKTargetLocation = { 0.1f, 0.2f, 0.3f };
+    const csp::common::Vector4 NewHandRotation = { 0.1f, 0.2f, 0.3f, 1.0f };
+    const csp::common::Vector4 NewHeadRotation = { 0.4f, 0.5f, 0.6f, 1.0f };
+    const float NewWalkRunBlendPercentage = 0.75f;
+    const float NewTorsoTwistAlpha = 0.5f;
+    const csp::common::Vector3 NewMovementDirection = { 0.0f, 1.0f, 0.0f };
 
     AvatarComponent->SetAvatarId(NewAvatarId);
     AvatarComponent->SetState(NewAvatarState);
@@ -203,11 +203,11 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     const csp::common::String& UserName = "Creator 1";
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.11f, 2.22f, 3.33f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
-    bool IsVisible = false;
-    AvatarState UserAvatarState = AvatarState::Idle;
+    const bool IsVisible = false;
+    const AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "Creator1Avatar";
-    AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Creator;
-    LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
+    const AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Creator;
+    const LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
 
     auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -80,6 +80,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
     const csp::common::String UserName = "Player 1";
     const SpaceTransform UserTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
+    const bool IsVisible = true;
     const AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String UserAvatarId = "MyCoolAvatar";
     const AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
@@ -91,7 +92,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-        auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
         // Create object to represent the portal
         csp::common::String ObjectName = "Object 1";
@@ -118,7 +119,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
-        auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -51,30 +51,17 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    const char* TestSpaceName2 = "OLY-UNITTEST-SPACE-REWIND-2";
-    const char* TestSpaceDescription2 = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
-    char UniqueSpaceName2[256];
-    SPRINTF(UniqueSpaceName2, "%s-%s", TestSpaceName2, GetUniqueString().c_str());
-
     // Log in
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
+    // Create space 2
     csp::systems::Space Space2;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName2, TestSpaceDescription2, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space2);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     csp::common::String PortalSpaceID;
 
@@ -189,18 +176,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalThumbnailTest)
     PortalComponent->SetSpaceId(Space.Id);
     PortalComponent->GetSpaceThumbnail(Callback);
 
-    auto Start = std::chrono::steady_clock::now();
-    auto Current = std::chrono::steady_clock::now();
-    int64_t TestTime = 0;
-
-    while (!HasThumbailResult && TestTime < 20)
-    {
-        std::this_thread::sleep_for(50ms);
-
-        Current = std::chrono::steady_clock::now();
-        TestTime = std::chrono::duration_cast<std::chrono::seconds>(Current - Start).count();
-    }
-
+    WaitForCallback(HasThumbailResult);
     EXPECT_TRUE(HasThumbailResult);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -221,20 +197,13 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalScriptInterfaceTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     // Log in
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -284,12 +284,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -308,8 +303,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
 
@@ -345,12 +339,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -362,8 +351,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     InitialiseTestingConnection();
 
@@ -395,12 +383,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -412,8 +395,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     InitialiseTestingConnection();
 
@@ -449,12 +431,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -466,8 +443,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     InitialiseTestingConnection();
 
@@ -528,12 +504,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -545,8 +516,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -625,12 +595,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -638,8 +602,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -700,12 +663,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -713,8 +670,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -782,12 +738,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     auto ThisProcessTestUser = CreateTestUser();
@@ -797,8 +747,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Unlisted, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -869,12 +818,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -882,8 +825,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -937,12 +879,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -954,8 +891,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     InitialiseTestingConnection();
 
@@ -997,12 +933,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -1010,8 +940,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -1097,12 +1026,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -1110,8 +1033,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -1194,12 +1116,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpa
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -1207,8 +1123,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpa
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -1322,12 +1237,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
     const char* TestAssetCollectionName = "OLY-UNITTEST-ASSETCOLLECTION-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
     char UniqueAssetCollectionName[256];
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
@@ -1339,8 +1249,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     bool Interrupted = false;
     bool Disconnected = false;
@@ -1403,20 +1312,13 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     // Log in
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -1470,12 +1372,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -1483,8 +1379,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -1553,12 +1448,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -1566,8 +1455,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
@@ -1645,12 +1533,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
-    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
-    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::common::String UserId;
 
     // Log in
@@ -1658,8 +1540,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -1707,15 +1588,8 @@ void RunParentEntityReplicationTest(bool Local)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -1936,15 +1810,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -2029,15 +1896,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -2122,15 +1982,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -2218,15 +2071,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -2308,15 +2154,8 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ParentEntityEnterSpaceRepl
     LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -2434,15 +2273,8 @@ void RunParentChildDeletionTest(bool Local)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -2610,15 +2442,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateObjectParentTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
@@ -2666,15 +2491,8 @@ void RunParentDeletionTest(bool Local)
     LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
 
     // Create space
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
     csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -128,12 +128,13 @@ void OnConnect(SpaceEntitySystem* EntitySystem)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    EntitySystem->CreateAvatar(UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode,
+    EntitySystem->CreateAvatar(UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode,
         [EntitySystem](SpaceEntity* NewAvatar)
         {
             EXPECT_NE(NewAvatar, nullptr);
@@ -650,12 +651,13 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
     LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -678,6 +680,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
     EXPECT_EQ(AvatarComponent->GetState(), UserAvatarState);
     EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), UserAvatarPlayMode);
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
+    EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
@@ -723,12 +726,13 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
     const csp::common::String& UserName = "Creator 1";
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "MyCoolCreatorAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Creator;
     LocomotionModel UserAvatarLocomotionModel = LocomotionModel::Grounded;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -751,6 +755,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
     EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), UserAvatarPlayMode);
     EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), AvatarPlayMode::Creator);
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
+    EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
@@ -890,11 +895,12 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     auto& Components = *Avatar->GetComponents();
@@ -1346,15 +1352,16 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
     EntitySystem->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
-    auto [Avatar]
-        = Awaitable(&SpaceEntitySystem::CreateAvatar, EntitySystem, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode)
-              .Await();
+    auto [Avatar] = Awaitable(
+        &SpaceEntitySystem::CreateAvatar, EntitySystem, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode)
+                        .Await();
 
     auto Start = std::chrono::steady_clock::now();
     auto Current = std::chrono::steady_clock::now();
@@ -1489,11 +1496,12 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     const csp::common::String& UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -738,6 +738,12 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
+    const char* TestSpaceName = "OLY-UNITTEST-SPACE-REWIND";
+    const char* TestSpaceDescription = "OLY-UNITTEST-SPACEDESC-REWIND";
+
+    char UniqueSpaceName[256];
+    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
     csp::common::String UserId;
 
     auto ThisProcessTestUser = CreateTestUser();
@@ -747,7 +753,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
 
     // Create space
     csp::systems::Space Space;
-    CreateDefaultTestSpace(SpaceSystem, Space);
+    CreateSpace(
+        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Unlisted, nullptr, nullptr, nullptr, nullptr, Space);
 
     // Enter space
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -242,12 +242,13 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -354,11 +355,12 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AvatarScriptTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
     EXPECT_EQ(Avatar->GetName(), UserName);
@@ -448,11 +450,12 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptLogTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     AvatarState UserAvatarState = AvatarState::Idle;
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
     EXPECT_EQ(Avatar->GetName(), UserName);
@@ -521,12 +524,13 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteScriptTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -628,12 +632,13 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteAndChangeComponentTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -755,12 +760,13 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -893,12 +899,13 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptDeltaTimeTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -1007,12 +1014,13 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubs
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -1118,12 +1126,13 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
     csp::common::String UserAvatarId = "MyCoolAvatar";
 
     AvatarState UserState = AvatarState::Idle;
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;

--- a/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
@@ -147,10 +147,12 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInSendNewAvatarObj
 
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
 
     async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
         .then(async::inline_scheduler(),
-            SpaceEntitySystem->SendNewAvatarObjectMessage("Username", UserTransform, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
+            SpaceEntitySystem->SendNewAvatarObjectMessage(
+                "Username", UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
         .then(async::inline_scheduler(),
             [](std::tuple<const signalr::value&, std::exception_ptr> Results)
             {
@@ -188,10 +190,12 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorInSendNewAvatarObjec
 
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
 
     async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
         .then(async::inline_scheduler(),
-            SpaceEntitySystem->SendNewAvatarObjectMessage("Username", UserTransform, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
+            SpaceEntitySystem->SendNewAvatarObjectMessage(
+                "Username", UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
         .then(async::inline_scheduler(),
             [](std::tuple<const signalr::value&, std::exception_ptr> Results)
             {
@@ -235,10 +239,11 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInCreateNewLocalAv
     const uint64_t Id = 55;
     const SpaceTransform UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
 
     EXPECT_CALL(MockCallback, Call(::testing::_))
         .WillOnce(::testing::Invoke(
-            [Id, &Username, &AvatarId, AvatarState, AvatarPlayMode, &UserTransform](SpaceEntity* CreatedSpaceEntity)
+            [Id, &Username, &AvatarId, AvatarState, AvatarPlayMode, &UserTransform, IsVisible](SpaceEntity* CreatedSpaceEntity)
             {
                 ASSERT_NE(CreatedSpaceEntity, nullptr);
                 ASSERT_EQ(CreatedSpaceEntity->GetId(), Id);
@@ -254,6 +259,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInCreateNewLocalAv
                 ASSERT_EQ(AvatarComponent->GetAvatarId(), AvatarId);
                 ASSERT_EQ(AvatarComponent->GetAvatarPlayMode(), AvatarPlayMode);
                 ASSERT_EQ(AvatarComponent->GetState(), AvatarState);
+                ASSERT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
             }));
 
     async::spawn(async::inline_scheduler(),
@@ -262,7 +268,8 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInCreateNewLocalAv
             return std::make_tuple(async::make_task(uint64_t { 55 }).share(), async::make_task());
         }) // This continuation takes the ID (and another void return from a when_all branch) as its input
         .then(async::inline_scheduler(),
-            SpaceEntitySystem->CreateNewLocalAvatar(Username, UserTransform, AvatarId, AvatarState, AvatarPlayMode, MockCallback.AsStdFunction()));
+            SpaceEntitySystem->CreateNewLocalAvatar(
+                Username, UserTransform, IsVisible, AvatarId, AvatarState, AvatarPlayMode, MockCallback.AsStdFunction()));
 
     // During destruction (test cleanup) CSP can access the connection.
     // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.
@@ -301,8 +308,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorLoggedFromWholeCreat
 
     const SpaceTransform& UserTransform
         = { csp::common::Vector3 { 1.452322f, 2.34f, 3.45f }, csp::common::Vector4 { 4.1f, 5.1f, 6.1f, 7.1f }, csp::common::Vector3 { 1, 1, 1 } };
+    bool IsVisible = true;
 
-    SpaceEntitySystem->CreateAvatar("Username", UserTransform, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default, MockCallback.AsStdFunction());
+    SpaceEntitySystem->CreateAvatar(
+        "Username", UserTransform, IsVisible, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default, MockCallback.AsStdFunction());
 
     // During destruction (test cleanup) CSP can access the connection.
     // We can't leave the main Mock dangling because it needs to run RAII test assertion behaviour, so use a throwaway.


### PR DESCRIPTION
Added support for visibility control to the AvatarSpaceComponent.

- Implemented the IVisibleComponent interface in the AvatarSpaceComponent.
- Updated the Avatar component script interface to add script support for the new IsVisible and IsARVisible properties.
- Updated Entity script bindings to include new visibility properties.
- Updated the SpaceEntitySystem Avatar creation methods to take an initial Avatar visibility argument.
- Added tests to cover the new visibility property for the Avatar component.

Only 3 commits but probably easier to review them individually as the last commit is just concerned with minor improvements to the existing tests that required updates as part of this work.

> [!NOTE]
> There were no existing tests for the Avatar Space Component so I have added two, one to test Avatar property updating and the other to test the Avatar Script interface. I had intended to add a third to test to ensure that property updates persist between Spaces, but of course Avatars are transient and so this was removed. 

> [!IMPORTANT]
> While do this work I noticed that one of the Avatar components existing properties `LocomotionModel`  had not been exposed via the script interface, so I added that while I was in the area.

