### PR TITLE
[Ob-4479] Fix: Updating conversation was causing annotation to be lost

### DIFF
--- a/Library/src/Systems/Conversation/ConversationSystemHelpers.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemHelpers.cpp
@@ -268,4 +268,15 @@ multiplayer::MessageInfo GetConversationInfoFromConversationAssetCollection(cons
     return Info;
 }
 
+void AppendMetadata(csp::common::Map<csp::common::String, csp::common::String>& MetadataToUpdate,
+    const csp::common::Map<csp::common::String, csp::common::String>& NewMetadataValues)
+{
+    std::unique_ptr<common::Array<common::String>> Keys(const_cast<common::Array<common::String>*>(NewMetadataValues.Keys()));
+
+    for (const auto& Key : *Keys)
+    {
+        MetadataToUpdate[Key] = NewMetadataValues[Key];
+    }
+}
+
 } // namespace csp::multiplayer

--- a/Library/src/Systems/Conversation/ConversationSystemHelpers.h
+++ b/Library/src/Systems/Conversation/ConversationSystemHelpers.h
@@ -60,6 +60,9 @@ namespace ConversationSystemHelpers
         const AssetCollectionsResult& Result);
 
     csp::common::Array<multiplayer::ReplicatedValue> MessageInfoToReplicatedValueArray(const multiplayer::ConversationEventParams& Params);
+
+    void AppendMetadata(csp::common::Map<csp::common::String, csp::common::String>& MetadataToUpdate,
+        const csp::common::Map<csp::common::String, csp::common::String>& NewMetadataValues);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
@@ -641,13 +641,20 @@ void ConversationSystemInternal::UpdateConversation(
             SendConversationEvent(multiplayer::ConversationEventType::ConversationInformation, UpdatedInfo, EventBus, SignalRCallback);
         };
 
-        multiplayer::MessageInfo NewConversationData
-            = ConversationSystemHelpers::GetConversationInfoFromConversationAssetCollection(GetConversationResult.GetAssetCollection());
+        const AssetCollection& ConversationAssetCollection = GetConversationResult.GetAssetCollection();
+        common::Map<common::String, common::String> ConversationAssetCollectionMetadata = ConversationAssetCollection.GetMetadataImmutable();
 
+        multiplayer::MessageInfo NewConversationData
+            = ConversationSystemHelpers::GetConversationInfoFromConversationAssetCollection(ConversationAssetCollection);
         NewConversationData.Message = NewData.NewMessage;
 
-        this->AssetSystem->UpdateAssetCollectionMetadata(GetConversationResult.GetAssetCollection(),
-            ConversationSystemHelpers::GenerateConversationAssetCollectionMetadata(NewConversationData), nullptr, GetUpdatedConversationCallback);
+        common::Map<common::String, common::String> NewConversationMessageMetadata
+            = ConversationSystemHelpers::GenerateConversationAssetCollectionMetadata(NewConversationData);
+
+        ConversationSystemHelpers::AppendMetadata(ConversationAssetCollectionMetadata, NewConversationMessageMetadata);
+
+        this->AssetSystem->UpdateAssetCollectionMetadata(
+            ConversationAssetCollection, ConversationAssetCollectionMetadata, nullptr, GetUpdatedConversationCallback);
     };
 
     AssetSystem->GetAssetCollectionById(ConversationId, GetConversationCallback);
@@ -723,13 +730,18 @@ void ConversationSystemInternal::UpdateMessage(const common::String& /*Conversat
             SendConversationEvent(multiplayer::ConversationEventType::MessageInformation, Result.GetMessageInfo(), EventBus, SignalRCallback);
         };
 
-        multiplayer::MessageInfo NewMessageData
-            = ConversationSystemHelpers::GetMessageInfoFromMessageAssetCollection(GetMessageResult.GetAssetCollection());
+        const AssetCollection& MessageAssetCollection = GetMessageResult.GetAssetCollection();
+        common::Map<common::String, common::String> MessageAssetCollectionMetadata = MessageAssetCollection.GetMetadataImmutable();
 
+        multiplayer::MessageInfo NewMessageData = ConversationSystemHelpers::GetMessageInfoFromMessageAssetCollection(MessageAssetCollection);
         NewMessageData.Message = NewData.NewMessage;
 
-        this->AssetSystem->UpdateAssetCollectionMetadata(GetMessageResult.GetAssetCollection(),
-            ConversationSystemHelpers::GenerateMessageAssetCollectionMetadata(NewMessageData), nullptr, GetUpdatedMessageCallback);
+        common::Map<common::String, common::String> NewMessageMetadata
+            = ConversationSystemHelpers::GenerateMessageAssetCollectionMetadata(NewMessageData);
+
+        ConversationSystemHelpers::AppendMetadata(MessageAssetCollectionMetadata, NewMessageMetadata);
+
+        this->AssetSystem->UpdateAssetCollectionMetadata(MessageAssetCollection, MessageAssetCollectionMetadata, nullptr, GetUpdatedMessageCallback);
     };
 
     AssetSystem->GetAssetCollectionById(MessageId, GetMessageCallback);

--- a/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
@@ -180,12 +180,7 @@ namespace
         {
             auto NewMetadata = MessageCollection->GetMetadataImmutable();
 
-            std::unique_ptr<common::Array<common::String>> Keys(const_cast<common::Array<common::String>*>(Metadata.Keys()));
-
-            for (const auto& Key : *Keys)
-            {
-                NewMetadata[Key] = Metadata[Key];
-            }
+            ConversationSystemHelpers::AppendMetadata(NewMetadata, Metadata);
 
             return AssetSystem->UpdateAssetCollectionMetadata(*MessageCollection, NewMetadata, nullptr);
         };


### PR DESCRIPTION
When updating the conversation message using `ConversationSystemInternal::UpdateConversation` the conversation asset collection metadata was being overwritten with version containing only the new message string. This was resulting in any previously set metadata values pertaining to the annotation to be lost.
The fix is to merge the updated conversation message metadata values with the existing values for the conversation metadata.

There was a similar problem with updating messages (replies) when the message had an annotation. The same fix has been applied in this case.