### PR TITLE
[OF-1672] refac!: Decouple script execution from election manager

### DIFF
--- a/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
+++ b/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "CSP/Common/String.h"
+
+namespace csp::common
+{
+
+/**
+ * @class IScriptRunner
+ * @brief Interface abstraction of an entity capable of running a script.
+ *
+ * This type enforces an interface allowing a call into the CSP script system.
+ * The motivation of this type was initially architectural, representing a dependency break
+ * between the existing ScriptSystem and other modules that need to invoke script behaviour.
+ * For that reason, there are some interface quirks, particularly the script context ID
+ * being specifically relevant to the context provided by the current CSP Script System.
+ *
+ * CSP's ScriptSystem fulfils this interface, you may pass it into any methods that
+ * require IJSScriptRunner.
+ */
+class CSP_API IJSScriptRunner
+{
+public:
+    /// @brief Virtual destructor.
+    virtual ~IJSScriptRunner() = default;
+
+    /**
+     * @brief Attempts to execute a script in a given context.
+     * @param ContextId The Id of the CSP script context in which to run the script.
+     *                  If the provided context does not exist, the script run will fail.
+     * @param ScriptText The text of the script to be executed by the javascript engine.
+     * @return A boolean representing success running the script.
+     */
+    virtual bool RunScript(int64_t ContextId, const csp::common::String& ScriptText) = 0;
+};
+}

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "CSP/CSPCommon.h"
+#include "CSP/Common/Interfaces/IJSScriptRunner.h"
 #include "CSP/Common/List.h"
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Common/String.h"
@@ -271,7 +272,9 @@ public:
     bool SetSelectionStateOfEntity(const bool SelectedState, SpaceEntity* Entity);
 
     /// @brief Enable Leader Election feature.
-    void EnableLeaderElection();
+    /// @param RemoteScriptRunner IJSScriptRunner : Object capable of running a script. Called to execute scripts when the leader election system
+    /// receives a remote script run event.
+    void EnableLeaderElection(csp::common::IJSScriptRunner& RemoteScriptRunner);
 
     /// @brief Disable Leader Election feature.
     void DisableLeaderElection();
@@ -337,14 +340,18 @@ public:
     CSP_NO_EXPORT void ResolveEntityHierarchy(SpaceEntity* Entity);
 
     /// @brief Initialise the SpaceEntitySystem
-    CSP_NO_EXPORT void Initialise();
+    /// @param RemoteScriptRunner IJSScriptRunner : Object capable of running a script. Called to execute scripts when the leader election system
+    /// receives a remote script run event.
+    CSP_NO_EXPORT void Initialise(csp::common::IJSScriptRunner& RemoteScriptRunner);
 
     /// @brief Shut down the SpaceEntitySystem
     CSP_NO_EXPORT void Shutdown();
 
     /// @brief SpaceEntitySystem constructor
     /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the SpaceEntitySystem with
-    CSP_NO_EXPORT SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem);
+    /// @param
+    CSP_NO_EXPORT SpaceEntitySystem(
+        MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner);
 
     /// @brief SpaceEntitySystem destructor
     CSP_NO_EXPORT ~SpaceEntitySystem();

--- a/Library/include/CSP/Systems/Script/ScriptSystem.h
+++ b/Library/include/CSP/Systems/Script/ScriptSystem.h
@@ -18,6 +18,7 @@
 
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/Array.h"
+#include "CSP/Common/Interfaces/IJSScriptRunner.h"
 #include "CSP/Common/String.h"
 
 #include <functional>
@@ -35,7 +36,7 @@ public:
 };
 
 /// @brief A JavaScript based scripting system that can be used to create advanced behaviours and interactions between entities in spaces.
