### PR TITLE
[OF-1708] feat: Break WebSocket dependencies

### DIFF
--- a/Library/include/CSP/Common/Interfaces/IAuthContext.h
+++ b/Library/include/CSP/Common/Interfaces/IAuthContext.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "CSP/Common/LoginState.h"
+
+/**
+ * @class IAuthContext
+ * @brief Represents an object which holds information about the authentication session state,
+ * and refreshing the refresh token to keep the session in a valid state.
+ *
+ * This was created to seperate systems logic from multiplayer
+ * by providing a public interface that doesn't rely on any systems types
+ * due to the WebClient needing the ability to refresh token, and the web client is used in both
+ * systems and multiplayer.
+ */
+
+namespace csp::common
+{
+
+class IAuthContext
+{
+public:
+    /// @brief Gets information about the state of authentication and information about the current session.
+    /// @return csp::common::LoginState&
+    virtual const csp::common::LoginState& GetLoginState() const = 0;
+
+    /// @brief Refreshes the current refresh token for the authentication session.
+    /// @Paramm Callback std::function<void(bool)> : Function that is called when the token refreshes. True = success.
+    CSP_NO_EXPORT virtual void RefreshToken(std::function<void(bool)> Callback) = 0;
+
+    virtual ~IAuthContext() = default;
+};
+}

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -43,6 +43,7 @@ namespace csp::common
 {
 class LogSystem;
 class ReplicatedValue;
+class IAuthContext;
 }
 
 /// @brief Namespace that encompasses everything in the multiplayer system
@@ -129,7 +130,7 @@ public:
 
     /// @brief Create a default SignalRConnection configured to the configured MultiplayerServiceURI
     /// @return ISignalRConnection* Pointer to SignalR connection. The caller should take ownership of the pointer.
-    CSP_NO_EXPORT static ISignalRConnection* MakeSignalRConnection();
+    CSP_NO_EXPORT static ISignalRConnection* MakeSignalRConnection(csp::common::IAuthContext& AuthContext);
 
     /// @brief Start the connection and register to start receiving updates from the server.
     /// Connect should be called after LogIn and before EnterSpace.

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -140,7 +140,8 @@ public:
     /// @param SpaceEntitySystem SpaceEntitySystem& : System provided such that it can create bindings at the appropriate point in the connection
     /// flow, prior to entity fetches.
     CSP_NO_EXPORT void Connect(ErrorCodeCallbackHandler Callback, ISignalRConnection* SignalRConnection,
-        csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, const csp::common::String& AccessToken, const csp::common::String& DeviceId);
+        csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, [[maybe_unused]] const csp::common::String& MultiplayerUri,
+        const csp::common::String& AccessToken, const csp::common::String& DeviceId);
 
     /// @brief Indicates whether the multiplayer connection is established
     /// @return bool : true if connected, false otherwise

--- a/Library/include/CSP/Systems/Analytics/AnalyticsProviderGoogleUA.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsProviderGoogleUA.h
@@ -19,6 +19,11 @@
 
 #include <chrono>
 
