### PR TITLE
[OF-1714] build: Ensure internal headers compile with warnings

### DIFF
--- a/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
+++ b/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
@@ -65,13 +65,16 @@ public:
      * @param ScriptText String& : The text of the script to be executed by the javascript engine.
      * @return Whether the script was successfully run.
      */
-    virtual bool RunScript(int64_t ContextId, const String& ScriptText) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    virtual bool RunScript(int64_t /*ContextId*/, const String& /*ScriptText*/)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /**
      * @brief Register a binding object with the script runner. The script runner should store this for use.
      * @param ScriptBinding IScriptBinding* : Object capable of binding a script. The binding is eventually used to call back into IJSScriptRunner.
      */
-    CSP_NO_EXPORT virtual void RegisterScriptBinding(IScriptBinding* ScriptBinding)
+    CSP_NO_EXPORT virtual void RegisterScriptBinding(IScriptBinding* /*ScriptBinding*/)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
@@ -81,7 +84,7 @@ public:
      * @param ScriptBinding IScriptBinding : Object capable of binding a script.
      * @pre ScriptBinding has been registered via RegisterScriptBinding
      */
-    CSP_NO_EXPORT virtual void UnregisterScriptBinding(IScriptBinding* ScriptBinding)
+    CSP_NO_EXPORT virtual void UnregisterScriptBinding(IScriptBinding* /*ScriptBinding*/)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
@@ -92,7 +95,7 @@ public:
      *                  If the provided context does not exist, the script bind will fail.
      * @return Whether the context was successfully bound.
      */
-    CSP_NO_EXPORT virtual bool BindContext(int64_t ContextId) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    CSP_NO_EXPORT virtual bool BindContext(int64_t /*ContextId*/) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /**
      * @brief Reset the script context. This will likely shutdown and re-initialize any modules in the context.
@@ -100,7 +103,7 @@ public:
      *                  If the provided context does not exist, the script reset will fail.
      * @return Whether the context was successfully reset.
      */
-    CSP_NO_EXPORT virtual bool ResetContext(int64_t ContextId) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    CSP_NO_EXPORT virtual bool ResetContext(int64_t /*ContextId*/) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /**
      * @brief Get the script context object.
@@ -108,7 +111,7 @@ public:
      * @return The script context object. This specific type of this is implementation defined. However, if using CSP's ScriptSystem at time of
      * writing, it will be a csp::systems::ScriptContext*, which you should cast to. Returns nullptr if the provided context does not exist.
      */
-    CSP_NO_EXPORT virtual void* GetContext(int64_t ContextId) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    CSP_NO_EXPORT virtual void* GetContext(int64_t /*ContextId*/) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /**
      * @brief Get a script module object within a context.
@@ -118,7 +121,7 @@ public:
      * writing, it will be a csp::systems::ScriptModule*, which you should cast to. Returns nullptr if the specified module does not exist in the
      * context.
      */
-    CSP_NO_EXPORT virtual void* GetModule(int64_t ContextId, const String& ModuleName)
+    CSP_NO_EXPORT virtual void* GetModule(int64_t /*ContextId*/, const String& /*ModuleName*/)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
@@ -128,14 +131,14 @@ public:
      * @param ContextId int64_t : The Id of the context to create, must be unique to other contexts.
      * @return Whether the context was created successfully.
      */
-    CSP_NO_EXPORT virtual bool CreateContext(int64_t ContextId) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    CSP_NO_EXPORT virtual bool CreateContext(int64_t /*ContextId*/) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /**
      * @brief Destroy a pre-existing context with specified ID.
      * @param ContextId int64_t : The Id of the context to destroy.
      * @return Whether the context was destroyed successfully.
      */
-    CSP_NO_EXPORT virtual bool DestroyContext(int64_t ContextId) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    CSP_NO_EXPORT virtual bool DestroyContext(int64_t /*ContextId*/) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /**
      * @brief Set the javascript source code of a particular module
@@ -144,7 +147,7 @@ public:
      * @param Source String: The javascript source code to set.
      * @pre ModuleURL must be unique.
      */
-    CSP_NO_EXPORT virtual void SetModuleSource(csp::common::String ModuleUrl, csp::common::String Source)
+    CSP_NO_EXPORT virtual void SetModuleSource(csp::common::String /*ModuleUrl*/, csp::common::String /*Source*/)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
@@ -154,7 +157,7 @@ public:
      * @param ModuleUrl String : The URL of the module to clear.
      * @pre ModuleURL must already exist via setting it with SetModuleSource.
      */
-    CSP_NO_EXPORT virtual void ClearModuleSource(csp::common::String ModuleUrl)
+    CSP_NO_EXPORT virtual void ClearModuleSource(csp::common::String /*ModuleUrl*/)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }

--- a/Library/include/CSP/Common/Optional.h
+++ b/Library/include/CSP/Common/Optional.h
@@ -60,7 +60,7 @@ public:
 
     /// @brief Constructs an optional with a null value.
     /// @param InValue std::nullptr_t : nullptr value