-class CSP_API ScriptSystem
+class CSP_API ScriptSystem : csp::common::IJSScriptRunner
 {
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
@@ -54,7 +55,7 @@ public:
     /// @param ContextId : The context in which to run the script. If the provided context does not exist, the script run will fail.
     /// @param ScriptText : The script to execute.
     /// @return a boolean representing success running the script.
-    bool RunScript(int64_t ContextId, const csp::common::String& ScriptText);
+    bool RunScript(int64_t ContextId, const csp::common::String& ScriptText) override;
     /// @brief Attempts to execute a script from a given file path in the given context.
     /// @param ContextId  : The context in which to run the script. If the provided context does not exist, the script run will fail.
     /// @param ScriptFilePath  : The file path of the script to execute.

--- a/Library/src/Multiplayer/Election/ClientElectionManager.h
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "CSP/Common/Interfaces/IJSScriptRunner.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/SpaceEntitySystem.h"
 #include "ClientProxy.h"
@@ -48,7 +49,7 @@ class ClientElectionManager
     /** @endcond */
 
 public:
-    ClientElectionManager(SpaceEntitySystem* InSpaceEntitySystem, csp::common::LogSystem& LogSystem);
+    ClientElectionManager(SpaceEntitySystem* InSpaceEntitySystem, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& JSScriptRunner);
     ~ClientElectionManager();
 
     void OnConnect(const SpaceEntitySystem::SpaceEntityList& Avatars, const SpaceEntitySystem::SpaceEntityList& Objects);
@@ -122,6 +123,7 @@ private:
     ClientProxy* Leader;
 
     csp::multiplayer::SpaceEntitySystem::CallbackHandler ScriptSystemReadyCallback;
+    csp::common::IJSScriptRunner& RemoteScriptRunner;
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -202,7 +202,8 @@ SpaceEntitySystem::SpaceEntitySystem()
 {
 }
 
-SpaceEntitySystem::SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem)
+SpaceEntitySystem::SpaceEntitySystem(
+    MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner)
     : EntitiesLock(new std::recursive_mutex)
     , MultiplayerConnectionInst(InMultiplayerConnection)
     , Connection(nullptr)
@@ -218,7 +219,7 @@ SpaceEntitySystem::SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnect
     , LastTickTime(std::chrono::system_clock::now())
     , EntityPatchRate(90)
 {
-    Initialise();
+    Initialise(RemoteScriptRunner);
 }
 
 SpaceEntitySystem::~SpaceEntitySystem()
@@ -236,14 +237,14 @@ SpaceEntitySystem::~SpaceEntitySystem()
     delete (PendingIncomingUpdates);
 }
 
-void SpaceEntitySystem::Initialise()
+void SpaceEntitySystem::Initialise(csp::common::IJSScriptRunner& RemoteScriptRunner)
 {
     if (IsInitialised)
     {
         return;
     }
 
-    EnableLeaderElection();
+    EnableLeaderElection(RemoteScriptRunner);
 
     ScriptBinding = EntityScriptBinding::BindEntitySystem(this, *LogSystem);
 
@@ -1092,11 +1093,11 @@ bool SpaceEntitySystem::SetSelectionStateOfEntity(const bool SelectedState, Spac
     return false;
 }
 
-void SpaceEntitySystem::EnableLeaderElection()
+void SpaceEntitySystem::EnableLeaderElection(csp::common::IJSScriptRunner& RemoteScriptRunner)
 {
     if (ElectionManager == nullptr)
     {
-        ElectionManager = new ClientElectionManager(this, *LogSystem);
+        ElectionManager = new ClientElectionManager(this, *LogSystem, RemoteScriptRunner);
     }
 }
 

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -160,7 +160,7 @@ void SystemsManager::CreateSystems()
     ConversationSystem = new csp::systems::ConversationSystemInternal(AssetSystem, SpaceSystem, UserSystem, EventBus, *LogSystem);
 
     // Not a SystemBase inheritor (to become IRealtimeEngine anyway)
-    SpaceEntitySystem = new csp::multiplayer::SpaceEntitySystem(MultiplayerConnection, *LogSystem);
+    SpaceEntitySystem = new csp::multiplayer::SpaceEntitySystem(MultiplayerConnection, *LogSystem, *ScriptSystem);
 }
 
 void SystemsManager::DestroySystems()


### PR DESCRIPTION
The election manager existing in realtime engine (or at all) is a symptom of not having scope to do a total rearchitecture.
Currently, the election manager needs a way to run a script in order to respond to remote script run events.

Define an interface to break this dependency. Make the existing ScriptSystem fulfil this interface. Clients will need to inject this into their RealtimeEngine.

BREAKING
- `EnableLeaderElection` now takes an object that fulfills the scriptRunner interface. Just pass the scriptsystem to it if you are actually using this. Normal flows won't need this as `EnableLeaderElection` is set by default.
