### PR TITLE
[OF-1670] refac!: Online Realtime Engine

### DIFF
--- a/Library/docs/source/learn/physical_digital_realities/fiducial_markers.md
+++ b/Library/docs/source/learn/physical_digital_realities/fiducial_markers.md
@@ -151,7 +151,7 @@ SpaceTransform MarkerEntityTransform =
     csp::common::Vector3::One()
 };
 
-csp::multiplayer::SpaceEntitySystem::EntityCreatedCallback Callback = [](csp::multiplayer::SpaceEntity* CreatedSpaceEntity)
+csp::multiplayer::OnlineRealtimeEngine::EntityCreatedCallback Callback = [](csp::multiplayer::SpaceEntity* CreatedSpaceEntity)
 {
     if (CreatedSpaceEntity)
     {

--- a/Library/docs/source/learn/spaces/entities.md
+++ b/Library/docs/source/learn/spaces/entities.md
@@ -108,7 +108,7 @@ There are some important aspects to the ComponentBase class that it is worth rev
 
 ## Entity Lifetime Management
 
-In CSP, the `SpaceEntitySystem` governs how objects (space entities) are created, modified, synchronized, and deleted within a virtual space. Understanding this flow is crucial for building responsive, real-time applications in multi-user environments. Below is an overview of the expected flow when using space entities.
+In CSP, the `OnlineRealtimeEngine` governs how objects (space entities) are created, modified, synchronized, and deleted within a virtual space. Understanding this flow is crucial for building responsive, real-time applications in multi-user environments. Below is an overview of the expected flow when using space entities.
 
 1. **Entity Creation** 
 
@@ -119,7 +119,7 @@ In CSP, the `SpaceEntitySystem` governs how objects (space entities) are created
         // Respond to entity creation here...
     }
     SpaceTransform transform = SpaceTransform(); // Create an identity transform. 
-	SpaceEntity* entity = spaceEntitySystem->CreateEntity("myEntityName", transform, callback);
+	SpaceEntity* entity = OnlineRealtimeEngine->CreateEntity("myEntityName", transform, callback);
 	```
 
     This code creates a new `SpaceEntity` within the space. Once created, you can modify this entity by adding components that define its behavior and appearance.

--- a/Library/docs/source/learn/spaces/multiplayer_architecture.md
+++ b/Library/docs/source/learn/spaces/multiplayer_architecture.md
@@ -78,7 +78,7 @@ Unlike RESTful APIs, which rely on separate requests and responses for each inte
 The multiplayer system in CSP is built to support real-time, scalable, and interactive virtual spaces. This section introduces the key high-level abstractions of the multiplayer architecture that client application developers can expect to interact with.
 
 ```eval_rst
-1. :class:`csp::systems::SpaceEntitySystem` handles all multiplayer network traffic related to updates for Space Entities and their components. It ensures that changes to entities, avatars, and interactive objects are synchronized across all connected clients in real time. This system is essential for maintaining the consistency of shared spaces and ensuring that all users experience the same state of the environment.
+1. :class:`csp::systems::OnlineRealtimeEngine` handles all multiplayer network traffic related to updates for Space Entities and their components. It ensures that changes to entities, avatars, and interactive objects are synchronized across all connected clients in real time. This system is essential for maintaining the consistency of shared spaces and ensuring that all users experience the same state of the environment.
 
 2. :class:`csp::multiplayer::MultiplayerConnection` manages the actual connection between the server and clients. It is responsible for establishing and maintaining the network link that supports real-time communication. This system also handles the communication of transient events that can be sent and received via the CSP Event Bus.
 

--- a/Library/docs/source/manual/documentation/expected_application_flow.md
+++ b/Library/docs/source/manual/documentation/expected_application_flow.md
@@ -47,7 +47,7 @@ Once Login is complete, the client application should consider starting to call 
 
 ## 3. Set the EntityCreated Callback
 ```c++
-void SpaceEntitySystem::SetEntityCreatedCallback(EntityCreatedCallback Callback)
+void OnlineRealtimeEngine::SetEntityCreatedCallback(EntityCreatedCallback Callback)
 ```
 
 This callback will be triggered any time the client receives a message from a space the user is subscribed to, stating that an Entity has been created. It is advised to call this just prior to entering a space, as once subscribed to a space, this callback will be triggered for each Entity currently in the space. The Client should use the data passed here to initialize any local representation of the entities in their application.

--- a/Library/docs/source/manual/documentation/multiplayer_state_replication.md
+++ b/Library/docs/source/manual/documentation/multiplayer_state_replication.md
@@ -24,11 +24,11 @@ Once the client has made their changes to the component properties they need to 
 void SpaceEntity::SendUpdate(CallbackHandler Callback);
 ```
 
-This calls into the `SpaceEntitySystem` (which manages all entities and is responsible for multiplayer service communication) and the entity will be enqueued for patch message transmission.
+This calls into the `OnlineRealtimeEngine` (which manages all entities and is responsible for multiplayer service communication) and the entity will be enqueued for patch message transmission.
 
 ## Patch Message Serialization
 
-When the entity update is dequeued by the `SpaceEntitySystem` and prepared for transmission, it is first serialised into the expected data format for SignalR and MsgPack, as the payload of `SendObjectPatch`.
+When the entity update is dequeued by the `OnlineRealtimeEngine` and prepared for transmission, it is first serialised into the expected data format for SignalR and MsgPack, as the payload of `SendObjectPatch`.
 
 ```c++
 SignalRMsgPackEntitySerialiser Serialiser;
@@ -122,7 +122,7 @@ Using these callbacks, a client application can update their client-level repres
 
 ## Receiving a Patch Message
 
-When the `SpaceEntitySystem` sets the SignalR connection (`SpaceEntitySystem::SetConnection`), we set the callback for the `OnObjectPatch` multiplayer service invocation.
+When the `OnlineRealtimeEngine` sets the SignalR connection (`OnlineRealtimeEngine::SetConnection`), we set the callback for the `OnObjectPatch` multiplayer service invocation.
 
 This callback then fires when we receive a patch message from another client.
 

--- a/Library/include/CSP/CSPFoundation.h
+++ b/Library/include/CSP/CSPFoundation.h
@@ -25,6 +25,11 @@ namespace csp::systems
 class ServicesDeploymentStatus;
 } // namespace csp::systems
 
+namespace csp::multiplayer
+{
+class ISignalRConnection;
+}
+
 namespace csp
 {
 
@@ -119,6 +124,12 @@ public:
     /// interact with each other.
     /// @return bool : True for successful initialisation.
     static bool Initialise(const csp::common::String& EndpointRootURI, const csp::common::String& Tenant);
+
+    // Hidden function for testing. Lets us pass in state that would otherwise be injected in a set way in the SystemsManager.
+    // In a different, perhaps better api, this wouldn't be necessary as constructors would inject this at client level and the configurability would
+    // be there by default
+    CSP_NO_EXPORT static bool InitialiseWithInject(
+        const csp::common::String& EndpointRootURI, const csp::common::String& Tenant, csp::multiplayer::ISignalRConnection* SignalRInject);
 
     /// @brief This should be used at the end of the application lifecycle.
     /// Clears event queues and destroys foundation systems.

--- a/Library/include/CSP/Common/ContinuationUtils.h
+++ b/Library/include/CSP/Common/ContinuationUtils.h
@@ -21,6 +21,7 @@ CSP_START_IGNORE
 #include <optional>
 
 #include "CSP/Common/CSPAsyncScheduler.h"
+#include "CSP/Common/Interfaces/InvalidInterfaceUserError.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 
 namespace csp::common::continuations
@@ -59,6 +60,12 @@ template <typename Callable> inline auto InvokeIfExceptionInChain(Callable&& Inv
             LogSystem.LogMsg(
                 csp::common::LogLevel::Verbose, "Caught exception during async++ chain. Invoking callable from InvokeIfExceptionInChain");
             InvokeIfExceptionCallable(exception);
+        }
+        catch (const csp::common::InvalidInterfaceUseError& exception)
+        {
+            LogSystem.LogMsg(
+                csp::common::LogLevel::Verbose, "Error, CSP expects derived IRealtimeEngine type, but has received a base instantiation. ");
+            InvokeIfExceptionCallable(std::runtime_error(exception.msg));
         }
     };
 }

--- a/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
+++ b/Library/include/CSP/Common/Interfaces/IJSScriptRunner.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "CSP/CSPCommon.h"
+#include "CSP/Common/Interfaces/InvalidInterfaceUserError.h"
 #include "CSP/Common/String.h"
 
 namespace csp::common
@@ -40,17 +41,6 @@ class IScriptBinding;
  * @important This type is not a true interface, instead having throwing default
  * implementations. This is due to wrapper generator constraints, hopefully temporary ones.
  */
-
-// We do not want a dependency on the STL just to do this generator-hack-workaround. Use a custom type.
-class CSP_API InvalidInterfaceUseError
-{
-public:
-    csp::common::String msg;
-    InvalidInterfaceUseError(const csp::common::String& msg)
-        : msg(msg)
-    {
-    }
-};
 
 class CSP_API IJSScriptRunner
 {

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -164,10 +164,19 @@ public:
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
 
+    /// @brief Adds an entity to the set of selected entities
+    /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
+    /// @return True if the entity was succesfully added, false otherwise. Refer to your specific IRealtimeEngine instantiation for specific failure
+    /// cases.
     virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
+
+    /// @brief Removes an entity to the set of selected entities
+    /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
+    /// @return True if the entity was succesfully removed, false otherwise. Refer to your specific IRealtimeEngine instantiation for specific failure
+    /// cases.
     virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -168,7 +168,7 @@ public:
     /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
     /// @return True if the entity was succesfully added, false otherwise. Refer to your specific IRealtimeEngine instantiation for specific failure
     /// cases.
-    virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
+    CSP_NO_EXPORT virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
@@ -177,7 +177,7 @@ public:
     /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
     /// @return True if the entity was succesfully removed, false otherwise. Refer to your specific IRealtimeEngine instantiation for specific failure
     /// cases.
-    virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
+    CSP_NO_EXPORT virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include "CSP/CSPCommon.h"
+#include "CSP/Common/Interfaces/InvalidInterfaceUserError.h"
 #include "CSP/Common/List.h"
+#include "CSP/Common/Optional.h"
 #include "CSP/Common/String.h"
 
 namespace csp::multiplayer
@@ -40,20 +43,30 @@ typedef std::function<void(bool)> CallbackHandler;
 
 // Callback that provides a non-owning pointer to a SpaceEntity object.
 typedef std::function<void(csp::multiplayer::SpaceEntity*)> EntityCreatedCallback;
+
 }
 
 namespace csp::common
 {
+// Note: It's not great that we require std (function) dependencies in interop types, seems to defeat the whole point.
 
-// This callback should be fired during IRealtimeEngine::FetchAllEntitiesAndPopulateBuffers when the system is ready for
-// csp::systems::SpaceSystem::EnterSpace to yield control back to calling clients. This may be done prior to actually completing fetching all
-// entities, as that could be a long operation and the specific RealtimeEngine implementation may not wish to block clients entering a space.
+/**
+ * This callback should be fired during IRealtimeEngine::FetchAllEntitiesAndPopulateBuffers when the system is ready for
+ * csp::systems::SpaceSystem::EnterSpace to yield control back to calling clients. This may be done prior to actually completing fetching all
+ * entities, as that could be a long operation and the specific RealtimeEngine implementation may not wish to block clients entering a space.
+ */
 typedef std::function<void()> EntityFetchStartedCallback;
-// This callback should be fired once all the entities have been fetched upon initial space setup, invoked via
-// IRealtimeEngine::FetchAllEntitiesAndPopulateBuffers. This serves as a public notification to clients that the RealtimeEngine is in a valid state
-// and entity inspection and mutation may begin.
-// Provides the number of entities fetched as an argument
-typedef std::function<void(std::uint32_t)> EntityFetchCompleteCallback;
+
+/**
+ * This callback should be fired once all the entities have been fetched upon initial space setup, invoked via
+ * IRealtimeEngine::FetchAllEntitiesAndPopulateBuffers. This serves as a public notification to clients that the RealtimeEngine is in a valid state
+ * and entity inspection and mutation may begin.
+ *
+ * Provides the number of entities fetched as an argument
+ */
+typedef std::function<void(uint32_t)> EntityFetchCompleteCallback;
+
+class LoginState;
 
 // This, frustratingly, cannot be an in-class type due to the code generator.
 /// @brief Enum of concrete types of RealtimeEngines.
@@ -83,6 +96,9 @@ enum class RealtimeEngineType : int
  * - @b Entity: All items in a space are entities.
  * - @b Avatar: A specialization of Entity representing an avatar. Defined by whether the entity contains an AvatarSpaceComponent.
  * - @b Object: An entity that is not an avatar. Defined by that entity not containing an AvatarSpaceComponent.
+ *
+ * @important This type is not a true interface, instead throwing default implementations.
+ *            This is due to wrapper generator constraints, hopefully temporary ones.
  */
 class CSP_API IRealtimeEngine
 {
@@ -91,43 +107,72 @@ public:
     virtual ~IRealtimeEngine() = default;
 
     /// @brief Returns the concrete type of the instantiation of the abstract IRealtimeEngine.
-    virtual RealtimeEngineType GetRealtimeEngineType() const = 0;
+    virtual RealtimeEngineType GetRealtimeEngineType() const { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /***** ENTITY MANAGEMENT *************************************************/
 
     /// @brief Create and add a SpaceEntity with type Avatar, and relevant components and default states as specified.
     /// @param Name csp::common::String : The entity name of the newly created avatar entity.
+    /// @param LoginState const csp::common::Optional<csp::common::LoginState>& : Login state tokens for authenticating on the remote server. Only
+    /// required if backend data store requires authentication.
     /// @param SpaceTransform csp::multiplayer::SpaceTransform : The initial transform to set the SpaceEntity to.
-    /// @param State csp::multiplayer::AvatarState : The initial Avatar State to set.
+    /// @param IsVisible bool : Whether the avatar defaults to being visible.
+    /// @param AvatarState csp::multiplayer::AvatarState : The initial Avatar State to set.
     /// @param AvatarId csp::common::String : The ID to be set on the AvatarSpaceComponent
     /// @param AvatarPlayMode csp::multiplayer::AvatarPlayMode : The Initial AvatarPlayMode to set.
     /// @param Callback csp::multiplayer::EntityCreatedCallback A callback that executes when the creation is complete,
     /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
-    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::multiplayer::SpaceTransform& SpaceTransform,
-        const csp::multiplayer::AvatarState& State, const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode,
-        csp::multiplayer::EntityCreatedCallback Callback)
-        = 0;
+    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState> LoginState,
+        const csp::multiplayer::SpaceTransform& SpaceTransform, bool IsVisible, const csp::multiplayer::AvatarState& AvatarState,
+        const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode, csp::multiplayer::EntityCreatedCallback Callback)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Create and add a SpaceEntity, with relevant default values.
     /// @param Name csp::common::String : The name of the newly created SpaceEntity.
     /// @param SpaceTransform csp::multiplayer::SpaceTransform : The initial transform to set the SpaceEntity to.
+    /// @param ParentID csp::common::Optional<uint64_t> : ID of another entity in the space that this entity should be created as a child to. If
+    /// empty, entity is created as a root entity.
     /// @param Callback csp::multiplayer::EntityCreatedCallback : A callback that executes when the creation is complete,
     /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
-    CSP_ASYNC_RESULT virtual void CreateEntity(
-        const csp::common::String& Name, const csp::multiplayer::SpaceTransform& SpaceTransform, csp::multiplayer::EntityCreatedCallback Callback)
-        = 0;
+    CSP_ASYNC_RESULT virtual void CreateEntity(const csp::common::String& Name, const csp::multiplayer::SpaceTransform& SpaceTransform,
+        const csp::common::Optional<uint64_t>& ParentID, csp::multiplayer::EntityCreatedCallback Callback)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
+
+    virtual void AddEntity(csp::multiplayer::SpaceEntity* EntityToAdd) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /// @brief Destroy the specified entity.
     /// @param Entity csp::multiplayer::SpaceEntity : A non-owning pointer to the entity to be destroyed.
     /// @param Callback csp::multiplayer::CallbackHandler : A callback that executes when the entity destruction is complete.
-    CSP_ASYNC_RESULT virtual void DestroyEntity(csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::CallbackHandler Callback) = 0;
+    CSP_ASYNC_RESULT virtual void DestroyEntity(csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::CallbackHandler Callback)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Sets a callback to be executed when an entity is fully created.
     ///
     /// Only one EntityCreatedCallback may be registered, calling this function again will override whatever was previously set.
+    /// The better way to set this and avoid initialisation race conditions is via passing this in the constructor, only use this if you wish to
+    /// override or remove this callback.
     ///
     /// @param Callback csp::multiplayer::EntityCreatedCallback : the callback to execute.
-    CSP_EVENT virtual void SetEntityCreatedCallback(csp::multiplayer::EntityCreatedCallback Callback) = 0;
+    CSP_EVENT virtual void SetEntityCreatedCallback(csp::multiplayer::EntityCreatedCallback Callback)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
+
+    virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
+    virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
+
     /**
      * @brief Fetch space entities from the RealtimeEngine data source and perform initial setup to populate internal buffers
      *
@@ -137,85 +182,125 @@ public:
      * store indexes spaces.
      * @param FetchStartedCallback EntityFetchStartedCallback : Callback notifying for when csp::systems::SpaceSystem::EnterSpace can yield control
      * back to clients
-     * @params FetchCompleteCallback EntityFetchCompleteCallback : Callback notifying when all entities are fetched and stored appropriately, and
-     * clients may start entity mutation.
-     *
-     * @post @param FetchStartedCallback will have been called, and @param FetchCompleteCallback will either have been called, or an async job started
-     * with an intent to call it once fetch is complete.
+     * @post @param FetchStartedCallback will have been called, and the EntityFetchCompleteCallback the engine was constructed with will either have
+     * been called, or an async job started with an intent to call it once fetch is complete.
      */
-    CSP_NO_EXPORT virtual void FetchAllEntitiesAndPopulateBuffers(const csp::common::String& SpaceId, EntityFetchStartedCallback FetchStartedCallback,
-        csp::common::EntityFetchCompleteCallback FetchCompleteCallback)
-        = 0;
+    CSP_NO_EXPORT virtual void FetchAllEntitiesAndPopulateBuffers(const csp::common::String& SpaceId, EntityFetchStartedCallback FetchStartedCallback)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /***** ENTITY ACCESS *****************************************************/
 
     /// @brief Finds the first found SpaceEntity of a matching Name.
     /// @param Name csp::common::String : The name to search.
     /// @return A non-owning pointer to the first found matching SpaceEntity.
-    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntity(const csp::common::String& Name) = 0;
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntity(const csp::common::String& Name)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Finds the first found SpaceEntity that has the ID EntityId.
     /// @param EntityId uint64_t : The Id to look for.
     /// @return A non-owning pointer to the first found matching SpaceEntity.
-    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntityById(uint64_t EntityId) = 0;
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntityById(uint64_t EntityId)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Finds the first found SpaceEntity of a matching Name. The found SpaceEntity will contain an AvatarSpaceComponent.
     /// @param Name The name to search for.
     /// @return A pointer to the first found matching SpaceEntity.
-    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceAvatar(const csp::common::String& Name) = 0;
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceAvatar(const csp::common::String& Name)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Finds the first found SpaceEntity of a matching Name. The found SpaceEntity will not contain an AvatarSpaceComponent.
     /// @param Name The name to search for.
     /// @return A pointer to the first found matching SpaceEntity.
-    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceObject(const csp::common::String& Name) = 0;
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceObject(const csp::common::String& Name)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Get an Entity by its index.
     ///
     /// @param EntityIndex size_t : The index of the entity to get.
     /// @return A non-owning pointer to the entity at the given index.
-    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetEntityByIndex(size_t EntityIndex) = 0;
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetEntityByIndex(size_t EntityIndex)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Get an Avatar by its index. The returned pointer will be an entity that contains an AvatarSpaceComponent.
     ///
     /// @param AvatarIndex size_t : The index of the avatar entity to get.
     /// @return A non-owning pointer to the avatar entity with the given index.
-    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetAvatarByIndex(size_t AvatarIndex) = 0;
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetAvatarByIndex(size_t AvatarIndex)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Get an Object by its index. The returned pointer will be an entity that does not contain an AvatarSpaceComponent.
     ///
     /// @param ObjectIndex size_t : The index of the object entity to get.
     /// @return A non-owning pointer to the object entity with the given index.
-    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetObjectByIndex(size_t ObjectIndex) = 0;
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetObjectByIndex(size_t ObjectIndex)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
     /// @brief Get the number of total entities in the system.
     /// @return The total number of entities.
-    virtual size_t GetNumEntities() const = 0;
+    virtual size_t GetNumEntities() const { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /// @brief Get the number of total Avatars in the system. Avatars are entities that contain AvatarSpaceComponents.
     /// @return The total number of Avatar entities.
-    virtual size_t GetNumAvatars() const = 0;
+    virtual size_t GetNumAvatars() const { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /// @brief Get the number of total Objects in the system. Objects are entities that do not contain AvatarSpaceComponents.
     /// @return The total number of object entities.
-    virtual size_t GetNumObjects() const = 0;
+    virtual size_t GetNumObjects() const { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /// @brief Retrieves all entities that exist at the root level (do not have a parent entity).
     /// @return A list of root entities containing non-owning pointers to entities.
-    [[nodiscard]] virtual const csp::common::List<csp::multiplayer::SpaceEntity*>* GetRootHierarchyEntities() const = 0;
+    [[nodiscard]] virtual const csp::common::List<csp::multiplayer::SpaceEntity*>* GetRootHierarchyEntities() const
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+    }
 
-    /// @brief Sets a callback to be executed when all existing entities have been retrieved after entering a space.
-    /// @param Callback CallbackHandler : A callback that executes when all existing entities have been retrieved.
-    CSP_EVENT virtual void SetInitialEntitiesRetrievedCallback(csp::multiplayer::CallbackHandler Callback) = 0;
+    /// @brief Set Callback that notifies when the SpaceEntitySystem is in a valid state
+    /// after entering a space, and entity mutation can begin. Users should not mutate entities before receiving this callback.
+    /// This callback should be emitted in response to FetchAllEntitiesAndPopulateBuffers completing, either syncronously or asyncronously.
+    /// This callback must be set prior to entering a space.
+    /// @param FetchCompleteCallback csp::common::EntityFetchCompleteCallback : Callback that notifies when the RealtimeEngine has completed initial
+    /// entity fetch
+    void SetEntityFetchCompleteCallback(EntityFetchCompleteCallback Callback) { EntityFetchCompleteCallback = Callback; }
+
+    // Wrapper generator limitation, would rather expose this as it'd be handy to know :(
+    CSP_NO_EXPORT EntityFetchCompleteCallback GetEntityFetchCompleteCallback() const { return EntityFetchCompleteCallback; }
 
     /***** ENTITY PROCESSING *************************************************/
 
     /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.
     /// From a client perspective, ProcessPendingEntityOperations is normally called via the CSPFoundation::Tick method.
     /// @param Entity SpaceEntity : A non-owning pointer to the entity to be marked.
-    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity) = 0;
+    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
 
     /// @brief Applies any pending changes to entities that have been marked for update.
-    virtual void ProcessPendingEntityOperations() = 0;
+    virtual void ProcessPendingEntityOperations() { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+
+protected:
+    // We want copies and moves and such to be possible for derived types, but they need to be sure to explicitly implement the behaviour.
+    // Protect these operations by default to prevent accidental slicing.
+    IRealtimeEngine() = default; // Wrapper gen required ... :(
+    IRealtimeEngine(const IRealtimeEngine&) = delete;
+    IRealtimeEngine& operator=(const IRealtimeEngine&) = delete;
+    IRealtimeEngine(IRealtimeEngine&&) = delete;
+    IRealtimeEngine& operator=(IRealtimeEngine&&) = delete;
+
+    EntityFetchCompleteCallback EntityFetchCompleteCallback = nullptr;
 };
 }
 

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -191,7 +191,7 @@ public:
      * store indexes spaces.
      * @param FetchStartedCallback EntityFetchStartedCallback : Callback notifying for when csp::systems::SpaceSystem::EnterSpace can yield control
      * back to clients
-     * @post @param FetchStartedCallback will have been called, and the EntityFetchCompleteCallback the engine was constructed with will either have
+     * @post FetchStartedCallback will have been called, and the EntityFetchCompleteCallback the engine was constructed with will either have
      * been called, or an async job started with an intent to call it once fetch is complete.
      */
     CSP_NO_EXPORT virtual void FetchAllEntitiesAndPopulateBuffers(const csp::common::String& SpaceId, EntityFetchStartedCallback FetchStartedCallback)

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -70,10 +70,10 @@ class LoginState;
 
 // This, frustratingly, cannot be an in-class type due to the code generator.
 /// @brief Enum of concrete types of RealtimeEngines.
-enum class RealtimeEngineType : int
+enum class RealtimeEngineType
 {
-    OnlineMultiUser = 0,
-    OnlineSingleUser
+    Online = 0,
+    Offline
 };
 
 /**
@@ -270,7 +270,7 @@ public:
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
 
-    /// @brief Set Callback that notifies when the SpaceEntitySystem is in a valid state
+    /// @brief Set Callback that notifies when the OnlineRealtimeEngine is in a valid state
     /// after entering a space, and entity mutation can begin. Users should not mutate entities before receiving this callback.
     /// This callback should be emitted in response to FetchAllEntitiesAndPopulateBuffers completing, either syncronously or asyncronously.
     /// This callback must be set prior to entering a space.
@@ -306,44 +306,44 @@ protected:
 
 // The following doc is temporary for reference during the module migration effort.
 
-/* As this interface is more or less a conversion from `SpaceEntitySystem`, what follows are
+/* As this interface is more or less a conversion from `OnlineRealtimeEngine`, what follows are
  * the methods that were public, but are no longer going to be public as far as the interface
  * is concerned. I've checked via searching the Magnopus org for uses of these, and initial findings
  * show these can be hidden, although some client validation wouldn't go amiss.
- * In reality, SpaceEntitySystem isn't going anywhere and will continue to exists behind the interface, so these
+ * In reality, OnlineRealtimeEngine isn't going anywhere and will continue to exists behind the interface, so these
  * methods are not being deleted, they're just not being exposed to clients or CSP-core.
  * They'll still be called by methods internal to the module.
  *
  *
- * SpaceEntitySystem::AddEntity (We think only Ichabod uses this, we think incorrectly. _Definitely_ need to check this one. Potential full deletion
+ * OnlineRealtimeEngine::AddEntity (We think only Ichabod uses this, we think incorrectly. _Definitely_ need to check this one. Potential full deletion
  * candidate)
- * SpaceEntitySystem::LocalDestroyEntity SpaceEntitySystem::LockEntityUpdate SpaceEntitySystem::UnlockEntityUpdate
- * SpaceEntitySystem::SetConnection
- * SpaceEntitySystem::RegisterEntityScriptAsModule (Potential full deletion candidate)
- * SpaceEntitySystem::BindNewEntityToScript (Potential full deletion candidate)
- * SpaceEntitySystem::RetrieveAllEntities
- * SpaceEntitySystem::LocalDestroyAllEntities
- * SpaceEntitySystem::SetSelectionStateOfEntity (Covered by SpaceEntity Select/Deselect)
- * SpaceEntitySystem::CreateObjectInternal
- * SpaceEntitySystem::ResolveEntityHierarchy
- * SpaceEntitySystem::Initialise
- * SpaceEntitySystem::Shutdown
- * SpaceEntitySystem::GetPendingAdds
- * SpaceEntitySystem::CheckIfWeShouldRunScriptsLocally
- * SpaceEntitySystem::RunScriptRemotely (Public interface to this is EntityScript::RunScript)
+ * OnlineRealtimeEngine::LocalDestroyEntity OnlineRealtimeEngine::LockEntityUpdate OnlineRealtimeEngine::UnlockEntityUpdate
+ * OnlineRealtimeEngine::SetConnection
+ * OnlineRealtimeEngine::RegisterEntityScriptAsModule (Potential full deletion candidate)
+ * OnlineRealtimeEngine::BindNewEntityToScript (Potential full deletion candidate)
+ * OnlineRealtimeEngine::RetrieveAllEntities
+ * OnlineRealtimeEngine::LocalDestroyAllEntities
+ * OnlineRealtimeEngine::SetSelectionStateOfEntity (Covered by SpaceEntity Select/Deselect)
+ * OnlineRealtimeEngine::CreateObjectInternal
+ * OnlineRealtimeEngine::ResolveEntityHierarchy
+ * OnlineRealtimeEngine::Initialise
+ * OnlineRealtimeEngine::Shutdown
+ * OnlineRealtimeEngine::GetPendingAdds
+ * OnlineRealtimeEngine::CheckIfWeShouldRunScriptsLocally
+ * OnlineRealtimeEngine::RunScriptRemotely (Public interface to this is EntityScript::RunScript)
  */
 
 /* These are the methods that have been removed from the base interface, but will exist publicly on the Multi User concretion.
  *
- * SpaceEntitySystem::GetEntityPatchRateLimitEnabled
- * SpaceEntitySystem::SetEntityPatchRateLimitEnabled
- * SpaceEntitySystem::EnableLeaderElection
- * SpaceEntitySystem::DisableLeaderElection
- * SpaceEntitySystem::IsLeaderElectionEnabled
- * SpaceEntitySystem::GetLeaderId
- * SpaceEntitySystem::ClaimScriptOwnership
- * SpaceEntitySystem::SetScriptSystemReadyCallback (Should rename to SetScriptLeaderReadyCallback)
- * SpaceEntitySystem::GetMultiplayerConnectionInstance
+ * OnlineRealtimeEngine::GetEntityPatchRateLimitEnabled
+ * OnlineRealtimeEngine::SetEntityPatchRateLimitEnabled
+ * OnlineRealtimeEngine::EnableLeaderElection
+ * OnlineRealtimeEngine::DisableLeaderElection
+ * OnlineRealtimeEngine::IsLeaderElectionEnabled
+ * OnlineRealtimeEngine::GetLeaderId
+ * OnlineRealtimeEngine::ClaimScriptOwnership
+ * OnlineRealtimeEngine::SetScriptSystemReadyCallback (Should rename to SetScriptLeaderReadyCallback)
+ * OnlineRealtimeEngine::GetMultiplayerConnectionInstance
  * SystemsManager::GetEventBus (Rename EventBus -> NetworkEventBus)
- * SpaceEntitySystem::RefreshMultiplayerConnection
+ * OnlineRealtimeEngine::RefreshMultiplayerConnection
  */

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -122,7 +122,7 @@ public:
     /// @param AvatarPlayMode csp::multiplayer::AvatarPlayMode : The Initial AvatarPlayMode to set.
     /// @param Callback csp::multiplayer::EntityCreatedCallback A callback that executes when the creation is complete,
     /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
-    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState> LoginState,
+    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState>& LoginState,
         const csp::multiplayer::SpaceTransform& SpaceTransform, bool IsVisible, const csp::multiplayer::AvatarState& AvatarState,
         const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode, csp::multiplayer::EntityCreatedCallback Callback)
     {
@@ -276,7 +276,7 @@ public:
     /// This callback must be set prior to entering a space.
     /// @param FetchCompleteCallback csp::common::EntityFetchCompleteCallback : Callback that notifies when the RealtimeEngine has completed initial
     /// entity fetch
-    void SetEntityFetchCompleteCallback(EntityFetchCompleteCallback Callback) { EntityFetchCompleteCallback = Callback; }
+    CSP_EVENT void SetEntityFetchCompleteCallback(EntityFetchCompleteCallback Callback) { EntityFetchCompleteCallback = Callback; }
 
     // Wrapper generator limitation, would rather expose this as it'd be handy to know :(
     CSP_NO_EXPORT EntityFetchCompleteCallback GetEntityFetchCompleteCallback() const { return EntityFetchCompleteCallback; }
@@ -315,9 +315,8 @@ protected:
  * They'll still be called by methods internal to the module.
  *
  *
- * OnlineRealtimeEngine::AddEntity (We think only Ichabod uses this, we think incorrectly. _Definitely_ need to check this one. Potential full deletion
- * candidate)
- * OnlineRealtimeEngine::LocalDestroyEntity OnlineRealtimeEngine::LockEntityUpdate OnlineRealtimeEngine::UnlockEntityUpdate
+ * OnlineRealtimeEngine::AddEntity (We think only Ichabod uses this, we think incorrectly. _Definitely_ need to check this one. Potential full
+ * deletion candidate) OnlineRealtimeEngine::LocalDestroyEntity OnlineRealtimeEngine::LockEntityUpdate OnlineRealtimeEngine::UnlockEntityUpdate
  * OnlineRealtimeEngine::SetConnection
  * OnlineRealtimeEngine::RegisterEntityScriptAsModule (Potential full deletion candidate)
  * OnlineRealtimeEngine::BindNewEntityToScript (Potential full deletion candidate)

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -113,8 +113,8 @@ public:
 
     /// @brief Create and add a SpaceEntity with type Avatar, and relevant components and default states as specified.
     /// @param Name csp::common::String : The entity name of the newly created avatar entity.
-    /// @param LoginState const csp::common::Optional<csp::common::LoginState>& : Login state tokens for authenticating on the remote server. Only
-    /// required if backend data store requires authentication.
+    /// @param UserId  csp::common::String : Id of the user creating this avatar. If your backend data store requires authentication, this will
+    /// probably be your username or some similar unique identifier.
     /// @param SpaceTransform csp::multiplayer::SpaceTransform : The initial transform to set the SpaceEntity to.
     /// @param IsVisible bool : Whether the avatar defaults to being visible.
     /// @param AvatarState csp::multiplayer::AvatarState : The initial Avatar State to set.
@@ -122,7 +122,7 @@ public:
     /// @param AvatarPlayMode csp::multiplayer::AvatarPlayMode : The Initial AvatarPlayMode to set.
     /// @param Callback csp::multiplayer::EntityCreatedCallback A callback that executes when the creation is complete,
     /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
-    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState>& LoginState,
+    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::String& UserId,
         const csp::multiplayer::SpaceTransform& SpaceTransform, bool IsVisible, const csp::multiplayer::AvatarState& AvatarState,
         const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode, csp::multiplayer::EntityCreatedCallback Callback)
     {

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -126,6 +126,18 @@ public:
         const csp::multiplayer::SpaceTransform& SpaceTransform, bool IsVisible, const csp::multiplayer::AvatarState& AvatarState,
         const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode, csp::multiplayer::EntityCreatedCallback Callback)
     {
+        // Marking parameters as unused by casting them to void to suppress warnings.
+        // however this method is exported and the wrapper generator does not support that approach.
+        // C++ 17 adds support for the [[maybe_unused]] attribute, but again the wrapper generator does not support it.
+        (void)Name;
+        (void)UserId;
+        (void)SpaceTransform;
+        (void)IsVisible;
+        (void)AvatarState;
+        (void)AvatarId;
+        (void)AvatarPlayMode;
+        (void)Callback;
+
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
 
@@ -140,9 +152,21 @@ public:
         const csp::common::Optional<uint64_t>& ParentID, csp::multiplayer::EntityCreatedCallback Callback)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Name;
