### PR TITLE
[OB-4478] fix: Initialize SpaceEntitySystem when entering space

### DIFF
--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -370,6 +370,7 @@ void SpaceSystem::EnterSpace(const String& SpaceId, NullResultCallback Callback)
                 "SpaceSystem: EnterSpace, successfully refreshed multiplayer scopes", MakeInvalid<NullResult>(),
                 *csp::systems::SystemsManager::Get().GetLogSystem(), csp::common::LogLevel::Error))
         .then(async::inline_scheduler(), systems::continuations::ReportSuccess(Callback, "Successfully entered space."))
+        .then(async::inline_scheduler(), []() { csp::systems::SystemsManager::Get().GetSpaceEntitySystem()->Initialise(); })
         .then(async::inline_scheduler(),
             csp::common::continuations::InvokeIfExceptionInChain([&CurrentSpace = CurrentSpace](const std::exception& /*Except*/)
                 { CurrentSpace = {}; },

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -3136,6 +3136,57 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceTest)
     LogOut(UserSystem);
 }
 
+CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, ReEnterSpaceTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = ::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    const char* TestSpaceName = "CSP-TEST-SPACE";
+    const char* TestSpaceDescription = "CSP-TEST-SPACEDESC";
+
+    char UniqueSpaceName[256];
+    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+    String UserId;
+
+    // Create default and alt users
+    csp::systems::Profile DefaultUser = CreateTestUser();
+    csp::systems::Profile AlternativeUser = CreateTestUser();
+
+    // Log in
+    LogIn(UserSystem, UserId, DefaultUser.Email, GeneratedTestAccountPassword);
+
+    // Create space
+    ::Space Space;
+    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
+
+    // This is a regression test against the space entity system non initialising on re-entering a space
+    // Using Leader election enabled as a proxy as behind the scenes that just checks if the election manager is null, something that is set/unset
+    // during init/shutdown. This should hopefully be redundant soon as SpaceEntitySystem will be initialized by definition.
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+    ASSERT_TRUE(SystemsManager.GetSpaceEntitySystem()->IsLeaderElectionEnabled());
+
+    // Leave the space
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+    ASSERT_EQ(ExitSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
+    ASSERT_FALSE(SystemsManager.GetSpaceEntitySystem()->IsLeaderElectionEnabled());
+
+    // Re-enter the space
+    auto [ReEnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    ASSERT_EQ(ReEnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+    ASSERT_TRUE(SystemsManager.GetSpaceEntitySystem()->IsLeaderElectionEnabled());
+
+    // Delete space
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    // Log out
+    LogOut(UserSystem);
+}
+
 namespace CSPEngine
 {
 /*


### PR DESCRIPTION
During an otherwise innocuous function move, we removed the SpaceEntitySystem initialization from the EnterSpace flow. This occurred because it was hidden in the awful RefreshMultiplayerScopes tech debt we have in that flow, so a copy/paste error was invisible.

We almost never test space re-entry, added a test to at least prove pass/fail of this change.

This error has been in the codebase for about 3 weeks.
