### PR TITLE
[OF-1732] fix!: Shorthand signature wrapper gen bug workaround

### DIFF
--- a/Library/include/CSP/Multiplayer/NetworkEventBus.h
+++ b/Library/include/CSP/Multiplayer/NetworkEventBus.h
@@ -151,25 +151,21 @@ public:
         uint64_t TargetClientId, ErrorCodeCallbackHandler Callback);
 
     /// @brief Register interest in a network event, such that the NetworkEventBus will call the provided callback when it arrives
-    /// @param Registration NetworkEventRegistration : Registration information, containing a ReceiverID and an EventName.
-    /// @param Callback NetworkEventCallback : Callback to invoke when specified event is received.
-    /// @return True if the registration was successful, false otherwise, such as in the case where Registration was not-unique, or the callback was
-    /// null.
-    bool ListenNetworkEvent(NetworkEventRegistration Registration, NetworkEventCallback Callback);
+    /// @param Registration NetworkEventRegistration : Registration information, containing a ReceiverID and an EventName. Will fail to register if
+    /// identical callback registration already registered.
+    /// @param Callback NetworkEventCallback : Callback to invoke when specified event is received. Will fail to register if null.
+    void ListenNetworkEvent(NetworkEventRegistration Registration, NetworkEventCallback Callback);
 
     // Here is where a nice method overload would go that lets you pass 2 strings directly as a convenience, however it can't be done at the moment
     // due to the wrapper generator (JS), and having a distinct name seems more confusing than anything.
 
     /// @brief Deregister interest in a network event
     /// @param Registration NetworkEventRegistration : Registration information of already registered event, containing a ReceiverID and an EventName.
-    /// @return True if the deregistration was successful, false otherwise, such as in the case where Registration was not found
-    bool StopListenNetworkEvent(NetworkEventRegistration Registration);
+    void StopListenNetworkEvent(NetworkEventRegistration Registration);
 
     /// @brief Deregister interest in all network events registered to a particular EventReceiverId
     /// @param EventReceiverId const csp::common::String& : EventReceiverId to deregister.
-    /// @return True if the deregistration was successful, false otherwise, such as if no events were found to deregister under the provided
-    /// EventReceiverId.
-    bool StopListenAllNetworkEvents(const csp::common::String& EventReceiverId);
+    void StopListenAllNetworkEvents(const csp::common::String& EventReceiverId);
 
     /// @brief Get an array of all interests currently registered to the NetworkEventBus
     /// @return csp::common::Array<csp::multiplayer::NetworkEventRegistration> A container of all currently registered registrations.

--- a/Library/src/Multiplayer/NetworkEventBus.cpp
+++ b/Library/src/Multiplayer/NetworkEventBus.cpp
@@ -42,12 +42,12 @@ NetworkEventBus::NetworkEventBus(MultiplayerConnection* InMultiplayerConnection,
     MultiplayerConnectionInst = InMultiplayerConnection;
 }
 
-bool NetworkEventBus::ListenNetworkEvent(NetworkEventRegistration Registration, NetworkEventCallback Callback)
+void NetworkEventBus::ListenNetworkEvent(NetworkEventRegistration Registration, NetworkEventCallback Callback)
 {
     if (!Callback)
     {
         LogSystem.LogMsg(csp::common::LogLevel::Error, "Error: Expected non-null callback.");
-        return false;
+        return;
     }
 
     if (RegisteredEvents.find(Registration) != RegisteredEvents.end())
@@ -57,16 +57,15 @@ bool NetworkEventBus::ListenNetworkEvent(NetworkEventRegistration Registration, 
             fmt::format("Attempting to register a duplicate network event receiver with EventReceiverId: {}, Event: {}. Registration denied.",
                 Registration.EventReceiverId, Registration.EventName)
                 .c_str());
-        return false;
+        return;
     }
 
     LogSystem.LogMsg(csp::common::LogLevel::Verbose,
         fmt::format("Registering network event. EventReceiverId: {}, Event: {}.", Registration.EventReceiverId, Registration.EventName).c_str());
     RegisteredEvents[Registration] = Callback;
-    return true;
 }
 
-bool NetworkEventBus::StopListenNetworkEvent(NetworkEventRegistration Registration)
+void NetworkEventBus::StopListenNetworkEvent(NetworkEventRegistration Registration)
 {
     if (RegisteredEvents.find(Registration) == RegisteredEvents.end())
     {
@@ -74,14 +73,13 @@ bool NetworkEventBus::StopListenNetworkEvent(NetworkEventRegistration Registrati
             fmt::format("Could not find network event registration with EventReceiverId: {}, Event: {}. Deregistration denied.",
                 Registration.EventReceiverId, Registration.EventName)
                 .c_str());
-        return false;
+        return;
     }
 
     RegisteredEvents.erase(Registration);
-    return true;
 }
 
-bool NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& EventReceiverId)
+void NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& EventReceiverId)
 {
     std::vector<NetworkEventRegistration> RegistrationsToRemove {};
 
@@ -104,10 +102,7 @@ bool NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& Even
         LogSystem.LogMsg(csp::common::LogLevel::Log,
             fmt::format("Could not find any network event registration with EventReceiverId: {}. No events were deregistered.", EventReceiverId)
                 .c_str());
-        return false;
     }
-
-    return true;
 }
 
 csp::common::Array<NetworkEventRegistration> NetworkEventBus::AllRegistrations() const

--- a/WasmTesting/csp-wasm.test.ts
+++ b/WasmTesting/csp-wasm.test.ts
@@ -59,6 +59,28 @@ test('Cross Thread Callbacks From Log Callback, OB-3782', async () => {
   
 });
 
