### PR TITLE
[NT-0] fix: Remove redundant warning pop from bottom of IScriptRunner

### DIFF
--- a/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
+++ b/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
@@ -163,7 +163,3 @@ protected:
     IJSScriptRunner() = default;
 };
 }
-
-CSP_START_IGNORE
-#pragma warning(pop)
-CSP_END_IGNORE


### PR DESCRIPTION
We removed the first warning macro, but not the second. How did none of our compilers see this?
Fails builds on some build configs. Clients spotted it. :(