+        (void)SpaceTransform;
+        (void)ParentID;
+        (void)Callback;
     }
 
-    virtual void AddEntity(csp::multiplayer::SpaceEntity* EntityToAdd) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    virtual void AddEntity(csp::multiplayer::SpaceEntity* EntityToAdd)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)EntityToAdd;
+    }
 
     /// @brief Destroy the specified entity.
     /// @param Entity csp::multiplayer::SpaceEntity : A non-owning pointer to the entity to be destroyed.
@@ -150,6 +174,10 @@ public:
     CSP_ASYNC_RESULT virtual void DestroyEntity(csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::CallbackHandler Callback)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Entity;
+        (void)Callback;
     }
 
     /// @brief Sets a callback to be executed when an entity is fully created.
@@ -162,6 +190,9 @@ public:
     CSP_EVENT virtual void SetEntityCreatedCallback(csp::multiplayer::EntityCreatedCallback Callback)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Callback;
     }
 
     /// @brief Adds an entity to the set of selected entities
@@ -171,6 +202,9 @@ public:
     CSP_NO_EXPORT virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Entity;
     }
 
     /// @brief Removes an entity to the set of selected entities
@@ -180,6 +214,9 @@ public:
     CSP_NO_EXPORT virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Entity;
     }
 
     /**
@@ -197,6 +234,10 @@ public:
     CSP_NO_EXPORT virtual void FetchAllEntitiesAndPopulateBuffers(const csp::common::String& SpaceId, EntityFetchStartedCallback FetchStartedCallback)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)SpaceId;
+        (void)FetchStartedCallback;
     }
 
     /***** ENTITY ACCESS *****************************************************/
@@ -207,6 +248,9 @@ public:
     [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntity(const csp::common::String& Name)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Name;
     }
 
     /// @brief Finds the first found SpaceEntity that has the ID EntityId.
@@ -215,6 +259,9 @@ public:
     [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntityById(uint64_t EntityId)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)EntityId;
     }
 
     /// @brief Finds the first found SpaceEntity of a matching Name. The found SpaceEntity will contain an AvatarSpaceComponent.
@@ -223,6 +270,9 @@ public:
     [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceAvatar(const csp::common::String& Name)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Name;
     }
 
     /// @brief Finds the first found SpaceEntity of a matching Name. The found SpaceEntity will not contain an AvatarSpaceComponent.
@@ -231,6 +281,9 @@ public:
     [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceObject(const csp::common::String& Name)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Name;
     }
 
     /// @brief Get an Entity by its index.
@@ -240,6 +293,9 @@ public:
     [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetEntityByIndex(size_t EntityIndex)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)EntityIndex;
     }
 
     /// @brief Get an Avatar by its index. The returned pointer will be an entity that contains an AvatarSpaceComponent.
@@ -249,6 +305,9 @@ public:
     [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetAvatarByIndex(size_t AvatarIndex)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)AvatarIndex;
     }
 
     /// @brief Get an Object by its index. The returned pointer will be an entity that does not contain an AvatarSpaceComponent.
@@ -258,6 +317,9 @@ public:
     [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetObjectByIndex(size_t ObjectIndex)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)ObjectIndex;
     }
 
     /// @brief Get the number of total entities in the system.
@@ -295,7 +357,13 @@ public:
     /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.
     /// From a client perspective, ProcessPendingEntityOperations is normally called via the CSPFoundation::Tick method.
     /// @param Entity SpaceEntity : A non-owning pointer to the entity to be marked.
-    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity) { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }
+    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+        // Avoiding unused params, see comment in top method
+        (void)Entity;
+    }
 
     /// @brief Applies any pending changes to entities that have been marked for update.
     virtual void ProcessPendingEntityOperations() { throw InvalidInterfaceUseError("Illegal use of \"abstract\" type."); }

--- a/Library/include/CSP/Common/Interfaces/InvalidInterfaceUserError.h
+++ b/Library/include/CSP/Common/Interfaces/InvalidInterfaceUserError.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "CSP/Common/String.h"
+
+namespace csp::common
+{
+
+/**
+ * @class InvalidInterfaceUseError
+ * @brief Error to avoid introducing an STL dependency (<exception>) to publicly exposed common interfaces,
+ *        thrown when what should be a pure-virtual interface type is directly instantiated and called.
+ *
+ * @important This is a hopefully temporary hack in order to work around wrapper generator constraints.
+ *            There is no technical reason we should not be able to use true interfaces.
+ */
+
+class CSP_API InvalidInterfaceUseError
+{
+public:
+    csp::common::String msg;
+    InvalidInterfaceUseError(const csp::common::String& msg)
+        : msg(msg)
+    {
+    }
+};
+
+}