+test ('SendReceiveNetworkEvent', async() => {
+  // This test was added as a regression test against `RuntimeError: null function or function signature mismatch`
+  // Caused by a wrapper gen bug when you make a return type of an enclosing function different for the return type of the callback
+  // We didn't actually fix it at time of writing, change `ListenNetworkEvent` to return a bool and you'll see what I mean.
+  const user = await CreateTestUser();
+  await LoginAsUser(user);
+  const spaceId = await CreatePublicTestSpace();;
+
+  const {errors, consoleMessages} = await LaunchTestPage('http://127.0.0.1:8888/SendReceiveNetworkEvent.html', USE_DEBUG_CSP, { email: user.getProfile().email, password: TEST_ACCOUNT_PASSWORD }, spaceId);
+
+  console.log(consoleMessages);
+  console.log(errors);
+
+  assert.ok(consoleMessages.some(e => e.includes('Received event: EventName')));
+  assert.ok(errors.length == 0); //Should be no errors
+
+  //Cleanup
+  await DeleteSpace(spaceId);
+  await LogoutUser(user);
+})
+
+
 test.run();
 
 /*

--- a/WasmTesting/csp-wasm.test.ts
+++ b/WasmTesting/csp-wasm.test.ts
@@ -65,7 +65,7 @@ test ('SendReceiveNetworkEvent', async() => {
   // We didn't actually fix it at time of writing, change `ListenNetworkEvent` to return a bool and you'll see what I mean.
   const user = await CreateTestUser();
   await LoginAsUser(user);
-  const spaceId = await CreatePublicTestSpace();;
+  const spaceId = await CreatePublicTestSpace();
 
   const {errors, consoleMessages} = await LaunchTestPage('http://127.0.0.1:8888/SendReceiveNetworkEvent.html', USE_DEBUG_CSP, { email: user.getProfile().email, password: TEST_ACCOUNT_PASSWORD }, spaceId);
 

--- a/WasmTesting/html_tests/SendReceiveNetworkEvent.html
+++ b/WasmTesting/html_tests/SendReceiveNetworkEvent.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin">
+    <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp">
+    <meta charset="utf-8">
+    <title>CSP WASM Browser Test, SendReceiveNetworkEvent</title>
+    <script type="module">
+      import { ready, CSPFoundation, Systems, Multiplayer, Common } from './node_modules/connected-spaces-platform.web/connectedspacesplatform.js';
+      import { initializeCSP } from './shared/csp-initializer.js';
+      (async () => {
+
+      // Get email, password and spaceID from query parameters
+        const params = new URLSearchParams(window.location.search);
+        const useDebugCSP = params.get('useDebugCsp');
+        const email = params.get('email');
+        const password = params.get('password');
+        const spaceId = params.get(`spaceId`)
+
+        console.log ('email: ', email)
+        console.log ('password: ', password)
+        console.log ('spaceId: ', spaceId)
+
+        await initializeCSP(useDebugCSP);
+
+        const userSystem = Systems.SystemsManager.get().getUserSystem();
+
+        //Login
+        const loginResult = await userSystem.login('', email, password);
+        if (loginResult.getResultCode() == Systems.EResultCode.Success){
+          console.log("Successfully logged in");
+        }
+        else {
+          console.error("Failed to log in");
+        }
+        loginResult.delete();
+
+        await Systems.SystemsManager.get().getMultiplayerConnection().setAllowSelfMessagingFlag(true);
+
+        //Enter the space
+        const spaceSystem = Systems.SystemsManager.get().getSpaceSystem();
+        const enterSpaceResult = await spaceSystem.enterSpace(spaceId);
+
+        if (enterSpaceResult.getResultCode() == Systems.EResultCode.Success){
+          console.log("Successfully entered space");
+        }
+        else {
+          console.error("Failed to enter space");
+        }
+        
+        enterSpaceResult.delete(); 
+
+        const eventBus = Systems.SystemsManager.get().getEventBus();
+                 
+        const receiverId = "Id";
+        const eventName = "EventName";
+        const networkEventRegistration = Multiplayer.NetworkEventRegistration.create_eventReceiverId_eventName(receiverId, eventName);
+
+        const replicatedValues = Common.Array.ofcsp_common_ReplicatedValue()
+ 
+        function sendAndWaitForEvent() {
+          return new Promise((resolve, reject) => {
+            // Register for "EventName" event
+            const success = eventBus.listenNetworkEvent(networkEventRegistration, (ab, networkEventData) => {
+                console.log("Received event:", eventName);
+                resolve(networkEventData);
+              }
+            );
+
+            // Send the event, promise won't resolve until it is received.
+            eventBus.sendNetworkEvent(eventName, replicatedValues);
+
+          });
+        }
+
+        //Just getting the promise is good enough for the test
+        await sendAndWaitForEvent();
+
+      })();
+    </script>
+  </head>
+  <body>
+    <h1>Running CSP WASM browser test…</h1>
+  </body>
+</html>


### PR DESCRIPTION
Workaround the wrapper generator bug with shorthand signature generation.

There is an issue where if the return type of the accepting function is different from the return type of the registering callback (at least in cases like this where we're registering for later behaviour, not making a task/promise sort of construct), then the shorthand type sig used for binding callbacks will generate wrong, using the return type of the enclosing function.

Coincidently, we'd never done this before.

Wrapper generator bug still exists, this just avoids it.

Add a regression test, which I saw fails before the change, and passes after.

**Breaking changes**
Return types of following methods changed from bool -> void
- NetworkEventBus::ListenNetworkEvent(NetworkEventRegistration, NetworkEventCallback)
- NetworkEventBus::StopListenNetworkEvent(NetworkEventRegistration Registration)
- NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& EventReceiverId)