### PR TITLE
[OF-1646] fix: re-instate the Agora tests after CHS enabled proxy services on the local tenant

### DIFF
--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -938,8 +938,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AppleLogInTest)
 }
 #endif
 
-// This test is to be fixed as part of OF-1646.
-CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
 {
     SetRandSeed();
 
@@ -1006,8 +1005,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, GetAgoraUserTokenTest)
     LogOut(UserSystem);
 }
 
-// This test is to be fixed as part of OF-1646.
-CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, PostServiceProxyTest)
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, PostServiceProxyTest)
 {
     SetRandSeed();
 


### PR DESCRIPTION
What the title says, really. The tests started passing, presumably after CHS implemented proxy services in the local tenant. I have updated my CHS image this morning, and I hadn't in a while. So the change might have already been there longer.

- Passed using local CHS on my local machine, 55 successful runs each so far. I killed it after it reached 100 successful successive runs for each
![image](https://github.com/user-attachments/assets/8e1891bc-e3bf-4ae8-8e35-f9c09cbde314)
- Green local CHS CI job: https://magnopus.teamcity.com/buildConfiguration/Olympus_Foundation_X64_TestsLocalChsInstance/291280 (see also below, in the checks)
- Green live CHS CI job: https://magnopus.teamcity.com/buildConfiguration/Olympus_Foundation_X64_FunctionalTests/291295?buildTab=overview&focusLine=NaN