--- a/Library/include/CSP/Common/Systems/Log/LogSystem.h
+++ b/Library/include/CSP/Common/Systems/Log/LogSystem.h
@@ -41,12 +41,6 @@ enum class LogLevel
 /// Contains a callback system that allows clients to react to specific logs or events.
 class CSP_API LogSystem
 {
-    CSP_START_IGNORE
-    /** @cond DO_NOT_DOCUMENT */
-    friend class SystemsManager;
-    /** @endcond */
-    CSP_END_IGNORE
-
 public:
     LogSystem();
     ~LogSystem();

--- a/Library/include/CSP/Multiplayer/CSPSceneDescription.h
+++ b/Library/include/CSP/Multiplayer/CSPSceneDescription.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 
 namespace csp::multiplayer
 {
@@ -29,10 +29,10 @@ class CSP_API CSPSceneDescription
 public:
     /// @brief Constructor for CSPSceneDescription by deserializing a SceneDescription json file.
     /// @param SceneDescriptionJson csp::common::String : The SceneDescription to deserialize.
-    /// @param EntitySystem csp::multiplayer::SpaceEntitySystem& : The SpaceEntitySystem for this session.
-    /// @param LogSystem csp::common::LogSystem& : The SpaceEntitySystem for this session.
+    /// @param EntitySystem csp::multiplayer::OnlineRealtimeEngine& : The OnlineRealtimeEngine for this session.
+    /// @param LogSystem csp::common::LogSystem& : The OnlineRealtimeEngine for this session.
     /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : The ScriptRunner for this session.
-    CSPSceneDescription(const csp::common::String& SceneDescriptionJson, csp::multiplayer::SpaceEntitySystem& EntitySystem,
+    CSPSceneDescription(const csp::common::String& SceneDescriptionJson, csp::multiplayer::OnlineRealtimeEngine& EntitySystem,
         csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner);
 
     /// @brief The Entities that exist for this scene.

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -85,7 +85,7 @@ class CSP_API ComponentBase
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
     friend class SpaceEntity;
-    friend class SpaceEntitySystem;
+    friend class OnlineRealtimeEngine;
     friend class EntityScriptInterface;
 #ifdef CSP_TESTS
     friend class ::CSPEngine_SerialisationTests_SpaceEntityUserSignalRSerialisationTest_Test;

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -201,6 +201,11 @@ public:
     /// themselves. Unfortunate manual state management.
     CSP_NO_EXPORT void SetOnlineRealtimeEngine(csp::multiplayer::OnlineRealtimeEngine* OnlineRealtimeEngine);
 
+    /// @brief Get the currently set realtime engine.
+    /// @return Non-owning pointer to currently set realtime engine. This should be non-null when in a space, and null before entering, or after
+    /// exiting a space.
+    csp::multiplayer::OnlineRealtimeEngine* GetOnlineRealtimeEngine() const;
+
 private:
     MultiplayerConnection(const MultiplayerConnection& InBoundConnection);
 

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -52,7 +52,7 @@ class IRealtimeEngine;
 /// @brief Namespace that encompasses everything in the multiplayer system
 namespace csp::multiplayer
 {
-class SpaceEntitySystem;
+class OnlineRealtimeEngine;
 class ClientElectionManager;
 class ISignalRConnection;
 class NetworkEventManagerImpl;
@@ -195,11 +195,11 @@ public:
     /// @return MultiplayerHubMethodMap : the MultiplayerHubMethodMap instance
     CSP_NO_EXPORT MultiplayerHubMethodMap GetMultiplayerHubMethods() const { return MultiplayerHubMethods; }
 
-    /// @brief Sets the internal reference to the SpaceEntitySystem. Should be called when entering a space.
-    /// @param SpaceEntitySystem SpaceEntitySystem* : Non-owning pointer. Ideally this would be an owned structure, but we can't due to the wrapper
-    /// generator. Remember to null this when exiting a space as object dispatch depends on that, until clients are capable of managing this
+    /// @brief Sets the internal reference to the OnlineRealtimeEngine. Should be called when entering a space.
+    /// @param OnlineRealtimeEngine OnlineRealtimeEngine* : Non-owning pointer. Ideally this would be an owned structure, but we can't due to the
+    /// wrapper generator. Remember to null this when exiting a space as object dispatch depends on that, until clients are capable of managing this
     /// themselves. Unfortunate manual state management.
-    CSP_NO_EXPORT void SetSpaceEntitySystem(csp::multiplayer::SpaceEntitySystem* SpaceEntitySystem);
+    CSP_NO_EXPORT void SetOnlineRealtimeEngine(csp::multiplayer::OnlineRealtimeEngine* OnlineRealtimeEngine);
 
 private:
     MultiplayerConnection(const MultiplayerConnection& InBoundConnection);
@@ -223,7 +223,7 @@ private:
     /*
      * Bind the SignalR messages that are recieved from MCS to facilitate realtime communication.
      * These are bound for the entire lifetime of the MultiplayerConnection (conceptually Login/Logout scoped).
-     * These messages are dispatched to the SpaceEntitySystem if it exists.
+     * These messages are dispatched to the OnlineRealtimeEngine if it exists.
      * For the future, consider how pleasant it might be if we bound everything all at once here, and had a single
      * container of observers to recieve the bindings. That would make registering/deregistering AND lifetime the
      * same concept, and we'd have a single pipe of realtime events that were obvious to trace.
@@ -255,7 +255,7 @@ private:
 
     MultiplayerHubMethodMap MultiplayerHubMethods;
 
-    SpaceEntitySystem* MultiplayerRealtimeEngine = nullptr;
+    OnlineRealtimeEngine* MultiplayerRealtimeEngine = nullptr;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -138,10 +138,7 @@ public:
     /// @brief Start the connection and register to start receiving updates from the server.
     /// Connect should be called after LogIn and before EnterSpace.
     /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
-    /// @param SignalRConnection ISignalRConnection* : The SignalR connection to use when talking to the server. The MultiplayerConnection takes
-    /// ownership of this pointer.
-    CSP_NO_EXPORT void Connect(ErrorCodeCallbackHandler Callback, [[maybe_unused]] const csp::common::String& MultiplayerUri, const csp::common::String& AccessToken, const csp::common::String& DeviceId,
-        ISignalRConnection* SignalRConnection);
+    CSP_NO_EXPORT void Connect(ErrorCodeCallbackHandler Callback, [[maybe_unused]] const csp::common::String& MultiplayerUri, const csp::common::String& AccessToken, const csp::common::String& DeviceId);
 
     /// @brief Indicates whether the multiplayer connection is established
     /// @return bool : true if connected, false otherwise
@@ -182,7 +179,10 @@ public:
     CSP_NO_EXPORT void ResetScopes(ErrorCodeCallbackHandler Callback);
 
     /// @brief MultiplayerConnection constructor
-    CSP_NO_EXPORT MultiplayerConnection(csp::common::LogSystem& LogSystem);
+    /// @param LogSystem csp::common::LogSystem& LogSystem injection.
+    /// @param Connection csp::multiplayer::ISignalRConnection& Connection injection. Multiplayer connection allows connection/disconnection, and
+    /// tracks that with a boolean flag, but the connection object itself is invariant, always set.
+    CSP_NO_EXPORT MultiplayerConnection(csp::common::LogSystem& LogSystem, csp::multiplayer::ISignalRConnection& Connection);
 
     /// @brief MultiplayerConnection destructor
     CSP_NO_EXPORT ~MultiplayerConnection();
@@ -233,7 +233,9 @@ private:
     void BindOnRequestToSendObject();
     void BindOnRequestToDisconnect();
 
+    // May not be null
     class csp::multiplayer::ISignalRConnection* Connection;
+
     class csp::multiplayer::IWebSocketClient* WebSocketClient;
     class NetworkEventManagerImpl* NetworkEventManager;
     class NetworkEventBus* EventBusPtr;

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -196,7 +196,10 @@ public:
     CSP_NO_EXPORT MultiplayerHubMethodMap GetMultiplayerHubMethods() const { return MultiplayerHubMethods; }
 
     /// @brief Sets the internal reference to the SpaceEntitySystem. Should be called when entering a space.
-    CSP_NO_EXPORT void SetSpaceEntitySystem(std::shared_ptr<SpaceEntitySystem>& SpaceEntitySystem);
+    /// @param SpaceEntitySystem SpaceEntitySystem* : Non-owning pointer. Ideally this would be an owned structure, but we can't due to the wrapper
+    /// generator. Remember to null this when exiting a space as object dispatch depends on that, until clients are capable of managing this
+    /// themselves. Unfortunate manual state management.
+    CSP_NO_EXPORT void SetSpaceEntitySystem(csp::multiplayer::SpaceEntitySystem* SpaceEntitySystem);
 
 private:
     MultiplayerConnection(const MultiplayerConnection& InBoundConnection);
@@ -250,13 +253,7 @@ private:
 
     MultiplayerHubMethodMap MultiplayerHubMethods;
 
-    // Space Entity System is created and destroyed on space entry/de-entry
-    // HOWEVER, for better or worse, bindings are only made once, on login. (They have to be, cant reregister signalR bindings, and we want
-    // out-of-space messaging) Therefore, this SpaceEntitySystem needs to be set each time we enter a space. The weak pointer nature means that we can
-    // discard messages that come to us when not in a space (which WILL happen during exiting a space due to network async).
-    // This used to be done by recycling the same SpaceEntitySystem, but we can't (and don't want to!) do that anymore.
-    // Review note: This may vanish depending on what decisions are made regarding ownership of the IRealtimeEngine.
-    std::weak_ptr<SpaceEntitySystem> SpaceEntitySystemWeak;
+    SpaceEntitySystem* MultiplayerRealtimeEngine = nullptr;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/MultiplayerHubMethods.h
+++ b/Library/include/CSP/Multiplayer/MultiplayerHubMethods.h
@@ -41,7 +41,11 @@ enum class MultiplayerHubMethod
     SET_ALLOW_SELF_MESSAGING,
     SET_SCOPES,
     START_LISTENING,
-    STOP_LISTENING
+    STOP_LISTENING,
+    ON_OBJECT_MESSAGE,
+    ON_OBJECT_PATCH,
+    ON_REQUEST_TO_SEND_OBJECT,
+    ON_REQUEST_TO_DISCONNECT
 };
 
 /// @brief Utility class to map input values from MultiplayerHubMethod to string representations.
@@ -63,6 +67,10 @@ struct MultiplayerHubMethodMap : public std::unordered_map<MultiplayerHubMethod,
         this->insert({ MultiplayerHubMethod::SET_SCOPES, "SetScopes" });
         this->insert({ MultiplayerHubMethod::START_LISTENING, "StartListening" });
         this->insert({ MultiplayerHubMethod::STOP_LISTENING, "StopListening" });
+        this->insert({ MultiplayerHubMethod::ON_OBJECT_MESSAGE, "OnObjectMessage" });
+        this->insert({ MultiplayerHubMethod::ON_OBJECT_PATCH, "OnObjectPatch" });
+        this->insert({ MultiplayerHubMethod::ON_REQUEST_TO_SEND_OBJECT, "OnRequestToSendObject" });
+        this->insert({ MultiplayerHubMethod::ON_REQUEST_TO_DISCONNECT, "OnRequestToDisconnect" });
     }
 
     ~MultiplayerHubMethodMap() { }

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -204,13 +204,14 @@ public:
 
     /// @brief Create and add a SpaceEntity with type Avatar, and relevant components and default states as specified.
     /// @param Name csp::common::String : The entity name of the newly created avatar entity.
+    /// @param UserId csp::common::String : The Id of the user creating the avatar. This can be fetched from csp::systems::UserSystem::GetLoginState
     /// @param SpaceTransform csp::multiplayer::SpaceTransform : The initial transform to set the SpaceEntity to.
     /// @param State csp::multiplayer::AvatarState : The initial Avatar State to set.
     /// @param AvatarId csp::common::String : The ID to be set on the AvatarSpaceComponent
     /// @param AvatarPlayMode csp::multiplayer::AvatarPlayMode : The Initial AvatarPlayMode to set.
     /// @param Callback csp::multiplayer::EntityCreatedCallback A callback that executes when the creation is complete,
     /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
-    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState>& LoginState,
+    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::String& UserId,
         const csp::multiplayer::SpaceTransform& SpaceTransform, bool IsVisible, const csp::multiplayer::AvatarState& State,
         const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode,
         csp::multiplayer::EntityCreatedCallback Callback) override;
@@ -232,7 +233,7 @@ public:
     /// is called from the main thread.
     ///
     /// @param EntityToAdd SpaceEntity : Pointer to the entity to be added.
-    void AddEntity(SpaceEntity* EntityToAdd) override; // NOTE: This needs to become an interface method, will likely hit this problem during rebase
+    void AddEntity(SpaceEntity* EntityToAdd) override;
 
     /// @brief Destroy the specified entity.
     /// @param Entity csp::multiplayer::SpaceEntity : A non-owning pointer to the entity to be destroyed.
@@ -414,10 +415,10 @@ private:
     CSP_START_IGNORE
     async::shared_task<uint64_t> RemoteGenerateNewAvatarId();
     std::function<async::task<std::tuple<signalr::value, std::exception_ptr>>(uint64_t)> SendNewAvatarObjectMessage(const csp::common::String& Name,
-        const csp::common::LoginState& LoginState, const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId,
+        const csp::common::String& UserId, const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId,
         AvatarState AvatarState, AvatarPlayMode AvatarPlayMode);
     std::function<void(std::tuple<async::shared_task<uint64_t>, async::task<void>>)> CreateNewLocalAvatar(const csp::common::String& Name,
-        const csp::common::LoginState& LoginState, const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId,
+        const csp::common::String& UserId, const SpaceTransform& Transform, bool IsVisible, const csp::common::String& AvatarId,
         AvatarState AvatarState, AvatarPlayMode AvatarPlayMode, EntityCreatedCallback Callback);
     CSP_END_IGNORE
 

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -49,11 +49,11 @@ namespace signalr
 class value;
 } // namespace signalr
 
-class CSPEngine_SpaceEntitySystemTests_TestErrorInRemoteGenerateNewAvatarId_Test;
-class CSPEngine_SpaceEntitySystemTests_TestSuccessInRemoteGenerateNewAvatarId_Test;
-class CSPEngine_SpaceEntitySystemTests_TestErrorInSendNewAvatarObjectMessage_Test;
-class CSPEngine_SpaceEntitySystemTests_TestSuccessInSendNewAvatarObjectMessage_Test;
-class CSPEngine_SpaceEntitySystemTests_TestSuccessInCreateNewLocalAvatar_Test;
+class CSPEngine_OnlineRealtimeEngineTests_TestErrorInRemoteGenerateNewAvatarId_Test;
+class CSPEngine_OnlineRealtimeEngineTests_TestSuccessInRemoteGenerateNewAvatarId_Test;
+class CSPEngine_OnlineRealtimeEngineTests_TestErrorInSendNewAvatarObjectMessage_Test;
+class CSPEngine_OnlineRealtimeEngineTests_TestSuccessInSendNewAvatarObjectMessage_Test;
+class CSPEngine_OnlineRealtimeEngineTests_TestSuccessInCreateNewLocalAvatar_Test;
 class CSPEngine_MultiplayerTests_ManyEntitiesTest_Test;
 
 namespace csp::common
@@ -82,15 +82,15 @@ class NetworkEventBus;
 /// It manages things like queueing updated entities and triggering tick events. Callbacks
 /// can be registered for certain events that occur within the entity system so clients can
 /// react appropriately.
-class CSP_API SpaceEntitySystem : public csp::common::IRealtimeEngine
+class CSP_API OnlineRealtimeEngine : public csp::common::IRealtimeEngine
 {
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
-    friend class CSPEngine_SpaceEntitySystemTests_TestErrorInRemoteGenerateNewAvatarId_Test;
-    friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInRemoteGenerateNewAvatarId_Test;
-    friend class CSPEngine_SpaceEntitySystemTests_TestErrorInSendNewAvatarObjectMessage_Test;
-    friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInSendNewAvatarObjectMessage_Test;
-    friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInCreateNewLocalAvatar_Test;
+    friend class CSPEngine_OnlineRealtimeEngineTests_TestErrorInRemoteGenerateNewAvatarId_Test;
+    friend class CSPEngine_OnlineRealtimeEngineTests_TestSuccessInRemoteGenerateNewAvatarId_Test;
+    friend class CSPEngine_OnlineRealtimeEngineTests_TestErrorInSendNewAvatarObjectMessage_Test;
+    friend class CSPEngine_OnlineRealtimeEngineTests_TestSuccessInSendNewAvatarObjectMessage_Test;
+    friend class CSPEngine_OnlineRealtimeEngineTests_TestSuccessInCreateNewLocalAvatar_Test;
     friend class CSPEngine_MultiplayerTests_ManyEntitiesTest_Test;
     /** @endcond */
     CSP_END_IGNORE
@@ -157,17 +157,17 @@ public:
     /// @param ScriptText csp::common::String& : the text of the script to run
     CSP_NO_EXPORT void RunScriptRemotely(int64_t ContextId, const csp::common::String& ScriptText);
 
-    /// @brief SpaceEntitySystem constructor
-    /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the SpaceEntitySystem with
+    /// @brief OnlineRealtimeEngine constructor
+    /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the OnlineRealtimeEngine with
     /// @param LogSystem csp::common::LogSystem : Logger such that this system can print status and debug output
     /// @param NetworkEventBus csp::multiplayer::NetworkEventbus& : Reference the the network event bus, used for leadership election messaging.
     /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : Object capable of running a script. Called to execute scripts when the leader
     /// election system
-    SpaceEntitySystem(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
+    OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
         csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& RemoteScriptRunner);
 
-    /// @brief SpaceEntitySystem destructor
-    CSP_NO_EXPORT ~SpaceEntitySystem();
+    /// @brief OnlineRealtimeEngine destructor
+    CSP_NO_EXPORT ~OnlineRealtimeEngine();
 
     /// @brief Getter for the pending adds
     /// @return: SpaceEntityQueue*
@@ -349,7 +349,7 @@ protected:
     std::recursive_mutex* EntitiesLock;
 
 private:
-    SpaceEntitySystem(); // needed for the wrapper generator
+    OnlineRealtimeEngine(); // needed for the wrapper generator
 
     // Should not be null
     MultiplayerConnection* MultiplayerConnectionInst;

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -250,8 +250,8 @@ public:
      * @param SpaceId const csp::common::String& : MCS formatted SpaceId
      * @param FetchStartedCallback EntityFetchStartedCallback Callback called once scopes are reset and entity fetch has begun.
      *
-     * @pre @param Space represented by SpaceId must exist on the configured server endpoint. See csp::systems::SpaceSystem::CreateSpace
-     * @post @param FetchStartedCallback will be called. The csp::common::EntityFetchCompleteCallback passed in the constructor will be called async
+     * @pre Space represented by SpaceId must exist on the configured server endpoint. See csp::systems::SpaceSystem::CreateSpace
+     * @post FetchStartedCallback will be called. The csp::common::EntityFetchCompleteCallback passed in the constructor will be called async
      * once all the entities are fetched.
      */
     CSP_NO_EXPORT void FetchAllEntitiesAndPopulateBuffers(

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -246,7 +246,14 @@ public:
     /// @param Callback csp::multiplayer::EntityCreatedCallback : the callback to execute.
     CSP_EVENT virtual void SetEntityCreatedCallback(csp::multiplayer::EntityCreatedCallback Callback) override;
 
+    /// @brief Adds an entity to the set of selected entities
+    /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
+    /// @return True if the entity was succesfully added, false if the entity already existed in the selection and thus could not be added.
     virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
+
+    /// @brief Removes an entity to the set of selected entities
+    /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
+    /// @return True if the entity was succesfully removed, false if the entity did not exist in the selection and thus could not be removed.
     virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
 
     /***** ENTITY ACCESS *****************************************************/

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -167,12 +167,12 @@ public:
     /// @brief Adds an entity to the set of selected entities
     /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
     /// @return True if the entity was succesfully added, false if the entity already existed in the selection and thus could not be added.
-    virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
+    CSP_NO_EXPORT virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
 
     /// @brief Removes an entity to the set of selected entities
     /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
     /// @return True if the entity was succesfully removed, false if the entity did not exist in the selection and thus could not be removed.
-    virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
+    CSP_NO_EXPORT virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
 
     /***** ENTITY ACCESS *****************************************************/
 

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -210,7 +210,7 @@ public:
     /// @param AvatarPlayMode csp::multiplayer::AvatarPlayMode : The Initial AvatarPlayMode to set.
     /// @param Callback csp::multiplayer::EntityCreatedCallback A callback that executes when the creation is complete,
     /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
-    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState> LoginState,
+    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState>& LoginState,
         const csp::multiplayer::SpaceTransform& SpaceTransform, bool IsVisible, const csp::multiplayer::AvatarState& State,
         const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode,
         csp::multiplayer::EntityCreatedCallback Callback) override;

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -99,68 +99,10 @@ public:
     // Callback that will provide a pointer to a SpaceEntity object.
     typedef std::function<void(SpaceEntity*)> EntityCreatedCallback;
 
-    /// @brief Sets a callback to be executed when the script system is ready to run scripts.
-    /// @param Callback CallbackHandler : the callback to execute.
-    CSP_EVENT void SetScriptLeaderReadyCallback(CallbackHandler Callback);
-
-    /// @brief Sets the script owner for the given entity to the current client
-    /// @param Entity SpaceEntity : A pointer to the entity
-    void ClaimScriptOwnership(SpaceEntity* Entity) const;
-
-    /// @brief Enable Leader Election feature.
-    void EnableLeaderElection();
-
-    /// @brief Disable Leader Election feature.
-    void DisableLeaderElection();
-
-    /// @brief Check if the Leader Election feature is enabled.
-    /// @return true if enabled, false otherwise.
-    bool IsLeaderElectionEnabled() const;
-
-    /// @brief Debug helper to get the id of the currently elected script leader.
-    /// @return The id of the leader.
-    uint64_t GetLeaderId() const;
-
-    /// @brief Retrieve the state of the patch rate limiter. If true, patches are limited for each individual entity to a fixed rate.
-    /// @return True if enabled, false otherwise.
-    bool GetEntityPatchRateLimitEnabled() const;
-
-    /// @brief Set the state of the patch rate limiter. If true, patches are limited for each individual entity to a fixed rate.
-    ///
-    /// This feature is enabled by default and should only be disabled if you are encountering issues.
-    ///
-    /// @param Enabled : sets if the feature should be enabled or not.
-    /// \rst
-    ///.. note::
-    ///   If disabling this feature, more requests will be made to Magnopus Connected Services,
-    ///   and consequently more patch merges may occur on the server as a result.
-    /// \endrst
-    void SetEntityPatchRateLimitEnabled(bool Enabled);
-
-    /// @brief "Refreshes" (ie, turns on an off again), the multiplayer connection, in order to refresh scopes.
-    /// This shouldn't be neccesary, we should devote some effort to checking if it still is at some point
-    /// @param SpaceId csp::Common:String& : The Id of the space to refresh
-    /// @param RefreshMultiplayerContinuationEvent : std::shared_ptr<async::event_task<std::optional<csp::multiplayer::ErrorCode>>> Continuation event
-    /// that populates an optional error code on failure. Error is empty on success.
-    CSP_NO_EXPORT void RefreshMultiplayerConnectionToEnactScopeChange(csp::common::String SpaceId,
-        std::shared_ptr<async::event_task<std::optional<csp::multiplayer::ErrorCode>>> RefreshMultiplayerContinuationEvent);
-
-    using SpaceEntityList = csp::common::List<SpaceEntity*>;
-    using SpaceEntityQueue = std::deque<SpaceEntity*>;
-
-    /// @brief Checks whether we should run scripts locally
-    /// @return bool
-    CSP_NO_EXPORT bool CheckIfWeShouldRunScriptsLocally() const;
-
-    /// @brief Runs the provided script remotely
-    /// @param ContextId int64_t : the ID of the context on which to run the script
-    /// @param ScriptText csp::common::String& : the text of the script to run
-    CSP_NO_EXPORT void RunScriptRemotely(int64_t ContextId, const csp::common::String& ScriptText);
-
     /// @brief OnlineRealtimeEngine constructor
     /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the OnlineRealtimeEngine with
     /// @param LogSystem csp::common::LogSystem : Logger such that this system can print status and debug output
-    /// @param NetworkEventBus csp::multiplayer::NetworkEventbus& : Reference the the network event bus, used for leadership election messaging.
+    /// @param NetworkEventBus csp::multiplayer::NetworkEventBus& : Reference the the network event bus, used for leadership election messaging.
     /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : Object capable of running a script. Called to execute scripts when the leader
     /// election system
     OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
@@ -168,31 +110,6 @@ public:
 
     /// @brief OnlineRealtimeEngine destructor
     CSP_NO_EXPORT ~OnlineRealtimeEngine();
-
-    /// @brief Getter for the pending adds
-    /// @return: SpaceEntityQueue*
-    CSP_NO_EXPORT SpaceEntityQueue* GetPendingAdds();
-
-    /// @brief Getter for the multiplayer connection instance
-    /// @return: MultiplayerConnection*
-    CSP_NO_EXPORT MultiplayerConnection* GetMultiplayerConnectionInstance();
-
-    // @brief Ticks all entities and scripts, processing any pending local and remote updates
-    // Will only tick scrips if EnableEntityTick is enabled, which it should be if entity fetch has completed.
-    CSP_NO_EXPORT void TickEntities();
-
-    /// @brief Locks the entity mutex.
-    void LockEntityUpdate() const;
-
-    /// @brief Unlocks the entity mutex.
-    void UnlockEntityUpdate() const;
-
-    /// @brief Queues a specific entity to update. Used in SpaceEntity to queue updates via passing the this pointer
-    void QueueEntityUpdate(SpaceEntity* EntityToUpdate);
-
-    /// @brief "Resolves" the entity heirarchy, such that the entity is parented appropriately, and internal buffers are populated appropriately.
-    /// (Vague, need more understanding about what this does)
-    void ResolveEntityHierarchy(SpaceEntity* Entity);
 
     /********************** REALTIME ENGINE INTERFACE ************************/
     /*************************************************************************/
@@ -339,6 +256,91 @@ public:
      */
     CSP_NO_EXPORT void FetchAllEntitiesAndPopulateBuffers(
         const csp::common::String& SpaceId, csp::common::EntityFetchStartedCallback FetchStartedCallback) override;
+
+    /***** IREALTIMEENGINE INTERFACE IMPLEMENTAITON END *************************************************/
+
+    using SpaceEntityList = csp::common::List<SpaceEntity*>;
+    using SpaceEntityQueue = std::deque<SpaceEntity*>;
+
+    /// @brief Sets a callback to be executed when the script system is ready to run scripts.
+    /// @param Callback CallbackHandler : the callback to execute.
+    CSP_EVENT void SetScriptLeaderReadyCallback(CallbackHandler Callback);
+
+    /// @brief Sets the script owner for the given entity to the current client
+    /// @param Entity SpaceEntity : A pointer to the entity
+    void ClaimScriptOwnership(SpaceEntity* Entity) const;
+
+    /// @brief Enable Leader Election feature.
+    void EnableLeaderElection();
+
+    /// @brief Disable Leader Election feature.
+    void DisableLeaderElection();
+
+    /// @brief Check if the Leader Election feature is enabled.
+    /// @return true if enabled, false otherwise.
+    bool IsLeaderElectionEnabled() const;
+
+    /// @brief Debug helper to get the id of the currently elected script leader.
+    /// @return The id of the leader.
+    uint64_t GetLeaderId() const;
+
+    /// @brief Retrieve the state of the patch rate limiter. If true, patches are limited for each individual entity to a fixed rate.
+    /// @return True if enabled, false otherwise.
+    bool GetEntityPatchRateLimitEnabled() const;
+
+    /// @brief Set the state of the patch rate limiter. If true, patches are limited for each individual entity to a fixed rate.
+    ///
+    /// This feature is enabled by default and should only be disabled if you are encountering issues.
+    ///
+    /// @param Enabled : sets if the feature should be enabled or not.
+    /// \rst
+    ///.. note::
+    ///   If disabling this feature, more requests will be made to Magnopus Connected Services,
+    ///   and consequently more patch merges may occur on the server as a result.
+    /// \endrst
+    void SetEntityPatchRateLimitEnabled(bool Enabled);
+
+    /// @brief "Refreshes" (ie, turns on an off again), the multiplayer connection, in order to refresh scopes.
+    /// This shouldn't be neccesary, we should devote some effort to checking if it still is at some point
+    /// @param SpaceId csp::Common:String& : The Id of the space to refresh
+    /// @param RefreshMultiplayerContinuationEvent : std::shared_ptr<async::event_task<std::optional<csp::multiplayer::ErrorCode>>> Continuation event
+    /// that populates an optional error code on failure. Error is empty on success.
+    CSP_NO_EXPORT void RefreshMultiplayerConnectionToEnactScopeChange(csp::common::String SpaceId,
+        std::shared_ptr<async::event_task<std::optional<csp::multiplayer::ErrorCode>>> RefreshMultiplayerContinuationEvent);
+
+    /// @brief Checks whether we should run scripts locally
+    /// @return bool
+    CSP_NO_EXPORT bool CheckIfWeShouldRunScriptsLocally() const;
+
+    /// @brief Runs the provided script remotely
+    /// @param ContextId int64_t : the ID of the context on which to run the script
+    /// @param ScriptText csp::common::String& : the text of the script to run
+    CSP_NO_EXPORT void RunScriptRemotely(int64_t ContextId, const csp::common::String& ScriptText);
+
+    /// @brief Getter for the pending adds
+    /// @return: SpaceEntityQueue*
+    CSP_NO_EXPORT SpaceEntityQueue* GetPendingAdds();
+
+    /// @brief Getter for the multiplayer connection instance
+    /// @return: MultiplayerConnection*
+    CSP_NO_EXPORT MultiplayerConnection* GetMultiplayerConnectionInstance();
+
+    // @brief Ticks all entities and scripts, processing any pending local and remote updates
+    // Will only tick scrips if EnableEntityTick is enabled, which it should be if entity fetch has completed.
+    CSP_NO_EXPORT void TickEntities();
+
+    /// @brief Locks the entity mutex.
+    void LockEntityUpdate() const;
+
+    /// @brief Unlocks the entity mutex.
+    void UnlockEntityUpdate() const;
+
+    /// @brief Queues a specific entity to update. Used in SpaceEntity to queue updates via passing the this pointer
+    void QueueEntityUpdate(SpaceEntity* EntityToUpdate);
+
+    /// @brief "Resolves" the entity heirarchy, such that the entity is parented appropriately, and internal buffers are populated appropriately.
+    /// (Vague, need more understanding about what this does)
+    void ResolveEntityHierarchy(SpaceEntity* Entity);
 
     /*
      * Called when MultiplayerConnection recieved signalR events.

--- a/Library/include/CSP/Multiplayer/Script/EntityScript.h
+++ b/Library/include/CSP/Multiplayer/Script/EntityScript.h
@@ -34,7 +34,7 @@ class ScriptSystem;
 /// @brief Namespace that encompasses everything in the multiplayer system
 namespace csp::multiplayer
 {
-class SpaceEntitySystem;
+class OnlineRealtimeEngine;
 
 class SpaceEntity;
 class ScriptSpaceComponent;
@@ -48,8 +48,8 @@ class CSP_API EntityScript
 public:
     // Don't want to be constructable by public users.
     CSP_START_IGNORE
-    EntityScript(
-        SpaceEntity* InEntity, SpaceEntitySystem* InSpaceEntitySystem, csp::common::IJSScriptRunner* ScriptRunner, csp::common::LogSystem* LogSystem);
+    EntityScript(SpaceEntity* InEntity, OnlineRealtimeEngine* InOnlineRealtimeEngine, csp::common::IJSScriptRunner* ScriptRunner,
+        csp::common::LogSystem* LogSystem);
     CSP_END_IGNORE
 
     /// @brief Destroy the instance of EntityScript.
@@ -153,7 +153,7 @@ private:
 
     bool HasBinding;
 
-    SpaceEntitySystem* SpaceEntitySystemPtr;
+    OnlineRealtimeEngine* OnlineRealtimeEnginePtr;
 
     // may be null
     csp::common::LogSystem* LogSystem = nullptr;

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -23,7 +23,7 @@
 #include "CSP/Multiplayer/ComponentBase.h"
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "CSP/Multiplayer/SpaceTransform.h"
-#include "SpaceEntitySystem.h"
+#include "OnlineRealtimeEngine.h"
 
 #include <atomic>
 #include <chrono>
@@ -121,7 +121,7 @@ class CSP_API SpaceEntity
 {
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
-    friend class SpaceEntitySystem;
+    friend class OnlineRealtimeEngine;
 
 #ifdef CSP_TESTS
     friend class ::CSPEngine_MultiplayerTests_LockPrerequisitesTest_Test;
@@ -148,11 +148,11 @@ public:
     SpaceEntity();
 
     /// @brief Creates a SpaceEntity instance using the space entity system provided.
-    SpaceEntity(SpaceEntitySystem* InEntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem);
+    SpaceEntity(OnlineRealtimeEngine* InEntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem);
 
     /// Internal constructor to explicitly create a SpaceEntity in a specified state.
-    /// Initially implemented for use in SpaceEntitySystem::CreateAvatar
-    CSP_NO_EXPORT SpaceEntity(SpaceEntitySystem* EntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem,
+    /// Initially implemented for use in OnlineRealtimeEngine::CreateAvatar
+    CSP_NO_EXPORT SpaceEntity(OnlineRealtimeEngine* EntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem,
         SpaceEntityType Type, uint64_t Id, const csp::common::String& Name, const SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable,
         bool IsPersistent);
 
@@ -443,7 +443,7 @@ public:
 
     /// @brief Apply a local patch
     /// @param InvokeUpdateCallback bool : whether to invoke the update callback (default: true)
-    /// @param AllowSelfMessaging bool : Whether or not to apply local patches. Normally sources from the SpaceEntitySystem state. Don't set this
+    /// @param AllowSelfMessaging bool : Whether or not to apply local patches. Normally sources from the OnlineRealtimeEngine state. Don't set this
     /// unless you know what you are doing. (default: false)
     CSP_NO_EXPORT void ApplyLocalPatch(bool InvokeUpdateCallback = true, bool AllowSelfMessaging = false);
 
@@ -498,7 +498,7 @@ private:
     // Called when we're parsing a component from an mcs::ObjectPatch
     ComponentUpdateInfo ComponentFromItemComponentDataPatch(uint16_t ComponentId, const csp::multiplayer::mcs::ItemComponentData& ComponentData);
 
-    SpaceEntitySystem* EntitySystem;
+    OnlineRealtimeEngine* EntitySystem;
 
     SpaceEntityType Type;
     uint64_t Id;
@@ -562,7 +562,7 @@ private:
     /// @brief Set ParentId to nullptr
     void RemoveParentId();
 
-    // Do NOT call directly, always call either Select() Deselect() or SpaceEntitySystem::InternalSetSelectionStateOfEntity()
+    // Do NOT call directly, always call either Select() Deselect() or OnlineRealtimeEngine::InternalSetSelectionStateOfEntity()
     /// @brief Internal version of the selected state of the entity setter
     /// @param SelectedState bool : the selected state to set
     /// @param ClientID uint64_t : the client ID of the entity for which to set the selected state

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -346,9 +346,6 @@ public:
     /// @return True if deselection occurred. False if not.
     bool Deselect();
 
-    // ClientID is the clientID that comes from the multiplayer connection, ie the clientID of the client that is executing the code at the time.
-    bool SetSelectionState(bool SelectionState, uint64_t ClientId);
-
     /// @brief Checks if the entity can be modified.
     /// Specifically whether the local client already owns the entity or can take ownership of the entity.
     /// @return True if the entity can be modified, False if not.
@@ -567,7 +564,7 @@ private:
     /// @param SelectedState bool : the selected state to set
     /// @param ClientID uint64_t : the client ID of the entity for which to set the selected state
     /// @return bool : the selection state of the entity
-    bool InternalSetSelectionStateOfEntity(const bool SelectedState, uint64_t ClientID);
+    bool InternalSetSelectionStateOfEntity(const bool SelectedState);
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -246,10 +246,6 @@ public:
     /// @return The SpaceEntityType enum value.
     SpaceEntityType GetEntityType() const;
 
-    /// @brief Get SpaceEntitySystem Object
-    /// @return SpaceEntitySystem
-    SpaceEntitySystem* GetSpaceEntitySystem();
-
     /// @brief Sets the parent for this entity
     /// QueueUpdate() should be called afterwards to enable changes to the parent.
     /// @param ParentId uint64_t The new parent id of this entity.
@@ -349,6 +345,9 @@ public:
     ///
     /// @return True if deselection occurred. False if not.
     bool Deselect();
+
+    // ClientID is the clientID that comes from the multiplayer connection, ie the clientID of the client that is executing the code at the time.
+    bool SetSelectionState(bool SelectionState, uint64_t ClientId);
 
     /// @brief Checks if the entity can be modified.
     /// Specifically whether the local client already owns the entity or can take ownership of the entity.

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -322,13 +322,13 @@ public:
      *
      * @param SpaceId const csp::common::String& : MCS formatted SpaceId
      * @param FetchStartedCallback EntityFetchStartedCallback Callback called once scopes are reset and entity fetch has begun.
-     * @param FetchCompleteCallback EntityFetchCompleteCallback Callback called async once all entities are fetched and stored.
      *
      * @pre @param Space represented by SpaceId must exist on the configured server endpoint. See csp::systems::SpaceSystem::CreateSpace
-     * @post @param FetchStartedCallback will be called. @param FetchCompleteCallback will be called async once all the entities are fetched.
+     * @post @param FetchStartedCallback will be called. The csp::common::EntityFetchCompleteCallback passed in the constructor will be called async
+     * once all the entities are fetched.
      */
-    CSP_NO_EXPORT void FetchAllEntitiesAndPopulateBuffers(const csp::common::String& SpaceId,
-        csp::common::EntityFetchStartedCallback FetchStartedCallback, csp::common::EntityFetchCompleteCallback FetchCompleteCallback) override;
+    CSP_NO_EXPORT void FetchAllEntitiesAndPopulateBuffers(
+        const csp::common::String& SpaceId, csp::common::EntityFetchStartedCallback FetchStartedCallback) override;
 
     /*
      * Called when MultiplayerConnection recieved signalR events.

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -54,6 +54,7 @@ class CSPEngine_SpaceEntitySystemTests_TestSuccessInRemoteGenerateNewAvatarId_Te
 class CSPEngine_SpaceEntitySystemTests_TestErrorInSendNewAvatarObjectMessage_Test;
 class CSPEngine_SpaceEntitySystemTests_TestSuccessInSendNewAvatarObjectMessage_Test;
 class CSPEngine_SpaceEntitySystemTests_TestSuccessInCreateNewLocalAvatar_Test;
+class CSPEngine_MultiplayerTests_ManyEntitiesTest_Test;
 
 namespace csp::common
 {
@@ -90,6 +91,7 @@ class CSP_API SpaceEntitySystem : public csp::common::IRealtimeEngine
     friend class CSPEngine_SpaceEntitySystemTests_TestErrorInSendNewAvatarObjectMessage_Test;
     friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInSendNewAvatarObjectMessage_Test;
     friend class CSPEngine_SpaceEntitySystemTests_TestSuccessInCreateNewLocalAvatar_Test;
+    friend class CSPEngine_MultiplayerTests_ManyEntitiesTest_Test;
     /** @endcond */
     CSP_END_IGNORE
 

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -404,7 +404,6 @@ private:
     SpaceEntitySystem(); // needed for the wrapper generator
 
     MultiplayerConnection* MultiplayerConnectionInst;
-    csp::multiplayer::ISignalRConnection* Connection;
 
     // Should not be null
     csp::common::LogSystem* LogSystem;
@@ -471,8 +470,6 @@ private:
     std::chrono::milliseconds EntityPatchRate;
 
     bool EntityPatchRateLimitEnabled = true;
-
-    bool IsInitialised = false;
 
     // May not be null
     csp::common::IJSScriptRunner* ScriptRunner;

--- a/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntitySystem.h
@@ -161,7 +161,7 @@ public:
     /// @param NetworkEventBus csp::multiplayer::NetworkEventbus& : Reference the the network event bus, used for leadership election messaging.
     /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : Object capable of running a script. Called to execute scripts when the leader
     /// election system
-    CSP_NO_EXPORT SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem,
+    SpaceEntitySystem(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
         csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& RemoteScriptRunner);
 
     /// @brief SpaceEntitySystem destructor
@@ -349,6 +349,7 @@ protected:
 private:
     SpaceEntitySystem(); // needed for the wrapper generator
 
+    // Should not be null
     MultiplayerConnection* MultiplayerConnectionInst;
 
     // Should not be null

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -84,18 +84,6 @@ public:
     /// @param Callback EnterSpaceResultCallback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void EnterSpace(const csp::common::String& SpaceId, csp::common::IRealtimeEngine* RealtimeEngine, SpaceResultCallback Callback);
 
-    // TEMPORARY hack as I am doing a staged refactor. This is in fact, a hack of a hack.
-    // 1. I will eventually be passing IRealtimeEngine to EnterSpace, so this callback wants to be set on that object, however, I want to ensure
-    //    the interface changes are working first by getting green tests.
-    // 2. The natural way to do _that_ is to pass this callback to EnterSpace temporarily, but I cant even do that because both the wrapper gen
-    //    and our tests assume only one callback on an async function ... (to my mind, this condemns the AWAIT_PRE macros forever, unacceptable
-    //    burden to refactoring, even once the wrapper gen is gone.)
-    // This will not exist in subsequent commits, if this is here during PR, look me in the eyes and call me a fool.
-    CSP_NO_EXPORT csp::common::EntityFetchCompleteCallback EntityFetchComplete = nullptr;
-
-    // In the same vein, TEMPORARY hack.
-    CSP_NO_EXPORT csp::multiplayer::EntityCreatedCallback SpaceEntityCreatedCallback = nullptr;
-
     /// @brief Exits the space and deregisters from the space scope.
     CSP_ASYNC_RESULT void ExitSpace(NullResultCallback Callback);
 

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -72,13 +72,17 @@ public:
      *   @{ */
 
     /// @brief Enter a space if you have permission to, based on the Space settings.
-    /// This includes setting scopes (and toggling event listening in order to set the scope).
-    /// It also retrieves all entities in the space. Ensure Connect is called prior to this.
+    /// Registers the user as in the space on the backend service, and calls csp::common::IRealtimeEngine::FetchAllEntitiesAndPopulateBuffers.
+    /// The initial load behaviour will differ based on the concrete IRealtimeEngine passed to this function.
     /// If user does not have permission to discover or enter the space, callback will be called with EResultCode::Failed and
     /// ERequestFailureReason::UserSpaceAccessDenied
     /// @param Space Space : space to enter into
+    /// @param RealtimeEngine IRealtimeEngine* : RealtimeEngine to load the space with. This object belongs to the caller, and does not
+    /// transfer ownership. Once the space is loaded, the caller should be sure to maintain the lifetime of the RealtimeEngine so long
+    /// as the space is active. Once the caller has called csp::systems::SpaceSystem::ExitSpace and received the callback, then they are
+    /// free to release the memory.
     /// @param Callback EnterSpaceResultCallback : callback when asynchronous task finishes
-    CSP_ASYNC_RESULT void EnterSpace(const csp::common::String& SpaceId, SpaceResultCallback Callback);
+    CSP_ASYNC_RESULT void EnterSpace(const csp::common::String& SpaceId, csp::common::IRealtimeEngine* RealtimeEngine, SpaceResultCallback Callback);
 
     // TEMPORARY hack as I am doing a staged refactor. This is in fact, a hack of a hack.
     // 1. I will eventually be passing IRealtimeEngine to EnterSpace, so this callback wants to be set on that object, however, I want to ensure

--- a/Library/include/CSP/Systems/SystemsManager.h
+++ b/Library/include/CSP/Systems/SystemsManager.h
@@ -25,6 +25,7 @@
 namespace csp::common
 {
 class LogSystem;
+class IRealtimeEngine;
 }
 
 namespace csp::systems
@@ -156,7 +157,9 @@ public:
     /// @return HotspotSequenceSystem : pointer to the HotspotSequenceSystem system class
     HotspotSequenceSystem* GetHotspotSequenceSystem();
 
-    csp::multiplayer::SpaceEntitySystem* GetSpaceEntitySystem();
+    CSP_NO_EXPORT std::weak_ptr<csp::common::IRealtimeEngine> GetRealtimeEngine();
+    CSP_NO_EXPORT std::weak_ptr<csp::common::IRealtimeEngine> InstantiateMultiplayerRealtimeEngine();
+    CSP_NO_EXPORT void DestroyRealtimeEngine();
 
     csp::multiplayer::MultiplayerConnection* GetMultiplayerConnection();
 
@@ -180,7 +183,7 @@ private:
 
     csp::multiplayer::MultiplayerConnection* MultiplayerConnection;
     csp::multiplayer::NetworkEventBus* NetworkEventBus;
-    csp::multiplayer::SpaceEntitySystem* SpaceEntitySystem;
+    std::shared_ptr<csp::common::IRealtimeEngine> RealtimeEngine;
     UserSystem* UserSystem;
     SpaceSystem* SpaceSystem;
     AssetSystem* AssetSystem;

--- a/Library/include/CSP/Systems/SystemsManager.h
+++ b/Library/include/CSP/Systems/SystemsManager.h
@@ -164,7 +164,7 @@ public:
     // Convenience method for the moment. This will need to be broken at formal modularization, but the standard pattern it creates throughout
     // integrations/tests will no doubt be helpful in doing that anyhow, rather than having big constructors everywhere.
     // @deprecated This method is a transitional method, and should not be expected to exist in the long term.
-    csp::multiplayer::SpaceEntitySystem* MakeOnlineRealtimeEngine();
+    csp::multiplayer::OnlineRealtimeEngine* MakeOnlineRealtimeEngine();
 
 private:
     SystemsManager();

--- a/Library/include/CSP/Systems/SystemsManager.h
+++ b/Library/include/CSP/Systems/SystemsManager.h
@@ -172,12 +172,14 @@ private:
 
     ConversationSystemInternal* GetConversationSystem();
 
-    static void Instantiate();
+    // Optional SignalR inject, null means the systemsmanager will make one of its own
+    static void Instantiate(csp::multiplayer::ISignalRConnection* SignalRInject = nullptr);
     static void Destroy();
 
     static SystemsManager* Instance;
 
-    void CreateSystems();
+    // Optional SignalR inject, null means the systemsmanager will make one of its own
+    void CreateSystems(csp::multiplayer::ISignalRConnection* SignalRInject);
     void DestroySystems();
 
     csp::web::WebClient* WebClient;

--- a/Library/include/CSP/Systems/SystemsManager.h
+++ b/Library/include/CSP/Systems/SystemsManager.h
@@ -157,13 +157,14 @@ public:
     /// @return HotspotSequenceSystem : pointer to the HotspotSequenceSystem system class
     HotspotSequenceSystem* GetHotspotSequenceSystem();
 
-    CSP_NO_EXPORT std::weak_ptr<csp::common::IRealtimeEngine> GetRealtimeEngine();
-    CSP_NO_EXPORT std::weak_ptr<csp::common::IRealtimeEngine> InstantiateMultiplayerRealtimeEngine();
-    CSP_NO_EXPORT void DestroyRealtimeEngine();
-
     csp::multiplayer::MultiplayerConnection* GetMultiplayerConnection();
 
     csp::multiplayer::NetworkEventBus* GetEventBus();
+
+    // Convenience method for the moment. This will need to be broken at formal modularization, but the standard pattern it creates throughout
+    // integrations/tests will no doubt be helpful in doing that anyhow, rather than having big constructors everywhere.
+    // @deprecated This method is a transitional method, and should not be expected to exist in the long term.
+    csp::multiplayer::SpaceEntitySystem* MakeOnlineRealtimeEngine();
 
 private:
     SystemsManager();

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -400,10 +400,14 @@ EndpointURIs CSPFoundation::CreateEndpointsFromRoot(const csp::common::String& E
 
 bool CSPFoundation::Initialise(const csp::common::String& EndpointRootURI, const csp::common::String& InTenant)
 {
-    if (IsInitialised)
-    {
-        return false;
-    }
+    // Nullptr means the signalRConnection will be internally instantiated
+    return InitialiseWithInject(EndpointRootURI, InTenant, nullptr);
+}
+
+bool CSPFoundation::InitialiseWithInject(
+    const csp::common::String& EndpointRootURI, const csp::common::String& InTenant, csp::multiplayer::ISignalRConnection* SignalRInject)
+{
+    assert(!IsInitialised && "Please call csp::CSPFoundation::Shutdown() before calling csp::CSPFoundation::Initialize() again.");
 
     Tenant = new csp::common::String(InTenant);
 
@@ -412,7 +416,7 @@ bool CSPFoundation::Initialise(const csp::common::String& EndpointRootURI, const
     DeviceId = new csp::common::String("");
     ClientUserAgentString = new csp::common::String("");
 
-    csp::systems::SystemsManager::Instantiate();
+    csp::systems::SystemsManager::Instantiate(SignalRInject);
 
     *DeviceId = LoadDeviceId().c_str();
     IsInitialised = true;

--- a/Library/src/ExplicitTypes.cpp
+++ b/Library/src/ExplicitTypes.cpp
@@ -15,6 +15,7 @@
  */
 #include "CSP/Common/Array.h"
 #include "CSP/Common/List.h"
+#include "CSP/Common/LoginState.h"
 #include "CSP/Common/Optional.h"
 #include "CSP/Common/String.h"
 #include "CSP/Common/Vector.h"
@@ -86,3 +87,4 @@ template class CSP_API csp::common::Optional<csp::systems::EAssetCollectionType>
 template class CSP_API csp::common::Optional<csp::systems::FileAssetDataSource>;
 template class CSP_API csp::common::Optional<csp::systems::Space>;
 template class CSP_API csp::common::Optional<csp::systems::SpaceAttributes>;
+template class CSP_API csp::common::Optional<csp::common::LoginState>;

--- a/Library/src/Multiplayer/CSPSceneDescription.cpp
+++ b/Library/src/Multiplayer/CSPSceneDescription.cpp
@@ -21,7 +21,7 @@
 
 namespace csp::multiplayer
 {
-CSPSceneDescription::CSPSceneDescription(const csp::common::String& SceneDescriptionJson, csp::multiplayer::SpaceEntitySystem& EntitySystem,
+CSPSceneDescription::CSPSceneDescription(const csp::common::String& SceneDescriptionJson, csp::multiplayer::OnlineRealtimeEngine& EntitySystem,
     csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner)
 {
     mcs::SceneDescription SceneDescription;

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -16,7 +16,7 @@
 #include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
 
 #include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h"
 
 namespace

--- a/Library/src/Multiplayer/Election/ClientElectionManager.cpp
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.cpp
@@ -19,7 +19,7 @@
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/NetworkEventBus.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "Events/Event.h"
 #include "Events/EventId.h"
 #include "Events/EventListener.h"
@@ -58,8 +58,8 @@ void ClientElectionEventHandler::OnEvent(const csp::events::Event& InEvent)
 }
 
 ClientElectionManager::ClientElectionManager(
-    SpaceEntitySystem* InSpaceEntitySystem, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& JSScriptRunner)
-    : SpaceEntitySystemPtr(InSpaceEntitySystem)
+    OnlineRealtimeEngine* InOnlineRealtimeEngine, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& JSScriptRunner)
+    : OnlineRealtimeEnginePtr(InOnlineRealtimeEngine)
     , LogSystem(LogSystem)
     , EventHandler(new ClientElectionEventHandler(this))
     , TheConnectionState(ConnectionState::Disconnected)
@@ -89,7 +89,7 @@ ClientElectionManager::~ClientElectionManager()
     }
 }
 
-void ClientElectionManager::OnConnect(const SpaceEntitySystem::SpaceEntityList& Avatars, const SpaceEntitySystem::SpaceEntityList& /*Objects*/)
+void ClientElectionManager::OnConnect(const OnlineRealtimeEngine::SpaceEntityList& Avatars, const OnlineRealtimeEngine::SpaceEntityList& /*Objects*/)
 {
     LogSystem.LogMsg(csp::common::LogLevel::Verbose, "ClientElectionManager::OnConnect called");
 
@@ -121,7 +121,7 @@ void ClientElectionManager::OnDisconnect()
 }
 
 void ClientElectionManager::OnLocalClientAdd(
-    const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& Avatars, NetworkEventBus& NetworkEventBus)
+    const SpaceEntity* ClientAvatar, const OnlineRealtimeEngine::SpaceEntityList& Avatars, NetworkEventBus& NetworkEventBus)
 {
     LogSystem.LogMsg(csp::common::LogLevel::VeryVerbose,
         fmt::format("ClientElectionManager::OnLocalClientAdd called : ClientId={}", ClientAvatar->GetOwnerId()).c_str());
@@ -153,27 +153,27 @@ void ClientElectionManager::OnLocalClientAdd(
 }
 
 void ClientElectionManager::OnClientAdd(
-    const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& /*Avatars*/, NetworkEventBus& NetworkEventBus)
+    const SpaceEntity* ClientAvatar, const OnlineRealtimeEngine::SpaceEntityList& /*Avatars*/, NetworkEventBus& NetworkEventBus)
 {
     LogSystem.LogMsg(csp::common::LogLevel::VeryVerbose,
         fmt::format("ClientElectionManager::OnLocalClientAdd called : ClientId={}", ClientAvatar->GetOwnerId()).c_str());
     AddClientUsingAvatar(ClientAvatar, NetworkEventBus);
 }
 
-void ClientElectionManager::OnClientRemove(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& /*Avatars*/)
+void ClientElectionManager::OnClientRemove(const SpaceEntity* ClientAvatar, const OnlineRealtimeEngine::SpaceEntityList& /*Avatars*/)
 {
     LogSystem.LogMsg(csp::common::LogLevel::VeryVerbose,
         fmt::format("ClientElectionManager::OnLocalClientAdd called : ClientId={}", ClientAvatar->GetOwnerId()).c_str());
     RemoveClientUsingAvatar(ClientAvatar);
 }
 
-void ClientElectionManager::OnObjectAdd(const SpaceEntity* /*Object*/, const SpaceEntitySystem::SpaceEntityList& /*Objects*/)
+void ClientElectionManager::OnObjectAdd(const SpaceEntity* /*Object*/, const OnlineRealtimeEngine::SpaceEntityList& /*Objects*/)
 {
     LogSystem.LogMsg(csp::common::LogLevel::VeryVerbose, "ClientElectionManager::OnObjectAdd called");
     // @Todo - This event allows us to track individual object ownership
 }
 
-void ClientElectionManager::OnObjectRemove(const SpaceEntity* /*Object*/, const SpaceEntitySystem::SpaceEntityList& /*Objects*/)
+void ClientElectionManager::OnObjectRemove(const SpaceEntity* /*Object*/, const OnlineRealtimeEngine::SpaceEntityList& /*Objects*/)
 {
     LogSystem.LogMsg(csp::common::LogLevel::VeryVerbose, "ClientElectionManager::OnObjectRemove called");
     // @Todo - This event allows us to track individual object ownership
@@ -477,7 +477,7 @@ void ClientElectionManager::OnLeaderNotification(int64_t LeaderId)
 
 bool ClientElectionManager::IsConnected() const
 {
-    MultiplayerConnection* Connection = SpaceEntitySystemPtr->GetMultiplayerConnectionInstance();
+    MultiplayerConnection* Connection = OnlineRealtimeEnginePtr->GetMultiplayerConnectionInstance();
 
     if (Connection == nullptr)
     {
@@ -489,7 +489,7 @@ bool ClientElectionManager::IsConnected() const
 
 void ClientElectionManager::BindNetworkEvents()
 {
-    NetworkEventBus* NetworkEventBus = SpaceEntitySystemPtr->GetMultiplayerConnectionInstance()->GetEventBusPtr();
+    NetworkEventBus* NetworkEventBus = OnlineRealtimeEnginePtr->GetMultiplayerConnectionInstance()->GetEventBusPtr();
 
     NetworkEventBus->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration("CSPInternal::ClientElectionManager", ClientElectionMessage),
         [this](const csp::common::NetworkEventData& NetworkEventData) { this->OnClientElectionEvent(NetworkEventData.EventValues); });
@@ -500,7 +500,7 @@ void ClientElectionManager::BindNetworkEvents()
 
 void ClientElectionManager::UnBindNetworkEvents()
 {
-    NetworkEventBus* NetworkEventBus = SpaceEntitySystemPtr->GetMultiplayerConnectionInstance()->GetEventBusPtr();
+    NetworkEventBus* NetworkEventBus = OnlineRealtimeEnginePtr->GetMultiplayerConnectionInstance()->GetEventBusPtr();
 
     NetworkEventBus->StopListenNetworkEvent(csp::multiplayer::NetworkEventRegistration("CSPInternal::ClientElectionManager", ClientElectionMessage));
     NetworkEventBus->StopListenNetworkEvent(csp::multiplayer::NetworkEventRegistration("CSPInternal::ClientElectionManager", RemoteRunScriptMessage));

--- a/Library/src/Multiplayer/Election/ClientElectionManager.cpp
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.cpp
@@ -328,8 +328,6 @@ void ClientElectionManager::Update()
     }
 }
 
-SpaceEntitySystem* ClientElectionManager::GetSpaceEntitySystem() { return SpaceEntitySystemPtr; }
-
 bool ClientElectionManager::IsLocalClientLeader() const { return (LocalClient && (LocalClient == Leader)); }
 
 ClientProxy* ClientElectionManager::GetLeader() const { return Leader; }
@@ -348,9 +346,9 @@ void ClientElectionManager::SetLeader(ClientProxy* Client)
     Leader = Client;
 
     // Notify Scripts ready callback now we have a valid leader
-    if (ScriptSystemReadyCallback)
+    if (LeaderReadyCallback)
     {
-        ScriptSystemReadyCallback(true);
+        LeaderReadyCallback(true);
     }
 }
 
@@ -402,9 +400,9 @@ void ClientElectionManager::SetElectionState(ElectionState NewState)
     TheElectionState = NewState;
 }
 
-void ClientElectionManager::SetScriptSystemReadyCallback(csp::multiplayer::SpaceEntitySystem::CallbackHandler InScriptSystemReadyCallback)
+void ClientElectionManager::SetScriptLeaderReadyCallback(ScriptLeaderReadyCallback ScriptLeaderReadyCallback)
 {
-    ScriptSystemReadyCallback = InScriptSystemReadyCallback;
+    LeaderReadyCallback = ScriptLeaderReadyCallback;
 }
 
 void ClientElectionManager::HandleElectionStateIdle()

--- a/Library/src/Multiplayer/Election/ClientElectionManager.h
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.h
@@ -42,6 +42,8 @@ enum class ElectionState
 
 class ClientElectionManager
 {
+    typedef std::function<void(bool)> ScriptLeaderReadyCallback;
+
     /** @cond DO_NOT_DOCUMENT */
     friend class ClientProxy;
     friend class SpaceEntitySystem;
@@ -63,8 +65,6 @@ public:
     void OnObjectRemove(const SpaceEntity* Object, const SpaceEntitySystem::SpaceEntityList& Objects);
 
     void Update();
-
-    SpaceEntitySystem* GetSpaceEntitySystem();
 
     bool IsLocalClientLeader() const;
 
@@ -106,7 +106,7 @@ private:
 
     void SetElectionState(ElectionState NewState);
 
-    void SetScriptSystemReadyCallback(csp::multiplayer::SpaceEntitySystem::CallbackHandler InScriptSystemReadyCallback);
+    void SetScriptLeaderReadyCallback(ScriptLeaderReadyCallback ScriptLeaderReadyCallback);
 
 private:
     SpaceEntitySystem* SpaceEntitySystemPtr;
@@ -122,7 +122,7 @@ private:
 
     ClientProxy* Leader;
 
-    csp::multiplayer::SpaceEntitySystem::CallbackHandler ScriptSystemReadyCallback;
+    ScriptLeaderReadyCallback LeaderReadyCallback;
     csp::common::IJSScriptRunner& RemoteScriptRunner;
 };
 

--- a/Library/src/Multiplayer/Election/ClientElectionManager.h
+++ b/Library/src/Multiplayer/Election/ClientElectionManager.h
@@ -18,7 +18,7 @@
 
 #include "CSP/Common/Interfaces/IJSScriptRunner.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "ClientProxy.h"
 
 namespace csp::common
@@ -30,7 +30,7 @@ namespace csp::multiplayer
 {
 
 class IClientSelectionCriteria;
-class SpaceEntitySystem;
+class OnlineRealtimeEngine;
 class SpaceEntity;
 
 enum class ElectionState
@@ -46,23 +46,23 @@ class ClientElectionManager
 
     /** @cond DO_NOT_DOCUMENT */
     friend class ClientProxy;
-    friend class SpaceEntitySystem;
+    friend class OnlineRealtimeEngine;
     friend class ClientElectionEventHandler;
     /** @endcond */
 
 public:
-    ClientElectionManager(SpaceEntitySystem* InSpaceEntitySystem, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& JSScriptRunner);
+    ClientElectionManager(OnlineRealtimeEngine* InOnlineRealtimeEngine, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& JSScriptRunner);
     ~ClientElectionManager();
 
-    void OnConnect(const SpaceEntitySystem::SpaceEntityList& Avatars, const SpaceEntitySystem::SpaceEntityList& Objects);
+    void OnConnect(const OnlineRealtimeEngine::SpaceEntityList& Avatars, const OnlineRealtimeEngine::SpaceEntityList& Objects);
     void OnDisconnect();
 
-    void OnLocalClientAdd(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& Avatars, NetworkEventBus& NetworkEventBus);
+    void OnLocalClientAdd(const SpaceEntity* ClientAvatar, const OnlineRealtimeEngine::SpaceEntityList& Avatars, NetworkEventBus& NetworkEventBus);
 
-    void OnClientAdd(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& Avatars, NetworkEventBus& NetworkEventBus);
-    void OnClientRemove(const SpaceEntity* ClientAvatar, const SpaceEntitySystem::SpaceEntityList& Avatars);
-    void OnObjectAdd(const SpaceEntity* Object, const SpaceEntitySystem::SpaceEntityList& Objects);
-    void OnObjectRemove(const SpaceEntity* Object, const SpaceEntitySystem::SpaceEntityList& Objects);
+    void OnClientAdd(const SpaceEntity* ClientAvatar, const OnlineRealtimeEngine::SpaceEntityList& Avatars, NetworkEventBus& NetworkEventBus);
+    void OnClientRemove(const SpaceEntity* ClientAvatar, const OnlineRealtimeEngine::SpaceEntityList& Avatars);
+    void OnObjectAdd(const SpaceEntity* Object, const OnlineRealtimeEngine::SpaceEntityList& Objects);
+    void OnObjectRemove(const SpaceEntity* Object, const OnlineRealtimeEngine::SpaceEntityList& Objects);
 
     void Update();
 
@@ -109,7 +109,7 @@ private:
     void SetScriptLeaderReadyCallback(ScriptLeaderReadyCallback ScriptLeaderReadyCallback);
 
 private:
-    SpaceEntitySystem* SpaceEntitySystemPtr;
+    OnlineRealtimeEngine* OnlineRealtimeEnginePtr;
     csp::common::LogSystem& LogSystem;
     class ClientElectionEventHandler* EventHandler;
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -190,9 +190,9 @@ MultiplayerConnection::~MultiplayerConnection()
     }
 }
 
-void MultiplayerConnection::SetSpaceEntitySystem(csp::multiplayer::SpaceEntitySystem* SpaceEntitySystem)
+void MultiplayerConnection::SetOnlineRealtimeEngine(csp::multiplayer::OnlineRealtimeEngine* OnlineRealtimeEngine)
 {
-    MultiplayerRealtimeEngine = SpaceEntitySystem;
+    MultiplayerRealtimeEngine = OnlineRealtimeEngine;
 }
 
 MultiplayerConnection::MultiplayerConnection(const MultiplayerConnection& InBoundConnection)

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -190,10 +190,9 @@ MultiplayerConnection::~MultiplayerConnection()
     }
 }
 
-void MultiplayerConnection::SetSpaceEntitySystem(std::shared_ptr<csp::multiplayer::SpaceEntitySystem>& SpaceEntitySystem)
+void MultiplayerConnection::SetSpaceEntitySystem(csp::multiplayer::SpaceEntitySystem* SpaceEntitySystem)
 {
-    // Take a weak ptr
-    this->SpaceEntitySystemWeak = SpaceEntitySystem;
+    MultiplayerRealtimeEngine = SpaceEntitySystem;
 }
 
 MultiplayerConnection::MultiplayerConnection(const MultiplayerConnection& InBoundConnection)
@@ -664,14 +663,14 @@ void MultiplayerConnection::BindOnObjectMessage()
         OnObjectMessage,
         [this](const signalr::value& Params)
         {
-            if (auto EntitySystem = SpaceEntitySystemWeak.lock())
+            if (MultiplayerRealtimeEngine != nullptr)
             {
-                EntitySystem->OnObjectMessage(Params);
+                MultiplayerRealtimeEngine->OnObjectMessage(Params);
             }
             else
             {
                 LogSystem.LogMsg(
-                    common::LogLevel::Log, "Recieved OnObjectMessage without an alive EntitySystem. This is expected if leaving a space.");
+                    common::LogLevel::Log, "Received OnObjectMessage without an alive EntitySystem. This is expected if leaving a space.");
             }
         });
 }