-    Optional(std::nullptr_t InValue)
+    Optional(std::nullptr_t /*InValue*/)
     {
         Value = nullptr;
         ValueDestructor = DefaultDestructor<T>;

--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -69,11 +69,14 @@ if not Project then
         end
 
         characterset ("ASCII")
-
-        -- Include directories for this project
-        externalincludedirs {
+		
+		-- Include directories for this project
+        includedirs {
             "%{wks.location}/Library/src",
-            "%{wks.location}/Library/include",
+            "%{wks.location}/Library/include"
+        }
+
+        externalincludedirs {
             "%{wks.location}/ThirdParty/signalrclient/include",
             "%{wks.location}/ThirdParty/rapidjson/include",
             "%{wks.location}/ThirdParty/msgpack/include",

--- a/Library/src/Common/Web/Json.h
+++ b/Library/src/Common/Web/Json.h
@@ -191,7 +191,7 @@ template <typename U, typename V> inline rapidjson::Value TypeToJsonValue(const 
 
 // Full template specialisations for TypeToJsonValue
 
-template <> inline rapidjson::Value TypeToJsonValue(const bool& Value, RapidJsonAlloc& Allocator)
+template <> inline rapidjson::Value TypeToJsonValue(const bool& Value, RapidJsonAlloc& /*Allocator*/)
 {
     rapidjson::Value JsonValue;
     JsonValue.SetBool(Value);
@@ -199,17 +199,17 @@ template <> inline rapidjson::Value TypeToJsonValue(const bool& Value, RapidJson
     return JsonValue;
 }
 
-template <> inline rapidjson::Value TypeToJsonValue(const int32_t& Value, RapidJsonAlloc& Allocator) { return rapidjson::Value(Value); }
+template <> inline rapidjson::Value TypeToJsonValue(const int32_t& Value, RapidJsonAlloc& /*Allocator*/) { return rapidjson::Value(Value); }
 
-template <> inline rapidjson::Value TypeToJsonValue(const uint32_t& Value, RapidJsonAlloc& Allocator) { return rapidjson::Value(Value); }
+template <> inline rapidjson::Value TypeToJsonValue(const uint32_t& Value, RapidJsonAlloc& /*Allocator*/) { return rapidjson::Value(Value); }
 
-template <> inline rapidjson::Value TypeToJsonValue(const int64_t& Value, RapidJsonAlloc& Allocator) { return rapidjson::Value(Value); }
+template <> inline rapidjson::Value TypeToJsonValue(const int64_t& Value, RapidJsonAlloc& /*Allocator*/) { return rapidjson::Value(Value); }
 
-template <> inline rapidjson::Value TypeToJsonValue(const uint64_t& Value, RapidJsonAlloc& Allocator) { return rapidjson::Value(Value); }
+template <> inline rapidjson::Value TypeToJsonValue(const uint64_t& Value, RapidJsonAlloc& /*Allocator*/) { return rapidjson::Value(Value); }
 
-template <> inline rapidjson::Value TypeToJsonValue(const float& Value, RapidJsonAlloc& Allocator) { return rapidjson::Value(Value); }
+template <> inline rapidjson::Value TypeToJsonValue(const float& Value, RapidJsonAlloc& /*Allocator*/) { return rapidjson::Value(Value); }
 
-template <> inline rapidjson::Value TypeToJsonValue(const double& Value, RapidJsonAlloc& Allocator) { return rapidjson::Value(Value); }
+template <> inline rapidjson::Value TypeToJsonValue(const double& Value, RapidJsonAlloc& /*Allocator*/) { return rapidjson::Value(Value); }
 
 template <> inline rapidjson::Value TypeToJsonValue(const csp::common::String& Value, RapidJsonAlloc& Allocator)
 {

--- a/Library/src/Common/Web/Json.h
+++ b/Library/src/Common/Web/Json.h
@@ -45,7 +45,7 @@ template <class T> inline csp::common::String TypeToJsonString(const std::shared
 
 template <class T>
 [[deprecated("Unsupported type for JSON (string) serialisation! You should probably add support for it :)")]] inline csp::common::String
-TypeToJsonString(const T& Value)
+TypeToJsonString(const T& /*Value*/)
 {
     return csp::common::String("");
 }

--- a/Library/src/Common/Web/Json_HttpPayload.h
+++ b/Library/src/Common/Web/Json_HttpPayload.h
@@ -23,14 +23,14 @@
 namespace csp::web
 {
 
-template <> inline rapidjson::Value TypeToJsonValue(const csp::web::HttpPayload& Value, RapidJsonAlloc& Allocator)
+template <> inline rapidjson::Value TypeToJsonValue(const csp::web::HttpPayload& /*Value*/, RapidJsonAlloc& Allocator)
 {
     assert(false && "This function is just a stub. Please flesh it out!");
 
     return rapidjson::Value("", Allocator);
 }
 
-template <> inline void JsonValueToType(const rapidjson::Value& Value, csp::web::HttpPayload& Type)
+template <> inline void JsonValueToType(const rapidjson::Value& /*Value*/, csp::web::HttpPayload& /*Type*/)
 {
     assert(false && "This function is just a stub. Please flesh it out!");
 }


### PR DESCRIPTION
We have enabled Warnings as Errors, however we currently classify all includes as external includes which mean they are getting compiled without warnings.

To ensure that includes are correctly classified I have updated the premake file to remove `src` and `include` directories from `externalincludedirs` and to add them to `includedirs` instead.

This resulted is wErrors for the following header files:
- IJSScriptRunner
- Json
- Json_HttpPayload
- Optional
- Json

The above wErrors have been resolved, with each file in its own commit to make it easier to review.