+namespace csp::common
+{
+class IAuthContext;
+}
+
 namespace csp::web
 {
 class WebClient;
@@ -32,7 +37,7 @@ namespace csp::systems
 class AnalyticsProviderGoogleUA : public IAnalyticsProvider
 {
 public:
-    AnalyticsProviderGoogleUA(const csp::common::String& ClientId, const csp::common::String& PropertyTag);
+    AnalyticsProviderGoogleUA(const csp::common::String& ClientId, const csp::common::String& PropertyTag, csp::common::IAuthContext& AuthContext);
 
     CSP_START_IGNORE
     void Log(AnalyticsEvent* Event) override;

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -54,7 +54,7 @@ public:
 
     /// @brief Refreshes the sessions RefreshToken.
     /// This is currently used internally by the web client.
-    virtual void RefreshToken(std::function<void(bool)> Callback) override;
+    void RefreshToken(std::function<void(bool)> Callback) override;
 
 private:
     UserSystem& UserSystem;

--- a/Library/src/Common/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
+++ b/Library/src/Common/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
@@ -115,6 +115,12 @@ template <size_t N> constexpr size_t CStringLength(char const (&)[N]) { return N
 namespace csp::web
 {
 
+EmscriptenWebClient::EmscriptenWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem, bool AutoRefresh)
+    : WebClient(InPort, Tp, AuthContext, LogSystem, AutoRefresh)
+{
+    std::srand(std::time(nullptr));
+}
+
 EmscriptenWebClient::EmscriptenWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh)
     : WebClient(InPort, Tp, LogSystem, AutoRefresh)
 {

--- a/Library/src/Common/Web/EmscriptenWebClient/EmscriptenWebClient.h
+++ b/Library/src/Common/Web/EmscriptenWebClient/EmscriptenWebClient.h
@@ -21,25 +21,11 @@ namespace csp::common
 {
 class LogSystem;
 }
-
-namespace csp::systems
-{
-class SystemsManager;
-}
-
-namespace csp::multiplayer
-{
-class CSPHttpClient;
-}
-
 namespace csp::web
 {
 
 class EmscriptenWebClient : public WebClient
 {
-    friend class csp::systems::SystemsManager;
-    friend class csp::multiplayer::CSPHttpClient;
-
 public:
     virtual ~EmscriptenWebClient() {};
 
@@ -50,8 +36,8 @@ public:
     void SetFileUploadContentFromBuffer(HttpPayload* Payload, const char* Buffer, size_t BufferLength, const csp::common::String& FileName,
         const char* Version, const csp::common::String& MediaType) override;
 
-protected:
     // Instances of EmscriptenWebClient should not be created. You should instead rely on the instance that `csp::systems::SystemsManager` holds.
+    EmscriptenWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem, bool AutoRefresh = true);
     EmscriptenWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh = true);
 
 private:

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
@@ -70,8 +70,8 @@ const uint32_t kPOCOAsyncBufferSize = 2 * 1024;
 
 EResponseCodes GetOlyResponseCode(Poco::Net::HTTPResponse::HTTPStatus PocoResponseCode) { return (EResponseCodes)PocoResponseCode; }
 
-POCOWebClient::POCOWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh)
-    : WebClient(InPort, Tp, LogSystem, AutoRefresh)
+POCOWebClient::POCOWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh) 
+: WebClient(InPort, Tp, LogSystem, AutoRefresh)
 {
     Poco::Net::initializeSSL();
 
@@ -88,6 +88,13 @@ POCOWebClient::POCOWebClient(const Port InPort, const ETransferProtocol Tp, csp:
     Poco::Net::SSLManager::instance().initializeClient(PrivateKeyHandler, CertHandler, PocoContext);
 
     Cookies = new std::remove_pointer_t<decltype(Cookies)>();
+}
+
+POCOWebClient::POCOWebClient(
+    const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem, bool AutoRefresh)
+    : POCOWebClient(InPort, Tp, LogSystem, AutoRefresh)
+{
+    SetAuthContext(AuthContext);
 }
 
 POCOWebClient::~POCOWebClient() { delete Cookies; }

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
@@ -26,17 +26,6 @@ namespace csp::common
 {
 class LogSystem;
 }
-
-namespace csp::systems
-{
-class SystemsManager;
-}
-
-namespace csp::multiplayer
-{
-class CSPHttpClient;
-}
-
 namespace csp::web
 {
 
@@ -53,11 +42,10 @@ public:
 
 class POCOWebClient : public WebClient
 {
-    friend class csp::systems::SystemsManager;
-    friend class csp::multiplayer::CSPHttpClient;
-
 public:
     virtual ~POCOWebClient();
+
+    using WebClient::WebClient;
 
     std::string MD5Hash(const void* Data, const size_t Size) override;
 
@@ -67,10 +55,11 @@ public:
     void SetFileUploadContentFromBuffer(HttpPayload* Payload, const char* Buffer, size_t BufferLength, const csp::common::String& FileName,
         const char* Version, const csp::common::String& MediaType) override;
 
-protected:
     // Instances of POCOWebClient should not be created. You should instead rely on the instance that `csp::systems::SystemsManager` holds.
     POCOWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh = true);
+    POCOWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem, bool AutoRefresh = true);
 
+protected:
     void SetFileUploadContent(HttpPayload* Payload, Poco::Net::PartSource* Source, const char* Version);
 
     void Send(HttpRequest& Request) override;

--- a/Library/src/Common/Web/WebClient.h
+++ b/Library/src/Common/Web/WebClient.h
@@ -33,14 +33,9 @@
 namespace csp::common
 {
 class LogSystem;
+class IAuthContext;
 class LoginState;
 } // namespace csp::common
-
-namespace csp::systems
-{
-class SystemsManager;
-class UserSystem;
-} // namespace csp::systems
 
 namespace csp::web
 {
@@ -76,10 +71,11 @@ enum class ETransferProtocol : uint8_t
 class WebClient
 {
     friend class HttpRequest;
-    friend class csp::systems::SystemsManager;
 
 public:
     WebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh = true);
+    WebClient(const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem,
+        bool AutoRefresh = true);
     virtual ~WebClient();
 
     /// @brief Main method for sending a Http Request
@@ -107,6 +103,8 @@ public:
         const char* Version, const csp::common::String& MediaType)
         = 0;
 
+    void SetAuthContext(csp::common::IAuthContext& AuthContext);
+
 protected:
     /// @brief Send a http request
     /// @param Request Details of the web request headers and payload
@@ -115,16 +113,17 @@ protected:
 
     const Port RootPort;
 
-    // The RealtimeEngine SignalR connection uses the same POCO/Emscripten web client as our MCS RESTApi.
-    // For the SignalR connection null be will passed to the ctor for the LogSystem to avoid logging high frequency multiplayer API exchange.
-    csp::common::LogSystem* LogSystem = nullptr;
-
 private:
     void AddRequest(HttpRequest* Request, std::chrono::milliseconds SendDelay = std::chrono::milliseconds(0));
     void RefreshIfExpired();
     void PrintClientErrorResponseMessages(const HttpResponse& Response);
-    csp::systems::UserSystem* UserSystem;
-    const csp::common::LoginState* LoginState;
+    csp::common::IAuthContext* AuthContext;
+    // The RealtimeEngine SignalR connection uses the same POCO/Emscripten web client as our MCS RESTApi.
+    // For the SignalR connection null be will passed to the ctor for the LogSystem to avoid logging high frequency multiplayer API exchange.
+protected:
+    csp::common::LogSystem* LogSystem = nullptr;
+
+private:
     std::atomic_bool RefreshNeeded, RefreshStarted;
     bool AutoRefreshEnabled;
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -352,7 +352,8 @@ std::function<async::task<void>()> MultiplayerConnection::StartListening()
 }
 
 void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback, ISignalRConnection* SignalRConnection,
-    csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, const csp::common::String& AccessToken, const csp::common::String& DeviceId)
+    csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, [[maybe_unused]] const csp::common::String& MultiplayerUri,
+    const csp::common::String& AccessToken, const csp::common::String& DeviceId)
 {
     if (Connection != nullptr)
     {
@@ -366,10 +367,13 @@ void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback, ISignalRC
         delete Connection;
     }
 
+// You will notice that the Emscripten webclient doesn't take the Uri into its constructor.
+// This is because it uses the url passed into its Start function, which gets modified by SignalR.
+// This modified version isn't compatible with our POCO implementation, so we need to directly use the MultiplayerUri.
 #ifdef CSP_WASM
     WebSocketClient = new csp::multiplayer::CSPWebSocketClientEmscripten(AccessToken.c_str(), DeviceId.c_str());
 #else
-    WebSocketClient = new csp::multiplayer::CSPWebSocketClientPOCO(AccessToken.c_str(), DeviceId.c_str(), LogSystem);
+    WebSocketClient = new csp::multiplayer::CSPWebSocketClientPOCO(MultiplayerUri.c_str(), AccessToken.c_str(), DeviceId.c_str(), LogSystem);
 #endif
     csp::multiplayer::SetWebSocketClient(WebSocketClient);
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -17,6 +17,7 @@
 
 #include "CSP/CSPFoundation.h"
 #include "CSP/Common/CSPAsyncScheduler.h"
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CSP/Common/ReplicatedValue.h"
 #include "CSP/Common/fmt_Formatters.h"
 #include "CSP/Multiplayer/ContinuationUtils.h"
@@ -149,10 +150,10 @@ namespace
     };
 }
 