@@ -683,13 +682,13 @@ void MultiplayerConnection::BindOnObjectPatch()
         OnObjectPatch,
         [this](const signalr::value& Params)
         {
-            if (auto EntitySystem = SpaceEntitySystemWeak.lock())
+            if (MultiplayerRealtimeEngine != nullptr)
             {
-                EntitySystem->OnObjectPatch(Params);
+                MultiplayerRealtimeEngine->OnObjectPatch(Params);
             }
             else
             {
-                LogSystem.LogMsg(common::LogLevel::Log, "Recieved OnObjectPatch without an alive EntitySystem. This is expected if leaving a space.");
+                LogSystem.LogMsg(common::LogLevel::Log, "Received OnObjectPatch without an alive EntitySystem. This is expected if leaving a space.");
             }
         });
 }
@@ -701,14 +700,14 @@ void MultiplayerConnection::BindOnRequestToSendObject()
         OnRequestToSendObject,
         [this](const signalr::value& Params)
         {
-            if (auto EntitySystem = SpaceEntitySystemWeak.lock())
+            if (MultiplayerRealtimeEngine != nullptr)
             {
-                EntitySystem->OnRequestToSendObject(Params);
+                MultiplayerRealtimeEngine->OnRequestToSendObject(Params);
             }
             else
             {
                 LogSystem.LogMsg(
-                    common::LogLevel::Log, "Recieved OnRequestToSendObject without an alive EntitySystem. This is expected if leaving a space.");
+                    common::LogLevel::Log, "Received OnRequestToSendObject without an alive EntitySystem. This is expected if leaving a space.");
             }
         });
 }

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -195,6 +195,8 @@ void MultiplayerConnection::SetOnlineRealtimeEngine(csp::multiplayer::OnlineReal
     MultiplayerRealtimeEngine = OnlineRealtimeEngine;
 }
 
+csp::multiplayer::OnlineRealtimeEngine* MultiplayerConnection::GetOnlineRealtimeEngine() const { return MultiplayerRealtimeEngine; }
+
 MultiplayerConnection::MultiplayerConnection(const MultiplayerConnection& InBoundConnection)
     : LogSystem(InBoundConnection.LogSystem)
 {

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -637,7 +637,7 @@ void MultiplayerConnection::BindOnObjectMessage()
             else
             {
                 LogSystem.LogMsg(
-                    common::LogLevel::Log, "Received OnObjectMessage without an alive EntitySystem. This is expected if leaving a space.");
+                    common::LogLevel::Verbose, "Received OnObjectMessage without an alive EntitySystem. This is expected if leaving a space.");
             }
         },
         LogSystem);
@@ -656,7 +656,8 @@ void MultiplayerConnection::BindOnObjectPatch()
             }
             else
             {
-                LogSystem.LogMsg(common::LogLevel::Log, "Received OnObjectPatch without an alive EntitySystem. This is expected if leaving a space.");
+                LogSystem.LogMsg(
+                    common::LogLevel::Verbose, "Received OnObjectPatch without an alive EntitySystem. This is expected if leaving a space.");
             }
         },
         LogSystem);
@@ -676,7 +677,7 @@ void MultiplayerConnection::BindOnRequestToSendObject()
             else
             {
                 LogSystem.LogMsg(
-                    common::LogLevel::Log, "Received OnRequestToSendObject without an alive EntitySystem. This is expected if leaving a space.");
+                    common::LogLevel::Verbose, "Received OnRequestToSendObject without an alive EntitySystem. This is expected if leaving a space.");
             }
         },
         LogSystem);

--- a/Library/src/Multiplayer/NetworkEventBus.cpp
+++ b/Library/src/Multiplayer/NetworkEventBus.cpp
@@ -170,7 +170,7 @@ bool NetworkEventBus::StartEventMessageListening()
         }
     };
 
-    MultiplayerConnectionInst->GetSignalRConnection()->On("OnEventMessage", EventDispatchCallback);
+    MultiplayerConnectionInst->GetSignalRConnection()->On("OnEventMessage", EventDispatchCallback, LogSystem);
     return true;
 }
 

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -38,7 +38,7 @@ NetworkEventManagerImpl::NetworkEventManagerImpl(MultiplayerConnection* InMultip
 {
 }
 
-void NetworkEventManagerImpl::SetConnection(csp::multiplayer::ISignalRConnection* InConnection) { Connection = InConnection; }
+void NetworkEventManagerImpl::SetConnection(csp::multiplayer::ISignalRConnection& InConnection) { Connection = &InConnection; }
 
 void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventName,
     const csp::common::Array<csp::common::ReplicatedValue>& Arguments, uint64_t TargetClientId, ErrorCodeCallbackHandler Callback)

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.h
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.h
@@ -41,7 +41,7 @@ public:
 
     typedef std::function<void(ErrorCode)> ErrorCodeCallbackHandler;
 
-    void SetConnection(csp::multiplayer::ISignalRConnection* InConnection);
+    void SetConnection(csp::multiplayer::ISignalRConnection& InConnection);
 
     CSP_NO_EXPORT void SendNetworkEvent(const csp::common::String& EventName, const csp::common::Array<csp::common::ReplicatedValue>& Arguments,
         uint64_t TargetClientId, ErrorCodeCallbackHandler Callback);

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -363,7 +363,7 @@ std::function<void(std::tuple<async::shared_task<uint64_t>, async::task<void>>)>
     };
 }
 
-void OnlineRealtimeEngine::CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState> LoginState,
+void OnlineRealtimeEngine::CreateAvatar(const csp::common::String& Name, const csp::common::Optional<csp::common::LoginState>& LoginState,
     const csp::multiplayer::SpaceTransform& SpaceTransform, bool IsVisible, const csp::multiplayer::AvatarState& AvatarState,
     const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode, csp::multiplayer::EntityCreatedCallback Callback)
 {

--- a/Library/src/Multiplayer/Script/EntityScript.cpp
+++ b/Library/src/Multiplayer/Script/EntityScript.cpp
@@ -31,12 +31,12 @@ constexpr const char* SCRIPT_ERROR_NO_COMPONENT = "No script component";
 constexpr const char* SCRIPT_ERROR_EMPTY_SCRIPT = "Script is empty";
 
 EntityScript::EntityScript(
-    SpaceEntity* InEntity, SpaceEntitySystem* InSpaceEntitySystem, csp::common::IJSScriptRunner* ScriptRunner, csp::common::LogSystem* LogSystem)
+    SpaceEntity* InEntity, OnlineRealtimeEngine* InOnlineRealtimeEngine, csp::common::IJSScriptRunner* ScriptRunner, csp::common::LogSystem* LogSystem)
     : Entity(InEntity)
     , EntityScriptComponent(nullptr)
     , HasLastError(false)
     , HasBinding(false)
-    , SpaceEntitySystemPtr(InSpaceEntitySystem)
+    , OnlineRealtimeEnginePtr(InOnlineRealtimeEngine)
     , LogSystem(LogSystem)
     , ScriptRunner(ScriptRunner)
 {
@@ -91,9 +91,9 @@ void EntityScript::RunScript(const csp::common::String& ScriptSource)
 {
     bool RunScriptLocally = true;
 
-    if (SpaceEntitySystemPtr)
+    if (OnlineRealtimeEnginePtr)
     {
-        RunScriptLocally = SpaceEntitySystemPtr->CheckIfWeShouldRunScriptsLocally();
+        RunScriptLocally = OnlineRealtimeEnginePtr->CheckIfWeShouldRunScriptsLocally();
     }
 
     if (RunScriptLocally)
@@ -103,7 +103,7 @@ void EntityScript::RunScript(const csp::common::String& ScriptSource)
     else
     {
 
-        SpaceEntitySystemPtr->RunScriptRemotely(Entity->GetId(), ScriptSource);
+        OnlineRealtimeEnginePtr->RunScriptRemotely(Entity->GetId(), ScriptSource);
     }
 }
 

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -20,7 +20,7 @@
 #include "CSP/Common/List.h"
 #include "CSP/Common/Vector.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h"
@@ -54,7 +54,7 @@ using SpaceEntityList = csp::common::List<SpaceEntity*>;
 class EntitySystemScriptInterface
 {
 public:
-    EntitySystemScriptInterface(SpaceEntitySystem* InEntitySystem = nullptr)
+    EntitySystemScriptInterface(OnlineRealtimeEngine* InEntitySystem = nullptr)
         : EntitySystem(InEntitySystem)
     {
     }
@@ -225,7 +225,7 @@ public:
     std::string GetFoundationVersion() { return csp::CSPFoundation::GetVersion().c_str(); }
 
 private:
-    SpaceEntitySystem* EntitySystem;
+    OnlineRealtimeEngine* EntitySystem;
 };
 
 void EntityScriptLog(qjs::rest<std::string> Args, csp::common::LogSystem& LogSystem)
@@ -240,14 +240,14 @@ void EntityScriptLog(qjs::rest<std::string> Args, csp::common::LogSystem& LogSys
     LogSystem.LogMsg(csp::common::LogLevel::Log, Str.str().c_str());
 }
 
-EntityScriptBinding::EntityScriptBinding(SpaceEntitySystem* InEntitySystem, csp::common::LogSystem& LogSystem)
+EntityScriptBinding::EntityScriptBinding(OnlineRealtimeEngine* InEntitySystem, csp::common::LogSystem& LogSystem)
     : EntitySystem(InEntitySystem)
     , LogSystem(LogSystem)
 {
 }
 
 EntityScriptBinding* EntityScriptBinding::BindEntitySystem(
-    SpaceEntitySystem* InEntitySystem, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& ScriptRunner)
+    OnlineRealtimeEngine* InEntitySystem, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& ScriptRunner)
 {
     EntityScriptBinding* ScriptBinding = new EntityScriptBinding(InEntitySystem, LogSystem);
     ScriptRunner.RegisterScriptBinding(ScriptBinding);

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.h
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.h
@@ -26,20 +26,20 @@ class IJSScriptRunner;
 namespace csp::multiplayer
 {
 
-class SpaceEntitySystem;
+class OnlineRealtimeEngine;
 
 class EntityScriptBinding : public csp::common::IScriptBinding
 {
 public:
-    EntityScriptBinding(SpaceEntitySystem* InEntitySystem, csp::common::LogSystem& LogSystem);
+    EntityScriptBinding(OnlineRealtimeEngine* InEntitySystem, csp::common::LogSystem& LogSystem);
     void Bind(int64_t ContextId, csp::common::IJSScriptRunner& ScriptRunner) override;
 
     static EntityScriptBinding* BindEntitySystem(
-        SpaceEntitySystem* InEntitySystem, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& ScriptRunner);
+        OnlineRealtimeEngine* InEntitySystem, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& ScriptRunner);
     static void RemoveBinding(EntityScriptBinding* InEntityBinding, csp::common::IJSScriptRunner& ScriptRunner);
 
 private:
-    SpaceEntitySystem* EntitySystem;
+    OnlineRealtimeEngine* EntitySystem;
     csp::common::LogSystem& LogSystem;
 };
 

--- a/Library/src/Multiplayer/SignalR/ISignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/ISignalRConnection.h
@@ -25,6 +25,11 @@ namespace signalr
 class value;
 }
 
+namespace csp::common
+{
+class LogSystem;
+}
+
 namespace csp::multiplayer
 {
 // This interface written initially to allow Mocks to be created in tests for the SignalRConnection
@@ -48,7 +53,7 @@ public:
     virtual ISignalRConnection::ConnectionState GetConnectionState() const = 0;
     virtual std::string GetConnectionId() const = 0;
     virtual void SetDisconnected(const std::function<void(std::exception_ptr)>& DisconnectedCallback) = 0;
-    virtual void On(const std::string& EventName, const MethodInvokedHandler& Handler) = 0;
+    virtual bool On(const std::string& EventName, const MethodInvokedHandler& Handler, csp::common::LogSystem& LogSystem) = 0;
     virtual async::task<std::tuple<signalr::value, std::exception_ptr>> Invoke(
         const std::string& MethodName, const signalr::value& Arguments,
         std::function<void(const signalr::value&, std::exception_ptr)> Callback = [](const signalr::value&, std::exception_ptr) {})

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.cpp
@@ -125,7 +125,7 @@ bool SignalRConnection::On(const std::string& EventName, const SignalRConnection
     {
         // If you register an event twice, you'll throw. Very hard to debug if this happens off thread, which it does with re-logging in.
         // Not really an error though, expected behaviour for our flow, just log to help in debugability
-        LogSystem.LogMsg(csp::common::LogLevel::Log,
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
             fmt::format("Caught SignalR error, ignoring 'On' registration for {}. : {}", EventName, exception.what()).c_str());
         return false;
     }

--- a/Library/src/Multiplayer/SignalR/SignalRConnection.h
+++ b/Library/src/Multiplayer/SignalR/SignalRConnection.h
@@ -20,6 +20,7 @@
 #include "Multiplayer/SignalR/ISignalRConnection.h"
 #include <atomic>
 #include <signalrclient/hub_connection_builder.h>
+#include <unordered_set>
 
 CSP_START_IGNORE
 class CSPEngine_MultiplayerTests_SignalRConnectionTest_Test;
@@ -55,7 +56,8 @@ public:
 
     void SetDisconnected(const std::function<void(std::exception_ptr)>& DisconnectedCallback) override;
 
-    void On(const std::string& EventName, const MethodInvokedHandler& Handler) override;
+    // Returns false if the event has already been bound, true otherwise
+    bool On(const std::string& EventName, const MethodInvokedHandler& Handler, csp::common::LogSystem& LogSystem) override;
 
     async::task<std::tuple<signalr::value, std::exception_ptr>> Invoke(
         const std::string& MethodName, const signalr::value& Arguments = signalr::value(),

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -43,7 +43,7 @@
 #include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/Script/EntityScript.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "Common/Convert.h"
 #include "Multiplayer/MCS/MCSTypes.h"
 #include "Multiplayer/MCSComponentPacker.h"
@@ -109,7 +109,7 @@ SpaceEntity::SpaceEntity()
 {
 }
 
-SpaceEntity::SpaceEntity(SpaceEntitySystem* InEntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem)
+SpaceEntity::SpaceEntity(OnlineRealtimeEngine* InEntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem)
     : EntitySystem(InEntitySystem)
     , Type(SpaceEntityType::Avatar)
     , Id(0)
@@ -132,7 +132,7 @@ SpaceEntity::SpaceEntity(SpaceEntitySystem* InEntitySystem, csp::common::IJSScri
 {
 }
 
-SpaceEntity::SpaceEntity(SpaceEntitySystem* EntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem,
+SpaceEntity::SpaceEntity(OnlineRealtimeEngine* EntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem,
     SpaceEntityType Type, uint64_t Id, const csp::common::String& Name, const csp::multiplayer::SpaceTransform& Transform, uint64_t OwnerId,
     bool IsTransferable, bool IsPersistent)
     : SpaceEntity(EntitySystem, ScriptRunner, LogSystem)

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -201,10 +201,10 @@ SpaceEntitySystem::SpaceEntitySystem()
 {
 }
 
-SpaceEntitySystem::SpaceEntitySystem(MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem,
+SpaceEntitySystem::SpaceEntitySystem(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
     csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& ScriptRunner)
     : EntitiesLock(new std::recursive_mutex)
-    , MultiplayerConnectionInst(InMultiplayerConnection)
+    , MultiplayerConnectionInst(&InMultiplayerConnection)
     , LogSystem(&LogSystem)
     , EventHandler(new SpaceEntityEventHandler(this))
     , ElectionManager(nullptr)

--- a/Library/src/Multiplayer/SpaceEntitySystem.cpp
+++ b/Library/src/Multiplayer/SpaceEntitySystem.cpp
@@ -664,7 +664,7 @@ void SpaceEntitySystem::SetScriptLeaderReadyCallback(CallbackHandler Callback)
 {
     if (ScriptSystemReadyCallback)
     {
-        LogSystem->LogMsg(common::LogLevel::Warning, "ScriptSystemReadyCallback has already been set. Previous callback overwritten.");
+        LogSystem->LogMsg(common::LogLevel::Warning, "ScriptLeaderReadyCallback has already been set. Previous callback overwritten.");
     }
 
     ScriptSystemReadyCallback = std::move(Callback);

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -38,6 +38,7 @@
 #include "Systems/Spatial/PointOfInterestInternalSystem.h"
 
 #include <exception>
+#include <fmt/format.h>
 #include <memory>
 #include <optional>
 #include <rapidjson/rapidjson.h>
@@ -422,8 +423,10 @@ void SpaceSystem::ExitSpace(NullResultCallback Callback)
             {
                 if (Error != multiplayer::ErrorCode::None)
                 {
-                    CSP_LOG_ERROR_FORMAT("Error on exiting spaces, whilst stopping listening in order to clear scopes, ErrorCode: %s",
-                        multiplayer::ErrorCodeToString(Error).c_str());
+                    csp::systems::SystemsManager::Get().GetLogSystem()->LogMsg(csp::common::LogLevel::Fatal,
+                        fmt::format("Error on exiting spaces, whilst stopping listening in order to clear scopes, ErrorCode: {}",
+                            multiplayer::ErrorCodeToString(Error))
+                            .c_str());
                     INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
 
                     return;
@@ -434,9 +437,14 @@ void SpaceSystem::ExitSpace(NullResultCallback Callback)
                     {
                         if (Error != multiplayer::ErrorCode::None)
                         {
-                            CSP_LOG_ERROR_FORMAT(
-                                "Error on exiting spaces whilst clearing scopes, ErrorCode: %s", multiplayer::ErrorCodeToString(Error).c_str());
+                            csp::systems::SystemsManager::Get().GetLogSystem()->LogMsg(csp::common::LogLevel::Fatal,
+                                fmt::format("Error on exiting spaces whilst clearing scopes, ErrorCode: {}", multiplayer::ErrorCodeToString(Error))
+                                    .c_str());
                             INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
+
+                            // This is a fatal error path, we'll null the realtime engine. You still leave the space, despite the services not
+                            // agreeing.
+                            MultiplayerConnection->SetOnlineRealtimeEngine(nullptr);
 
                             return;
                         }

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -153,7 +153,8 @@ void SystemsManager::CreateSystems(csp::multiplayer::ISignalRConnection* SignalR
     ScriptSystem->Initialise();
 
     // At the moment, the inject is for mocking behaviour. In the future this will probably not even be instantiated here at all.
-    auto* SignalRConnection = (SignalRInject == nullptr) ? csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() : SignalRInject;
+    auto* SignalRConnection
+        = (SignalRInject == nullptr) ? csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(UserSystem->GetAuthContext()) : SignalRInject;
 
     MultiplayerConnection = new csp::multiplayer::MultiplayerConnection(*LogSystem, *SignalRConnection);
 

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -99,9 +99,9 @@ csp::multiplayer::MultiplayerConnection* SystemsManager::GetMultiplayerConnectio
 
 csp::multiplayer::NetworkEventBus* SystemsManager::GetEventBus() { return NetworkEventBus; }
 
-csp::multiplayer::SpaceEntitySystem* SystemsManager::MakeOnlineRealtimeEngine()
+csp::multiplayer::OnlineRealtimeEngine* SystemsManager::MakeOnlineRealtimeEngine()
 {
-    return new csp::multiplayer::SpaceEntitySystem { *GetMultiplayerConnection(), *GetLogSystem(), *GetEventBus(), *GetScriptSystem() };
+    return new csp::multiplayer::OnlineRealtimeEngine { *GetMultiplayerConnection(), *GetLogSystem(), *GetEventBus(), *GetScriptSystem() };
 }
 
 SystemsManager::SystemsManager()

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -93,40 +93,14 @@ SequenceSystem* SystemsManager::GetSequenceSystem() { return SequenceSystem; }
 
 HotspotSequenceSystem* SystemsManager::GetHotspotSequenceSystem() { return HotspotSequenceSystem; }
 
-std::weak_ptr<csp::common::IRealtimeEngine> SystemsManager::GetRealtimeEngine() { return RealtimeEngine; }
-
-std::weak_ptr<csp::common::IRealtimeEngine> SystemsManager::InstantiateMultiplayerRealtimeEngine()
-{
-    // The reason we do this is because if the tests, most tests get the pointer to the space entity system right at the beginning.
-    // However, in the new world it wont exist until clients provide it in enterspace, so the pointer they get will be invalid.
-    // This whole method will dissapear when that happens.
-    // This way, the tests will still work as EnterSpace wont _actually_ set a new RealtimeEngine.
-    if (RealtimeEngine != nullptr)
-    {
-        return RealtimeEngine; // Not real logic, remove after integration
-    }
-
-    // This will change once api is given to clients to init a realtime engine of their choosing.
-    RealtimeEngine = std::make_shared<csp::multiplayer::SpaceEntitySystem>(MultiplayerConnection, *LogSystem, *NetworkEventBus, *ScriptSystem);
-    std::shared_ptr<csp::multiplayer::SpaceEntitySystem> SpaceEntitySystemPtr
-        = std::static_pointer_cast<csp::multiplayer::SpaceEntitySystem>(RealtimeEngine);
-    MultiplayerConnection->SetSpaceEntitySystem(SpaceEntitySystemPtr);
-
-    return RealtimeEngine;
-}
-
-void SystemsManager::DestroyRealtimeEngine()
-{
-    // We shut down realtime engine  when leaving a space, hence why this is different to the rest of the systems here.
-    if (RealtimeEngine != nullptr)
-    {
-        RealtimeEngine.reset();
-    }
-}
-
 csp::multiplayer::MultiplayerConnection* SystemsManager::GetMultiplayerConnection() { return MultiplayerConnection; }
 
 csp::multiplayer::NetworkEventBus* SystemsManager::GetEventBus() { return NetworkEventBus; }
+
+csp::multiplayer::SpaceEntitySystem* SystemsManager::MakeOnlineRealtimeEngine()
+{
+    return new csp::multiplayer::SpaceEntitySystem { *GetMultiplayerConnection(), *GetLogSystem(), *GetEventBus(), *GetScriptSystem() };
+}
 
 SystemsManager::SystemsManager()
     : WebClient(nullptr)
@@ -197,17 +171,12 @@ void SystemsManager::CreateSystems()
     SequenceSystem = new csp::systems::SequenceSystem(WebClient, NetworkEventBus, *LogSystem);
     HotspotSequenceSystem = new csp::systems::HotspotSequenceSystem(SequenceSystem, SpaceSystem, NetworkEventBus, *LogSystem);
     ConversationSystem = new csp::systems::ConversationSystemInternal(AssetSystem, SpaceSystem, UserSystem, NetworkEventBus, *LogSystem);
-
-    // Just for integration, this shouldn't actually be done here, as we want clients to create this
-    // See InstantiateMultiplayerRealtimeEngine for explanation, it's just for tests, and temporary.
-    InstantiateMultiplayerRealtimeEngine();
 }
 
 void SystemsManager::DestroySystems()
 {
     // Systems must be shut down in reverse order to CreateSystems() to ensure that any
     // dependencies continue to exist until each system is successfully shut down.
-    DestroyRealtimeEngine();
     delete ConversationSystem;
     delete HotspotSequenceSystem;
     delete SequenceSystem;

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -56,10 +56,10 @@ namespace
  *
  * This dependency needs to be broken prior to formal modularization, I suspect by injecting the MultiplayerConnection much like we inject
  * the RealtimeEngine. */
-void StartMultiplayerConnection(csp::multiplayer::MultiplayerConnection& MultiplayerConnection,
+void StartMultiplayerConnection(csp::multiplayer::MultiplayerConnection& MultiplayerConnection, const csp::common::String& MultiplayerURI,
     csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ErrorCallback, const csp::systems::LoginStateResult& LoginStateRes)
 {
-    MultiplayerConnection.Connect(ErrorCallback, LoginStateRes.GetLoginState().AccessToken, LoginStateRes.GetLoginState().DeviceId);
+    MultiplayerConnection.Connect(ErrorCallback, MultiplayerURI, LoginStateRes.GetLoginState().AccessToken, LoginStateRes.GetLoginState().DeviceId);
 }
 
 }
@@ -233,7 +233,8 @@ void UserSystem::Login(const csp::common::String& UserName, const csp::common::S
                     Callback(LoginStateRes);
                 };
 
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(), ErrorCallback, LoginStateRes, GetAuthContext());
+                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                    CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), ErrorCallback, LoginStateRes);
             }
             else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
             {
@@ -292,7 +293,8 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
                     Callback(LoginStateRes);
                 };
 
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(), ErrorCallback, LoginStateRes, GetAuthContext());
+                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                    CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), ErrorCallback, LoginStateRes);
             }
             else
             {
@@ -348,7 +350,8 @@ void UserSystem::LoginAsGuest(const csp::common::Optional<bool>& UserHasVerified
                     Callback(LoginStateRes);
                 };
 
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(), ErrorCallback, LoginStateRes, GetAuthContext());
+                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                    CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), ErrorCallback, LoginStateRes);
             }
             else
             {
@@ -472,7 +475,8 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
                 Callback(LoginStateRes);
             };
 
