### PR TITLE
[OF-1696] feat: enable cppcheck as post build command in premake

### DIFF
--- a/cppcheck_suppressions.txt
+++ b/cppcheck_suppressions.txt
@@ -1,8 +1,10 @@
-unusedMacro:CSP_API
 unusedMacro:CSP_NO_EXPORT
-unusedMacro:CSP_START_IGNORE
-unusedMacro:CSP_END_IGNORE
 unusedMacro:CSP_ASYNC_RESULT
 unusedMacro:CSP_ASYNC_RESULT_WITH_PROGRESS
 unusedMacro:CSP_EVENT
+unusedMacro:CSP_OUT
+unusedMacro:CSP_IN_OUT
+unusedMacro:CSP_START_IGNORE
+unusedMacro:CSP_END_IGNORE
 unusedMacro:CSP_INTERFACE
+unusedMacro:CSP_FLAGS

--- a/cppcheck_suppressions.txt
+++ b/cppcheck_suppressions.txt
@@ -1,0 +1,8 @@
+unusedMacro:CSP_API
+unusedMacro:CSP_NO_EXPORT
+unusedMacro:CSP_START_IGNORE
+unusedMacro:CSP_END_IGNORE
+unusedMacro:CSP_ASYNC_RESULT
+unusedMacro:CSP_ASYNC_RESULT_WITH_PROGRESS
+unusedMacro:CSP_EVENT
+unusedMacro:CSP_INTERFACE

--- a/premake5.lua
+++ b/premake5.lua
@@ -62,7 +62,7 @@ solution( "ConnectedSpacesPlatform" )
         'set "INCS=$(AdditionalIncludeDirectories)"',
         'set "DEFS=!DEFS:;= -D!"',
         'set "INCS=!INCS:;= -I!"',
-        'cppcheck --enable=all --xml --xml-version=2 --output-file="$(SolutionDir)$(ProjectName)_$(Configuration)_$(Platform).xml" --std=c++17 -D"!DEFS!" -I"!INCS!" "$(ProjectDir)src"',
+        'cppcheck --enable=all --xml --xml-version=2 --output-file="$(SolutionDir)$(ProjectName)_$(Configuration)_$(Platform).xml" --suppressions-list=$(SolutionDir)cppcheck_suppressions.txt --std=c++17 -D"!DEFS!" -I"!INCS!" "$(ProjectDir)src"',
         'echo "Cppcheck analysis complete for $(ProjectName) - $(Configuration)."',
         'goto :eof',
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -48,7 +48,29 @@ solution( "ConnectedSpacesPlatform" )
         CSP.Platforms.AddMac()
         CSP.Platforms.AddIOS()
     end
-    
+
+    postbuildcommands {
+        'if "$(ProjectName)" == "ConnectedSpacesPlatform" goto :run_cppcheck',
+        'if "$(ProjectName)" == "Tests" goto :run_cppcheck',
+        'if "$(ProjectName)" == "MultiplayerTestRunner" goto :run_cppcheck',
+        'goto :skip_cppcheck',
+
+        ':run_cppcheck',
+        'echo "Running Cppcheck analysis for $(ProjectName) - $(Configuration)..."',
+        'setlocal enabledelayedexpansion',
+        'set "DEFS=$(PreprocessorDefinitions)"',
+        'set "INCS=$(AdditionalIncludeDirectories)"',
+        'set "DEFS=!DEFS:;= -D!"',
+        'set "INCS=!INCS:;= -I!"',
+        'cppcheck --enable=all --xml --xml-version=2 --output-file="$(SolutionDir)$(ProjectName)_$(Configuration)_$(Platform).xml" --std=c++17 -D"!DEFS!" -I"!INCS!" "$(ProjectDir)src"',
+        'echo "Cppcheck analysis complete for $(ProjectName) - $(Configuration)."',
+        'goto :eof',
+
+        ':skip_cppcheck',
+        'echo "Skipping Cppcheck analysis for $(ProjectName) - not a specified project to run on."',
+        ':eof'
+    }
+
     -- Visual studio projects
     Project.AddProject()
     


### PR DESCRIPTION
The following change allows cppcheck to run as after the build step in vs2022, due to the limitation of premake, the script checks for the projects are compatible because the filter::projects is not available. 

The output from the process will generate a '$(SolutionDir)$(ProjectName)_$(Configuration)_$(Platform).xml' file that can be viewed in cppcheck GUI application. 

there is still some remaining work and validation needed, but the base implementation is there:

- guarantee that we have cppcheck available (might be able to provide this through chocolatey)
- Configure cppcheck as currently it is just running everything 
- GUI reading of files is providing 'unknownMacro' error 