-ISignalRConnection* MultiplayerConnection::MakeSignalRConnection()
+ISignalRConnection* MultiplayerConnection::MakeSignalRConnection(csp::common::IAuthContext& AuthContext)
 {
     return new csp::multiplayer::SignalRConnection(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI().c_str(), KEEP_ALIVE_INTERVAL,
-        std::make_shared<csp::multiplayer::CSPWebsocketClient>());
+        std::make_shared<csp::multiplayer::CSPWebsocketClient>(), AuthContext);
 }
 
 MultiplayerConnection::MultiplayerConnection(csp::common::LogSystem& LogSystem)

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -37,9 +37,10 @@ namespace csp::multiplayer
 {
 
 CSPWebSocketClientPOCO::CSPWebSocketClientPOCO(
-    const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept
+    const std::string& MultiplayerUri, const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept
     : PocoWebSocket(nullptr)
     , StopFlag(false)
+    , MultiplayerUri { MultiplayerUri }
     , AccessToken { AccessToken }
     , DeviceId { DeviceId }
     , LogSystem(LogSystem)
@@ -78,8 +79,7 @@ void CSPWebSocketClientPOCO::Start(const std::string& /*Url*/, CallbackHandler C
 
     try
     {
-        CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint
-            = ParseMultiplayerServiceUriEndPoint(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI().c_str());
+        CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint = ParseMultiplayerServiceUriEndPoint(MultiplayerUri);
 
         auto domain = ParsedEndpoint.Domain;
         auto protocol = ParsedEndpoint.Protocol;

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.h
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.h
@@ -35,7 +35,8 @@ namespace csp::multiplayer
 class CSPWebSocketClientPOCO : public IWebSocketClient
 {
 public:
-    CSPWebSocketClientPOCO(const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept;
+    CSPWebSocketClientPOCO(
+        const std::string& MultiplayerUri, const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept;
     ~CSPWebSocketClientPOCO();
 
     void Start(const std::string& Url, CallbackHandler Callback) override;
@@ -66,6 +67,7 @@ private:
     ReceiveHandler ReceiveCallback;
     std::atomic_bool StopFlag;
 
+    std::string MultiplayerUri;
     std::string AccessToken;
     std::string DeviceId;
     csp::common::LogSystem& LogSystem;

--- a/Library/src/Multiplayer/SignalR/SignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRClient.cpp
@@ -16,7 +16,6 @@
 
 #include "SignalRClient.h"
 
-#include "CSP/CSPFoundation.h"
 #include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CSP/Common/String.h"
 #include "Multiplayer/WebSocketClient.h"

--- a/Library/src/Multiplayer/SignalR/SignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRClient.cpp
@@ -17,6 +17,7 @@
 #include "SignalRClient.h"
 
 #include "CSP/CSPFoundation.h"
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CSP/Common/String.h"
 #include "Multiplayer/WebSocketClient.h"
 
@@ -134,13 +135,13 @@ private:
     std::thread::id ThreadId;
 };
 
-CSPHttpClient::CSPHttpClient()
+CSPHttpClient::CSPHttpClient(csp::common::IAuthContext& AuthContext)
 {
 // Passing null for the LogSystem to the POCO/Emscripten web client ctor to avoid logging high frequency multiplayer API exchange.
 #ifdef CSP_WASM
-    WebClientHttps = new csp::web::EmscriptenWebClient(443, csp::web::ETransferProtocol::HTTPS, nullptr);
+    WebClientHttps = new csp::web::EmscriptenWebClient(443, csp::web::ETransferProtocol::HTTPS, AuthContext, nullptr);
 #else
-    WebClientHttps = new csp::web::POCOWebClient(443, csp::web::ETransferProtocol::HTTPS, nullptr);
+    WebClientHttps = new csp::web::POCOWebClient(443, csp::web::ETransferProtocol::HTTPS, AuthContext, nullptr);
 #endif
 }
 

--- a/Library/src/Multiplayer/SignalR/SignalRClient.h
+++ b/Library/src/Multiplayer/SignalR/SignalRClient.h
@@ -21,6 +21,11 @@
 #include <signalrclient/signalr_client_config.h>
 #include <signalrclient/websocket_client.h>
 
+namespace csp::common
+{
+class IAuthContext;
+}
+
 namespace csp::multiplayer
 {
 
@@ -41,7 +46,7 @@ private:
 class CSPHttpClient : public signalr::http_client
 {
 public:
-    CSPHttpClient();
+    CSPHttpClient(csp::common::IAuthContext& AuthContext);
 
     void send(const std::string& url, const signalr::http_request& request,
         std::function<void(const signalr::http_response&, std::exception_ptr)> callback) override;

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 #include "SignalRConnection.h"
-
-#include "CSP/CSPFoundation.h"
 #include "CSP/Common/Interfaces/IAuthContext.h"
 #include "SignalRClient.h"
 #include <memory>

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
@@ -16,6 +16,7 @@
 #include "SignalRConnection.h"
 
 #include "CSP/CSPFoundation.h"
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "SignalRClient.h"
 #include <memory>
 
@@ -57,9 +58,10 @@ public:
 };
 #endif
 
-SignalRConnection::SignalRConnection(const std::string& BaseUri, const uint32_t KeepAliveSeconds, std::shared_ptr<websocket_client> WebsocketClient)
+SignalRConnection::SignalRConnection(const std::string& BaseUri, const uint32_t KeepAliveSeconds, std::shared_ptr<websocket_client> WebsocketClient,
+    csp::common::IAuthContext& AuthContext)
     : Connection(hub_connection_builder::create(BaseUri)
-                     .with_http_client_factory([](const signalr_client_config&) { return std::make_shared<CSPHttpClient>(); })
+                     .with_http_client_factory([&AuthContext](const signalr_client_config&) { return std::make_shared<CSPHttpClient>(AuthContext); })
                      .with_websocket_factory([WebsocketClient](const signalr_client_config&) { return WebsocketClient; })
                      .skip_negotiation(true)
                      .with_messagepack_hub_protocol()

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.h
@@ -25,6 +25,11 @@ CSP_START_IGNORE
 class CSPEngine_MultiplayerTests_SignalRConnectionTest_Test;
 CSP_END_IGNORE
 
+namespace csp::common
+{
+class IAuthContext;
+}
+
 namespace csp::multiplayer
 {
 
@@ -37,7 +42,8 @@ public:
 
     typedef std::function<void __cdecl(const signalr::value&)> MethodInvokedHandler;
 
-    SignalRConnection(const std::string& url, const uint32_t KeepAliveSeconds, std::shared_ptr<signalr::websocket_client> WebSocketClient);
+    SignalRConnection(const std::string& url, const uint32_t KeepAliveSeconds, std::shared_ptr<signalr::websocket_client> WebSocketClient,
+        csp::common::IAuthContext& AuthContext);
     virtual ~SignalRConnection();
 
     void Start(std::function<void(std::exception_ptr)> Callback) override;

--- a/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsProviderGoogleUA.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "CSP/Systems/Analytics/AnalyticsProviderGoogleUA.h"
+#include "CSP/Common/Interfaces/IAuthContext.h"
 
 #ifdef CSP_WASM
 #include "Common/Web/EmscriptenWebClient/EmscriptenWebClient.h"
@@ -27,8 +28,8 @@ namespace
 class UAEmscriptenWebClient : public csp::web::EmscriptenWebClient
 {
 public:
-    UAEmscriptenWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp)
-        : csp::web::EmscriptenWebClient(InPort, Tp, nullptr)
+    UAEmscriptenWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp, csp::common::IAuthContext& AuthContext)
+        : csp::web::EmscriptenWebClient(InPort, Tp, AuthContext, nullptr)
     {
     }
 };
@@ -36,8 +37,8 @@ public:
 class UAPOCOWebClient : public csp::web::POCOWebClient
 {
 public:
-    UAPOCOWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp)
-        : csp::web::POCOWebClient(InPort, Tp, nullptr)
+    UAPOCOWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp, csp::common::IAuthContext& AuthContext)
+        : csp::web::POCOWebClient(InPort, Tp, AuthContext, nullptr)
     {
     }
 };
@@ -112,15 +113,16 @@ csp::common::String CreateUAEventString(const csp::common::String& ClientId, con
     return EventString;
 }
 
-AnalyticsProviderGoogleUA::AnalyticsProviderGoogleUA(const csp::common::String& ClientId, const csp::common::String& PropertyTag)
+AnalyticsProviderGoogleUA::AnalyticsProviderGoogleUA(
+    const csp::common::String& ClientId, const csp::common::String& PropertyTag, csp::common::IAuthContext& AuthContext)
     : ClientId { ClientId }
     , PropertyTag { PropertyTag }
     , Start { std::chrono::steady_clock::now() }
 {
 #ifdef CSP_WASM
-    WebClient = new UAEmscriptenWebClient(80, csp::web::ETransferProtocol::HTTPS);
+    WebClient = new UAEmscriptenWebClient(80, csp::web::ETransferProtocol::HTTPS, AuthContext);
 #else
-    WebClient = new UAPOCOWebClient(80, csp::web::ETransferProtocol::HTTPS);
+    WebClient = new UAPOCOWebClient(80, csp::web::ETransferProtocol::HTTPS, AuthContext);
 #endif
 }
 

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -134,8 +134,11 @@ void SystemsManager::CreateSystems()
 #else
     WebClient = new csp::web::POCOWebClient(80, csp::web::ETransferProtocol::HTTPS, LogSystem);
 #endif
-    ScriptSystem = new csp::systems::ScriptSystem();
 
+    UserSystem = new csp::systems::UserSystem(WebClient, NetworkEventBus, *LogSystem);
+    WebClient->SetAuthContext(UserSystem->GetAuthContext());
+
+    ScriptSystem = new csp::systems::ScriptSystem();
     ScriptSystem->Initialise();
 
     MultiplayerConnection = new csp::multiplayer::MultiplayerConnection(*LogSystem);
@@ -144,7 +147,7 @@ void SystemsManager::CreateSystems()
     VoipSystem = new csp::systems::VoipSystem();
 
     // SystemBase inheritors
-    UserSystem = new csp::systems::UserSystem(WebClient, NetworkEventBus, *LogSystem);
+
     SpaceSystem = new csp::systems::SpaceSystem(WebClient, *LogSystem);
     AssetSystem = new csp::systems::AssetSystem(WebClient, NetworkEventBus, *LogSystem);
     AnchorSystem = new csp::systems::AnchorSystem(WebClient, *LogSystem);

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -201,7 +201,8 @@ void UserSystem::Login(const csp::common::String& UserName, const csp::common::S
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
                 MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                    CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
             {
@@ -262,7 +263,8 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
                 MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                    CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else
             {
@@ -351,7 +353,8 @@ void UserSystem::LoginAsGuest(const csp::common::Optional<bool>& UserHasVerified
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
                 MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                    CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else
             {
@@ -477,7 +480,8 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
 
             auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
             MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
         }
         else
         {
@@ -863,7 +867,6 @@ void UserSystem::OnAccessControlChangedEvent(const csp::common::NetworkEventData
     UserPermissionsChangedCallback(AccessControlChangedNetworkEventData);
 }
 
-AuthContext& UserSystem::GetAuthContext()
-{ return Auth; }
+AuthContext& UserSystem::GetAuthContext() { return Auth; }
 
 } // namespace csp::systems

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -86,7 +86,7 @@ AuthContext::AuthContext(csp::systems::UserSystem& UserSystem)
 {
 }
 
-const csp::common::LoginState& AuthContext::GetLoginState() const { UserSystem.GetLoginState(); }
+const csp::common::LoginState& AuthContext::GetLoginState() const { return UserSystem.GetLoginState(); }
 
 void AuthContext::RefreshToken(std::function<void(bool)> Callback)
 {
@@ -200,7 +200,7 @@ void UserSystem::Login(const csp::common::String& UserName, const csp::common::S
                 };
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(*this),
+                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
                     *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
@@ -261,7 +261,7 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
                 };
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(*this),
+                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
                     *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else
@@ -350,7 +350,7 @@ void UserSystem::LoginAsGuest(const csp::common::Optional<bool>& UserHasVerified
                 };
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(*this),
+                MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
                     *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else
@@ -476,7 +476,7 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
             };
 
             auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-            MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(*this),
+            MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
                 *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
         }
         else

--- a/Tests/src/InternalTests/PlatformTestUtils.cpp
+++ b/Tests/src/InternalTests/PlatformTestUtils.cpp
@@ -62,12 +62,13 @@ csp::multiplayer::IWebSocketClient* WebSocketStart(
     };
 
 #ifdef CSP_WASM
-    auto* WebSocketClient = new csp::multiplayer::CSPWebSocketClientEmscripten();
+    auto* WebSocketClient = new csp::multiplayer::CSPWebSocketClientEmscripten(
+        Uri.c_str(), AccessToken.c_str(), DeviceId.c_str(), *csp::systems::SystemsManager::Get().GetLogSystem());
 
     std::thread TestThread([&]() { WebSocketClient->Start(Uri.c_str(), Fn); });
 #else
-    auto* WebSocketClient
-        = new csp::multiplayer::CSPWebSocketClientPOCO(AccessToken.c_str(), DeviceId.c_str(), *csp::systems::SystemsManager::Get().GetLogSystem());
+    auto* WebSocketClient = new csp::multiplayer::CSPWebSocketClientPOCO(
+        Uri.c_str(), AccessToken.c_str(), DeviceId.c_str(), *csp::systems::SystemsManager::Get().GetLogSystem());
     WebSocketClient->Start(Uri.c_str(), Fn);
 #endif
 

--- a/Tests/src/InternalTests/WebClientTests.cpp
+++ b/Tests/src/InternalTests/WebClientTests.cpp
@@ -17,6 +17,7 @@
 #include "CSP/CSPFoundation.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "Debug/Logging.h"
+#include "CSP/Systems/Users/UserSystem.h"
 #include "PlatformTestUtils.h"
 #include "RAIIMockLogger.h"
 #include "TestHelpers.h"
@@ -78,8 +79,8 @@ private:
 class TestWebClient : public EmscriptenWebClient
 {
 public:
-    TestWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem)
-        : EmscriptenWebClient(InPort, Tp, LogSystem, false)
+    TestWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem)
+        : EmscriptenWebClient(InPort, Tp, AuthContext, LogSystem, false)
     {
     }
 };
@@ -89,8 +90,8 @@ public:
 class TestWebClient : public POCOWebClient
 {
 public:
-    TestWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem)
-        : POCOWebClient(InPort, Tp, LogSystem, false)
+    TestWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem)
+        : POCOWebClient(InPort, Tp, AuthContext, LogSystem, false)
     {
     }
 };
@@ -113,10 +114,10 @@ template <typename TReceiver>
 void RunWebClientTest(const char* Url, ERequestVerb Verb, uint32_t Port, HttpPayload& Payload, EResponseCodes ExpectedResponse)
 {
     TReceiver Receiver;
-
+    auto& UserSystem = *csp::systems::SystemsManager::Get().GetUserSystem();
     csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
 
-    TestWebClient WebClient(Port, ETransferProtocol::HTTP, LogSystem);
+    TestWebClient WebClient(Port, ETransferProtocol::HTTP, UserSystem.GetAuthContext(), LogSystem);
 
     WebClientSendRequest(&WebClient, Url, Verb, Payload, &Receiver);
 
@@ -402,13 +403,13 @@ CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientPollingTest)
     PollingLoginResponseReceiver Receiver(std::this_thread::get_id());
 
     {
+        auto& UserSystem = *csp::systems::SystemsManager::Get().GetUserSystem();
         csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-
         WebClient* Client;
 #ifdef CSP_WASM
-        Client = new csp::web::EmscriptenWebClient(80, csp::web::ETransferProtocol::HTTPS, LogSystem);
+        Client = new csp::web::EmscriptenWebClient(80, csp::web::ETransferProtocol::HTTPS, UserSystem, LogSystem);
 #else
-        Client = new TestWebClient(80, csp::web::ETransferProtocol::HTTPS, LogSystem);
+        Client = new TestWebClient(80, csp::web::ETransferProtocol::HTTPS, UserSystem.GetAuthContext(), LogSystem);
 #endif
         EXPECT_TRUE(Client != nullptr);
 
@@ -552,9 +553,9 @@ CSP_INTERNAL_TEST(CSPEngine, WebClientTests, WebClientUserAgentTest)
     HttpPayload Payload;
     ResponseReceiver Receiver;
 
+    auto& UserSystem = *csp::systems::SystemsManager::Get().GetUserSystem();
     csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-
-    auto* WebClient = new TestWebClient(80, ETransferProtocol::HTTP, LogSystem);
+    auto* WebClient = new TestWebClient(80, ETransferProtocol::HTTP, UserSystem.GetAuthContext(), LogSystem);
     EXPECT_TRUE(WebClient != nullptr);
 
     WebClientSendRequest(WebClient, "https://postman-echo.com/get", ERequestVerb::Get, Payload, &Receiver);

--- a/Tests/src/PublicAPITests/Analytics/AnalyticsSystemFunctionalTests.cpp
+++ b/Tests/src/PublicAPITests/Analytics/AnalyticsSystemFunctionalTests.cpp
@@ -15,11 +15,13 @@
  */
 
 #include "AnalyticsSystemTestHelpers.h"
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CSP/Systems/Analytics/AnalyticsProvider.h"
 #include "CSP/Systems/Analytics/AnalyticsProviderGoogleUA.h"
 #include "CSP/Systems/Analytics/AnalyticsSystem.h"
 #include "CSP/Systems/Analytics/AnalyticsSystemUtils.h"
 #include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
 #include "Systems/Analytics/Analytics.h"
 #include "TestHelpers.h"
 
@@ -63,8 +65,9 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, UATest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     csp::systems::AnalyticsSystem* System = SystemsManager.GetAnalyticsSystem();
+    csp::systems::UserSystem* UserSystem = SystemsManager.GetUserSystem();
 
-    csp::systems::AnalyticsProviderGoogleUA Provider("11111", "22222");
+    csp::systems::AnalyticsProviderGoogleUA Provider("11111", "22222", UserSystem->GetAuthContext());
 
     System->RegisterProvider(&Provider);
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2774,7 +2774,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRStartErrorsThenDisconnec
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsErrorsThenDisconnectionFunctionsCalled)
@@ -2812,7 +2812,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsThenDisconnectionFunctionsCalled)
@@ -2863,7 +2863,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErrorsThenDisconnectionFunctionsCalled)
@@ -2918,7 +2918,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCallbacksCalled)
@@ -2971,7 +2971,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
 
     Connection->SetConnectionCallback(std::bind(&MockConnectionCallback::Call, &MockSuccessConnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, TestParseMultiplayerError)

--- a/Tests/src/PublicAPITests/SystemResultTests.cpp
+++ b/Tests/src/PublicAPITests/SystemResultTests.cpp
@@ -48,8 +48,8 @@ typedef std::function<void(const NullResult& Result)> NullResultCallback;
 class TestWebClient : public csp::web::EmscriptenWebClient
 {
 public:
-    TestWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp, csp::common::LogSystem* LogSystem)
-        : EmscriptenWebClient(InPort, Tp, LogSystem, false)
+    TestWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem)
+        : EmscriptenWebClient(InPort, Tp, AuthContext, LogSystem, false)
     {
     }
 };