-            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(), ErrorCallback, LoginStateRes, GetAuthContext());
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(), CSPFoundation::GetEndpoints().MultiplayerService.GetURI(),
+                ErrorCallback, LoginStateRes);
         }
         else
         {

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -59,8 +59,7 @@ namespace
 void StartMultiplayerConnection(csp::multiplayer::MultiplayerConnection& MultiplayerConnection,
     csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ErrorCallback, const csp::systems::LoginStateResult& LoginStateRes)
 {
-    MultiplayerConnection.Connect(ErrorCallback, LoginStateRes.GetLoginState().AccessToken, LoginStateRes.GetLoginState().DeviceId,
-        csp::multiplayer::MultiplayerConnection::MakeSignalRConnection());
+    MultiplayerConnection.Connect(ErrorCallback, LoginStateRes.GetLoginState().AccessToken, LoginStateRes.GetLoginState().DeviceId);
 }
 
 }

--- a/MultiplayerTestRunner/src/InternalUnitTests/Test_RunnableTests.cpp
+++ b/MultiplayerTestRunner/src/InternalUnitTests/Test_RunnableTests.cpp
@@ -45,5 +45,5 @@ TEST_F(RunnableTests, CreateAvatar)
     // Make a throwaway space
     SpaceRAII Space({});
 
-    CreateAvatar::RunTest();
+    CreateAvatar::RunTest(Space.GetRealtimeEngine());
 }

--- a/MultiplayerTestRunner/src/InternalUnitTests/Test_SpaceRAII.cpp
+++ b/MultiplayerTestRunner/src/InternalUnitTests/Test_SpaceRAII.cpp
@@ -121,7 +121,7 @@ TEST_F(SpaceRAIITest, TestUseInvalidExistingSpace)
     try
     {
         ::testing::internal::CaptureStdout();
-        SpaceRAII Space({ Invalid_SpaceID });
+        SpaceRAII Space(std::make_optional(Invalid_SpaceID));
     }
     catch (const Utils::ExceptionWithCode& Exception)
     {

--- a/MultiplayerTestRunner/src/Main.cpp
+++ b/MultiplayerTestRunner/src/Main.cpp
@@ -54,16 +54,16 @@
  * By this point, the client should be logged in and inside a space, hence tests need not concern themselves with space creation and cleanup.
  * This function blocks until the timeout has elapsed.
  */
-void RunTest(CLIArgs::RunnerSettings Settings, std::chrono::steady_clock::time_point ProgramStartTime)
+void RunTest(CLIArgs::RunnerSettings Settings, std::chrono::steady_clock::time_point ProgramStartTime, SpaceRAII& SpaceRAII)
 {
     using namespace MultiplayerTestRunner::TestIdentifiers;
     switch (Settings.TestIdentifier)
     {
     case TestIdentifier::CREATE_AVATAR:
-        CreateAvatar::RunTest();
+        CreateAvatar::RunTest(SpaceRAII.GetRealtimeEngine());
         break;
     case TestIdentifier::CREATE_CONVERSATION:
-        CreateConversation::RunTest();
+        CreateConversation::RunTest(SpaceRAII.GetRealtimeEngine());
         break;
     case TestIdentifier::EVENT_BUS_PING:
         EventBusPing::RunTest();
@@ -111,14 +111,14 @@ int main(int argc, char* argv[])
         Utils::InitialiseCSPWithUserAgentInfo(Settings.Endpoint.c_str());
 
         // Log in
-        LoginRAII loggedIn { Settings.LoginEmailAndPassword.first, Settings.LoginEmailAndPassword.second };
+        LoginRAII LoggedIn { Settings.LoginEmailAndPassword.first, Settings.LoginEmailAndPassword.second };
 
         // Enter space (creating one if it dosen't exist)
-        SpaceRAII space { Settings.SpaceId };
-        Settings.SpaceId = space.GetSpaceId(); // We need to update the settings as a new space may have been created
+        SpaceRAII Space { Settings.SpaceId };
+        Settings.SpaceId = Space.GetSpaceId(); // We need to update the settings as a new space may have been created
 
         // Run the specified test according to the TestIdentifier. Wont return earlier than timeout.
-        RunTest(Settings, ProgramStartTime);
+        RunTest(Settings, ProgramStartTime, Space);
 
         return 0;
     }

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -55,8 +55,8 @@ void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine)
 
     const auto LoginState = UserSystem.GetLoginState();
 
-    RealtimeEngine.CreateAvatar(UserName, csp::common::Optional(LoginState), UserTransform, IsVisible, UserAvatarState, UserAvatarId,
-        UserAvatarPlayMode, [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
+    RealtimeEngine.CreateAvatar(UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode,
+        [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
 
     csp::multiplayer::SpaceEntity* CreatedAvatar = ResultFuture.get();
     if (CreatedAvatar == nullptr)

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -18,7 +18,7 @@
 
 #include "uuid_v4.h"
 #include <CSP/Common/Optional.h>
-#include <CSP/Multiplayer/SpaceEntitySystem.h>
+#include <CSP/Multiplayer/OnlineRealtimeEngine.h>
 #include <CSP/Multiplayer/SpaceTransform.h>
 #include <CSP/Systems/Spaces/SpaceSystem.h>
 #include <CSP/Systems/SystemsManager.h>
@@ -28,7 +28,7 @@
 namespace CreateAvatar
 {
 
-void RunTest(csp::multiplayer::SpaceEntitySystem& RealtimeEngine)
+void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine)
 {
     using namespace csp::multiplayer;
 

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -16,23 +16,23 @@
 
 #include "CreateAvatar.h"
 
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
-#include "CSP/Multiplayer/SpaceTransform.h"
-#include "CSP/Systems/Spaces/SpaceSystem.h"
-#include "CSP/Systems/SystemsManager.h"
-#include "CSP/Systems/Users/UserSystem.h"
 #include "uuid_v4.h"
+#include <CSP/Common/Optional.h>
+#include <CSP/Multiplayer/SpaceEntitySystem.h>
+#include <CSP/Multiplayer/SpaceTransform.h>
+#include <CSP/Systems/Spaces/SpaceSystem.h>
+#include <CSP/Systems/SystemsManager.h>
+#include <CSP/Systems/Users/UserSystem.h>
 #include <future>
 
 namespace CreateAvatar
 {
 
-void RunTest()
+void RunTest(csp::multiplayer::SpaceEntitySystem& RealtimeEngine)
 {
     using namespace csp::multiplayer;
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
-    auto& EntitySystem = *SystemsManager.GetSpaceEntitySystem();
     auto& UserSystem = *SystemsManager.GetUserSystem();
 
     UUIDv4::UUIDGenerator<std::mt19937_64> uuidGenerator;
@@ -48,19 +48,23 @@ void RunTest()
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    EntitySystem.SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine.SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     std::promise<csp::multiplayer::SpaceEntity*> ResultPromise;
     std::future<csp::multiplayer::SpaceEntity*> ResultFuture = ResultPromise.get_future();
 
     const auto LoginState = UserSystem.GetLoginState();
 
-    EntitySystem.CreateAvatar(UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode,
-        [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
+    RealtimeEngine.CreateAvatar(UserName, csp::common::Optional(LoginState), UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+        UserAvatarPlayMode, [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
 
-    ResultFuture.get();
+    csp::multiplayer::SpaceEntity* CreatedAvatar = ResultFuture.get();
+    if (CreatedAvatar == nullptr)
+    {
+        throw std::runtime_error("Failed to create avatar!");
+    }
 
-    EntitySystem.ProcessPendingEntityOperations();
+    RealtimeEngine.ProcessPendingEntityOperations();
 
     // This is a hail mary attempt to get this to stop being flaky on CI. CHS is known to sometimes have a processing delay, which is unfortunate.
     std::this_thread::sleep_for(std::chrono::seconds(7));

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.h
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.h
@@ -20,7 +20,7 @@
 
 namespace csp::multiplayer
 {
-class SpaceEntitySystem;
+class OnlineRealtimeEngine;
 }
 
 namespace CreateAvatar
@@ -28,5 +28,5 @@ namespace CreateAvatar
 /*
  * Example test that simply creates an avatar in a room.
  */
-void RunTest(csp::multiplayer::SpaceEntitySystem& RealtimeEngine);
+void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine);
 } // namespace CreateAvatar

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.h
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.h
@@ -18,10 +18,15 @@
 
 #include "../CLIArgs.h"
 
+namespace csp::multiplayer
+{
+class SpaceEntitySystem;
+}
+
 namespace CreateAvatar
 {
 /*
  * Example test that simply creates an avatar in a room.
  */
-void RunTest();
+void RunTest(csp::multiplayer::SpaceEntitySystem& RealtimeEngine);
 } // namespace CreateAvatar

--- a/MultiplayerTestRunner/src/RunnableTests/CreateConversation.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateConversation.cpp
@@ -19,11 +19,11 @@
 #include "CreateConversation.h"
 #include "../CLIArgs.h"
 
-#include "CSP/Multiplayer/Components/ConversationSpaceComponent.h"
-#include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
-#include "CSP/Multiplayer/SpaceTransform.h"
-#include "CSP/Systems/SystemsManager.h"
+#include <CSP/Multiplayer/Components/ConversationSpaceComponent.h>
+#include <CSP/Multiplayer/SpaceEntity.h>
+#include <CSP/Multiplayer/OnlineRealtimeEngine.h>
+#include <CSP/Multiplayer/SpaceTransform.h>
+#include <CSP/Systems/SystemsManager.h>
 
 #include <future>
 #include <iostream>
@@ -36,7 +36,7 @@ when receiving 2 patches, the first being the initial component creation, and th
 the ConversationId property update.
 This scenario would fail if events arent correctly stored, and then flushed when receiving the conversation id
 */
-void RunTest(csp::multiplayer::SpaceEntitySystem& RealtimeEngine)
+void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine)
 {
     // Ensure patch rate limiting is off, as we're sending patches in quick succession.
     RealtimeEngine.SetEntityPatchRateLimitEnabled(false);

--- a/MultiplayerTestRunner/src/RunnableTests/CreateConversation.h
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateConversation.h
@@ -18,10 +18,15 @@
 
 #include "../CLIArgs.h"
 
+namespace csp::multiplayer
+{
+class SpaceEntitySystem;
+}
+
 namespace CreateConversation
 {
 /*
  * Example test that creates a conversation component with a conversation message
  */
-void RunTest();
+void RunTest(csp::multiplayer::SpaceEntitySystem& RealtimeEngine);
 } // namespace CreateConversation

--- a/MultiplayerTestRunner/src/RunnableTests/CreateConversation.h
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateConversation.h
@@ -20,7 +20,7 @@
 
 namespace csp::multiplayer
 {
-class SpaceEntitySystem;
+class OnlineRealtimeEngine;
 }
 
 namespace CreateConversation
@@ -28,5 +28,5 @@ namespace CreateConversation
 /*
  * Example test that creates a conversation component with a conversation message
  */
-void RunTest(csp::multiplayer::SpaceEntitySystem& RealtimeEngine);
+void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine);
 } // namespace CreateConversation

--- a/MultiplayerTestRunner/src/SpaceRAII.cpp
+++ b/MultiplayerTestRunner/src/SpaceRAII.cpp
@@ -49,11 +49,11 @@ SpaceRAII::SpaceRAII(std::optional<std::string> ExistingSpaceId)
     }
 
     // Enter space
-    std::promise<csp::systems::NullResult> ResultPromise;
-    std::future<csp::systems::NullResult> ResultFuture = ResultPromise.get_future();
+    std::promise<csp::systems::SpaceResult> ResultPromise;
+    std::future<csp::systems::SpaceResult> ResultFuture = ResultPromise.get_future();
 
     SpaceSystem.EnterSpace(SpaceId.c_str(), RealtimeEngine.get(),
-        [&ResultPromise](csp::systems::NullResult Result)
+        [&ResultPromise](csp::systems::SpaceResult Result)
         {
             // Callbacks are called both in progress and at the end, guard against double promise sets
             if (Result.GetResultCode() == csp::systems::EResultCode::Success || Result.GetResultCode() == csp::systems::EResultCode::Failed)
@@ -62,7 +62,7 @@ SpaceRAII::SpaceRAII(std::optional<std::string> ExistingSpaceId)
             }
         });
 
-    csp::systems::NullResult EnterSpaceResult = ResultFuture.get();
+    csp::systems::SpaceResult EnterSpaceResult = ResultFuture.get();
 
     if (EnterSpaceResult.GetResultCode() != csp::systems::EResultCode::Success)
     {

--- a/MultiplayerTestRunner/src/SpaceRAII.cpp
+++ b/MultiplayerTestRunner/src/SpaceRAII.cpp
@@ -18,6 +18,7 @@
 
 #include "../include/ErrorCodes.h"
 #include "../include/ProcessDescriptors.h"
+#include "CSP/Multiplayer/SpaceEntitySystem.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "Utils.h"
 #include "uuid_v4.h"
@@ -30,6 +31,7 @@ namespace
 } // namespace
 
 SpaceRAII::SpaceRAII(std::optional<std::string> ExistingSpaceId)
+    : RealtimeEngine(csp::systems::SystemsManager::Get().MakeOnlineRealtimeEngine())
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto& SpaceSystem = *SystemsManager.GetSpaceSystem();
@@ -50,7 +52,7 @@ SpaceRAII::SpaceRAII(std::optional<std::string> ExistingSpaceId)
     std::promise<csp::systems::NullResult> ResultPromise;
     std::future<csp::systems::NullResult> ResultFuture = ResultPromise.get_future();
 
-    SpaceSystem.EnterSpace(SpaceId.c_str(),
+    SpaceSystem.EnterSpace(SpaceId.c_str(), RealtimeEngine.get(),
         [&ResultPromise](csp::systems::NullResult Result)
         {
             // Callbacks are called both in progress and at the end, guard against double promise sets
@@ -160,3 +162,5 @@ csp::systems::Space SpaceRAII::CreateDefaultTestSpace(csp::systems::SpaceSystem&
 
     return Result.GetSpace();
 }
+
+csp::multiplayer::SpaceEntitySystem& SpaceRAII::GetRealtimeEngine() const { return *RealtimeEngine; }

--- a/MultiplayerTestRunner/src/SpaceRAII.cpp
+++ b/MultiplayerTestRunner/src/SpaceRAII.cpp
@@ -18,7 +18,7 @@
 
 #include "../include/ErrorCodes.h"
 #include "../include/ProcessDescriptors.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "Utils.h"
 #include "uuid_v4.h"
@@ -171,4 +171,4 @@ csp::systems::Space SpaceRAII::CreateDefaultTestSpace(csp::systems::SpaceSystem&
     return Result.GetSpace();
 }
 
-csp::multiplayer::SpaceEntitySystem& SpaceRAII::GetRealtimeEngine() const { return *RealtimeEngine; }
+csp::multiplayer::OnlineRealtimeEngine& SpaceRAII::GetRealtimeEngine() const { return *RealtimeEngine; }

--- a/MultiplayerTestRunner/src/SpaceRAII.h
+++ b/MultiplayerTestRunner/src/SpaceRAII.h
@@ -18,6 +18,7 @@
 
 #include "CSP/Systems/Spaces/SpaceSystem.h"
 
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -33,6 +34,11 @@ public:
     SpaceRAII(std::optional<std::string> SpaceId);
     ~SpaceRAII();
 
+    SpaceRAII(const SpaceRAII&) = delete;
+    SpaceRAII& operator=(const SpaceRAII&) = delete;
+    SpaceRAII(SpaceRAII&&) = delete;
+    SpaceRAII& operator=(SpaceRAII&&) = delete;
+
     /*
      * The SpaceID of the space this object is managing.
      * If the object was constructed with an empty SpaceId, then this will be the ID of the newly created space.
@@ -45,7 +51,13 @@ public:
      */
     static csp::systems::Space SpaceRAII::CreateDefaultTestSpace(csp::systems::SpaceSystem& SpaceSystem);
 
+    /*
+     * Get the RealtimeEngine that is instantiated for the lifetime that we are in the space for.
+     */
+    csp::multiplayer::SpaceEntitySystem& GetRealtimeEngine() const;
+
 private:
     bool CreatedThisSpace = false; // If we created this space, we should destroy it when done.
     std::string SpaceId;
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine;
 };

--- a/MultiplayerTestRunner/src/SpaceRAII.h
+++ b/MultiplayerTestRunner/src/SpaceRAII.h
@@ -54,10 +54,10 @@ public:
     /*
      * Get the RealtimeEngine that is instantiated for the lifetime that we are in the space for.
      */
-    csp::multiplayer::SpaceEntitySystem& GetRealtimeEngine() const;
+    csp::multiplayer::OnlineRealtimeEngine& GetRealtimeEngine() const;
 
 private:
     bool CreatedThisSpace = false; // If we created this space, we should destroy it when done.
     std::string SpaceId;
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine;
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine;
 };

--- a/Tests/src/InternalTests/SceneDescriptionTests.cpp
+++ b/Tests/src/InternalTests/SceneDescriptionTests.cpp
@@ -260,7 +260,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeE
     csp::common::LogSystem LogSystem;
     csp::multiplayer::MultiplayerConnection Connection { LogSystem };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::SpaceEntitySystem EntitySystem(&Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
     CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };
@@ -293,7 +293,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeT
     csp::common::LogSystem LogSystem;
     csp::multiplayer::MultiplayerConnection Connection { LogSystem };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::SpaceEntitySystem EntitySystem(&Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
     CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };
@@ -398,7 +398,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeser
     csp::common::LogSystem LogSystem;
     csp::multiplayer::MultiplayerConnection Connection { LogSystem };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::SpaceEntitySystem EntitySystem(&Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
     CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };

--- a/Tests/src/InternalTests/SceneDescriptionTests.cpp
+++ b/Tests/src/InternalTests/SceneDescriptionTests.cpp
@@ -19,7 +19,7 @@
 
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Multiplayer/CSPSceneDescription.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Systems/CSPSceneData.h"
 #include "Multiplayer/MCS/MCSSceneDescription.h"
 #include "Multiplayer/MCS/MCSTypes.h"
@@ -260,7 +260,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeE
     csp::common::LogSystem LogSystem;
     csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
     CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };
@@ -295,7 +295,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeT
     csp::common::LogSystem LogSystem;
     csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
     CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };
@@ -402,7 +402,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeser
     csp::common::LogSystem LogSystem;
     csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
     CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };

--- a/Tests/src/InternalTests/SceneDescriptionTests.cpp
+++ b/Tests/src/InternalTests/SceneDescriptionTests.cpp
@@ -17,6 +17,7 @@
 #include "TestHelpers.h"
 #include "gtest/gtest.h"
 
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Multiplayer/CSPSceneDescription.h"
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
@@ -238,6 +239,16 @@ class MockScriptRunner : public csp::common::IJSScriptRunner
     void ClearModuleSource(csp::common::String) override { }
 };
 
+class TestAuthContext : public csp::common::IAuthContext
+{
+public:
+    const csp::common::LoginState& GetLoginState() const override { return State; }
+    void RefreshToken(std::function<void(bool)> Success) override { Success(true); }
+
+private:
+    csp::common::LoginState State;
+};
+
 CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeEmptyTest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -258,7 +269,9 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeE
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
+    TestAuthContext AuthContext;
+
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(AuthContext) };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
     csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
@@ -293,7 +306,8 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeT
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
+    TestAuthContext AuthContext;
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(AuthContext) };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
     csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
@@ -400,7 +414,8 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeser
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
+    TestAuthContext AuthContext;
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(AuthContext) };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
     csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 

--- a/Tests/src/InternalTests/SceneDescriptionTests.cpp
+++ b/Tests/src/InternalTests/SceneDescriptionTests.cpp
@@ -258,7 +258,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeE
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
     csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
@@ -269,6 +269,8 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeE
     EXPECT_EQ(SceneData.AssetCollections.Size(), 0);
     EXPECT_EQ(SceneData.Assets.Size(), 0);
     EXPECT_EQ(SceneData.Sequences.Size(), 0);
+
+    csp::CSPFoundation::Shutdown();
 }
 
 CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeTest)
@@ -291,7 +293,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeT
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
     csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
@@ -374,6 +376,8 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeT
 
     // Sequences
     EXPECT_EQ(SceneData.Sequences.Size(), 0);
+
+    csp::CSPFoundation::Shutdown();
 }
 
 CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeserializeTest)
@@ -396,7 +400,7 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeser
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection() };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
     csp::multiplayer::SpaceEntitySystem EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
 
@@ -474,4 +478,6 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeser
 
     // Sequences
     EXPECT_EQ(SceneData.Sequences.Size(), 0);
+
+    csp::CSPFoundation::Shutdown();
 }

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -43,7 +43,7 @@ namespace
 
 bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
 
-void CreateAvatarForLeaderElection(csp::multiplayer::SpaceEntitySystem* EntitySystem)
+void CreateAvatarForLeaderElection(csp::multiplayer::OnlineRealtimeEngine* EntitySystem)
 {
     const csp::common::String& UserName = "Player 1";
     const SpaceTransform& UserTransform
@@ -103,7 +103,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalPositionTest
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
     RealtimeEngine->SetScriptLeaderReadyCallback(ScriptSystemReadyCallback);
@@ -236,7 +236,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalRotationTest
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
     RealtimeEngine->SetScriptLeaderReadyCallback(ScriptSystemReadyCallback);
@@ -368,7 +368,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityGlobalScaleTest)
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
     RealtimeEngine->SetScriptLeaderReadyCallback(ScriptSystemReadyCallback);
@@ -500,7 +500,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, UpdateSpaceEntityParentIdTest)
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
     RealtimeEngine->SetScriptLeaderReadyCallback(ScriptSystemReadyCallback);
@@ -631,7 +631,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, RemoveSpaceEntityParentTest)
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
     RealtimeEngine->SetScriptLeaderReadyCallback(ScriptSystemReadyCallback);
@@ -760,7 +760,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceEntityTests, GetRootHierarchyEntitiesTest)
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
     RealtimeEngine->SetScriptLeaderReadyCallback(ScriptSystemReadyCallback);

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -56,7 +56,7 @@ void CreateAvatarForLeaderElection(csp::multiplayer::OnlineRealtimeEngine* Entit
     const auto LoginState = csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState();
 
     auto [Avatar]
-        = AWAIT(EntitySystem, CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        = AWAIT(EntitySystem, CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cout << "CreateAvatar Local Callback" << std::endl;

--- a/Tests/src/InternalTests/WebSocketClientTests.cpp
+++ b/Tests/src/InternalTests/WebSocketClientTests.cpp
@@ -42,14 +42,16 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientStartStopTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(
-        csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), csp::web::HttpAuth::GetAccessToken().c_str(), csp::CSPFoundation::GetDeviceId());
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), csp::web::HttpAuth::GetAccessToken().c_str(),
+        csp::CSPFoundation::GetDeviceId());
 
     // Stop
     WebSocketStop(WebSocket);
 
     // Logout
     LogOut(UserSystem);
+
+    csp::CSPFoundation::Shutdown();
 }
 
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendTest)
@@ -65,8 +67,8 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(
-        csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), csp::web::HttpAuth::GetAccessToken().c_str(), csp::CSPFoundation::GetDeviceId());
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), csp::web::HttpAuth::GetAccessToken().c_str(),
+        csp::CSPFoundation::GetDeviceId());
 
     // Send
     WebSocketSend(WebSocket, "test");
@@ -76,6 +78,8 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendTest)
 
     // Logout
     LogOut(UserSystem);
+
+    csp::CSPFoundation::Shutdown();
 }
 
 CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
@@ -91,8 +95,8 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
     LogInAsNewTestUser(UserSystem, UserId);
 
     // Start
-    auto* WebSocket = WebSocketStart(
-        csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), csp::web::HttpAuth::GetAccessToken().c_str(), csp::CSPFoundation::GetDeviceId());
+    auto* WebSocket = WebSocketStart(csp::CSPFoundation::GetEndpoints().MultiplayerService.GetURI(), csp::web::HttpAuth::GetAccessToken().c_str(),
+        csp::CSPFoundation::GetDeviceId());
 
     // Receive
     WebSocketSendReceive(WebSocket);
@@ -102,6 +106,8 @@ CSP_INTERNAL_TEST(CSPEngine, WebSocketClientTests, SignalRClientSendReceiveTest)
 
     // Logout
     LogOut(UserSystem);
