### PR TITLE
[OF-1708] feat: Break system dependencies on WebSocketClient

### DIFF
--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -140,7 +140,8 @@ public:
     /// @param SpaceEntitySystem SpaceEntitySystem& : System provided such that it can create bindings at the appropriate point in the connection
     /// flow, prior to entity fetches.
     CSP_NO_EXPORT void Connect(ErrorCodeCallbackHandler Callback, ISignalRConnection* SignalRConnection,
-        csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, const csp::common::String& AccessToken, const csp::common::String& DeviceId);
+        csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, [[maybe_unused]] const csp::common::String& MultiplayerUri,
+        const csp::common::String& AccessToken, const csp::common::String& DeviceId);
 
     /// @brief Indicates whether the multiplayer connection is established
     /// @return bool : true if connected, false otherwise

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -352,7 +352,8 @@ std::function<async::task<void>()> MultiplayerConnection::StartListening()
 }
 
 void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback, ISignalRConnection* SignalRConnection,
-    csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, const csp::common::String& AccessToken, const csp::common::String& DeviceId)
+    csp::multiplayer::SpaceEntitySystem& SpaceEntitySystem, [[maybe_unused]] const csp::common::String& MultiplayerUri,
+    const csp::common::String& AccessToken, const csp::common::String& DeviceId)
 {
     if (Connection != nullptr)
     {
@@ -366,10 +367,13 @@ void MultiplayerConnection::Connect(ErrorCodeCallbackHandler Callback, ISignalRC
         delete Connection;
     }
 
+// You will notice that the Emscripten webclient doesn't take the Uri into its constructor.
+// This is because it uses the url passed into its Start function, which gets modified by SignalR.
+// This modified version isn't compatible with our POCO implementation, so we need to directly use the MultiplayerUri.
 #ifdef CSP_WASM
     WebSocketClient = new csp::multiplayer::CSPWebSocketClientEmscripten(AccessToken.c_str(), DeviceId.c_str());
 #else
-    WebSocketClient = new csp::multiplayer::CSPWebSocketClientPOCO(AccessToken.c_str(), DeviceId.c_str(), LogSystem);
+    WebSocketClient = new csp::multiplayer::CSPWebSocketClientPOCO(MultiplayerUri.c_str(), AccessToken.c_str(), DeviceId.c_str(), LogSystem);
 #endif
     csp::multiplayer::SetWebSocketClient(WebSocketClient);
 

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -37,9 +37,10 @@ namespace csp::multiplayer
 {
 
 CSPWebSocketClientPOCO::CSPWebSocketClientPOCO(
-    const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept
+    const std::string& MultiplayerUri, const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept
     : PocoWebSocket(nullptr)
     , StopFlag(false)
+    , MultiplayerUri { MultiplayerUri }
     , AccessToken { AccessToken }
     , DeviceId { DeviceId }
     , LogSystem(LogSystem)
@@ -78,8 +79,7 @@ void CSPWebSocketClientPOCO::Start(const std::string& /*Url*/, CallbackHandler C
 
     try
     {
-        CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint
-            = ParseMultiplayerServiceUriEndPoint(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI().c_str());
+        CSPWebSocketClientPOCO::ParsedURIInfo ParsedEndpoint = ParseMultiplayerServiceUriEndPoint(MultiplayerUri);
 
         auto domain = ParsedEndpoint.Domain;
         auto protocol = ParsedEndpoint.Protocol;

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.h
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.h
@@ -35,7 +35,8 @@ namespace csp::multiplayer
 class CSPWebSocketClientPOCO : public IWebSocketClient
 {
 public:
-    CSPWebSocketClientPOCO(const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept;
+    CSPWebSocketClientPOCO(
+        const std::string& MultiplayerUri, const std::string& AccessToken, const std::string& DeviceId, csp::common::LogSystem& LogSystem) noexcept;
     ~CSPWebSocketClientPOCO();
 
     void Start(const std::string& Url, CallbackHandler Callback) override;
@@ -66,6 +67,7 @@ private:
     ReceiveHandler ReceiveCallback;
     std::atomic_bool StopFlag;
 
+    std::string MultiplayerUri;
     std::string AccessToken;
     std::string DeviceId;
     csp::common::LogSystem& LogSystem;

--- a/Library/src/Multiplayer/SignalR/SignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRClient.cpp
@@ -16,7 +16,6 @@
 
 #include "SignalRClient.h"
 
-#include "CSP/CSPFoundation.h"
 #include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CSP/Common/String.h"
 #include "Multiplayer/WebSocketClient.h"

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 #include "SignalRConnection.h"
-
-#include "CSP/CSPFoundation.h"
 #include "CSP/Common/Interfaces/IAuthContext.h"
 #include "SignalRClient.h"
 #include <memory>

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -214,7 +214,8 @@ void UserSystem::Login(const csp::common::String& UserName, const csp::common::S
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
                 MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                    CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
             {
@@ -275,7 +276,8 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
                 MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                    CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else
             {
@@ -333,7 +335,8 @@ void UserSystem::LoginAsGuest(const csp::common::Optional<bool>& UserHasVerified
 
                 auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
                 MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                    *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                    CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
             }
             else
             {
@@ -459,7 +462,8 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
 
             auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
             MultiplayerConnection->Connect(ErrorCallback, csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(GetAuthContext()),
-                *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
+                *csp::systems::SystemsManager::Get().GetSpaceEntitySystem(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                CurrentLoginState.AccessToken, CurrentLoginState.DeviceId);
         }
         else
         {

--- a/Tests/src/InternalTests/PlatformTestUtils.cpp
+++ b/Tests/src/InternalTests/PlatformTestUtils.cpp
@@ -62,12 +62,13 @@ csp::multiplayer::IWebSocketClient* WebSocketStart(
     };
 
 #ifdef CSP_WASM
-    auto* WebSocketClient = new csp::multiplayer::CSPWebSocketClientEmscripten();
+    auto* WebSocketClient = new csp::multiplayer::CSPWebSocketClientEmscripten(
+        Uri.c_str(), AccessToken.c_str(), DeviceId.c_str(), *csp::systems::SystemsManager::Get().GetLogSystem());
 
     std::thread TestThread([&]() { WebSocketClient->Start(Uri.c_str(), Fn); });
 #else
-    auto* WebSocketClient
-        = new csp::multiplayer::CSPWebSocketClientPOCO(AccessToken.c_str(), DeviceId.c_str(), *csp::systems::SystemsManager::Get().GetLogSystem());
+    auto* WebSocketClient = new csp::multiplayer::CSPWebSocketClientPOCO(
+        Uri.c_str(), AccessToken.c_str(), DeviceId.c_str(), *csp::systems::SystemsManager::Get().GetLogSystem());
     WebSocketClient->Start(Uri.c_str(), Fn);
 #endif
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2774,7 +2774,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRStartErrorsThenDisconnec
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsErrorsThenDisconnectionFunctionsCalled)
@@ -2812,7 +2812,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsThenDisconnectionFunctionsCalled)
@@ -2863,7 +2863,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErrorsThenDisconnectionFunctionsCalled)
@@ -2918,7 +2918,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCallbacksCalled)
@@ -2971,7 +2971,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
 
     Connection->SetConnectionCallback(std::bind(&MockConnectionCallback::Call, &MockSuccessConnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "");
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, TestParseMultiplayerError)


### PR DESCRIPTION
This ticket addressed the CSPFoundation dependency in POCOSignalrRClient. The Multiplayer URI is now passed through. This may seem confusing as it isn't done for the Emscripten version, but Emscripten uses a different URI, which is passed in when Start is called. This URI is modified by SignalR, which is needed for Emscripten, but not for POCO. I don't claim to understand the reasons for this modification.

I also removed a couple of redundant includes in the PR.