@@ -59,13 +59,23 @@ public:
 class TestWebClient : public csp::web::POCOWebClient
 {
 public:
-    TestWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp, csp::common::LogSystem* LogSystem)
-        : POCOWebClient(InPort, Tp, LogSystem, false)
+    TestWebClient(const csp::web::Port InPort, const csp::web::ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem)
+        : POCOWebClient(InPort, Tp, AuthContext, LogSystem, false)
     {
     }
 };
 
 #endif
+
+class TestAuthContext : public IAuthContext
+{
+public:
+    const csp::common::LoginState& GetLoginState() const override { return State; }
+    void RefreshToken(std::function<void(bool)> Success) override { Success(true); }
+
+private:
+    csp::common::LoginState State;
+};
 
 class ResponseReceiver : public ResponseWaiter, public csp::web::IHttpResponseHandler
 {
@@ -125,8 +135,8 @@ CSP_PUBLIC_TEST(CSPEngine, SystemResultTests, BaseResultTest)
 
     const csp::web::EResponseCodes MyTestResponseCode = csp::web::EResponseCodes::ResponseOK;
     const csp::common::String MyTestPayload = "1234";
-
-    auto* WebClient = new TestWebClient(80, csp::web::ETransferProtocol::HTTP, LogSystem);
+    TestAuthContext AuthContext;
+    auto* WebClient = new TestWebClient(80, csp::web::ETransferProtocol::HTTP, AuthContext, LogSystem);
     EXPECT_TRUE(WebClient != nullptr);
 
     ResponseReceiver Receiver;


### PR DESCRIPTION
This ticket addressed the CSPFoundation dependency in POCOSignalrRClient. The Multiplayer URI is now passed through. This may seem confusing as it isn't done for the Emscripten version, but Emscripten uses a different URI, which is passed in when Start is called. This URI is modified by SignalR, which is needed for Emscripten, but not for POCO. I don't claim to understand the reasons for this modification.

I also removed a couple of redundant includes in the PR.