+
+    csp::CSPFoundation::Shutdown();
 }
 
 /*

--- a/Tests/src/Mocks/SignalRConnectionMock.h
+++ b/Tests/src/Mocks/SignalRConnectionMock.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include "../../Library/src/Multiplayer/SignalR/ISignalRConnection.h"
+#include "CSP/Common/Systems/Log/LogSystem.h"
+#include "signalrclient/signalr_value.h"
 #include <gmock/gmock.h>
 
 class SignalRConnectionMock : public csp::multiplayer::ISignalRConnection
@@ -26,7 +28,7 @@ public:
     MOCK_METHOD(csp::multiplayer::ISignalRConnection::ConnectionState, GetConnectionState, (), (const, override));
     MOCK_METHOD(std::string, GetConnectionId, (), (const, override));
     MOCK_METHOD(void, SetDisconnected, (const std::function<void(std::exception_ptr)>&), (override));
-    MOCK_METHOD(void, On, (const std::string&, const MethodInvokedHandler&), (override));
+    MOCK_METHOD(bool, On, (const std::string&, const MethodInvokedHandler&, csp::common::LogSystem&), (override));
     MOCK_METHOD((async::task<std::tuple<signalr::value, std::exception_ptr>>), Invoke,
         (const std::string&, const signalr::value&, std::function<void(const signalr::value&, std::exception_ptr)>), (override));
     MOCK_METHOD(void, Send, (const std::string&, const signalr::value&, std::function<void(std::exception_ptr)>), (override));

--- a/Tests/src/PublicAPITests/AnchorSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnchorSystemTests.cpp
@@ -201,7 +201,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorInSpaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
@@ -264,7 +264,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, DeleteMultipleAnchorsTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
@@ -343,7 +343,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
     SpaceId[0] = Space.Id;
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
@@ -472,7 +472,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInSpaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
@@ -618,7 +618,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorResolutionTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 

--- a/Tests/src/PublicAPITests/AnchorSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnchorSystemTests.cpp
@@ -184,7 +184,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorInSpaceTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -202,15 +201,17 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorInSpaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
-
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     csp::systems::AssetCollection AssetCollection;
     CreateAssetCollection(
@@ -244,7 +245,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, DeleteMultipleAnchorsTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -264,18 +264,20 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, DeleteMultipleAnchorsTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
-
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
     csp::common::String ObjectName1 = "Object 1";
-    auto [CreatedObject1] = AWAIT(EntitySystem, CreateObject, ObjectName1, ObjectTransform);
+    auto [CreatedObject1] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName1, ObjectTransform, csp::common::Optional<uint64_t> {});
     csp::common::String ObjectName2 = "Object 2";
-    auto [CreatedObject2] = AWAIT(EntitySystem, CreateObject, ObjectName2, ObjectTransform);
+    auto [CreatedObject2] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName2, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     csp::systems::AssetCollection AssetCollection1;
     CreateAssetCollection(
@@ -322,7 +324,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -342,15 +343,17 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInsideCircularAreaTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
     SpaceId[0] = Space.Id;
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
-
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     csp::systems::AssetCollection AssetCollection;
     CreateAssetCollection(
@@ -450,7 +453,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInSpaceTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -470,18 +472,23 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, GetAnchorsInSpaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
-
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
     csp::common::String ObjectName1 = "Object 1";
-    auto [CreatedObject1] = AWAIT(EntitySystem, CreateObject, ObjectName1, ObjectTransform);
+    auto [CreatedObject1] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName1, ObjectTransform, csp::common::Optional<uint64_t> {});
     csp::common::String ObjectName2 = "Object 2";
-    auto [CreatedObject2] = AWAIT(EntitySystem, CreateObject, ObjectName2, ObjectTransform);
+    auto [CreatedObject2] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName2, ObjectTransform, csp::common::Optional<uint64_t> {});
+
+    ASSERT_TRUE(CreatedObject1);
+    ASSERT_TRUE(CreatedObject2);
 
     csp::systems::AssetCollection AssetCollection1;
     CreateAssetCollection(
@@ -594,7 +601,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorResolutionTest)
     auto* AnchorSystem = SystemsManager.GetAnchorSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -612,15 +618,17 @@ CSP_PUBLIC_TEST(CSPEngine, AnchorSystemTests, CreateAnchorResolutionTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
-
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     csp::systems::AssetCollection AssetCollection;
     CreateAssetCollection(

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -1963,7 +1963,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -1988,12 +1987,14 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
-
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Setup Asset callback
     bool AssetDetailBlobChangedCallbackCalled = false;
@@ -2058,7 +2059,6 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessGracefulFailureCallback
     auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* NetworkEventBus = SystemsManager.GetEventBus();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -2075,12 +2075,13 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessGracefulFailureCallback
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
-
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
-
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Setup Asset callback
     bool AssetDetailBlobChangedCallbackCalled = false;

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -16,7 +16,7 @@
 #include "AssetSystemTestHelpers.h"
 #include "CSP/CSPFoundation.h"
 #include "CSP/Common/Array.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Systems/Assets/AssetSystem.h"
 #include "CSP/Systems/Spaces/SpaceSystem.h"
 #include "CSP/Systems/SystemsManager.h"
@@ -1987,7 +1987,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
@@ -2075,7 +2075,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessGracefulFailureCallback
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -65,7 +65,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -190,7 +190,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -275,7 +275,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceT
     csp::common::String ObjectName = "Object 1";
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -305,7 +305,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceT
 
         auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
         auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -344,7 +344,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentEnterSpaceT
 
         auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
         auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
@@ -43,7 +43,6 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -60,16 +59,19 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create audio component
     auto* AudioComponent = static_cast<AudioSpaceComponent*>(CreatedObject->AddComponent(ComponentType::Audio));
@@ -141,7 +143,6 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -158,22 +159,25 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create audio component
     auto* AudioComponent = (AudioSpaceComponent*)CreatedObject->AddComponent(ComponentType::Audio);
 
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script
     std::string AudioScriptText = R"xx(
@@ -196,7 +200,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     CreatedObject->GetScript().SetScriptSource(AudioScriptText.c_str());
     CreatedObject->GetScript().Invoke();
 
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Ensure values are set correctly
     csp::common::String AssetId = "TEST_ASSET_ID";
@@ -218,7 +222,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
 		audio.volume = 1.75;
     )xx";
     CreatedObject->GetScript().Invoke();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
     EXPECT_EQ(AudioComponent->GetVolume(), 0.75f);
 
     AudioScriptText = R"xx(M
@@ -227,7 +231,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     )xx";
     CreatedObject->GetScript().SetScriptSource(AudioScriptText.c_str());
     CreatedObject->GetScript().Invoke();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
     EXPECT_EQ(AudioComponent->GetVolume(), 0.75f);
 
     // Test boundary volume values
@@ -237,7 +241,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     )xx";
     CreatedObject->GetScript().SetScriptSource(AudioScriptText.c_str());
     CreatedObject->GetScript().Invoke();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
     EXPECT_EQ(AudioComponent->GetVolume(), 1.f);
 
     AudioScriptText = R"xx(
@@ -246,7 +250,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     )xx";
     CreatedObject->GetScript().SetScriptSource(AudioScriptText.c_str());
     CreatedObject->GetScript().Invoke();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
     EXPECT_EQ(AudioComponent->GetVolume(), 0.f);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AudioComponentTests.cpp
@@ -59,7 +59,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -159,7 +159,7 @@ CSP_PUBLIC_TEST(CSPEngine, AudioTests, AudioScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -61,7 +61,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -198,7 +198,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -82,7 +82,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -219,7 +219,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -52,7 +52,6 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -62,8 +61,11 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -79,8 +81,8 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(EntitySystem, CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -187,7 +189,6 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -197,8 +198,11 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -214,8 +218,8 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(EntitySystem, CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -250,7 +254,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     EXPECT_EQ(AvatarComponent->GetMovementDirection(), csp::common::Vector3::Zero());
 
     Avatar->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script to set new properties
     std::string AvatarComponentScriptText = R"xx(
@@ -275,7 +279,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     Avatar->GetScript().SetScriptSource(AvatarComponentScriptText.c_str());
     Avatar->GetScript().Invoke();
 
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Test scripts sets new properties
     EXPECT_EQ(AvatarComponent->GetAvatarId(), "TestAvatarId");

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -66,7 +66,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -153,7 +153,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -227,7 +227,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -67,16 +66,19 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the Camera
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create Camera component
     auto* CinematicCamera = static_cast<CinematicCameraSpaceComponent*>(CreatedObject->AddComponent(ComponentType::CinematicCamera));
@@ -135,7 +137,6 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -152,16 +153,19 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentFovTest
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the Camera
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create Camera component
     auto* CinematicCamera = static_cast<CinematicCameraSpaceComponent*>(CreatedObject->AddComponent(ComponentType::CinematicCamera));
@@ -207,7 +211,6 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -224,22 +227,25 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the CinematicCamera
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create CinematicCamera component
     auto* CinematicCamera = (CinematicCameraSpaceComponent*)CreatedObject->AddComponent(ComponentType::CinematicCamera);
 
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script
     const std::string CinematicCameraScriptText = R"xx(
@@ -261,7 +267,7 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     CreatedObject->GetScript().SetScriptSource(CinematicCameraScriptText.c_str());
     CreatedObject->GetScript().Invoke();
 
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     EXPECT_EQ(CinematicCamera->GetPosition(), csp::common::Vector3(3, 2, 1));
     EXPECT_EQ(CinematicCamera->GetRotation(), csp::common::Vector4(1, 2, 3, 1));

--- a/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
@@ -47,7 +47,6 @@ CSP_PUBLIC_TEST(CSPEngine, CollisionTests, CollisionComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -64,16 +63,19 @@ CSP_PUBLIC_TEST(CSPEngine, CollisionTests, CollisionComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create collision component
     auto* CollisionComponent = static_cast<CollisionSpaceComponent*>(CreatedObject->AddComponent(ComponentType::Collision));

--- a/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CollisionComponentTests.cpp
@@ -63,7 +63,7 @@ CSP_PUBLIC_TEST(CSPEngine, CollisionTests, CollisionComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -212,7 +212,6 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -229,23 +228,26 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the custom
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create custom component
     auto* CustomComponent = (CustomSpaceComponent*)CreatedObject->AddComponent(ComponentType::Custom);
     // Create script component
     auto* ScriptComponent = (ScriptSpaceComponent*)CreatedObject->AddComponent(ComponentType::ScriptData);
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script
     std::string CustomScriptText = R"xx(
@@ -260,7 +262,7 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
     CreatedObject->GetScript().Invoke();
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Ensure values are set correctly
     EXPECT_EQ(CustomComponent->GetComponentName(), "ComponentName");

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -228,7 +228,7 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -65,7 +65,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPropertyTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
@@ -145,7 +145,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentScriptTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
@@ -224,7 +224,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
@@ -388,7 +388,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPrerequisites
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
@@ -636,7 +636,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetNumberOfRe
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -750,7 +750,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetMessagesFr
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -904,7 +904,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentDeleteTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -989,7 +989,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentEventTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1233,7 +1233,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Public, nullptr, InviteUsers, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1397,7 +1397,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTe
 
     auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
     RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
@@ -1590,7 +1590,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentCreateAnnotat
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -1860,7 +1860,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationEve
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -2089,7 +2089,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentOverwriteAnno
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -2247,7 +2247,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationsPr
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
@@ -2456,7 +2456,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationInv
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
@@ -2554,7 +2554,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationInc
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
@@ -2694,7 +2694,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationThu
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // Create object to hold component
     csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -2855,7 +2855,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentUpdateConvers
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     // Login
@@ -2866,11 +2865,14 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentUpdateConvers
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -3033,7 +3035,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentUpdateMessage
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     // Login
@@ -3044,11 +3045,14 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentUpdateMessage
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -56,7 +56,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPropertyTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -66,8 +65,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPropertyTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -135,7 +136,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentScriptTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -145,8 +145,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentScriptTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -162,7 +164,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentScriptTest)
     EXPECT_TRUE((ConversationComponent->GetConversationCameraRotation() == csp::common::Vector4::Identity()));
 
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script to set new properties
     std::string ConversationScriptText = R"xx(
@@ -180,7 +182,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentScriptTest)
     Object->GetScript().SetScriptSource(ConversationScriptText.c_str());
     Object->GetScript().Invoke();
 
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Test scripts sets new properties
     EXPECT_EQ(ConversationComponent->GetIsVisible(), false);
@@ -213,7 +215,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -223,8 +224,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -376,7 +379,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPrerequisites
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -386,8 +388,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPrerequisites
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -624,8 +628,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetNumberOfRe
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
 
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
-
     // Log in
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
@@ -634,16 +636,19 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetNumberOfRe
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the conversation
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create conversation component
     auto* ConversationComponent = (ConversationSpaceComponent*)CreatedObject->AddComponent(ComponentType::Conversation);
@@ -737,8 +742,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetMessagesFr
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
 
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
-
     // Log in
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
@@ -747,16 +750,19 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentGetMessagesFr
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the conversation
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create conversation component
     auto* ConversationComponent = (ConversationSpaceComponent*)CreatedObject->AddComponent(ComponentType::Conversation);
@@ -889,7 +895,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentDeleteTest)
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
 
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Log in
     csp::common::String UserId;
@@ -899,13 +904,16 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentDeleteTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Create object to represent the conversation
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     csp::common::String ConversationId;
 
@@ -914,7 +922,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentDeleteTest)
         auto* ConversationComponent = (ConversationSpaceComponent*)CreatedObject->AddComponent(ComponentType::Conversation);
 
         CreatedObject->QueueUpdate();
-        EntitySystem->ProcessPendingEntityOperations();
+        RealtimeEngine->ProcessPendingEntityOperations();
 
         auto [ConversationResult] = AWAIT(ConversationComponent, CreateConversation, "DefaultConversation");
         EXPECT_EQ(ConversationResult.GetResultCode(), csp::systems::EResultCode::Success);
@@ -945,7 +953,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentDeleteTest)
         CreatedObject->Destroy([](bool /*Success*/) {});
 
         CreatedObject->QueueUpdate();
-        EntitySystem->ProcessPendingEntityOperations();
+        RealtimeEngine->ProcessPendingEntityOperations();
 
         WaitForCallback(CallbackCalled);
 
@@ -971,7 +979,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentEventTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // Log in
@@ -982,18 +989,21 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentEventTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Allow us to receive and test our own conversation messages
     auto [FlagSetResult] = AWAIT(Connection, SetAllowSelfMessagingFlag, true);
 
     // Create object to represent the conversation
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
     auto* ConversationComponent = (ConversationSpaceComponent*)Object->AddComponent(ComponentType::Conversation);
 
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Ensure conversation created event is fired when calling ConversationComponent::CreateConversation
     {
@@ -1020,7 +1030,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentEventTest)
         ConversationComponent->SetConversationUpdateCallback(Callback);
 
         WaitForCallback(CallbackCalled);
-        EXPECT_TRUE(CallbackCalled);
+        ASSERT_TRUE(CallbackCalled);
 
         EXPECT_EQ(RetrievedParams.MessageType, csp::multiplayer::ConversationEventType::NewConversation);
         EXPECT_EQ(RetrievedParams.MessageInfo.ConversationId, ConversationComponent->GetConversationId());
@@ -1197,7 +1207,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Create users
     auto TestUser = CreateTestUser();
@@ -1224,8 +1233,11 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Public, nullptr, InviteUsers, nullptr, nullptr, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
     // Get conversation component created by other client
@@ -1247,8 +1259,8 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
     {
         bool CallbackCalled = false;
 
-        EntitySystem->SetEntityCreatedCallback(
-            [EntitySystem, &CallbackCalled, &Entity](csp::multiplayer::SpaceEntity* NewEntity)
+        RealtimeEngine->SetEntityCreatedCallback(
+            [&CallbackCalled, &Entity](csp::multiplayer::SpaceEntity* NewEntity)
             {
                 if (NewEntity->GetName() == "TestObject")
                 {
@@ -1286,7 +1298,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
             });
 
         // We need to wait and update here, as patches require us to process updates
-        WaitForCallbackWithUpdate(ComponentCreated, EntitySystem);
+        WaitForCallbackWithUpdate(ComponentCreated, RealtimeEngine.get());
 
         EXPECT_TRUE(ComponentCreated);
         EXPECT_TRUE(ConversationComponent != nullptr);
@@ -1307,7 +1319,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentSecondClientE
                 CallbackCalled = true;
             });
 
-        WaitForCallbackWithUpdate(CallbackCalled, EntitySystem);
+        WaitForCallbackWithUpdate(CallbackCalled, RealtimeEngine.get());
         EXPECT_TRUE(CallbackCalled);
         EXPECT_EQ(ReceivedParams.MessageType, csp::multiplayer::ConversationEventType::NewConversation);
 
@@ -1363,7 +1375,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTe
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Create user
     auto TestUser = CreateTestUser();
@@ -1382,6 +1393,14 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTe
     uint64_t ConversationObjectId = 0;
     csp::common::String MessageId;
 
+    bool EntitiesCreated = false;
+
+    auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
     // Add the second test user to the space
     {
         auto [Result] = AWAIT_PRE(SpaceSystem, InviteToSpace, RequestPredicate, Space.Id, AlternativeTestUser.Email, true, "", "");
@@ -1389,19 +1408,19 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTe
     }
 
     {
-        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
         // Ensure patch rate limiting is off, as we're sending patches in quick succession.
-        EntitySystem->SetEntityPatchRateLimitEnabled(false);
+        RealtimeEngine->SetEntityPatchRateLimitEnabled(false);
 
         // Create object to represent the conversation
-        csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+        csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
         ConversationObjectId = Object->GetId();
         auto* ConversationComponent = (ConversationSpaceComponent*)Object->AddComponent(ComponentType::Conversation);
 
         Object->QueueUpdate();
-        EntitySystem->ProcessPendingEntityOperations();
+        RealtimeEngine->ProcessPendingEntityOperations();
 
         // Create conversation
         {
@@ -1411,7 +1430,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTe
             EXPECT_TRUE(Result.GetValue() != "");
 
             Object->QueueUpdate();
-            EntitySystem->ProcessPendingEntityOperations();
+            RealtimeEngine->ProcessPendingEntityOperations();
         }
 
         // Create message
@@ -1435,25 +1454,14 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentPermissionsTe
         csp::common::String SecondTestUserId;
         LogIn(UserSystem, SecondTestUserId, AlternativeTestUser.Email, GeneratedTestAccountPassword);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+        EntitiesCreated = false;
 
-        bool EntitiesRetrieved = false;
-
-        EntitySystem->SetInitialEntitiesRetrievedCallback(
-            [&EntitiesRetrieved](bool Ok)
-            {
-                if (Ok)
-                {
-                    EntitiesRetrieved = true;
-                }
-            });
-
-        auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
         EXPECT_EQ(EnterResult2.GetResultCode(), csp::systems::EResultCode::Success);
 
-        WaitForCallbackWithUpdate(EntitiesRetrieved, EntitySystem);
+        WaitForCallbackWithUpdate(EntitiesCreated, RealtimeEngine.get());
 
-        auto* RetrievedConversationEntity = EntitySystem->FindSpaceEntityById(ConversationObjectId);
+        auto* RetrievedConversationEntity = RealtimeEngine->FindSpaceEntityById(ConversationObjectId);
         auto* RetrievedConversationComponent = static_cast<ConversationSpaceComponent*>(RetrievedConversationEntity->GetComponent(0));
 
         static const csp::common::String NoConversationPermissionsErrorLog = "User does not have permission to modify this conversation.";
@@ -1572,7 +1580,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentCreateAnnotat
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     // Login
@@ -1583,11 +1590,14 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentCreateAnnotat
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -1840,7 +1850,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationEve
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
     // Log in
@@ -1851,18 +1860,21 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationEve
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Allow us to receive and test our own conversation messages
     auto [FlagSetResult] = AWAIT(Connection, SetAllowSelfMessagingFlag, true);
 
     // Create object to represent the conversation
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
     auto* ConversationComponent = (ConversationSpaceComponent*)Object->AddComponent(ComponentType::Conversation);
 
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     static constexpr const char* ConversationMessage = "Test Conversation";
 
@@ -2067,7 +2079,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentOverwriteAnno
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     // Login
@@ -2078,11 +2089,14 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentOverwriteAnno
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -2224,7 +2238,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationsPr
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -2234,8 +2247,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationsPr
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -2432,7 +2447,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationInv
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -2442,8 +2456,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationInv
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -2529,7 +2545,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationInc
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     // Login
     csp::common::String UserId;
@@ -2539,8 +2554,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationInc
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));
@@ -2552,7 +2569,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationInc
     }
 
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object2 = CreateTestObject(EntitySystem, "Object2");
+    csp::multiplayer::SpaceEntity* Object2 = CreateTestObject(RealtimeEngine.get(), "Object2");
 
     // Create conversation component
     auto* ConversationComponent2 = static_cast<ConversationSpaceComponent*>(Object2->AddComponent(ComponentType::Conversation));
@@ -2667,7 +2684,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationThu
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
 
     // Login
@@ -2678,8 +2694,10 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationTests, ConversationComponentAnnotationThu
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
     // Create object to hold component
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
 
     // Create conversation component
     auto* ConversationComponent = static_cast<ConversationSpaceComponent*>(Object->AddComponent(ComponentType::Conversation));

--- a/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
@@ -92,7 +92,7 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -201,7 +201,7 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
         SpaceEntity* LoadedObject;
 
         // Reload the space and verify the contents match
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         RealtimeEngine->SetEntityCreatedCallback(

--- a/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ECommerceComponentTests.cpp
@@ -64,7 +64,7 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -127,7 +127,7 @@ CSP_PUBLIC_TEST(CSPEngine, ECommerceTests, ECommerceScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -71,7 +71,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -183,7 +183,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -52,7 +52,6 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -72,18 +71,21 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
-    auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [Object] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     const csp::common::String ModelAssetId = "NotARealId";
 
@@ -91,7 +93,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     // Process component creation
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Check component was created
     auto& Components = *Object->GetComponents();
@@ -165,7 +167,6 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -182,16 +183,19 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the image
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create image component
     auto* FiducialMarkerComponent = (FiducialMarkerSpaceComponent*)CreatedObject->AddComponent(ComponentType::FiducialMarker);
@@ -199,7 +203,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     auto* ScriptComponent = (ScriptSpaceComponent*)CreatedObject->AddComponent(ComponentType::ScriptData);
 
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     EXPECT_EQ(FiducialMarkerComponent->GetIsVisible(), true);
 
@@ -214,7 +218,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     ScriptComponent->SetScriptSource(FiducialMarkerScriptText.c_str());
     CreatedObject->GetScript().Invoke();
 
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -66,7 +66,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -154,7 +154,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -67,16 +66,19 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the fog
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create fog component
     auto* FogComponent = static_cast<FogSpaceComponent*>(CreatedObject->AddComponent(ComponentType::Fog));
@@ -136,7 +138,6 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -153,22 +154,25 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the fog
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create fog component
     auto* FogComponent = (FogSpaceComponent*)CreatedObject->AddComponent(ComponentType::Fog);
 
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script
     const std::string FogScriptText = R"xx(
@@ -189,7 +193,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     CreatedObject->GetScript().SetScriptSource(FogScriptText.c_str());
     CreatedObject->GetScript().Invoke();
 
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     EXPECT_EQ(FogComponent->GetFogMode(), FogMode::Exponential);
     EXPECT_EQ(FogComponent->GetPosition(), csp::common::Vector3::One());

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -68,7 +68,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -157,7 +157,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -65,7 +65,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -164,7 +164,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -49,7 +49,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -66,16 +65,19 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create hotspot component
     auto* HotspotComponent = static_cast<HotspotSpaceComponent*>(CreatedObject->AddComponent(ComponentType::Hotspot));
@@ -146,7 +148,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -163,23 +164,26 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create hotspot component
     auto* HotspotComponent = (HotspotSpaceComponent*)CreatedObject->AddComponent(ComponentType::Hotspot);
     // Create script component
     auto* ScriptComponent = (ScriptSpaceComponent*)CreatedObject->AddComponent(ComponentType::ScriptData);
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script
     std::string HotspotScriptText = R"xx(
@@ -206,7 +210,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     CreatedObject->GetScript().Invoke();
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Ensure values are set correctly
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().X, 1.0f);

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -71,7 +71,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -190,7 +190,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -70,18 +69,21 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
-    auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [Object] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     const csp::common::String ModelAssetId = "NotARealId";
 
@@ -89,7 +91,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
 
     // Process component creation
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Check component was created
     auto& Components = *Object->GetComponents();
@@ -187,7 +189,6 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -205,18 +206,21 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
-    auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [Object] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     const csp::common::String ModelAssetId = "NotARealId";
 
@@ -224,7 +228,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
 
     // Process component creation
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Check component was created
     auto& Components = *Object->GetComponents();

--- a/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
@@ -69,7 +69,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightComponentFieldsTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -206,7 +206,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, ActionHandlerTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -66,7 +66,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -49,7 +49,6 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -67,15 +66,18 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     {
-        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+        RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         csp::common::String ObjectName = "Object 1";
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-        auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+        auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
         // Create custom component
         auto* ExternalLinkComponent = (ExternalLinkSpaceComponent*)CreatedObject->AddComponent(ComponentType::ExternalLink);

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -72,7 +72,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
     const AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -105,7 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
     */
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -157,7 +157,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalThumbnailTest)
     csp::systems::Space Space;
     CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, Source, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -219,7 +219,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, PortalScriptInterfaceTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -83,8 +83,8 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         const auto LoginState = UserSystem->GetLoginState();
 
-        auto [Avatar] = AWAIT(
-            RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState,
+            UserAvatarId, UserAvatarPlayMode);
 
         // Create object to represent the portal
         csp::common::String ObjectName = "Object 1";
@@ -116,8 +116,8 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         const auto LoginState = UserSystem->GetLoginState();
 
-        auto [Avatar] = AWAIT(
-            RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState,
+            UserAvatarId, UserAvatarPlayMode);
 
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }

--- a/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
@@ -50,7 +50,6 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -70,18 +69,21 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     csp::common::String CallbackAssetId;
 
     const csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
 
-    auto [Object] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [Object] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     const csp::common::String ModelAssetId = "NotARealId";
 
@@ -89,7 +91,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
 
     // Process component creation
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Check component was created
     auto& Components = *Object->GetComponents();

--- a/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ReflectionComponentTests.cpp
@@ -69,7 +69,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReflectionTests, ReflectionComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/SplineComponentTests.cpp
@@ -69,7 +69,7 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, UseSplineTest)
     const csp::common::String UserAvatarId = "MyCoolAvatar";
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -157,7 +157,7 @@ CSP_PUBLIC_TEST(CSPEngine, SplineTests, SplineScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -48,7 +48,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -66,15 +65,18 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     {
-        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+        RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         csp::common::String ObjectName = "Object 1";
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-        auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+        auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
         // Create custom component
         auto* StaticModelComponent = (StaticModelSpaceComponent*)CreatedObject->AddComponent(ComponentType::StaticModel);
@@ -160,7 +162,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -177,22 +178,25 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the fog
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create fog component
     auto* StaticModelComponent = (StaticModelSpaceComponent*)CreatedObject->AddComponent(ComponentType::StaticModel);
 
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script
     const std::string StaticModelScriptText = R"xx(
@@ -208,7 +212,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     CreatedObject->GetScript().SetScriptSource(StaticModelScriptText.c_str());
     CreatedObject->GetScript().Invoke();
 
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Test new values
     EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), "TestExternalResourceAssetCollectionId");
