### PR TITLE
[OF-1722] feat: isEnabled for cinematic camera scripting

### DIFF
--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -390,6 +390,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(CinematicCameraSpaceComponent, Iso, "iso")
         .PROPERTY_GET_SET(CinematicCameraSpaceComponent, ShutterSpeed, "shutterSpeed")
         .PROPERTY_GET_SET(CinematicCameraSpaceComponent, Aperture, "aperture")
+        .PROPERTY_GET_SET(CinematicCameraSpaceComponent, IsEnabled, "isEnabled")
         .PROPERTY_GET_SET(CinematicCameraSpaceComponent, IsViewerCamera, "isViewerCamera");
 
     Module->class_<ImageSpaceComponentScriptInterface>("ImageSpaceComponent")

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -255,6 +255,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
 		cinematicCamera.aperture = 10;
 		cinematicCamera.focalLength = 2;
 		cinematicCamera.isViewerCamera = true;
+		cinematicCamera.isEnabled = false;
 	)xx";
 
     CreatedObject->GetScript().SetScriptSource(CinematicCameraScriptText.c_str());
@@ -273,6 +274,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     EXPECT_FLOAT_EQ(CinematicCamera->GetAperture(), 10.0f);
     EXPECT_FLOAT_EQ(CinematicCamera->GetFocalLength(), 2.0f);
     EXPECT_TRUE(CinematicCamera->GetIsViewerCamera());
+    EXPECT_FALSE(CinematicCamera->GetIsEnabled());
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 


### PR DESCRIPTION
[OF-1722] feat: isEnabled for cinematic camera scripting

- Added support for isEnabled in the cinematic camera script interface so it can be enabled/disabled from scripts

[OF-1722]: https://magnopus.atlassian.net/browse/OF-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