### PR TITLE
[OF-1687] refac: localize the multiplayer hub functions to a single point of configuration

### DIFF
--- a/Library/docs/source/manual/documentation/multiplayer_state_replication.md
+++ b/Library/docs/source/manual/documentation/multiplayer_state_replication.md
@@ -37,7 +37,7 @@ UpdatedEntity->SerialisePatch(Serialiser);
 auto SerialisedEntity = Serialiser.Finalise();
 
 std::vector<signalr::value> InvokeArguments = {SerialisedEntity};
-Connection->Invoke("SendObjectPatch", InvokeArguments, LocalCallback);
+Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::SEND_OBJECT_PATCH], InvokeArguments, LocalCallback);
 ```
 
 The serializer is set to parse over the `SpaceEntity` data in a specific way in order to format the message correctly. it starts with the Dto metadata of `Id`, `OwnerId`, `Destroy`, `ParentId`.

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -21,6 +21,7 @@
 #include "CSP/Common/String.h"
 #include "CSP/Multiplayer/Conversation/Conversation.h"
 #include "CSP/Multiplayer/EventParameters.h"
+#include "CSP/Multiplayer/MultiplayerHubMethods.h"
 
 #include <atomic>
 #include <functional>

--- a/Library/include/CSP/Multiplayer/MultiplayerHubMethods.h
+++ b/Library/include/CSP/Multiplayer/MultiplayerHubMethods.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace csp::multiplayer
+{
+
+/// @brief Enum used to specify the SignalR method to invoke in the multiplayer connection.
+enum class MultiplayerHubMethod
+{
+    DELETE_OBJECTS,
+    GENERATE_OBJECT_IDS,
+    GET_CLIENT_ID,
+    PAGE_SCOPED_OBJECTS,
+    RESET_SCOPES,
+    SEND_EVENT_MESSAGE,
+    SEND_OBJECT_MESSAGE,
+    SEND_OBJECT_NOT_FOUND,
+    SEND_OBJECT_PATCH,
+    SEND_OBJECT_PATCHES,
+    SET_ALLOW_SELF_MESSAGING,
+    SET_SCOPES,
+    START_LISTENING,
+    STOP_LISTENING
+};
+
+/// @brief Utility class to map input values from MultiplayerHubMethod to string representations.
+struct MultiplayerHubMethodMap : public std::unordered_map<MultiplayerHubMethod, std::string>
+{
+    MultiplayerHubMethodMap()
+    {
+        this->operator[](MultiplayerHubMethod::DELETE_OBJECTS) = "DeleteObjects";
+        this->operator[](MultiplayerHubMethod::GENERATE_OBJECT_IDS) = "GenerateObjectIds";
+        this->operator[](MultiplayerHubMethod::GET_CLIENT_ID) = "GetClientId";
+        this->operator[](MultiplayerHubMethod::PAGE_SCOPED_OBJECTS) = "PageScopedObjects";
+        this->operator[](MultiplayerHubMethod::RESET_SCOPES) = "ResetScopes";
+        this->operator[](MultiplayerHubMethod::SEND_EVENT_MESSAGE) = "SendEventMessage";
+        this->operator[](MultiplayerHubMethod::SEND_OBJECT_MESSAGE) = "SendObjectMessage";
+        this->operator[](MultiplayerHubMethod::SEND_OBJECT_NOT_FOUND) = "SendObjectNotFound";
+        this->operator[](MultiplayerHubMethod::SEND_OBJECT_PATCH) = "SendObjectPatch";
+        this->operator[](MultiplayerHubMethod::SEND_OBJECT_PATCHES) = "SendObjectPatches";
+        this->operator[](MultiplayerHubMethod::SET_ALLOW_SELF_MESSAGING) = "SetAllowSelfMessaging";
+        this->operator[](MultiplayerHubMethod::SET_SCOPES) = "SetScopes";
+        this->operator[](MultiplayerHubMethod::START_LISTENING) = "StartListening";
+        this->operator[](MultiplayerHubMethod::STOP_LISTENING) = "StopListening";
+    }
+
+    ~MultiplayerHubMethodMap() { }
+};
+
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -311,7 +311,7 @@ auto MultiplayerConnection::RequestClientId()
             ClientIdRequestedEvent->set(Result.as_uinteger());
         };
 
-        LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling GetClientId");
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose, ("Calling " + MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID]).c_str());
 
         Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID], signalr::value(signalr::value_type::array), LocalCallback);
         return ClientIdRequestedContinuation;
@@ -637,7 +637,8 @@ CSP_ASYNC_RESULT void MultiplayerConnection::SetAllowSelfMessagingFlag(const boo
         INVOKE_IF_NOT_NULL(Callback, ErrorCode::None);
     };
 
-    LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling SetAllowSelfMessaging");
+    LogSystem.LogMsg(
+        csp::common::LogLevel::Verbose, ("Calling " + MultiplayerHubMethodMap()[MultiplayerHubMethod::SET_ALLOW_SELF_MESSAGING]).c_str());
 
     const std::vector InvokeArguments = { signalr::value(InAllowSelfMessaging) };
     Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::SET_ALLOW_SELF_MESSAGING], InvokeArguments, LocalCallback);

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -345,7 +345,7 @@ std::function<async::task<void>()> MultiplayerConnection::StartListening()
             StartListeningEvent->set();
         };
 
-        LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling StartListening");
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose, ("Calling " + MultiplayerHubMethodMap()[MultiplayerHubMethod::START_LISTENING]).c_str());
         Connection->Invoke(
             MultiplayerHubMethodMap()[MultiplayerHubMethod::START_LISTENING], signalr::value(signalr::value_type::array), LocalCallback);
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -247,8 +247,9 @@ auto MultiplayerConnection::DeleteEntities(uint64_t EntityId) const
             if (Except != nullptr)
             {
                 auto [Error, ExceptionErrorMsg] = ParseMultiplayerErrorFromExceptionPtr(Except);
-                EntitiesDeletedEvent->set_exception(std::make_exception_ptr(ErrorCodeException(
-                    Error, "MultiplayerConnection::DeleteEntities, Unexpected error response from SignalR \"DeleteObjects\" invocation.")));
+                EntitiesDeletedEvent->set_exception(std::make_exception_ptr(ErrorCodeException(Error,
+                    "MultiplayerConnection::DeleteEntities, Unexpected error response from SignalR \""
+                        + MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS] + "\" invocation.")));
                 return;
             }
 
@@ -270,7 +271,7 @@ auto MultiplayerConnection::DeleteEntities(uint64_t EntityId) const
 
         signalr::value DeleteEntityMessage = signalr::value(std::move(ParamsVec));
 
-        LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling DeleteObjects");
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose, ("Calling " + MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS]).c_str());
 
         Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS], DeleteEntityMessage, LocalCallback);
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -272,7 +272,7 @@ auto MultiplayerConnection::DeleteEntities(uint64_t EntityId) const
 
         LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling DeleteObjects");
 
-        Connection->Invoke("DeleteObjects", DeleteEntityMessage, LocalCallback);
+        Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS], DeleteEntityMessage, LocalCallback);
 
         return EntitiesDeletedContinuation;
     };
@@ -312,7 +312,7 @@ auto MultiplayerConnection::RequestClientId()
 
         LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling GetClientId");
 
-        Connection->Invoke("GetClientId", signalr::value(signalr::value_type::array), LocalCallback);
+        Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID], signalr::value(signalr::value_type::array), LocalCallback);
         return ClientIdRequestedContinuation;
     };
 }
@@ -345,7 +345,8 @@ std::function<async::task<void>()> MultiplayerConnection::StartListening()
         };
 
         LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling StartListening");
-        Connection->Invoke("StartListening", signalr::value(signalr::value_type::array), LocalCallback);
+        Connection->Invoke(
+            MultiplayerHubMethodMap()[MultiplayerHubMethod::START_LISTENING], signalr::value(signalr::value_type::array), LocalCallback);
 
         return StartListeningContinuation;
     };
@@ -539,7 +540,7 @@ void MultiplayerConnection::SetScopes(csp::common::String InSpaceId, ErrorCodeCa
     ParamsVec.push_back(ScopesVec);
     signalr::value Params = signalr::value(std::move(ParamsVec));
 
-    Connection->Invoke("SetScopes", Params, LocalCallback);
+    Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::SET_SCOPES], Params, LocalCallback);
 }
 
 void MultiplayerConnection::ResetScopes(ErrorCodeCallbackHandler Callback)
@@ -566,7 +567,7 @@ void MultiplayerConnection::ResetScopes(ErrorCodeCallbackHandler Callback)
 
     std::vector<signalr::value> ParamsVec;
     signalr::value Params = signalr::value(std::move(ParamsVec));
-    Connection->Invoke("ResetScopes", Params, LocalCallback);
+    Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::RESET_SCOPES], Params, LocalCallback);
 }
 
 void MultiplayerConnection::StopListening(ErrorCodeCallbackHandler Callback)
@@ -593,7 +594,7 @@ void MultiplayerConnection::StopListening(ErrorCodeCallbackHandler Callback)
 
     LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling StopListening");
 
-    Connection->Invoke("StopListening", signalr::value(signalr::value_type::array), LocalCallback);
+    Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::STOP_LISTENING], signalr::value(signalr::value_type::array), LocalCallback);
 }
 
 uint64_t MultiplayerConnection::GetClientId() const { return ClientId; }
@@ -638,7 +639,7 @@ CSP_ASYNC_RESULT void MultiplayerConnection::SetAllowSelfMessagingFlag(const boo
     LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling SetAllowSelfMessaging");
 
     const std::vector InvokeArguments = { signalr::value(InAllowSelfMessaging) };
-    Connection->Invoke("SetAllowSelfMessaging", InvokeArguments, LocalCallback);
+    Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::SET_ALLOW_SELF_MESSAGING], InvokeArguments, LocalCallback);
 }
 
 bool MultiplayerConnection::GetAllowSelfMessagingFlag() const { return AllowSelfMessaging; }

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -593,7 +593,7 @@ void MultiplayerConnection::StopListening(ErrorCodeCallbackHandler Callback)
         INVOKE_IF_NOT_NULL(Callback, ErrorCode::None);
     };
 
-    LogSystem.LogMsg(csp::common::LogLevel::Verbose, "Calling StopListening");
+    LogSystem.LogMsg(csp::common::LogLevel::Verbose, ("Calling " + MultiplayerHubMethodMap()[MultiplayerHubMethod::STOP_LISTENING]).c_str());
 
     Connection->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::STOP_LISTENING], signalr::value(signalr::value_type::array), LocalCallback);
 }

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -172,7 +172,7 @@ void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventN
     std::vector<signalr::value> InvokeArguments;
     InvokeArguments.push_back(EventMessage);
 
-    ISignalRConnectionPtr->Invoke("SendEventMessage", InvokeArguments, LocalCallback);
+    ISignalRConnectionPtr->Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::SEND_EVENT_MESSAGE], InvokeArguments, LocalCallback);
 }
 
 } // namespace csp::multiplayer

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2823,10 +2823,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
                     Callback(Value, nullptr);
                     return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
                 }
-                else if (HubMethodName == "GetClientId")
+                else if (HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID])
                 {
                     // Fail getting client Id
-                    auto Value = signalr::value("Irrelevant value from GetClientId");
+                    auto Value = signalr::value("Irrelevant value from " + MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID]);
                     auto Except = std::make_exception_ptr(std::runtime_error("mock exception"));
                     Callback(Value, Except);
                     return async::make_task(std::make_tuple(Value, Except));
@@ -2872,7 +2872,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
                     Callback(Value, nullptr);
                     return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
                 }
-                else if (HubMethodName == "GetClientId")
+                else if (HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID])
                 {
                     // Succeed getting client Id
                     Callback(signalr::value(std::uint64_t(0)), nullptr);
@@ -2925,7 +2925,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
                     Callback(Value, nullptr);
                     return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
                 }
-                else if ((HubMethodName == "GetClientId") || (HubMethodName == "StartListening"))
+                else if ((HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID]) || (HubMethodName == "StartListening"))
                 {
                     // Succeed getting client Id
                     Callback(signalr::value(std::uint64_t(0)), nullptr);

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2878,7 +2878,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
                     Callback(signalr::value(std::uint64_t(0)), nullptr);
                     return async::make_task(std::make_tuple(signalr::value(std::uint64_t(0)), std::exception_ptr(nullptr)));
                 }
-                else if (HubMethodName == "StartListening")
+                else if (HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::START_LISTENING])
                 {
                     // Fail to start listening
                     auto Except = std::make_exception_ptr(std::runtime_error("mock exception"));
@@ -2925,7 +2925,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
                     Callback(Value, nullptr);
                     return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
                 }
-                else if ((HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID]) || (HubMethodName == "StartListening"))
+                else if ((HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::GET_CLIENT_ID])
+                    || (HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::START_LISTENING]))
                 {
                     // Succeed getting client Id
                     Callback(signalr::value(std::uint64_t(0)), nullptr);

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2779,7 +2779,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
             [](const std::string& /*DeleteObjectsMethodName*/, const signalr::value& /*DeleteEntityMessage*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
-                auto Value = signalr::value("Irrelevant value from DeleteObjects");
+                auto Value = signalr::value("Irrelevant value from " + MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS]);
                 auto Except = std::make_exception_ptr(std::runtime_error("mock exception"));
                 Callback(Value, Except);
                 return async::make_task(std::make_tuple(Value, Except));
@@ -2792,7 +2792,9 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
     // And the disconnection callback will be called with a message (weird)
     MockConnectionCallback MockDisconnectionCallback;
     EXPECT_CALL(MockDisconnectionCallback,
-        Call(csp::common::String("MultiplayerConnection::DeleteEntities, Unexpected error response from SignalR \"DeleteObjects\" invocation.")));
+        Call(csp::common::String(("MultiplayerConnection::DeleteEntities, Unexpected error response from SignalR \""
+            + MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS] + "\" invocation.")
+                                     .c_str())));
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, "", "");
@@ -2814,10 +2816,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
             [](const std::string& HubMethodName, const signalr::value& /*Message*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
-                if (HubMethodName == "DeleteObjects")
+                if (HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS])
                 {
                     // Succeed deleting objects
-                    auto Value = signalr::value("Irrelevant value from DeleteObjects");
+                    auto Value = signalr::value("Irrelevant value from " + MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS]);
                     Callback(Value, nullptr);
                     return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
                 }
@@ -2863,10 +2865,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
             [](const std::string& HubMethodName, const signalr::value& /*Message*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
-                if (HubMethodName == "DeleteObjects")
+                if (HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS])
                 {
                     // Succeed deleting objects
-                    auto Value = signalr::value("Irrelevant value from DeleteObjects");
+                    auto Value = signalr::value("Irrelevant value from " + MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS]);
                     Callback(Value, nullptr);
                     return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
                 }
@@ -2916,10 +2918,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
             [](const std::string& HubMethodName, const signalr::value& /*Message*/,
                 std::function<void(const signalr::value&, std::exception_ptr)> Callback)
             {
-                if (HubMethodName == "DeleteObjects")
+                if (HubMethodName == MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS])
                 {
                     // Succeed deleting objects
-                    auto Value = signalr::value("Irrelevant value from DeleteObjects");
+                    auto Value = signalr::value("Irrelevant value from " + MultiplayerHubMethodMap()[MultiplayerHubMethod::DELETE_OBJECTS]);
                     Callback(Value, nullptr);
                     return async::make_task(std::make_tuple(Value, std::exception_ptr(nullptr)));
                 }

--- a/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceEntitySystemTests.cpp
@@ -57,7 +57,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInRemoteGenerateNe
     SpaceEntitySystem->SetConnection(SignalRMock.get());
 
     // SignalR populates a result and not an exception
-    EXPECT_CALL(*SignalRMock, Invoke("GenerateObjectIds", ::testing::_, ::testing::_))
+    EXPECT_CALL(*SignalRMock, Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::GENERATE_OBJECT_IDS], ::testing::_, ::testing::_))
         .WillOnce(
             [](const std::string& /**/, const signalr::value& /**/,
                 std::function<void(const signalr::value&, std::exception_ptr)> /**/) -> async::task<std::tuple<signalr::value, std::exception_ptr>>
@@ -98,7 +98,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorInRemoteGenerateNewA
     SpaceEntitySystem->SetConnection(SignalRMock.get());
 
     // SignalR populates an exception
-    EXPECT_CALL(*SignalRMock, Invoke("GenerateObjectIds", ::testing::_, ::testing::_))
+    EXPECT_CALL(*SignalRMock, Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::GENERATE_OBJECT_IDS], ::testing::_, ::testing::_))
         .WillOnce(
             [](const std::string& /**/, const signalr::value& /**/, std::function<void(const signalr::value&, std::exception_ptr)> /**/) {
                 return async::make_task(
@@ -139,7 +139,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestSuccessInSendNewAvatarObj
     SpaceEntitySystem->SetConnection(SignalRMock.get());
 
     // SignalR populates a result and not an exception
-    EXPECT_CALL(*SignalRMock, Invoke("SendObjectMessage", ::testing::_, ::testing::_))
+    EXPECT_CALL(*SignalRMock, Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::SEND_OBJECT_MESSAGE], ::testing::_, ::testing::_))
         .WillOnce(
             [](const std::string& /**/, const signalr::value& /**/,
                 std::function<void(const signalr::value&, std::exception_ptr)> /**/) -> async::task<std::tuple<signalr::value, std::exception_ptr>>
@@ -180,7 +180,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntitySystemTests, TestErrorInSendNewAvatarObjec
     SpaceEntitySystem->SetConnection(SignalRMock.get());
 
     // SignalR populates an exception
-    EXPECT_CALL(*SignalRMock, Invoke("SendObjectMessage", ::testing::_, ::testing::_))
+    EXPECT_CALL(*SignalRMock, Invoke(MultiplayerHubMethodMap()[MultiplayerHubMethod::SEND_OBJECT_MESSAGE], ::testing::_, ::testing::_))
         .WillOnce(
             [](const std::string& /**/, const signalr::value& /**/,
                 std::function<void(const signalr::value&, std::exception_ptr)> /**/) -> async::task<std::tuple<signalr::value, std::exception_ptr>> {


### PR DESCRIPTION
The overall changes are a refactor of the current usage of fixed strings within the multiplayer system and should not affect existing behaviour. As a result, the changes can be described as follows:

 - Add MultiplayerHubMethod enum and mapping utility
 - Update all references in SignalR, Logs, and Tests 