@@ -234,7 +238,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -254,21 +257,24 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
     csp::common::String ObjectName = "Object 1";
 
     {
-        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-        EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+        RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
         SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-        auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+        auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
         // Create static model component
         auto* StaticModelComponent = (StaticModelSpaceComponent*)CreatedObject->AddComponent(ComponentType::StaticModel);
         StaticModelComponent->AddMaterialOverride("TestKey", "TestValue");
 
         CreatedObject->QueueUpdate();
-        EntitySystem->ProcessPendingEntityOperations();
+        RealtimeEngine->ProcessPendingEntityOperations();
 
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
@@ -279,21 +285,18 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
         // Re-enter space
         bool EntitiesCreated = false;
 
-        auto EntitiesReadyCallback = [&EntitiesCreated](bool Success)
-        {
-            EntitiesCreated = true;
-            EXPECT_TRUE(Success);
-        };
+        auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-        EntitySystem->SetInitialEntitiesRetrievedCallback(EntitiesReadyCallback);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
-        auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
         EXPECT_EQ(EnterResult2.GetResultCode(), csp::systems::EResultCode::Success);
 
-        WaitForCallbackWithUpdate(EntitiesCreated, EntitySystem);
+        WaitForCallbackWithUpdate(EntitiesCreated, RealtimeEngine.get());
         EXPECT_TRUE(EntitiesCreated);
 
-        SpaceEntity* FoundEntity = EntitySystem->FindSpaceObject(ObjectName);
+        SpaceEntity* FoundEntity = RealtimeEngine->FindSpaceObject(ObjectName);
         EXPECT_TRUE(FoundEntity != nullptr);
 
         auto* StaticModelComponent = (StaticModelSpaceComponent*)FoundEntity->GetComponent(0);
@@ -307,7 +310,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
         StaticModelComponent->RemoveMaterialOverride("TestKey");
 
         FoundEntity->QueueUpdate();
-        EntitySystem->ProcessPendingEntityOperations();
+        RealtimeEngine->ProcessPendingEntityOperations();
 
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
@@ -320,21 +323,18 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
         // Re-enter space
         bool EntitiesCreated = false;
 
-        auto EntitiesReadyCallback = [&EntitiesCreated](bool Success)
-        {
-            EntitiesCreated = true;
-            EXPECT_TRUE(Success);
-        };
+        auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-        EntitySystem->SetInitialEntitiesRetrievedCallback(EntitiesReadyCallback);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
-        auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
         EXPECT_EQ(EnterResult2.GetResultCode(), csp::systems::EResultCode::Success);
 
-        WaitForCallbackWithUpdate(EntitiesCreated, EntitySystem);
+        WaitForCallbackWithUpdate(EntitiesCreated, RealtimeEngine.get());
         EXPECT_TRUE(EntitiesCreated);
 
-        SpaceEntity* FoundEntity = EntitySystem->FindSpaceObject(ObjectName);
+        SpaceEntity* FoundEntity = RealtimeEngine->FindSpaceObject(ObjectName);
         EXPECT_TRUE(FoundEntity != nullptr);
 
         auto* StaticModelComponent = (StaticModelSpaceComponent*)FoundEntity->GetComponent(0);

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -65,7 +65,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -178,7 +178,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -257,7 +257,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
     csp::common::String ObjectName = "Object 1";
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -287,7 +287,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
 
         auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
         auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -325,7 +325,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentEnterSpaceTest)
 
         auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
         auto [EnterResult2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -65,7 +65,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -180,7 +180,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -49,7 +49,6 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -66,16 +65,19 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the text
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create text component
     auto* TextComponent = static_cast<TextSpaceComponent*>(CreatedObject->AddComponent(ComponentType::Text));
@@ -162,7 +164,6 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -179,23 +180,26 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the text
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create text component
     auto* TextComponent = (TextSpaceComponent*)CreatedObject->AddComponent(ComponentType::Text);
     // Create script component
     auto* ScriptComponent = (ScriptSpaceComponent*)CreatedObject->AddComponent(ComponentType::ScriptData);
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Setup script
     std::string TextScriptText = R"xx(
@@ -222,7 +226,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
     CreatedObject->GetScript().Invoke();
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Ensure values are set correctly
     EXPECT_FLOAT_EQ(TextComponent->GetPosition().X, 1.0f);

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -63,7 +63,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -47,7 +47,6 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
@@ -64,16 +63,19 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the audio
     csp::common::String ObjectName = "Object 1";
     SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     // Create audio component
     auto* VideoComponent = static_cast<VideoPlayerSpaceComponent*>(CreatedObject->AddComponent(ComponentType::VideoPlayer));
@@ -97,7 +99,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     CreatedObject->AddComponent(ComponentType::AnimatedModel);
 
     CreatedObject->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Set new values
     csp::common::String AssetId = "TEST_ASSET_ID";

--- a/Tests/src/PublicAPITests/ConversationSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ConversationSystemTests.cpp
@@ -19,7 +19,7 @@
 #include "CSP/Multiplayer/Components/ConversationSpaceComponent.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Systems/Spaces/Space.h"
 #include "CSP/Systems/Spaces/UserRoles.h"
 #include "CSP/Systems/SystemsManager.h"
@@ -82,7 +82,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -195,7 +195,7 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventDelay
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space

--- a/Tests/src/PublicAPITests/ConversationSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ConversationSystemTests.cpp
@@ -71,7 +71,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* NetworkEventBus = SystemsManager.GetEventBus();
 
@@ -83,21 +82,24 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Create 2 objects with a conversation component each
-    csp::multiplayer::SpaceEntity* Object1 = CreateTestObject(EntitySystem, "Object1");
+    csp::multiplayer::SpaceEntity* Object1 = CreateTestObject(RealtimeEngine.get(), "Object1");
     auto* ConversationComponent1 = (ConversationSpaceComponent*)Object1->AddComponent(ComponentType::Conversation);
     ConversationComponent1->SetConversationId("TestId1");
 
-    csp::multiplayer::SpaceEntity* Object2 = CreateTestObject(EntitySystem, "Object2");
+    csp::multiplayer::SpaceEntity* Object2 = CreateTestObject(RealtimeEngine.get(), "Object2");
     auto* ConversationComponent2 = (ConversationSpaceComponent*)Object2->AddComponent(ComponentType::Conversation);
     ConversationComponent2->SetConversationId("TestId2");
 
     Object1->QueueUpdate();
     Object2->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Test that when we send an event with the first components id, that only the first component receives the event.
     {
@@ -182,7 +184,6 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventDelay
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
     auto* NetworkEventBus = SystemsManager.GetEventBus();
 
@@ -194,8 +195,11 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventDelay
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     static constexpr const char* TestConversationId = "New Test Message";
 
@@ -216,14 +220,14 @@ CSP_PUBLIC_TEST(CSPEngine, ConversationSystemTests, ConversationSystemEventDelay
     std::this_thread::sleep_for(std::chrono::milliseconds { 2 });
 
     // Create object to represent the conversation
-    csp::multiplayer::SpaceEntity* Object = CreateTestObject(EntitySystem);
+    csp::multiplayer::SpaceEntity* Object = CreateTestObject(RealtimeEngine.get());
     auto* ConversationComponent = (ConversationSpaceComponent*)Object->AddComponent(ComponentType::Conversation);
 
     // Ensure the conversation id is set so the event system can find the component
     ConversationComponent->SetConversationId(TestConversationId);
 
     Object->QueueUpdate();
-    EntitySystem->ProcessPendingEntityOperations();
+    RealtimeEngine->ProcessPendingEntityOperations();
 
     // Test that the conversation component receives the event
     {

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -183,7 +183,10 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     // Create hot spot group
     csp::common::Array<csp::common::String> GroupItems { "Hotspot1", "Hotspot2", "Hotspot3" };
     csp::common::String TestGroupName = "CSP-UNITTEST-SEQUENCE-MAG";
@@ -253,7 +256,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotGroupTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Create hotspot group
     csp::common::Array<csp::common::String> SequenceItems { "Hotspot1", "Hotspot2", "Hotspot3" };
@@ -301,7 +308,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, UpdateHotspotGroupTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Create hotspot group
     csp::common::Array<csp::common::String> SequenceItems { "Hotspot1", "Hotspot2" };
@@ -353,7 +364,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameHotspotGroupTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Create hotspot group
     csp::common::Array<csp::common::String> SequenceItems { "Hotspot1", "Hotspot2" };
@@ -427,7 +442,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameFailHotspotGroupTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Create hotspot group
     csp::common::Array<csp::common::String> SequenceItems { "Hotspot1", "Hotspot2" };
@@ -473,7 +492,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotNoGroupTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     // Create hotspot group
     csp::common::String TestGroupName = "CSP-UNITTEST-SEQUENCE-MAG";
 
@@ -515,7 +538,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotsGroupsTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     csp::common::String spaceID = { UniqueSpaceName };
     // Create hotspot group
     csp::common::Array<csp::common::String> SequenceItems1 { "Hotspot1" };
@@ -581,7 +608,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotNoGroupTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     // Create hotspot group
     csp::common::String TestGroupName = "CSP-UNITTEST-SEQUENCE-MAG";
 
@@ -618,7 +649,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GenerateSequenceKeyTest)
     csp::systems::Space Space;
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     // Create hotspot group
     csp::common::Array<csp::common::String> SequenceItems { "Hotspot1", "Hotspot2", "Hotspot3" };
     csp::common::String TestGroupName = "CSP-UNITTEST-SEQUENCE-MAG";
@@ -646,7 +681,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
@@ -664,16 +698,19 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     bool ComponentAdded = false;
 
@@ -698,7 +735,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
         = static_cast<csp::multiplayer::HotspotSpaceComponent*>(CreatedObject->AddComponent(csp::multiplayer::ComponentType::Hotspot));
 
     CreatedObject->QueueUpdate();
-    WaitForCallbackWithUpdate(ComponentAdded, EntitySystem);
+    WaitForCallbackWithUpdate(ComponentAdded, RealtimeEngine.get());
 
     EXPECT_TRUE(ComponentAdded);
 
@@ -757,7 +794,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
 
         CreatedObject->QueueUpdate();
 
-        WaitForCallbackWithUpdate(SequencesUpdated, EntitySystem);
+        WaitForCallbackWithUpdate(SequencesUpdated, RealtimeEngine.get());
 
         EXPECT_TRUE(SequencesUpdated);
     }
@@ -793,7 +830,6 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-    auto* EntitySystem = SystemsManager.GetSpaceEntitySystem();
     auto* HotspotSystem = SystemsManager.GetHotspotSequenceSystem();
 
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
@@ -811,16 +847,19 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntitySystem->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
 
     // Create object to represent the hotspot
     csp::common::String ObjectName = "Object 1";
     csp::multiplayer::SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, ObjectName, ObjectTransform);
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
 
     bool ComponentAdded = false;
 
@@ -845,7 +884,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
         = static_cast<csp::multiplayer::HotspotSpaceComponent*>(CreatedObject->AddComponent(csp::multiplayer::ComponentType::Hotspot));
 
     CreatedObject->QueueUpdate();
-    WaitForCallbackWithUpdate(ComponentAdded, EntitySystem);
+    WaitForCallbackWithUpdate(ComponentAdded, RealtimeEngine.get());
 
     EXPECT_TRUE(ComponentAdded);
 
@@ -876,7 +915,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
     // Exit the space
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     // Reenter the space
-    auto [ReEnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [ReEnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     // Ensure the 3 groups still exist
     csp::common::Array<csp::systems::HotspotGroup> FoundGroups;

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -183,7 +183,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, CreateHotspotGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -257,7 +257,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -309,7 +309,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, UpdateHotspotGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -365,7 +365,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameHotspotGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -443,7 +443,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, RenameFailHotspotGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -493,7 +493,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotNoGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -539,7 +539,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GetHotspotsGroupsTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -609,7 +609,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotNoGroupTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -650,7 +650,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, GenerateSequenceKeyTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -698,7 +698,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, DeleteHotspotComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -847,7 +847,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());

--- a/Tests/src/PublicAPITests/LogSystemTests.cpp
+++ b/Tests/src/PublicAPITests/LogSystemTests.cpp
@@ -681,4 +681,6 @@ CSP_INTERNAL_TEST(CSPEngine, LogSystemTests, FailureMessageTest)
     }
 
     EXPECT_TRUE(LogConfirmed);
+
+    csp::CSPFoundation::Shutdown();
 }

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -717,8 +717,11 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     ::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space so we can get the material events
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     constexpr const char* TestMaterialName1 = "TestMaterial1";
     GLTFMaterial* CreatedGLTFMaterial = nullptr;
@@ -830,8 +833,11 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
     ::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space so we can get the material and asset events
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     constexpr const char* TestMaterialName1 = "TestMaterial1";
     GLTFMaterial* CreatedGLTFMaterial = nullptr;

--- a/Tests/src/PublicAPITests/MaterialTests.cpp
+++ b/Tests/src/PublicAPITests/MaterialTests.cpp
@@ -717,7 +717,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialEventTest)
     ::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space so we can get the material events
@@ -833,7 +833,7 @@ CSP_PUBLIC_TEST(CSPEngine, MaterialTests, MaterialAssetEventTest)
     ::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space so we can get the material and asset events

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -21,8 +21,8 @@
 #include "CSP/Common/ReplicatedValue.h"
 #include "CSP/Multiplayer/Components/StaticModelSpaceComponent.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
-#include "CSP/Multiplayer/SpaceEntity.h"
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
 #include "CSP/Systems/Script/ScriptSystem.h"
 #include "CSP/Systems/Spaces/Space.h"
 #include "CSP/Systems/Spaces/UserRoles.h"
@@ -138,7 +138,7 @@ void OnConnect(OnlineRealtimeEngine* RealtimeEngine)
 
     const auto LoginState = csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState();
 
-    RealtimeEngine->CreateAvatar(UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode,
+    RealtimeEngine->CreateAvatar(UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode,
         [RealtimeEngine](SpaceEntity* NewAvatar)
         {
             EXPECT_NE(NewAvatar, nullptr);
@@ -634,7 +634,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -707,7 +707,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -875,7 +875,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     auto& Components = *Avatar->GetComponents();
@@ -1313,7 +1313,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = Awaitable(&OnlineRealtimeEngine::CreateAvatar, RealtimeEngine.get(), UserName, LoginState, UserTransform, IsVisible,
+    auto [Avatar] = Awaitable(&OnlineRealtimeEngine::CreateAvatar, RealtimeEngine.get(), UserName, LoginState.UserId, UserTransform, IsVisible,
         UserAvatarState, UserAvatarId, UserAvatarPlayMode)
                         .Await();
 
@@ -1446,7 +1446,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     csp::common::String ObjectName = "Object 1";

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -1271,8 +1271,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpa
 // This test currently requires manual steps and will be reviewed as part of OF-1535.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
 {
-    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
-
     SetRandSeed();
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -1349,8 +1347,6 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
 {
     // Test for OB-1046
     // If the rate limiter hasn't processed all PendingOutgoingUpdates after SpaceEntity deletion it will crash when trying to process them
-
-    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
     SetRandSeed();
 
@@ -2814,7 +2810,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRStartErrorsThenDisconnec
 {
     csp::common::LogSystem LogSystem;
     SignalRConnectionMock* SignalRMock = new SignalRConnectionMock();
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *SignalRMock };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
 
     // The start function will throw internally
@@ -2831,14 +2827,14 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRStartErrorsThenDisconnec
 
     Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
     Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "", SignalRMock);
+        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsErrorsThenDisconnectionFunctionsCalled)
 {
     csp::common::LogSystem LogSystem;
     SignalRConnectionMock* SignalRMock = new SignalRConnectionMock();
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *SignalRMock };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
 
     // Start and stop will call their callbacks
@@ -2867,14 +2863,14 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsError
         Call(csp::common::String("MultiplayerConnection::DeleteEntities, Unexpected error response from SignalR \"DeleteObjects\" invocation.")));
 
     Connection.SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "", SignalRMock);
+    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsThenDisconnectionFunctionsCalled)
 {
     csp::common::LogSystem LogSystem;
     SignalRConnectionMock* SignalRMock = new SignalRConnectionMock();
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *SignalRMock };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
 
     // Start and stop will call their callbacks
@@ -2916,14 +2912,14 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeGetClientIdErrorsT
         MockDisconnectionCallback, Call(csp::common::String("MultiplayerConnection::RequestClientId, Error when starting requesting Client Id.")));
 
     Connection.SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "", SignalRMock);
+    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErrorsThenDisconnectionFunctionsCalled)
 {
     csp::common::LogSystem LogSystem;
     SignalRConnectionMock* SignalRMock = new SignalRConnectionMock();
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *SignalRMock };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
 
     // Start and stop will call their callbacks
@@ -2969,14 +2965,14 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeStartListeningErro
     EXPECT_CALL(MockDisconnectionCallback, Call(csp::common::String("MultiplayerConnection::StartListening, Error when starting listening.")));
 
     Connection.SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "", SignalRMock);
+    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCallbacksCalled)
 {
     csp::common::LogSystem LogSystem;
     SignalRConnectionMock* SignalRMock = new SignalRConnectionMock();
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem };
+    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *SignalRMock };
     csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
 
     // Start and stop will call their callbacks
@@ -3020,7 +3016,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenAllSignalRSucceedsThenSuccessCa
     EXPECT_CALL(MockDisconnectionCallback, Call(::testing::_)).Times(0);
 
     Connection.SetConnectionCallback(std::bind(&MockConnectionCallback::Call, &MockSuccessConnectionCallback, std::placeholders::_1));
-    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "", SignalRMock);
+    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, TestParseMultiplayerError)

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -2825,9 +2825,8 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRStartErrorsThenDisconnec
     MockConnectionCallback MockDisconnectionCallback;
     EXPECT_CALL(MockDisconnectionCallback, Call(csp::common::String("MultiplayerConnection::Start, Error when starting SignalR connection.")));
 
-    Connection->SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
-    Connection->Connect(
-        std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), SignalRMock, *SpaceEntitySystem, "", "", "");
+    Connection.SetDisconnectionCallback(std::bind(&MockConnectionCallback::Call, &MockDisconnectionCallback, std::placeholders::_1));
+    Connection.Connect(std::bind(&MockMultiplayerErrorCallback::Call, &MockErrorCallback, std::placeholders::_1), "", "", "");
 }
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, WhenSignalRInvokeDeleteObjectsErrorsThenDisconnectionFunctionsCalled)

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -22,7 +22,7 @@
 #include "CSP/Multiplayer/Components/StaticModelSpaceComponent.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Systems/Script/ScriptSystem.h"
 #include "CSP/Systems/Spaces/Space.h"
 #include "CSP/Systems/Spaces/UserRoles.h"
@@ -58,7 +58,7 @@ namespace
 void InitialiseTestingConnection();
 void OnConnect();
 void OnDisconnect(bool ok);
-void OnUserCreated(SpaceEntity* InUser, SpaceEntitySystem* RealtimeEngine);
+void OnUserCreated(SpaceEntity* InUser, OnlineRealtimeEngine* RealtimeEngine);
 
 std::atomic_bool IsTestComplete;
 std::atomic_bool IsDisconnected;
@@ -99,7 +99,7 @@ void InitialiseTestingConnection()
     ObjectStringProperty = "My replicated string";
 }
 
-void SetRandomProperties(SpaceEntity* User, SpaceEntitySystem* RealtimeEngine)
+void SetRandomProperties(SpaceEntity* User, OnlineRealtimeEngine* RealtimeEngine)
 {
     if (User == nullptr)
     {
@@ -125,7 +125,7 @@ void SetRandomProperties(SpaceEntity* User, SpaceEntitySystem* RealtimeEngine)
     RealtimeEngine->QueueEntityUpdate(User);
 }
 
-void OnConnect(SpaceEntitySystem* RealtimeEngine)
+void OnConnect(OnlineRealtimeEngine* RealtimeEngine)
 {
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform
@@ -163,7 +163,7 @@ void OnDisconnect(bool ok)
     IsDisconnected = true;
 }
 
-void OnUserCreated(SpaceEntity* InUser, SpaceEntitySystem* RealtimeEngine)
+void OnUserCreated(SpaceEntity* InUser, OnlineRealtimeEngine* RealtimeEngine)
 {
     EXPECT_EQ(InUser->GetComponents()->Size(), 1);
 
@@ -303,7 +303,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManualConnectionTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -358,7 +358,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRConnectionTest)
     auto Headers = Connection->Connection->HTTPHeaders();
     ASSERT_NE(Headers.find("X-DeviceUDID"), Headers.end());
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -401,7 +401,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SignalRKeepAliveTest)
 
     InitialiseTestingConnection();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -451,7 +451,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityReplicationTest)
 
     InitialiseTestingConnection();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -524,7 +524,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, SelfReplicationTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -612,7 +612,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateAvatarTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -685,7 +685,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateCreatorAvatarTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -774,7 +774,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateManyAvatarTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Unlisted, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -854,7 +854,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, AvatarMovementDirectionTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -927,7 +927,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectCreateTest)
 
     InitialiseTestingConnection();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -976,7 +976,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectAddComponentTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1071,7 +1071,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1167,7 +1167,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ObjectRemoveComponentTestReenterSpa
     bool EntitiesCreated = false;
     auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
     uint16_t KeepKey = 0;
@@ -1307,14 +1307,14 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
     csp::common::String UserAvatarId = "MyCoolAvatar";
     AvatarPlayMode UserAvatarPlayMode = AvatarPlayMode::Default;
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     RealtimeEngine->SetEntityCreatedCallback([](SpaceEntity* /*Entity*/) {});
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = Awaitable(&SpaceEntitySystem::CreateAvatar, RealtimeEngine.get(), UserName, LoginState, UserTransform, IsVisible, UserAvatarState,
-        UserAvatarId, UserAvatarPlayMode)
+    auto [Avatar] = Awaitable(&OnlineRealtimeEngine::CreateAvatar, RealtimeEngine.get(), UserName, LoginState, UserTransform, IsVisible,
+        UserAvatarState, UserAvatarId, UserAvatarPlayMode)
                         .Await();
 
     auto Start = std::chrono::steady_clock::now();
@@ -1362,7 +1362,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, DeleteMultipleEntitiesTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1425,7 +1425,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1472,10 +1472,10 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntitySelectionTest)
     LogOut(UserSystem);
 }
 
-// Derived type that allows us to access protected members of SpaceEntitySystemWeak
-class InternalSpaceEntitySystem : public csp::multiplayer::SpaceEntitySystem
+// Derived type that allows us to access protected members of OnlineRealtimeEngineWeak
+class InternalOnlineRealtimeEngine : public csp::multiplayer::OnlineRealtimeEngine
 {
-    ~InternalSpaceEntitySystem();
+    ~InternalOnlineRealtimeEngine();
 
 public:
     void ClearEntities()
@@ -1506,7 +1506,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -1539,7 +1539,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ManyEntitiesTest)
     RealtimeEngine->ProcessPendingEntityOperations();
 
     // Clear all entities locally
-    auto InternalEntitySystem = static_cast<InternalSpaceEntitySystem*>(RealtimeEngine.get());
+    auto InternalEntitySystem = static_cast<InternalOnlineRealtimeEngine*>(RealtimeEngine.get());
     InternalEntitySystem->ClearEntities();
 
     EXPECT_EQ(RealtimeEngine->GetNumEntities(), 0);
@@ -1602,7 +1602,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, InvalidComponentFieldsTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1653,7 +1653,7 @@ void RunParentEntityReplicationTest(bool Local)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1861,7 +1861,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ParentEntityReplicationTest)
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
 {
-    // Tests the SpaceEntitySystem::OnAllEntitiesCreated
+    // Tests the OnlineRealtimeEngine::OnAllEntitiesCreated
     // for ParentId and ChildEntities
     SetRandSeed();
 
@@ -1877,7 +1877,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1950,7 +1950,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalPositionTest)
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
 {
-    // Tests the SpaceEntitySystemWeak::OnAllEntitiesCreated
+    // Tests the OnlineRealtimeEngineWeak::OnAllEntitiesCreated
     // for ParentId and ChildEntities
     SetRandSeed();
 
@@ -1966,7 +1966,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -2039,7 +2039,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalRotationTest)
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
 {
-    // Tests the SpaceEntitySystemWeak::OnAllEntitiesCreated
+    // Tests the OnlineRealtimeEngineWeak::OnAllEntitiesCreated
     // for ParentId and ChildEntities
     SetRandSeed();
 
@@ -2055,7 +2055,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -2131,7 +2131,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalScaleTest)
 
 CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
 {
-    // Tests the SpaceEntitySystemWeak::OnAllEntitiesCreated
+    // Tests the OnlineRealtimeEngineWeak::OnAllEntitiesCreated
     // for ParentId and ChildEntities
     SetRandSeed();
 
@@ -2147,7 +2147,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -2216,7 +2216,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityGlobalTransformTest)
 // This test is to be fixed as part of OF-1651.
 CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ParentEntityEnterSpaceReplicationTest)
 {
-    // Tests the SpaceEntitySystemWeak::OnAllEntitiesCreated
+    // Tests the OnlineRealtimeEngineWeak::OnAllEntitiesCreated
     // for ParentId and ChildEntities
     SetRandSeed();
 
@@ -2236,7 +2236,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ParentEntityEnterSpaceRepl
     bool EntitiesCreated = false;
     auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
     // Enter space
@@ -2347,7 +2347,7 @@ void RunParentChildDeletionTest(bool Local)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -2518,7 +2518,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, CreateObjectParentTest)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -2569,7 +2569,7 @@ void RunParentDeletionTest(bool Local)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     bool EntitiesCreated = false;
 
@@ -3084,7 +3084,7 @@ void RunEntityLockTest(bool Local)
     csp::systems::Space Space;
     CreateDefaultTestSpace(SpaceSystem, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Ensure patch rate limiting is off, as we're sending patches in quick succession.
@@ -3217,7 +3217,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityLockPersistanceTest)
 
     auto EntitiesReadyCallback = [&EntitiesCreated](int /*NumEntitiesFetched*/) { EntitiesCreated = true; };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     RealtimeEngine->SetEntityFetchCompleteCallback(EntitiesReadyCallback);
 
@@ -3300,7 +3300,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityLockAddComponentTest)
 
     // Enter a space and lock an entity
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         // Enter space
@@ -3363,7 +3363,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, EntityLockRemoveComponentTest)
 
     // Enter a space and lock an entity
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         // Enter space

--- a/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
@@ -135,7 +135,7 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestSuccessInSe
     async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
         .then(async::inline_scheduler(),
             RealtimeEngine->SendNewAvatarObjectMessage(
-                "Username", LoginState, UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
+                "Username", LoginState.UserId, UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
         .then(async::inline_scheduler(),
             [](std::tuple<const signalr::value&, std::exception_ptr> Results)
             {
@@ -175,7 +175,7 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorInSend
     async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
         .then(async::inline_scheduler(),
             RealtimeEngine->SendNewAvatarObjectMessage(
-                "Username", LoginState, UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
+                "Username", LoginState.UserId, UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default))
         .then(async::inline_scheduler(),
             [](std::tuple<const signalr::value&, std::exception_ptr> Results)
             {
@@ -244,7 +244,7 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestSuccessInCr
         }) // This continuation takes the ID (and another void return from a when_all branch) as its input
         .then(async::inline_scheduler(),
             RealtimeEngine->CreateNewLocalAvatar(
-                Username, LoginState, UserTransform, IsVisible, AvatarId, AvatarState, AvatarPlayMode, MockCallback.AsStdFunction()));
+                Username, LoginState.UserId, UserTransform, IsVisible, AvatarId, AvatarState, AvatarPlayMode, MockCallback.AsStdFunction()));
 }
 
 CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorLoggedFromWholeCreateAvatarChain)
@@ -280,6 +280,6 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorLogged
 
     const auto LoginState = SystemsManager.GetUserSystem()->GetLoginState();
 
-    RealtimeEngine->CreateAvatar(
-        "Username", LoginState, UserTransform, IsVisible, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default, MockCallback.AsStdFunction());
+    RealtimeEngine->CreateAvatar("Username", LoginState.UserId, UserTransform, IsVisible, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default,
+        MockCallback.AsStdFunction());
 }

--- a/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
@@ -39,12 +39,12 @@ public:
 
 }
 
-CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestSuccessInRemoteGenerateNewAvatarId)
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestSuccessInRemoteGenerateNewAvatarId)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // SignalR populates a result and not an exception
     EXPECT_CALL(
@@ -75,12 +75,12 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestSuccessInRemot
                                                                     // will catch exceptions and convert to a friendly cancel if they occur.
 }
 
-CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestErrorInRemoteGenerateNewAvatarId)
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorInRemoteGenerateNewAvatarId)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // SignalR populates an exception
     EXPECT_CALL(
@@ -111,12 +111,12 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestErrorInRemoteG
                                                                     // will catch exceptions and convert to a friendly cancel if they occur.
 }
 
-CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestSuccessInSendNewAvatarObjectMessage)
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestSuccessInSendNewAvatarObjectMessage)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // SignalR populates a result and not an exception
     EXPECT_CALL(
@@ -149,12 +149,12 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestSuccessInSendN
                                                                     // will catch exceptions and convert to a friendly cancel if they occur.
 }
 
-CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestErrorInSendNewAvatarObjectMessage)
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorInSendNewAvatarObjectMessage)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* Connection = SystemsManager.GetMultiplayerConnection();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // SignalR populates an exception
     EXPECT_CALL(
@@ -196,11 +196,11 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestErrorInSendNew
                                                                     // will catch exceptions and convert to a friendly cancel if they occur.
 }
 
-CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestSuccessInCreateNewLocalAvatar)
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestSuccessInCreateNewLocalAvatar)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     using MockEntityCreatedCallback = testing::MockFunction<void(SpaceEntity*)>;
     MockEntityCreatedCallback MockCallback;
@@ -247,14 +247,14 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestSuccessInCreat
                 Username, LoginState, UserTransform, IsVisible, AvatarId, AvatarState, AvatarPlayMode, MockCallback.AsStdFunction()));
 }
 
-CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, SpaceEntitySystemTests, TestErrorLoggedFromWholeCreateAvatarChain)
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorLoggedFromWholeCreateAvatarChain)
 {
     RAIIMockLogger MockLogger {};
     csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(csp::common::LogLevel::Log);
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // SignalR populates an exception
     EXPECT_CALL(*SignalRMock, Invoke)

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -271,8 +271,11 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetConcurrentUsersInSpace)
     EXPECT_EQ(Result.GetFeatureLimitInfo().ActivityCount, 0);
     EXPECT_EQ(Result.GetFeatureLimitInfo().Limit, 50);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -271,7 +271,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetConcurrentUsersInSpace)
     EXPECT_EQ(Result.GetFeatureLimitInfo().ActivityCount, 0);
     EXPECT_EQ(Result.GetFeatureLimitInfo().Limit, 50);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -249,8 +249,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -367,7 +367,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AvatarScriptTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
     EXPECT_EQ(Avatar->GetName(), UserName);
@@ -467,7 +467,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptLogTest)
     const auto LoginState = UserSystem->GetLoginState();
 
     auto [Avatar] = AWAIT(
-        RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
     EXPECT_EQ(Avatar->GetName(), UserName);
@@ -555,8 +555,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteScriptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -668,8 +668,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteAndChangeComponentTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -797,8 +797,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -941,8 +941,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptDeltaTimeTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -1055,8 +1055,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubs
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;
@@ -1172,8 +1172,8 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar]
-        = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
+    auto [Avatar] = AWAIT(
+        RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode);
     EXPECT_NE(Avatar, nullptr);
 
     std::cerr << "CreateAvatar Local Callback" << std::endl;

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -132,7 +132,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CreateScriptTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -227,7 +227,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RunScriptTest)
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -347,7 +347,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AvatarScriptTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -447,7 +447,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptLogTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -535,7 +535,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteScriptTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -648,7 +648,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, DeleteAndChangeComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -773,7 +773,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, AddSecondScriptTest)
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -921,7 +921,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, ScriptDeltaTimeTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -1033,7 +1033,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, CustomComponentScriptInterfaceSubs
         ScriptSystemReady = true;
     };
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -1151,7 +1151,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, MultipleScriptComponentTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space
@@ -1233,7 +1233,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, ScriptSystemTests, ModifyExistingScriptTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 
     // we'll be using this in a few places below as part of the test, so we declare it upfront
     const std::string ScriptText = R"xx(

--- a/Tests/src/PublicAPITests/SequenceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceSystemTests.cpp
@@ -913,8 +913,11 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RegisterSequenceUpdatedTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Enter space
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     bool CallbackCalled = false;
 

--- a/Tests/src/PublicAPITests/SequenceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SequenceSystemTests.cpp
@@ -913,7 +913,7 @@ CSP_PUBLIC_TEST(CSPEngine, SequenceSystemTests, RegisterSequenceUpdatedTest)
     CreateSpace(
         SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Enter space

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1516,7 +1516,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateUserRolesTest)
 
     // Ensure alt test account can join space
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -2160,7 +2160,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetAcceptedUserInvitesTest)
     // Log in as User1 and enter the space, which triggers invite acceptance on the test tenant (for all users, so including User2)
     LogIn(UserSystem, User1Id, User1.Email, GeneratedTestAccountPassword);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -2262,7 +2262,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
     csp::systems::Profile AltUser = CreateTestUser();
     LogIn(UserSystem, AltUserId, AltUser.Email, GeneratedTestAccountPassword);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
@@ -2569,7 +2569,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
     {
         EXPECT_FALSE(SpaceSystem->IsInSpace());
 
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
@@ -2590,7 +2590,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
     LogIn(UserSystem, AltUserId, AltUser.Email, GeneratedTestAccountPassword);
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
@@ -2635,7 +2635,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsNonModeratorTest)
     LogIn(UserSystem, AltUserId, AltUser.Email, GeneratedTestAccountPassword);
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
@@ -2693,7 +2693,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsModeratorTest)
 
     // Note the space is now out of date and does not have the new user in its lists
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
@@ -3307,7 +3307,7 @@ TEST_P(EnterSpaceWhenGuest, EnterSpaceWhenGuestTest)
     String GuestUserId;
     LogInAsGuest(UserSystem, GuestUserId);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Attempt to enter the space and check the expected result
@@ -3360,7 +3360,7 @@ TEST_P(EnterSpaceWhenUninvited, EnterSpaceWhenUninvitedTest)
     csp::systems::Profile UninvitedUser = CreateTestUser();
     LogIn(UserSystem, UninvitedUserId, UninvitedUser.Email, GeneratedTestAccountPassword);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Attempt to enter the space and check the expected result
