### PR TITLE
[NT-0] ci: Update the PR Guidance workflow to support forks

### DIFF
--- a/.github/workflows/add-pr-guidance.yml
+++ b/.github/workflows/add-pr-guidance.yml
@@ -1,14 +1,16 @@
 # Name of the workflow as it appears in the GitHub Actions tab
 name: Add PR Review Guidance Comment
 
-# Trigger the workflow when a pull request is opened / reopened
+# Trigger the workflow when a pull request is opened / reopened - this will run in the context of the base repository
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 # Grant write access to pull requests (this is necessary to add comments)
 permissions:
   pull-requests: write
+  # Comments are considered issues in GitHub
+  issues: write
 
 # Define a single job named 'add-guidance-comment'
 jobs:


### PR DESCRIPTION
When a pull request is created from a fork, GitHub Actions workflows run in a more restricted context for security reasons. The `pull_request_target` event is used to give the workflow the appropriate write permissions and runs the workflow in the context of the base repository (the one the PR is targeting).

The `pull_request_target` event runs with elevated permissions so we must be careful with its use in workflows. We can mitigate this risk by not allowing workflows with this event to check out and run untrusted code from the pull request or to run untrusted scripts. 

This change means that when a PR is raised from a fork, the PR Guidance comment will be added.