@@ -3419,7 +3419,7 @@ TEST_P(EnterSpaceWhenInvited, EnterSpaceWhenInvitedTest)
     String InvitedUserId;
     LogIn(UserSystem, InvitedUserId, InvitedUser.Email, GeneratedTestAccountPassword);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Attempt to enter the space and check the expected result
@@ -3465,7 +3465,7 @@ TEST_P(EnterSpaceWhenCreator, EnterSpaceWhenCreatorTest)
     Space CreatedSpace;
     CreateSpace(SpaceSystem, UniqueSpaceName.c_str(), TestSpaceDescription, SpacePermission, nullptr, nullptr, nullptr, nullptr, CreatedSpace);
 
-    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
     RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
     // Attempt to enter the space and check the expected result
@@ -3522,7 +3522,7 @@ TEST_P(EnterSpaceWhenBanned, EnterSpaceWhenBannedTest)
     LogIn(UserSystem, BannedUserId, BannedUser.Email, GeneratedTestAccountPassword);
 
     {
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         // In order to ban the user, they have to have entered the space. (This seems like an underthought limitation)
@@ -3542,7 +3542,7 @@ TEST_P(EnterSpaceWhenBanned, EnterSpaceWhenBannedTest)
         // Login as the banned user and attempt to enter the space and check the expected result
         LogIn(UserSystem, BannedUserId, BannedUser.Email, GeneratedTestAccountPassword);
 
-        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
         RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
         testing::internal::CaptureStderr();

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -1516,7 +1516,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateUserRolesTest)
 
     // Ensure alt test account can join space
     {
-        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
         ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -2157,7 +2160,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetAcceptedUserInvitesTest)
     // Log in as User1 and enter the space, which triggers invite acceptance on the test tenant (for all users, so including User2)
     LogIn(UserSystem, User1Id, User1.Email, GeneratedTestAccountPassword);
 
-    auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     ASSERT_EQ(EnterSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
 
     // Log back in as Space Creator to check the accepted invites
@@ -2256,7 +2262,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
     csp::systems::Profile AltUser = CreateTestUser();
     LogIn(UserSystem, AltUserId, AltUser.Email, GeneratedTestAccountPassword);
 
-    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
     ASSERT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -2270,7 +2279,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
     // Exit and re-enter space to verify its OK to always add self to public space
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     {
-        auto [Result2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
+        auto [Result2] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(Result2.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -2560,7 +2569,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
     {
         EXPECT_FALSE(SpaceSystem->IsInSpace());
 
-        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -2578,7 +2590,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
     LogIn(UserSystem, AltUserId, AltUser.Email, GeneratedTestAccountPassword);
 
     {
-        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
     }
@@ -2620,7 +2635,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsNonModeratorTest)
     LogIn(UserSystem, AltUserId, AltUser.Email, GeneratedTestAccountPassword);
 
     {
-        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
     }
@@ -2675,7 +2693,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsModeratorTest)
 
     // Note the space is now out of date and does not have the new user in its lists
     {
-        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
@@ -3226,57 +3247,6 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceTest)
     LogOut(UserSystem);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, ReEnterSpaceTest)
-{
-    SetRandSeed();
-
-    auto& SystemsManager = ::SystemsManager::Get();
-    auto* UserSystem = SystemsManager.GetUserSystem();
-    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
-
-    const char* TestSpaceName = "CSP-TEST-SPACE";
-    const char* TestSpaceDescription = "CSP-TEST-SPACEDESC";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
-    String UserId;
-
-    // Create default and alt users
-    csp::systems::Profile DefaultUser = CreateTestUser();
-    csp::systems::Profile AlternativeUser = CreateTestUser();
-
-    // Log in
-    LogIn(UserSystem, UserId, DefaultUser.Email, GeneratedTestAccountPassword);
-
-    // Create space
-    ::Space Space;
-    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
-
-    // This is a regression test against the space entity system non initialising on re-entering a space
-    // Using Leader election enabled as a proxy as behind the scenes that just checks if the election manager is null, something that is set/unset
-    // during init/shutdown. This should hopefully be redundant soon as SpaceEntitySystem will be initialized by definition.
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
-    ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
-    ASSERT_TRUE(SystemsManager.GetSpaceEntitySystem()->IsLeaderElectionEnabled());
-
-    // Leave the space
-    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
-    ASSERT_EQ(ExitSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
-    ASSERT_FALSE(SystemsManager.GetSpaceEntitySystem()->IsLeaderElectionEnabled());
-
-    // Re-enter the space
-    auto [ReEnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id);
-    ASSERT_EQ(ReEnterResult.GetResultCode(), csp::systems::EResultCode::Success);
-    ASSERT_TRUE(SystemsManager.GetSpaceEntitySystem()->IsLeaderElectionEnabled());
-
-    // Delete space
-    DeleteSpace(SpaceSystem, Space.Id);
-
-    // Log out
-    LogOut(UserSystem);
-}
-
 namespace CSPEngine
 {
 /*
@@ -3337,9 +3307,13 @@ TEST_P(EnterSpaceWhenGuest, EnterSpaceWhenGuestTest)
     String GuestUserId;
     LogInAsGuest(UserSystem, GuestUserId);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id);
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
     ASSERT_EQ(EnterResult.GetResultCode(), JoinSpaceResultExpected);
 
     // Verify that Stderr contains expected message.
@@ -3386,9 +3360,12 @@ TEST_P(EnterSpaceWhenUninvited, EnterSpaceWhenUninvitedTest)
     csp::systems::Profile UninvitedUser = CreateTestUser();
     LogIn(UserSystem, UninvitedUserId, UninvitedUser.Email, GeneratedTestAccountPassword);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
     ASSERT_EQ(EnterResult.GetResultCode(), JoinSpaceResultExpected);
 
     // Verify that Stderr contains expected message.
@@ -3442,9 +3419,12 @@ TEST_P(EnterSpaceWhenInvited, EnterSpaceWhenInvitedTest)
     String InvitedUserId;
     LogIn(UserSystem, InvitedUserId, InvitedUser.Email, GeneratedTestAccountPassword);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
     ASSERT_EQ(EnterResult.GetResultCode(), JoinSpaceResultExpected);
 
     // Verify that Stderr contains expected message.
@@ -3485,9 +3465,12 @@ TEST_P(EnterSpaceWhenCreator, EnterSpaceWhenCreatorTest)
     Space CreatedSpace;
     CreateSpace(SpaceSystem, UniqueSpaceName.c_str(), TestSpaceDescription, SpacePermission, nullptr, nullptr, nullptr, nullptr, CreatedSpace);
 
+    std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id);
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
     ASSERT_EQ(EnterResult.GetResultCode(), JoinSpaceResultExpected);
 
     // Verify that Stderr contains expected message.
@@ -3537,31 +3520,42 @@ TEST_P(EnterSpaceWhenBanned, EnterSpaceWhenBannedTest)
     // Log in as banned user
     String BannedUserId;
     LogIn(UserSystem, BannedUserId, BannedUser.Email, GeneratedTestAccountPassword);
-    // In order to ban the user, they have to have entered the space. (This seems like an underthought limitation)
-    auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id);
-    ASSERT_EQ(EnterSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
-    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
-    ASSERT_EQ(ExitSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
-    LogOut(UserSystem);
 
-    // Log back in as owner and ban the user
-    LogIn(UserSystem, SpaceOwnerUserId, SpaceOwnerUser.Email, GeneratedTestAccountPassword);
-    auto [Result] = AWAIT_PRE(SpaceSystem, AddUserToSpaceBanList, RequestPredicate, CreatedSpace.Id, BannedUser.UserId);
-    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
-    LogOut(UserSystem);
+    {
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
 
-    // Login as the banned user and attempt to enter the space and check the expected result
-    LogIn(UserSystem, BannedUserId, BannedUser.Email, GeneratedTestAccountPassword);
-    testing::internal::CaptureStderr();
-    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id);
-    ASSERT_EQ(EnterResult.GetResultCode(), JoinSpaceResultExpected);
+        // In order to ban the user, they have to have entered the space. (This seems like an underthought limitation)
+        auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
+        ASSERT_EQ(EnterSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
+        auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+        ASSERT_EQ(ExitSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
+        LogOut(UserSystem);
 
-    // Verify that Stderr contains expected message.
-    std::string OutStdErr = testing::internal::GetCapturedStderr();
-    EXPECT_NE(OutStdErr.find(ExpectedMsg), std::string::npos);
+        // Log back in as owner and ban the user
+        LogIn(UserSystem, SpaceOwnerUserId, SpaceOwnerUser.Email, GeneratedTestAccountPassword);
+        auto [Result] = AWAIT_PRE(SpaceSystem, AddUserToSpaceBanList, RequestPredicate, CreatedSpace.Id, BannedUser.UserId);
+        EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+        LogOut(UserSystem);
+    }
+    {
+        // Login as the banned user and attempt to enter the space and check the expected result
+        LogIn(UserSystem, BannedUserId, BannedUser.Email, GeneratedTestAccountPassword);
 
-    // Log out
-    LogOut(UserSystem);
+        std::unique_ptr<csp::multiplayer::SpaceEntitySystem> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+        testing::internal::CaptureStderr();
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
+        ASSERT_EQ(EnterResult.GetResultCode(), JoinSpaceResultExpected);
+
+        // Verify that Stderr contains expected message.
+        std::string OutStdErr = testing::internal::GetCapturedStderr();
+        EXPECT_NE(OutStdErr.find(ExpectedMsg), std::string::npos);
+
+        // Log out
+        LogOut(UserSystem);
+    }
 
     // Login as owner user in order to be able to delete the test space
     LogIn(UserSystem, SpaceOwnerUserId, SpaceOwnerUser.Email, GeneratedTestAccountPassword);

--- a/Tests/src/PublicTestBase.cpp
+++ b/Tests/src/PublicTestBase.cpp
@@ -28,11 +28,10 @@ void PublicTestBase::SetUp()
 
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
-    csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
-
-    csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback([](csp::common::String Message) { fprintf(stderr, "%s\n", Message.c_str()); });
-
-    csp::systems::SystemsManager::Get().GetLogSystem()->LogMsg(csp::common::LogLevel::Verbose, "Foundation initialised!");
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
+    LogSystem->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
+    LogSystem->SetLogCallback([](csp::common::String Message) { fprintf(stderr, "%s\n", Message.c_str()); });
+    LogSystem->LogMsg(csp::common::LogLevel::Verbose, "Foundation initialised!");
 
     auto Connection = csp::systems::SystemsManager::Get().GetMultiplayerConnection();
 
@@ -64,11 +63,10 @@ void PublicTestBaseWithMocks::SetUp()
     // Yield SignalRMock ownership
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI(), SignalRMock);
 
-    csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
-
-    csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback([](csp::common::String Message) { fprintf(stderr, "%s\n", Message.c_str()); });
-
-    csp::systems::SystemsManager::Get().GetLogSystem()->LogMsg(csp::common::LogLevel::Verbose, "Foundation initialised!");
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
+    LogSystem->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
+    LogSystem->SetLogCallback([](csp::common::String Message) { fprintf(stderr, "%s\n", Message.c_str()); });
+    LogSystem->LogMsg(csp::common::LogLevel::Verbose, "Foundation initialised!");
 
     auto Connection = csp::systems::SystemsManager::Get().GetMultiplayerConnection();
 
@@ -97,11 +95,10 @@ template <typename T> void PublicTestBaseWithParam<T>::SetUp()
 
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
-    csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
-
-    csp::systems::SystemsManager::Get().GetLogSystem()->SetLogCallback([](csp::common::String Message) { fprintf(stderr, "%s\n", Message.c_str()); });
-
-    csp::systems::SystemsManager::Get().GetLogSystem()->LogMsg(csp::common::LogLevel::Verbose, "Foundation initialised!");
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
+    LogSystem->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
+    LogSystem->SetLogCallback([](csp::common::String Message) { fprintf(stderr, "%s\n", Message.c_str()); });
+    LogSystem->LogMsg(csp::common::LogLevel::Verbose, "Foundation initialised!");
 
     auto Connection = csp::systems::SystemsManager::Get().GetMultiplayerConnection();
 

--- a/Tests/src/PublicTestBase.h
+++ b/Tests/src/PublicTestBase.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "CSP/Systems/Spaces/Space.h"
+#include "Mocks/SignalRConnectionMock.h"
 #include <gtest/gtest.h>
 
 namespace
@@ -43,6 +44,18 @@ class PublicTestBase : public ::testing::Test
 protected:
     void SetUp() override;
     void TearDown() override;
+};
+
+class PublicTestBaseWithMocks : public ::testing::Test
+{
+protected:
+    void SetUp() override;
+    void TearDown() override;
+
+    // We don't have to/can't clean this up here, we inject it and CSP takes ownership.
+    // Confusing from an external user perspective I know, and somewhat fragile because we're relying on SystemsManager::destroy to trigger the RAII
+    // behaviour, may change with a new initialisation api.
+    SignalRConnectionMock* SignalRMock;
 };
 
 // For parameterized (data driven) tests

--- a/Tests/src/TestHelpers.h
+++ b/Tests/src/TestHelpers.h
@@ -66,6 +66,10 @@ inline const char* TESTS_CLIENT_SKU = "CPPTest";
 #define CSP_PUBLIC_TEST(namespace_name, test_case_name, test_name)                                                                                   \
     NAMESPACE_GTEST_TEST_(namespace_name, test_case_name, test_name, ::PublicTestBase, ::testing::internal::GetTypeId<::PublicTestBase>())
 
+#define CSP_PUBLIC_TEST_WITH_MOCKS(namespace_name, test_case_name, test_name)                                                                        \
+    NAMESPACE_GTEST_TEST_(                                                                                                                           \
+        namespace_name, test_case_name, test_name, ::PublicTestBaseWithMocks, ::testing::internal::GetTypeId<::PublicTestBaseWithMocks>())
+
 #define CSP_INTERNAL_TEST(namespace_name, test_case_name, test_name)                                                                                 \
     NAMESPACE_GTEST_TEST_(namespace_name, test_case_name, test_name, ::testing::Test, ::testing::internal::GetTestTypeId())
 
@@ -185,9 +189,9 @@ inline void LogFatal(std::string Message)
     exit(1);
 }
 
-inline void InitialiseFoundationWithUserAgentInfo(const csp::common::String& EndpointRootURI)
+inline void InitialiseFoundationWithUserAgentInfo(const csp::common::String& EndpointRootURI, SignalRConnectionMock* SignalRMock = nullptr)
 {
-    csp::CSPFoundation::Initialise(EndpointRootURI, "OKO_TESTS");
+    csp::CSPFoundation::InitialiseWithInject(EndpointRootURI, "OKO_TESTS", SignalRMock);
 
     csp::ClientUserAgent ClientHeaderInfo;
     ClientHeaderInfo.CSPVersion = csp::CSPFoundation::GetVersion();

--- a/Tests/src/TestHelpers.h
+++ b/Tests/src/TestHelpers.h
@@ -17,7 +17,7 @@
 
 #include "Awaitable.h"
 #include "CSP/CSPFoundation.h"
-#include "CSP/Multiplayer/SpaceEntitySystem.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Systems/WebService.h"
 #include "PublicTestBase.h"
 #include "uuid_v4.h"
@@ -225,7 +225,7 @@ inline void WaitForCallback(bool& CallbackCalled, int MaxTextTimeSeconds = 20)
     }
 }
 
-inline void WaitForCallbackWithUpdate(bool& CallbackCalled, csp::multiplayer::SpaceEntitySystem* EntitySystem, int MaxTextTimeSeconds = 20)
+inline void WaitForCallbackWithUpdate(bool& CallbackCalled, csp::multiplayer::OnlineRealtimeEngine* EntitySystem, int MaxTextTimeSeconds = 20)
 {
     // Wait for message
     auto Start = std::chrono::steady_clock::now();
@@ -251,7 +251,7 @@ inline void WaitForCallbackWithUpdate(bool& CallbackCalled, csp::multiplayer::Sp
     }
 }
 
-inline csp::multiplayer::SpaceEntity* CreateTestObject(csp::multiplayer::SpaceEntitySystem* EntitySystem, csp::common::String Name = "Object")
+inline csp::multiplayer::SpaceEntity* CreateTestObject(csp::multiplayer::OnlineRealtimeEngine* EntitySystem, csp::common::String Name = "Object")
 {
     csp::multiplayer::SpaceTransform ObjectTransform { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
     auto [CreatedObject] = AWAIT(EntitySystem, CreateEntity, Name, ObjectTransform, csp::common::Optional<uint64_t> {});

--- a/Tests/src/TestHelpers.h
+++ b/Tests/src/TestHelpers.h
@@ -250,7 +250,7 @@ inline void WaitForCallbackWithUpdate(bool& CallbackCalled, csp::multiplayer::Sp
 inline csp::multiplayer::SpaceEntity* CreateTestObject(csp::multiplayer::SpaceEntitySystem* EntitySystem, csp::common::String Name = "Object")
 {
     csp::multiplayer::SpaceTransform ObjectTransform { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
-    auto [CreatedObject] = AWAIT(EntitySystem, CreateObject, Name, ObjectTransform);
+    auto [CreatedObject] = AWAIT(EntitySystem, CreateEntity, Name, ObjectTransform, csp::common::Optional<uint64_t> {});
     EXPECT_TRUE(CreatedObject != nullptr);
     return CreatedObject;
 }

--- a/Tools/WrapperGenerator/CSharpWrapperGenerator.py
+++ b/Tools/WrapperGenerator/CSharpWrapperGenerator.py
@@ -596,6 +596,8 @@ class CSharpWrapperGenerator:
                 and len(param.type.function_signature.parameters) > 1
             ),
             "delegate": delegate,
+            "is_virtual" : method.is_virtual,
+            "is_override" : method.is_override
         }
 
         events.append(event)

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Event.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Event.mustache
@@ -54,7 +54,8 @@ event EventHandler<
 {{# has_multiple_parameters }}
     ){{/ has_multiple_parameters }}
 >? Real{{ name }};
-public event EventHandler<
+public {{# is_virtual }}{{^ is_override }}virtual{{/ is_override }}{{/ is_virtual }}
+       {{# is_override }}override{{/ is_override }} event EventHandler<
 {{# has_multiple_parameters }}
     (
 {{/ has_multiple_parameters }}

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/TaskMethod.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/TaskMethod.mustache
@@ -38,7 +38,8 @@ static void {{ delegate.name }}Function(
 static readonly {{ delegate.name }} {{ name }}DelegateInstance = {{ delegate.name }}Function;
 
 {{> DocComments }}
-public Task<{{# has_multiple_results }}({{/ has_multiple_results }}{{# results }}{{# type }}{{> Type }}{{/ type }}{{> Comma }}{{/ results }}{{# has_multiple_results }}){{/ has_multiple_results }}> {{ name }}({{# parameters }}{{# type }}{{> Type }}{{# is_optional }}?{{/ is_optional }}{{/ type }} {{ name }}{{> Comma }}{{/ parameters }})
+public {{# is_virtual }}{{^ is_override }}virtual{{/ is_override }}{{/ is_virtual }}
+       {{# is_override }}override{{/ is_override }} Task<{{# has_multiple_results }}({{/ has_multiple_results }}{{# results }}{{# type }}{{> Type }}{{/ type }}{{> Comma }}{{/ results }}{{# has_multiple_results }}){{/ has_multiple_results }}> {{ name }}({{# parameters }}{{# type }}{{> Type }}{{# is_optional }}?{{/ is_optional }}{{/ type }} {{ name }}{{> Comma }}{{/ parameters }})
 {
     var tcs = new TaskCompletionSource<{{# has_multiple_results }}({{/ has_multiple_results }}{{# results }}{{# type }}{{> Type }}{{/ type }}{{> Comma }}{{/ results }}{{# has_multiple_results }}){{/ has_multiple_results }}>(this);
     var handle = GCHandle.Alloc(tcs);

--- a/WasmTesting/html_tests/EnterSpace.html
+++ b/WasmTesting/html_tests/EnterSpace.html
@@ -29,9 +29,13 @@
           console.error("Failed to log in");
         }
 
+        //Create multiplayer realtime engine
+        const realtimeEngine = Systems.SystemsManager.get().makeOnlineRealtimeEngine();
+        realtimeEngine.setEntityFetchCompleteCallback((entitiesFetchedNum) => {})
+
         //Enter the space
         const spaceSystem = Systems.SystemsManager.get().getSpaceSystem();
-        const enterSpaceResult = await spaceSystem.enterSpace(spaceId);
+        const enterSpaceResult = await spaceSystem.enterSpace(spaceId, realtimeEngine);
 
         if (enterSpaceResult.getResultCode() == Systems.EResultCode.Success){
           console.log("Successfully entered space");
@@ -42,6 +46,12 @@
         
         loginResult.delete();
         enterSpaceResult.delete(); 
+
+        //Exit the space
+        const exitSpaceResult = await spaceSystem.exitSpace(spaceId);
+
+        //Delete the realtime engine now that we've exited the space
+        realtimeEngine.delete();
       })();
     </script>
   </head>

--- a/WasmTesting/html_tests/SendReceiveNetworkEvent.html
+++ b/WasmTesting/html_tests/SendReceiveNetworkEvent.html
@@ -37,9 +37,14 @@
 
         await Systems.SystemsManager.get().getMultiplayerConnection().setAllowSelfMessagingFlag(true);
 
+        //Create multiplayer realtime engine
+        const realtimeEngine = Systems.SystemsManager.get().makeOnlineRealtimeEngine();
+        realtimeEngine.setEntityFetchCompleteCallback((entitiesFetchedNum) => {})
+
+
         //Enter the space
         const spaceSystem = Systems.SystemsManager.get().getSpaceSystem();
-        const enterSpaceResult = await spaceSystem.enterSpace(spaceId);
+        const enterSpaceResult = await spaceSystem.enterSpace(spaceId, realtimeEngine);
 
         if (enterSpaceResult.getResultCode() == Systems.EResultCode.Success){
           console.log("Successfully entered space");
@@ -75,6 +80,12 @@
 
         //Just getting the promise is good enough for the test
         await sendAndWaitForEvent();
+
+        //Exit the space
+        const exitSpaceResult = await spaceSystem.exitSpace(spaceId);
+
+        //Delete the realtime engine now that we've exited the space
+        realtimeEngine.delete();
 
       })();
     </script>


### PR DESCRIPTION
## Online Realtime Engine
This PR converts `SpaceEntitySystem` to `OnlineRealtimeEngine`, providing an interface for clients to pass arbitrary `IRealtimeEngine` instances to `EnterSpace`, such that CSP can branch on different engine behaviour. The most immediate desire for this being the support of an `OfflineRealtimeEngine` which is coming soon, but also opens up lots of alternate behaviour, such as a more lean `ServerSideScriptRunnerRealtimeEngine` or even a `MockRealtimeEngine`, etc. I'm quite excited about how this interface point makes experimental implementations of radically new communication/entity management techniques possible.

This has many implications for our memory management during login and space entry. In general, you will see a removal of manual state management in objects, and an addition of constructor arguments being used to establish invariants. This all takes into account the future direction of the EnterSpace flow, and is a solid step towards the Summer Party Vision, as well as being bettter in general.

An important factor is the seperation of SignalR binding and dispatch, you'll see this in early commits. `MultiplayerConnection` is now explicitly bound during `Connect`, and maintains those bindings for its entire lifetime. Those bindings are only actually dispatched to a `RealtimeEngine` if one has been set, which is something that is invariant to the temporal scope of entering a space (as defined by the scope between the instruction when `EnterSpace` is first called, and the receiving instruction of the `ExitSpace` callback)
So long as this invariant holds, it is not possible to dispatch an off-thread network event to null memory. Remember, whilst `RealtimeEngine` has been extracted the way we want it, `MultiplayerConnection` as yet **has not**, so a shim is neccesary.

There are a **ton** of not-great decisions made here due to the wrapper generator, it's really been pushed to its limit during this work. (See [this](https://docs.google.com/document/d/13oJrWh2x07QdTPUdtwTR7tf4AOfTiNhEAlk0oTqYvtE/edit?tab=t.0#heading=h.w7400dxtrnuy) for a listing of some of the issues that occurred during this work.)

The most major of these compromises is the need for clients to manually ensure `RealtimeEngine` lifetime for the scope of being in a space. Ideally this would be expressed in the interface via a `shared_ptr/weak_ptr` link, or a different memory management strategy, but we're not there yet.

> [!NOTE]  
> `IRealtimeEngine`, whilst being an improved interface, is still 95% designed around its original legacy as `SpaceEntitySystem`. This has unfortunate consequences, but we knew we'd have a quirky interface going in. The biggest deal here is that even implementing a `SingleplayerRealtimeEngine` will require the usage of a patch processing model, as those interfaces (`ProcessPending`, etc) remain on `IRealtimeEngine` such that clients can have an easier time transitioning.
>
> However, I do hope to change this in the future. Having to account for late-update semantics, even in a fake way, is an uncomfortable burden. It's irrelevent in an offline engine, and there's many other threading models we could use to manage better even in the online model ... unreasonably restrictive.


## Reviewer Notes

- This PR shows the transitional steps to make this refactor, you will see in the initial commits the use of `weak/shared_ptr` that will disappear, as well as a bunch of static/global shims to maintain lifetime. This was in order to do red/green testing during the refactor. These shims and interfaces be removed over the next few commits. These are called out in code comments so you shouldn't get lost. Test passes were maintained between each major commit
- Tests are almost all shown at the end, despite me keeping them up to date as I went, with all the mass procedural changes to tests being isolated to [one commit,](https://github.com/magnopus-opensource/connected-spaces-platform/pull/755/commits/4b3f472e339895efe4ffa8a1df5f32b1bc5831b1) where the more interesting ones are in other commits.
- Near the end, there is a change to our init flow to allow injecting custom SignalRConnections, mostly driven by a need to inject `SignalRConnectionMock` more fundamentally into our actual systems. This wouldn't be necessary upon the completion of our full transformation plan, as "injection" would simply be a system property, not an explicit carveout. The temporaryness of this is called out in comments
- Much of the changes that may seem strange make more sense if you consider space re-entry or re-login. Because our library has been written in an assumed non-instantiable, static way, much of the handling around this has felt coincidental up until this point. These changes are more explicit about it, and I suspect will fix latent bugs around this sort of thing. The emergency re-enter space regression test has been removed, since the state it tested for is no longer possible.
- **Commit mistakes** : Quite a few, it's been a long PR. Sorry about these, hooks killed me.
  - Made a change to convert NullResult -> SpaceResult in EnterSpace, but split this over commits incorrectly. 
  - Also made a mistake splitting the moving of `SetSelectionState`. 
  - Interface changes to `IRealtimeEngine` about adding a parentID are rolled into the commit that does the fake interface throw, wouldn't be like that ideally.

## Breaking Changes
- `SpaceEntitySystem` removed
- New type `OnlineRealtimeEngine : public IRealtimeEngine` added, which serves as the replacement to `SpaceEntitySystem`
- `EnterSpace` now takes an `IRealtimeEngine` pointer. The client is responsible for instantiating this object, and maintaining its lifetime for the scope of being in a space. Deletion can happen once the `ExitSpace` callback has been received.
- Convenience method added : `SystemsManager::makeOnlineRealtimeEngine` for transitional convenience. However, this is a temporary method and is already deprecated. We still recommend its use during this transition however. Alternately, you may directly construct an `OnlineRealtimeEngine` by providing its constructor arguments (which are all systems that can be retrieved from `SystemsManager`)
- `EnterSpace` callback now returns a `SpaceResult` instead of a `NullResult`, for convenience
- `OnlineRealtimeEngine` conforms to the `IRealtimeEngine` interface, which has some changes from the previous `SpaceEntitySystem` interface (it is still mostly the same however)
  - `CreateAvatar` now takes an optional ParentID, this should be set to an empty optional if you wish to create a root entity (which was the previous behaviour).
  - `CreateObject` now correctly named `CreateEntity` (See IRealtimeEngine doc for new documentation on what these words actually mean)
  - `SetInitialEntitiesRetrievedCallback(CallbackHandler)` renamed `SetEntityFetchCompleteCallback(EntityFetchCompleteCallback)`.
  - `EntityFetchCompleteCallback` must be set before calling `EnterSpace`. `EnterSpace` will emit an error if this is not so.
  - `EntityFetchCompleteCallback` now provides a uint_32, that being the number of entities fetched in the initial entity retrieval
  - `SetSelectionStateOfEntity(SelectedState, SpaceEntity)` removed from `SpaceEntitySystem`, now call directly on SpaceEntity, `SpaceEntity()->Select` \ `SpaceEntity->Deselect() `
  - `SetScriptSystemReadyCallback(CallbackHandler)` renamed to `SetScriptLeaderReadyCallback(ScriptLeaderReadyCallback)` to better reflect what this actually does.
- `RegisterEntityScriptAsModule` and `BindEntityScript` removed, as we could find no evidence of their use, and original implementors left a note that they were only made public accidentally. (If you have any, let us know so we can reinstate them.)

## Example
Javascript example of new way to enter a space. From our tests.
```
//Create multiplayer realtime engine
const realtimeEngine = Systems.SystemsManager.get().makeOnlineRealtimeEngine();

//Set mandatory callback, you probably want to react to this in someway. Don't mutate entities before this is called.
realtimeEngine.setEntityFetchCompleteCallback((entitiesFetchedNum) => {})

//Enter the space
const spaceSystem = Systems.SystemsManager.get().getSpaceSystem();
const enterSpaceResult = await spaceSystem.enterSpace(spaceId, realtimeEngine);

if (enterSpaceResult.getResultCode() == Systems.EResultCode.Success){
  console.log("Successfully entered space");
}
else {
  console.error("Failed to enter space");
}

enterSpaceResult.delete(); 

//Exit the space
const exitSpaceResult = await spaceSystem.exitSpace(spaceId);

//Delete the realtime engine now that we've exited the space. Do not delete the engine before this.
realtimeEngine.delete();
```

Note deleting the realtime engine. The only condition is that the realtime engine must stay in-memory for the period between invoking `EnterSpace` and receiving the final callback from `ExitSpace`. You are free to defer these deletes, or even never do them at all.

## Wrapper Gen
This change required a change to the wrapper gen in order to add virtual/override functionality to events and async tasks in the C# generator, in order to do dynamic dispatch from an interface. I've assigned you @magnopus-swifty specifically to review this [one commit](https://github.com/magnopus-opensource/connected-spaces-platform/pull/755/commits/102bc0b24ee5d166b9006005479732ecead28471), as we don't have a good change strategy around C# changes. At least with JS we can observe one real working test.

This is so we can get the `virtual` (on the base) and `override` (on the derived) keywords here in event declarations:
```
bool OnEntityCreatedInitialised = false;
event EventHandler<Csp.Multiplayer.SpaceEntity>? RealOnEntityCreated;
public virtual event EventHandler<Csp.Multiplayer.SpaceEntity> OnEntityCreated
{...}
```

We don't normally change the wrapper gen _at all_, we treat it like this magic black box, so this is a fear. This should be an explicit callout for C# integration as I don't know the implications of doing this sort of thing.
