### PR TITLE
[OF-1689] feat: OfflineRealtimeEngine

### DIFF
--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -357,7 +357,7 @@ public:
     /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.
     /// From a client perspective, ProcessPendingEntityOperations is normally called via the CSPFoundation::Tick method.
     /// @param Entity SpaceEntity : A non-owning pointer to the entity to be marked.
-    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity)
+    virtual void QueueEntityUpdate(csp::multiplayer::SpaceEntity* Entity)
     {
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
 

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -341,6 +341,16 @@ public:
         throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
     }
 
+    /// @brief Adds the given entity to the hierarchy by updating entity children and root hierarchy.
+    /// @param Entity csp::multiplayer::SpaceEntity* : The Entity to add to the hierarchy.
+    CSP_NO_EXPORT virtual void ResolveEntityHierarchy(csp::multiplayer::SpaceEntity* Entity)
+    {
+        throw InvalidInterfaceUseError("Illegal use of \"abstract\" type.");
+
+         // Avoiding unused params, see comment in top method
+        (void)Entity;
+    }
+
     /// @brief Set Callback that notifies when the OnlineRealtimeEngine is in a valid state
     /// after entering a space, and entity mutation can begin. Users should not mutate entities before receiving this callback.
     /// This callback should be emitted in response to FetchAllEntitiesAndPopulateBuffers completing, either syncronously or asyncronously.

--- a/Library/include/CSP/Multiplayer/CSPSceneDescription.h
+++ b/Library/include/CSP/Multiplayer/CSPSceneDescription.h
@@ -15,8 +15,8 @@
  */
 #pragma once
 
+#include "CSP/Common/Interfaces/IRealtimeEngine.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
-#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 
 namespace csp::multiplayer
 {
@@ -29,14 +29,21 @@ class CSP_API CSPSceneDescription
 public:
     /// @brief Constructor for CSPSceneDescription by deserializing a SceneDescription json file.
     /// @param SceneDescriptionJson csp::common::String : The SceneDescription to deserialize.
-    /// @param EntitySystem csp::multiplayer::OnlineRealtimeEngine& : The OnlineRealtimeEngine for this session.
-    /// @param LogSystem csp::common::LogSystem& : The OnlineRealtimeEngine for this session.
-    /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : The ScriptRunner for this session.
-    CSPSceneDescription(const csp::common::String& SceneDescriptionJson, csp::multiplayer::OnlineRealtimeEngine& EntitySystem,
-        csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner);
+    CSPSceneDescription(const csp::common::String& SceneDescriptionJson);
 
-    /// @brief The Entities that exist for this scene.
-    csp::common::Array<csp::multiplayer::SpaceEntity*> Entities;
+    CSPSceneDescription() { }
+
+    /// @brief Generates an array of entities from the SceneDescription Json
+    /// This function exists because the constuction of SpaceEntites relies on a RealtimeEngine, and the OfflineRealtimeEngine requires a
+    /// CSPSceneDescription for constuction.
+    /// @param RealtimeEngine csp::common::IRealtimeEngine& : The RealtimeEngine for this session.
+    /// @param LogSystem csp::common::LogSystem& : The SpaceEntitySystem for this session.
+    /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : The ScriptRunner for this session.
+    CSP_NO_EXPORT csp::common::Array<csp::multiplayer::SpaceEntity*> CreateEntities(
+        csp::common::IRealtimeEngine& RealtimeEngine, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner) const;
+
+private:
+    csp::common::String SceneDescriptionJson;
 };
 
 }

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -155,6 +155,11 @@ public:
     /// @param Value - The new name to assign to the componenent.
     void SetComponentName(const csp::common::String& Value);
 
+    // Called when the component is locally deleted from the space,
+    // or the entity the component is attached to is locally deleted.
+    // Used for handling behavior when a client first deletes the component.
+    CSP_NO_EXPORT virtual void OnLocalDelete();
+
 protected:
     ComponentBase();
 
@@ -184,11 +189,6 @@ protected:
     // Called whenever an entity is removed from the system.
     // Used to shutdown any behavior managed by the entity.
     virtual void OnRemove();
-
-    // Called when the component is locally deleted from the space,
-    // or the entity the component is attached to is locally deleted.
-    // Used for handling behavior when a client first deletes the component.
-    virtual void OnLocalDelete();
 
     CSP_START_IGNORE
     void SetScriptInterface(ComponentScriptInterface* ScriptInterface);

--- a/Library/include/CSP/Multiplayer/Components/ConversationSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ConversationSpaceComponent.h
@@ -293,10 +293,11 @@ public:
     /// @return const csp::common::Vector4& : The camera view rotation.
     const csp::common::Vector4& GetConversationCameraRotation() const;
 
+    CSP_NO_EXPORT void OnLocalDelete() override;
+
 protected:
     void OnCreated() override;
     void OnRemove() override;
-    void OnLocalDelete() override;
 
     void SetPropertyFromPatch(uint32_t Key, const csp::common::ReplicatedValue& Value) override;
 

--- a/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
@@ -164,7 +164,7 @@ public:
     /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.
     /// From a client perspective, ProcessPendingEntityOperations is normally called via the CSPFoundation::Tick method.
     /// @param Entity SpaceEntity : A non-owning pointer to the entity to be marked.
-    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity) override;
+    virtual void QueueEntityUpdate(csp::multiplayer::SpaceEntity* Entity) override;
 
     /// @brief Applies any pending changes to entities that have been marked for update.
     /// This only processes changes to existing entities, such as properties or components. All entity creations and deletions are handled instantly.

--- a/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
@@ -159,6 +159,10 @@ public:
     /// @return A list of root entities containing non-owning pointers to entities.
     [[nodiscard]] virtual const csp::common::List<csp::multiplayer::SpaceEntity*>* GetRootHierarchyEntities() const override;
 
+    /// @brief Adds the given entity to the hierarchy by updating entity children and root hierarchy.
+    /// @param Entity csp::multiplayer::SpaceEntity* : The Entity to add to the hierarchy.
+    CSP_NO_EXPORT virtual void ResolveEntityHierarchy(csp::multiplayer::SpaceEntity* Entity) override;
+
     /***** ENTITY PROCESSING *************************************************/
 
     /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.

--- a/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
@@ -23,6 +23,12 @@
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Common/String.h"
 
+#include <memory>
+#include <mutex>
+#include <set>
+
+class CSPEngine_OfflineRealtimeEngineTests_SelectEntity_Test;
+
 namespace csp::common
 {
 class LoginState;
@@ -39,6 +45,12 @@ class CSPSceneDescription;
 /// The callbacks that are injected into functions are all synchronous, meaning they are called before the funciton ends.
 class CSP_API OfflineRealtimeEngine : public csp::common::IRealtimeEngine
 {
+    CSP_START_IGNORE
+    /** @cond DO_NOT_DOCUMENT */
+    friend class ::CSPEngine_OfflineRealtimeEngineTests_SelectEntity_Test;
+    /** @endcond */
+    CSP_END_IGNORE
+
 public:
     // Callback that will provide a pointer to a SpaceEntity object.
     typedef std::function<void(SpaceEntity*)> EntityCreatedCallback;
@@ -197,6 +209,30 @@ public:
     OfflineRealtimeEngine(
         const CSPSceneDescription& SceneDescription, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner);
 
+    using SpaceEntityList = csp::common::List<SpaceEntity*>;
+
 private:
+    using SpaceEntitySet = std::set<SpaceEntity*>;
+
+    // Should not be null
+    csp::common::LogSystem* LogSystem;
+
+    // May not be null
+    csp::common::IJSScriptRunner* ScriptRunner;
+
+    SpaceEntityList Entities;
+    SpaceEntityList Avatars;
+    SpaceEntityList Objects;
+    SpaceEntityList SelectedEntities;
+    SpaceEntityList RootHierarchyEntities;
+
+    std::unique_ptr<SpaceEntitySet> EntitiesToUpdate;
+
+    std::unique_ptr<std::recursive_mutex> EntitiesLock;
+
+    EntityCreatedCallback SpaceEntityCreatedCallback;
+
+    void AddPendingEntity(SpaceEntity* EntityToAdd);
+    void RemovePendingEntity(SpaceEntity* EntityToRemove);
 };
 }

--- a/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "CSP/Common/Interfaces/IRealtimeEngine.h"
+
+#include "CSP/CSPCommon.h"
+#include "CSP/Common/Interfaces/IJSScriptRunner.h"
+#include "CSP/Common/List.h"
+#include "CSP/Common/SharedEnums.h"
+#include "CSP/Common/String.h"
+
+namespace csp::common
+{
+class LoginState;
+class LogSystem;
+}
+
+namespace csp::multiplayer
+{
+class CSPSceneDescription;
+
+/// @brief Class for creating and managing objects in an offline context.
+///
+/// This provides functionality to create and manage a player avatar and other objects while being offline.
+/// The callbacks that are injected into functions are all synchronous, meaning they are called before the funciton ends.
+class CSP_API OfflineRealtimeEngine : public csp::common::IRealtimeEngine
+{
+public:
+    // Callback that will provide a pointer to a SpaceEntity object.
+    typedef std::function<void(SpaceEntity*)> EntityCreatedCallback;
+
+    /********************** REALTIME ENGINE INTERFACE ************************/
+    /*************************************************************************/
+
+    /// @brief Returns the concrete type of the instantiation of the abstract IRealtimeEngine.
+    virtual csp::common::RealtimeEngineType GetRealtimeEngineType() const override;
+
+    /***** ENTITY MANAGEMENT *************************************************/
+
+    /// @brief Create and add a SpaceEntity with type Avatar, and relevant components and default states as specified.
+    /// @param Name csp::common::String : The entity name of the newly created avatar entity.
+    /// @param UserId csp::common::String : The Id of the user creating the avatar. This can be fetched from csp::systems::UserSystem::GetLoginState
+    /// @param Transform csp::multiplayer::SpaceTransform : The initial transform to set the SpaceEntity to.
+    /// @param State csp::multiplayer::AvatarState : The initial Avatar State to set.
+    /// @param AvatarId csp::common::String : The ID to be set on the AvatarSpaceComponent
+    /// @param AvatarPlayMode csp::multiplayer::AvatarPlayMode : The Initial AvatarPlayMode to set.
+    /// @param Callback csp::multiplayer::EntityCreatedCallback A callback that executes when the creation is complete,
+    /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
+    CSP_ASYNC_RESULT virtual void CreateAvatar(const csp::common::String& Name, const csp::common::String& UserId,
+        const csp::multiplayer::SpaceTransform& Transform, bool IsVisible, const csp::multiplayer::AvatarState& State,
+        const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode,
+        csp::multiplayer::EntityCreatedCallback Callback) override;
+
+    /// @brief Create and add a SpaceEntity, with relevant default values.
+    /// @param Name csp::common::String : The name of the newly created SpaceEntity.
+    /// @param Transform csp::multiplayer::SpaceTransform : The initial transform to set the SpaceEntity to.
+    /// @param ParentID csp::common::Optional<int64_t> : ID of another entity in the space that this entity should be created as a child to. If empty,
+    /// entity is created as a root entity.
+    /// @param Callback csp::multiplayer::EntityCreatedCallback : A callback that executes when the creation is complete,
+    /// which will provide a non-owning pointer to the new SpaceEntity so that it can be used on the local client.
+    CSP_ASYNC_RESULT virtual void CreateEntity(const csp::common::String& Name, const csp::multiplayer::SpaceTransform& Transform,
+        const csp::common::Optional<uint64_t>& ParentID, csp::multiplayer::EntityCreatedCallback Callback) override;
+
+    /// @brief Add a new entity to the system.
+    /// This can be called at any time from any thread and internally add the entity to the entities list.
+    ///
+    /// @param EntityToAdd SpaceEntity : Pointer to the entity to be added.
+    void AddEntity(SpaceEntity* EntityToAdd) override;
+
+    /// @brief Destroy the specified entity.
+    /// @param Entity csp::multiplayer::SpaceEntity : A non-owning pointer to the entity to be destroyed.
+    /// @param Callback csp::multiplayer::CallbackHandler : A callback that executes when the entity destruction is complete.
+    CSP_ASYNC_RESULT virtual void DestroyEntity(csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::CallbackHandler Callback) override;
+
+    /// @brief Sets a callback to be executed when an entity is fully created.
+    ///
+    /// Only one EntityCreatedCallback may be registered, calling this function again will override whatever was previously set.
+    ///
+    /// @param Callback csp::multiplayer::EntityCreatedCallback : the callback to execute.
+    CSP_EVENT virtual void SetEntityCreatedCallback(csp::multiplayer::EntityCreatedCallback Callback) override;
+
+    /// @brief Adds an entity to the set of selected entities
+    /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
+    /// @return True if the entity was succesfully added, false if the entity already existed in the selection and thus could not be added.
+    CSP_NO_EXPORT virtual bool AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
+
+    /// @brief Removes an entity to the set of selected entities
+    /// @param Entity csp::multiplayer::SpaceEntity* Entity to set as selected
+    /// @return True if the entity was succesfully removed, false if the entity did not exist in the selection and thus could not be removed.
+    CSP_NO_EXPORT virtual bool RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity) override;
+
+    /***** ENTITY ACCESS *****************************************************/
+
+    /// @brief Finds the first found SpaceEntity of a matching Name.
+    /// @param Name csp::common::String : The name to search.
+    /// @return A non-owning pointer to the first found matching SpaceEntity.
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntity(const csp::common::String& Name) override;
+
+    /// @brief Finds the first found SpaceEntity that has the ID EntityId.
+    /// @param EntityId uint64_t : The Id to look for.
+    /// @return A non-owning pointer to the first found matching SpaceEntity.
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceEntityById(uint64_t EntityId) override;
+
+    /// @brief Finds the first found SpaceEntity of a matching Name. The found SpaceEntity will contain an AvatarSpaceComponent.
+    /// @param Name The name to search for.
+    /// @return A pointer to the first found matching SpaceEntity.
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceAvatar(const csp::common::String& Name) override;
+
+    /// @brief Finds the first found SpaceEntity of a matching Name. The found SpaceEntity will not contain an AvatarSpaceComponent.
+    /// @param Name The name to search for.
+    /// @return A pointer to the first found matching SpaceEntity.
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* FindSpaceObject(const csp::common::String& Name) override;
+
+    /// @brief Get an Entity by its index.
+    ///
+    /// @param EntityIndex size_t : The index of the entity to get.
+    /// @return A non-owning pointer to the entity at the given index.
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetEntityByIndex(size_t EntityIndex) override;
+
+    /// @brief Get an Avatar by its index. The returned pointer will be an entity that contains an AvatarSpaceComponent.
+    ///
+    /// @param AvatarIndex size_t : The index of the avatar entity to get.
+    /// @return A non-owning pointer to the avatar entity with the given index.
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetAvatarByIndex(size_t AvatarIndex) override;
+
+    /// @brief Get an Object by its index. The returned pointer will be an entity that does not contain an AvatarSpaceComponent.
+    ///
+    /// @param ObjectIndex size_t : The index of the object entity to get.
+    /// @return A non-owning pointer to the object entity with the given index.
+    [[nodiscard]] virtual csp::multiplayer::SpaceEntity* GetObjectByIndex(size_t ObjectIndex) override;
+
+    /// @brief Get the number of total entities in the system.
+    /// @return The total number of entities.
+    virtual size_t GetNumEntities() const override;
+
+    /// @brief Get the number of total Avatars in the system. Avatars are entities that contain AvatarSpaceComponents.
+    /// @return The total number of Avatar entities.
+    virtual size_t GetNumAvatars() const override;
+
+    /// @brief Get the number of total Objects in the system. Objects are entities that do not contain AvatarSpaceComponents.
+    /// @return The total number of object entities.
+    virtual size_t GetNumObjects() const override;
+
+    /// @brief Retrieves all entities that exist at the root level (do not have a parent entity).
+    /// @return A list of root entities containing non-owning pointers to entities.
+    [[nodiscard]] virtual const csp::common::List<csp::multiplayer::SpaceEntity*>* GetRootHierarchyEntities() const override;
+
+    /***** ENTITY PROCESSING *************************************************/
+
+    /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.
+    /// From a client perspective, ProcessPendingEntityOperations is normally called via the CSPFoundation::Tick method.
+    /// @param Entity SpaceEntity : A non-owning pointer to the entity to be marked.
+    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity) override;
+
+    /// @brief Applies any pending changes to entities that have been marked for update.
+    /// This only processes changes to existing entities, such as properties or components. All entity creations and deletions are handled instantly.
+    virtual void ProcessPendingEntityOperations() override;
+
+    /**
+     * @brief TODO: I'm not sure what this function will do yet.
+     *
+     * @param SpaceId const csp::common::String& : MCS formatted SpaceId
+     * @param FetchStartedCallback EntityFetchStartedCallback Callback called once scopes are reset and entity fetch has begun.
+     *
+     * @pre Space represented by SpaceId must exist on the configured server endpoint. See csp::systems::SpaceSystem::CreateSpace
+     * @post FetchStartedCallback will be called. The csp::common::EntityFetchCompleteCallback passed in the constructor will be called async
+     * once all the entities are fetched.
+     */
+    CSP_NO_EXPORT void FetchAllEntitiesAndPopulateBuffers(
+        const csp::common::String& SpaceId, csp::common::EntityFetchStartedCallback FetchStartedCallback) override;
+
+    /***** IREALTIMEENGINE INTERFACE IMPLEMENTAITON END *************************************************/
+
+    /// @brief OnlineRealtimeEngine constructor
+    /// @param SceneDescription CSPSceneDescription : The scene description containing entities within the scene.
+    /// These entities will be populated in the RealtimeEngine.
+    /// @param LogSystem csp::common::LogSystem : Logger such that this system can print status and debug output
+    /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : Object capable of running a script.
+    OfflineRealtimeEngine(
+        const CSPSceneDescription& SceneDescription, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner);
+
+private:
+};
+}

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -235,7 +235,7 @@ public:
     /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.
     /// From a client perspective, ProcessPendingEntityOperations is normally called via the CSPFoundation::Tick method.
     /// @param Entity SpaceEntity : A non-owning pointer to the entity to be marked.
-    virtual void MarkEntityForUpdate(csp::multiplayer::SpaceEntity* Entity) override;
+    virtual void QueueEntityUpdate(csp::multiplayer::SpaceEntity* Entity) override;
 
     /// @brief Applies any pending changes to entities that have been marked for update.
     virtual void ProcessPendingEntityOperations() override;
@@ -334,9 +334,6 @@ public:
 
     /// @brief Unlocks the entity mutex.
     void UnlockEntityUpdate() const;
-
-    /// @brief Queues a specific entity to update. Used in SpaceEntity to queue updates via passing the this pointer
-    void QueueEntityUpdate(SpaceEntity* EntityToUpdate);
 
     /// @brief "Resolves" the entity heirarchy, such that the entity is parented appropriately, and internal buffers are populated appropriately.
     /// (Vague, need more understanding about what this does)

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -230,6 +230,10 @@ public:
     /// @return A list of root entities containing non-owning pointers to entities.
     [[nodiscard]] virtual const csp::common::List<csp::multiplayer::SpaceEntity*>* GetRootHierarchyEntities() const override;
 
+    /// @brief Adds the given entity to the hierarchy by updating entity children and root hierarchy.
+    /// @param Entity csp::multiplayer::SpaceEntity* : The Entity to add to the hierarchy.
+    CSP_NO_EXPORT virtual void ResolveEntityHierarchy(csp::multiplayer::SpaceEntity* Entity) override;
+
     /***** ENTITY PROCESSING *************************************************/
 
     /// @brief Adds an entity to a list of entities to be updated when ProcessPendingEntityOperations is called.
@@ -334,10 +338,6 @@ public:
 
     /// @brief Unlocks the entity mutex.
     void UnlockEntityUpdate() const;
-
-    /// @brief "Resolves" the entity heirarchy, such that the entity is parented appropriately, and internal buffers are populated appropriately.
-    /// (Vague, need more understanding about what this does)
-    void ResolveEntityHierarchy(SpaceEntity* Entity);
 
     /*
      * Called when MultiplayerConnection recieved signalR events.

--- a/Library/include/CSP/Multiplayer/Script/EntityScript.h
+++ b/Library/include/CSP/Multiplayer/Script/EntityScript.h
@@ -24,6 +24,7 @@
 namespace csp::common
 {
 class LogSystem;
+class IRealtimeEngine;
 }
 
 namespace csp::systems
@@ -48,7 +49,7 @@ class CSP_API EntityScript
 public:
     // Don't want to be constructable by public users.
     CSP_START_IGNORE
-    EntityScript(SpaceEntity* InEntity, OnlineRealtimeEngine* InOnlineRealtimeEngine, csp::common::IJSScriptRunner* ScriptRunner,
+    EntityScript(SpaceEntity* InEntity, csp::common::IRealtimeEngine* InRealtimeEngine, csp::common::IJSScriptRunner* ScriptRunner,
         csp::common::LogSystem* LogSystem);
     CSP_END_IGNORE
 
@@ -153,7 +154,7 @@ private:
 
     bool HasBinding;
 
-    OnlineRealtimeEngine* OnlineRealtimeEnginePtr;
+    csp::common::IRealtimeEngine* RealtimeEnginePtr;
 
     // may be null
     csp::common::LogSystem* LogSystem = nullptr;

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -478,6 +478,12 @@ public:
     /// @param PropertyKey int32_t : the key of the property to update
     CSP_NO_EXPORT void OnPropertyChanged(ComponentBase* DirtyComponent, int32_t PropertyKey);
 
+    /// @brief Remove child entities from parent.
+    CSP_NO_EXPORT void RemoveChildEntities();
+
+    /// @brief Sets the internal ParentId to nullptr
+    CSP_NO_EXPORT void RemoveParentId();
+
 private:
     uint16_t GenerateComponentId();
     ComponentBase* InstantiateComponent(uint16_t Id, ComponentType Type);
@@ -554,13 +560,7 @@ private:
     /// @param InOwnerId uint64_t : the owner ID to set
     void SetOwnerId(const uint64_t InOwnerId);
 
-    /// @brief Remove child entities from parent
-    void RemoveChildEntities();
-
-    /// @brief Set ParentId to nullptr
-    void RemoveParentId();
-
-    // Do NOT call directly, always call either Select() Deselect()
+    // Do NOT call directly, always call either Select() Deselect() or SpaceEntitySystem::InternalSetSelectionStateOfEntity()
     /// @brief Internal version of the selected state of the entity setter
     /// @param SelectedState bool : the selected state to set
     /// @param ClientID uint64_t : the client ID of the entity for which to set the selected state

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -148,11 +148,12 @@ public:
     SpaceEntity();
 
     /// @brief Creates a SpaceEntity instance using the space entity system provided.
-    SpaceEntity(OnlineRealtimeEngine* InEntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem);
+    SpaceEntity(csp::common::IRealtimeEngine* InEntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem);
 
     /// Internal constructor to explicitly create a SpaceEntity in a specified state.
     /// Initially implemented for use in OnlineRealtimeEngine::CreateAvatar
-    CSP_NO_EXPORT SpaceEntity(OnlineRealtimeEngine* EntitySystem, csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem* LogSystem,
+    CSP_NO_EXPORT SpaceEntity(csp::common::IRealtimeEngine* EntitySystem, csp::common::IJSScriptRunner& ScriptRunner,
+        csp::common::LogSystem* LogSystem,
         SpaceEntityType Type, uint64_t Id, const csp::common::String& Name, const SpaceTransform& Transform, uint64_t OwnerId, bool IsTransferable,
         bool IsPersistent);
 
@@ -271,9 +272,6 @@ public:
     /// @return csp::common::List<SpaceEntity>
     const csp::common::List<SpaceEntity*>* GetChildEntities() const;
 
-    /// @brief Queues an update which will be executed on next Tick() or ProcessPendingEntityOperations(). Not a blocking or async function.
-    void QueueUpdate();
-
     /// @brief Sends a patch message with a flag to destroy the entity.
     ///
     /// Will remove the entity from endpoints and signal remote clients to delete the entity.
@@ -369,6 +367,9 @@ public:
     /// @return bool
     bool IsLocked() const;
 
+    /// @brief Queues an update which will be executed on next Tick() or ProcessPendingEntityOperations(). Not a blocking or async function.
+    void QueueUpdate();
+
     /// @brief Getter for the EntityUpdateCallback
     /// @return: UpdateCallback
     CSP_NO_EXPORT UpdateCallback GetEntityUpdateCallback();
@@ -440,7 +441,7 @@ public:
 
     /// @brief Apply a local patch
     /// @param InvokeUpdateCallback bool : whether to invoke the update callback (default: true)
-    /// @param AllowSelfMessaging bool : Whether or not to apply local patches. Normally sources from the OnlineRealtimeEngine state. Don't set this
+    /// @param AllowSelfMessaging bool : Whether or not to apply local patches. Normally sources from the RealtimeEngine state. Don't set this
     /// unless you know what you are doing. (default: false)
     CSP_NO_EXPORT void ApplyLocalPatch(bool InvokeUpdateCallback = true, bool AllowSelfMessaging = false);
 
@@ -495,7 +496,7 @@ private:
     // Called when we're parsing a component from an mcs::ObjectPatch
     ComponentUpdateInfo ComponentFromItemComponentDataPatch(uint16_t ComponentId, const csp::multiplayer::mcs::ItemComponentData& ComponentData);
 
-    OnlineRealtimeEngine* EntitySystem;
+    csp::common::IRealtimeEngine* EntitySystem;
 
     SpaceEntityType Type;
     uint64_t Id;
@@ -559,7 +560,7 @@ private:
     /// @brief Set ParentId to nullptr
     void RemoveParentId();
 
-    // Do NOT call directly, always call either Select() Deselect() or OnlineRealtimeEngine::InternalSetSelectionStateOfEntity()
+    // Do NOT call directly, always call either Select() Deselect()
     /// @brief Internal version of the selected state of the entity setter
     /// @param SelectedState bool : the selected state to set
     /// @param ClientID uint64_t : the client ID of the entity for which to set the selected state

--- a/Library/src/Common/UUIDGenerator.h
+++ b/Library/src/Common/UUIDGenerator.h
@@ -24,6 +24,16 @@
 namespace csp
 {
 
+inline uint64_t RandInt()
+{
+    // Use this as rand() only offers 15 bits of randomness
+    std::mt19937_64 Rand;
+    auto CurrentTime = std::chrono::high_resolution_clock::now();
+    auto CurrentNanoseconds = std::chrono::time_point_cast<std::chrono::nanoseconds>(CurrentTime);
+    Rand.seed(CurrentNanoseconds.time_since_epoch().count());
+    return Rand();
+}
+
 /// @brief Generates a uuid
 /// @return std::string
 inline std::string GenerateUUID()
@@ -31,18 +41,8 @@ inline std::string GenerateUUID()
     // Generate a random UUID by combining 2 64-bit unsigned integers
     uint8_t Uuid[16];
 
-    // Use this as rand() only offers 15 bits of randomness
-    std::mt19937_64 Rand;
-    auto CurrentTime = std::chrono::high_resolution_clock::now();
-    auto CurrentNanoseconds = std::chrono::time_point_cast<std::chrono::nanoseconds>(CurrentTime);
-    Rand.seed(CurrentNanoseconds.time_since_epoch().count());
-    *reinterpret_cast<uint64_t*>(&Uuid[0]) = Rand();
-    // Re-seed for extra randomness
-    CurrentTime = std::chrono::high_resolution_clock::now();
-    CurrentNanoseconds = std::chrono::time_point_cast<std::chrono::nanoseconds>(CurrentTime);
-    Rand.seed(CurrentNanoseconds.time_since_epoch().count());
-    [[maybe_unused]] auto SkippedVal = Rand(); // Skip one pseudo-random number
-    *reinterpret_cast<uint64_t*>(&Uuid[8]) = Rand();
+    *reinterpret_cast<uint64_t*>(&Uuid[0]) = RandInt();
+    *reinterpret_cast<uint64_t*>(&Uuid[8]) = RandInt();
 
     // Convert to hex string
     std::ostringstream UUIDStringStream;

--- a/Library/src/Multiplayer/CSPSceneDescription.cpp
+++ b/Library/src/Multiplayer/CSPSceneDescription.cpp
@@ -21,24 +21,30 @@
 
 namespace csp::multiplayer
 {
-CSPSceneDescription::CSPSceneDescription(const csp::common::String& SceneDescriptionJson, csp::multiplayer::OnlineRealtimeEngine& EntitySystem,
-    csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner)
+CSPSceneDescription::CSPSceneDescription(const csp::common::String& SceneDescriptionJson)
+    : SceneDescriptionJson { SceneDescriptionJson }
+{
+}
+
+csp::common::Array<csp::multiplayer::SpaceEntity*> CSPSceneDescription::CreateEntities(
+    csp::common::IRealtimeEngine& RealtimeEngine, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner) const
 {
     mcs::SceneDescription SceneDescription;
     csp::json::JsonDeserializer::Deserialize(SceneDescriptionJson.c_str(), SceneDescription);
 
-    Entities = csp::common::Array<csp::multiplayer::SpaceEntity*>(SceneDescription.Objects.size());
+    csp::common::Array<csp::multiplayer::SpaceEntity*> Entities { SceneDescription.Objects.size() };
 
     size_t ObjectsIndex = 0;
     for (const auto& Object : SceneDescription.Objects)
     {
-        auto* Entity = new multiplayer::SpaceEntity(&EntitySystem, RemoteScriptRunner, &LogSystem);
+        auto* Entity = new multiplayer::SpaceEntity(&RealtimeEngine, RemoteScriptRunner, &LogSystem);
         Entity->FromObjectMessage(Object);
 
-        EntitySystem.AddEntity(Entity);
         Entities[ObjectsIndex] = Entity;
         ObjectsIndex++;
     }
+
+    return Entities;
 }
 
 }

--- a/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/Multiplayer/OfflineRealtimeEngine.h"
+#include "CSP/Common/Interfaces/IJSScriptRunner.h"
+#include "CSP/Common/Systems/Log/LogSystem.h"
+#include "CSP/Multiplayer/CSPSceneDescription.h"
+#include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "Common/UUIDGenerator.h"
+#include "Multiplayer/RealtimeEngineUtils.h"
+
+#include <unordered_set>
+
+namespace csp::multiplayer
+{
+
+csp::common::RealtimeEngineType OfflineRealtimeEngine::GetRealtimeEngineType() const { return csp::common::RealtimeEngineType::Offline; }
+
+void csp::multiplayer::OfflineRealtimeEngine::CreateAvatar(const csp::common::String& Name, const csp::common::String& UserId,
+    const csp::multiplayer::SpaceTransform& Transform, bool IsVisible, const csp::multiplayer::AvatarState& State,
+    const csp::common::String& AvatarId, const csp::multiplayer::AvatarPlayMode& AvatarPlayMode, csp::multiplayer::EntityCreatedCallback Callback)
+{
+    const uint64_t Id = RandInt();
+
+    std::unique_ptr<csp::multiplayer::SpaceEntity> NewAvatar
+        = BuildNewAvatar(UserId, *this, *ScriptRunner, *LogSystem, Id, Name, Transform, IsVisible, 0, false, false, AvatarId, State, AvatarPlayMode);
+
+    std::scoped_lock EntitiesLocker(*EntitiesLock);
+
+    Entities.Append(NewAvatar.get());
+    Avatars.Append(NewAvatar.get());
+
+    auto* Avatar = NewAvatar.release();
+
+    Avatar->ApplyLocalPatch(false, false);
+
+    if (SpaceEntityCreatedCallback)
+    {
+        SpaceEntityCreatedCallback(Avatar);
+    }
+
+    Callback(Avatar);
+}
+
+void OfflineRealtimeEngine::CreateEntity(const csp::common::String& Name, const csp::multiplayer::SpaceTransform& Transform,
+    const csp::common::Optional<uint64_t>& ParentID, csp::multiplayer::EntityCreatedCallback Callback)
+{
+    uint64_t Id = RandInt();
+    // Client id doesnt matter for single player
+    uint64_t ClientId = 0;
+
+    auto* NewEntity = new SpaceEntity { this, *ScriptRunner, LogSystem, SpaceEntityType::Object, Id, Name, Transform, ClientId, false, false };
+
+    if (ParentID.HasValue())
+    {
+        NewEntity->SetParentId(*ParentID);
+    }
+
+    std::scoped_lock EntitiesLocker { *EntitiesLock };
+
+    ResolveEntityHierarchy(NewEntity);
+
+    Entities.Append(NewEntity);
+    Objects.Append(NewEntity);
+
+    if (SpaceEntityCreatedCallback)
+    {
+        SpaceEntityCreatedCallback(NewEntity);
+    }
+
+    Callback(NewEntity);
+}
+
+void OfflineRealtimeEngine::AddEntity(SpaceEntity* EntityToAdd)
+{
+    std::scoped_lock EntitiesLocker(*EntitiesLock);
+    AddPendingEntity(EntityToAdd);
+}
+
+void OfflineRealtimeEngine::DestroyEntity(csp::multiplayer::SpaceEntity* Entity, csp::multiplayer::CallbackHandler Callback)
+{
+    std::scoped_lock EntitiesLocker(*EntitiesLock);
+
+    StartEntityDeletion(*this, RootHierarchyEntities, Entity);
+
+    RemovePendingEntity(Entity);
+
+    Callback(true);
+}
+
+void OfflineRealtimeEngine::SetEntityCreatedCallback(csp::multiplayer::EntityCreatedCallback Callback)
+{
+    if (SpaceEntityCreatedCallback)
+    {
+        LogSystem->LogMsg(common::LogLevel::Warning, "OfflineRealtimeEngine has already been set. Previous callback overwritten.");
+    }
+
+    SpaceEntityCreatedCallback = std::move(Callback);
+}
+
+bool OfflineRealtimeEngine::AddEntityToSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
+{
+    if (!SelectedEntities.Contains(Entity))
+    {
+        SelectedEntities.Append(Entity);
+        return true;
+    }
+    return false;
+}
+
+bool OfflineRealtimeEngine::RemoveEntityFromSelectedEntities(csp::multiplayer::SpaceEntity* Entity)
+{
+    if (SelectedEntities.Contains(Entity))
+    {
+        SelectedEntities.RemoveItem(Entity);
+        return true;
+    }
+    return false;
+}
+
+csp::multiplayer::SpaceEntity* OfflineRealtimeEngine::FindSpaceEntity(const csp::common::String& Name)
+{
+    return csp::multiplayer::FindSpaceEntity(*this, Name);
+}
+
+csp::multiplayer::SpaceEntity* OfflineRealtimeEngine::FindSpaceEntityById(uint64_t EntityId)
+{
+    for (size_t i = 0; i < Entities.Size(); ++i)
+    {
+        if (Entities[i]->GetId() == EntityId)
+        {
+            return Entities[i];
+        }
+    }
+
+    return nullptr;
+}
+
+csp::multiplayer::SpaceEntity* OfflineRealtimeEngine::FindSpaceAvatar(const csp::common::String& Name)
+{
+    for (size_t i = 0; i < Avatars.Size(); ++i)
+    {
+        if (Avatars[i]->GetName() == Name)
+        {
+            return Avatars[i];
+        }
+    }
+
+    return nullptr;
+}
+
+csp::multiplayer::SpaceEntity* OfflineRealtimeEngine::FindSpaceObject(const csp::common::String& Name)
+{
+    for (size_t i = 0; i < Objects.Size(); ++i)
+    {
+        if (Objects[i]->GetName() == Name)
+        {
+            return Objects[i];
+        }
+    }
+
+    return nullptr;
+}
+
+csp::multiplayer::SpaceEntity* OfflineRealtimeEngine::GetEntityByIndex(size_t EntityIndex) { return Entities[EntityIndex]; }
+
+csp::multiplayer::SpaceEntity* OfflineRealtimeEngine::GetAvatarByIndex(size_t AvatarIndex) { return Avatars[AvatarIndex]; }
+
+csp::multiplayer::SpaceEntity* OfflineRealtimeEngine::GetObjectByIndex(size_t ObjectIndex) { return Objects[ObjectIndex]; }
+
+size_t OfflineRealtimeEngine::GetNumEntities() const { return Entities.Size(); }
+
+size_t OfflineRealtimeEngine::GetNumAvatars() const { return Avatars.Size(); }
+
+size_t OfflineRealtimeEngine::GetNumObjects() const { return Objects.Size(); }
+
+const csp::common::List<csp::multiplayer::SpaceEntity*>* OfflineRealtimeEngine::GetRootHierarchyEntities() const { return &RootHierarchyEntities; }
+
+void OfflineRealtimeEngine::QueueEntityUpdate(csp::multiplayer::SpaceEntity* Entity) { EntitiesToUpdate->insert(Entity); }
+
+void OfflineRealtimeEngine::ProcessPendingEntityOperations()
+{
+    std::scoped_lock EntitiesLocker(*EntitiesLock);
+
+    // Process any changes that have been made to entities.
+    for (const auto& Entity : *EntitiesToUpdate)
+    {
+        Entity->ApplyLocalPatch(true, false);
+    }
+
+    EntitiesToUpdate->clear();
+}
+
+void OfflineRealtimeEngine::FetchAllEntitiesAndPopulateBuffers(const csp::common::String&, csp::common::EntityFetchStartedCallback Callback)
+{
+    // TODO: Currently dont do anything here as Entities are populated in the constructor.
+    // This will likely change when integrating new RealtimeEngine changes.
+    Callback();
+}
+
+OfflineRealtimeEngine::OfflineRealtimeEngine(
+    const CSPSceneDescription& SceneDescription, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner)
+    : LogSystem { &LogSystem }
+    , ScriptRunner { &RemoteScriptRunner }
+    , EntitiesToUpdate { std::make_unique<SpaceEntitySet>() }
+    , EntitiesLock { std::make_unique<std::recursive_mutex>() }
+{
+    std::scoped_lock EntitiesLocker(*EntitiesLock);
+
+    auto DeserializedEntities = SceneDescription.CreateEntities(*this, LogSystem, RemoteScriptRunner);
+
+    for (size_t i = 0; i < DeserializedEntities.Size(); ++i)
+    {
+        AddPendingEntity(DeserializedEntities[i]);
+    }
+}
+
+void OfflineRealtimeEngine::AddPendingEntity(SpaceEntity* EntityToAdd)
+{
+    if (FindSpaceEntityById(EntityToAdd->GetId()) == nullptr)
+    {
+        Entities.Append(EntityToAdd);
+
+        switch (EntityToAdd->GetEntityType())
+        {
+        case SpaceEntityType::Avatar:
+            Avatars.Append(EntityToAdd);
+            break;
+
+        case SpaceEntityType::Object:
+            Objects.Append(EntityToAdd);
+            break;
+        }
+    }
+    else
+    {
+        LogSystem->LogMsg(common::LogLevel::Error, "Attempted to add a pending entity that we already have!");
+    }
+}
+
+void OfflineRealtimeEngine::RemovePendingEntity(SpaceEntity* EntityToRemove)
+{
+    assert(Entities.Contains(EntityToRemove));
+
+    switch (EntityToRemove->GetEntityType())
+    {
+    case SpaceEntityType::Avatar:
+        assert(Avatars.Contains(EntityToRemove));
+        Avatars.RemoveItem(EntityToRemove);
+        break;
+
+    case SpaceEntityType::Object:
+        assert(Objects.Contains(EntityToRemove));
+        Objects.RemoveItem(EntityToRemove);
+        break;
+
+    default:
+        assert(false && "Unhandled entity type encountered during its destruction!");
+        break;
+    }
+
+    RootHierarchyEntities.RemoveItem(EntityToRemove);
+    ResolveParentChildForDeletion(*this, RootHierarchyEntities, EntityToRemove);
+
+    Entities.RemoveItem(EntityToRemove);
+
+    delete (EntityToRemove);
+}
+}

--- a/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
@@ -190,6 +190,11 @@ size_t OfflineRealtimeEngine::GetNumObjects() const { return Objects.Size(); }
 
 const csp::common::List<csp::multiplayer::SpaceEntity*>* OfflineRealtimeEngine::GetRootHierarchyEntities() const { return &RootHierarchyEntities; }
 
+void OfflineRealtimeEngine::ResolveEntityHierarchy(csp::multiplayer::SpaceEntity* Entity)
+{
+    csp::multiplayer::ResolveEntityHierarchy(*this, RootHierarchyEntities, Entity);
+}
+
 void OfflineRealtimeEngine::QueueEntityUpdate(csp::multiplayer::SpaceEntity* Entity) { EntitiesToUpdate->insert(Entity); }
 
 void OfflineRealtimeEngine::ProcessPendingEntityOperations()

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -34,6 +34,7 @@
 #include "Multiplayer/Script/EntityScriptBinding.h"
 #include "Multiplayer/SignalR/ISignalRConnection.h"
 #include "Multiplayer/SignalR/SignalRClient.h"
+#include "Multiplayer/RealtimeEngineUtils.h"
 #include "SignalRSerializer.h"
 #ifdef CSP_WASM
 #include "Multiplayer/SignalR/EmscriptenSignalRClient/EmscriptenSignalRClient.h"
@@ -1009,30 +1010,6 @@ void OnlineRealtimeEngine::ResolveParentChildForDeletion(SpaceEntity* Deletion)
     }
 }
 
-void OnlineRealtimeEngine::ResolveEntityHierarchy(SpaceEntity* Entity)
-{
-    if (Entity->GetParentId().HasValue())
-    {
-        for (size_t i = 0; i < RootHierarchyEntities.Size(); ++i)
-        {
-            if (RootHierarchyEntities[i]->GetId() == Entity->GetId())
-            {
-                RootHierarchyEntities.Remove(i);
-                break;
-            }
-        }
-    }
-    else
-    {
-        if (EntityIsInRootHierarchy(Entity) == false)
-        {
-            RootHierarchyEntities.Append(Entity);
-        }
-    }
-
-    Entity->ResolveParentChildRelationship();
-}
-
 bool OnlineRealtimeEngine::EntityIsInRootHierarchy(SpaceEntity* Entity)
 {
     for (size_t i = 0; i < RootHierarchyEntities.Size(); ++i)
@@ -1127,6 +1104,11 @@ bool OnlineRealtimeEngine::GetEntityPatchRateLimitEnabled() const { return Entit
 void OnlineRealtimeEngine::SetEntityPatchRateLimitEnabled(bool Enabled) { EntityPatchRateLimitEnabled = Enabled; }
 
 const csp::common::List<SpaceEntity*>* OnlineRealtimeEngine::GetRootHierarchyEntities() const { return &RootHierarchyEntities; }
+
+void OnlineRealtimeEngine::ResolveEntityHierarchy(csp::multiplayer::SpaceEntity* Entity)
+{
+    csp::multiplayer::ResolveEntityHierarchy(*this, RootHierarchyEntities, Entity);
+}
 
 void OnlineRealtimeEngine::RefreshMultiplayerConnectionToEnactScopeChange(
     csp::common::String SpaceId, std::shared_ptr<async::event_task<std::optional<csp::multiplayer::ErrorCode>>> RefreshMultiplayerContinuationEvent)

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -977,14 +977,6 @@ void OnlineRealtimeEngine::TickEntities()
     }
 }
 
-void OnlineRealtimeEngine::MarkEntityForUpdate(SpaceEntity* Entity)
-{
-    std::scoped_lock TickEntitiesLocker(*TickEntitiesLock);
-
-    // Duplicates can be added here and will be ignored when sending updates
-    TickUpdateEntities.push_back(Entity);
-}
-
 // @brief Simple script ownership
 //
 // Simple MVP script ownership for testing:

--- a/Library/src/Multiplayer/RealtimeEngineUtils.cpp
+++ b/Library/src/Multiplayer/RealtimeEngineUtils.cpp
@@ -1,0 +1,168 @@
+#include "Multiplayer/RealtimeEngineUtils.h"
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/Common/Interfaces/IRealtimeEngine.h"
+#include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "Multiplayer/RealtimeEngineUtils.h"
+
+namespace csp::multiplayer
+{
+csp::multiplayer::SpaceEntity* FindSpaceEntity(csp::common::IRealtimeEngine& RealtimeEngine, const csp::common::String& Name)
+{
+    for (size_t i = 0; i < RealtimeEngine.GetNumEntities(); ++i)
+    {
+        if (RealtimeEngine.GetEntityByIndex(i)->GetName() == Name)
+        {
+            return RealtimeEngine.GetEntityByIndex(i);
+        }
+    }
+
+    return nullptr;
+}
+
+csp::multiplayer::SpaceEntity* FindSpaceAvatar(csp::common::IRealtimeEngine& RealtimeEngine, const csp::common::String& Name)
+{
+    for (size_t i = 0; i < RealtimeEngine.GetNumAvatars(); ++i)
+    {
+        if (RealtimeEngine.GetAvatarByIndex(i)->GetName() == Name)
+        {
+            return RealtimeEngine.GetAvatarByIndex(i);
+        }
+    }
+
+    return nullptr;
+}
+
+csp::multiplayer::SpaceEntity* FindSpaceObject(csp::common::IRealtimeEngine& RealtimeEngine, const csp::common::String& Name)
+{
+    for (size_t i = 0; i < RealtimeEngine.GetNumObjects(); ++i)
+    {
+        if (RealtimeEngine.GetObjectByIndex(i)->GetName() == Name)
+        {
+            return RealtimeEngine.GetObjectByIndex(i);
+        }
+    }
+
+    return nullptr;
+}
+
+std::unique_ptr<csp::multiplayer::SpaceEntity> BuildNewAvatar(const csp::common::String& UserId, csp::common::IRealtimeEngine&,
+    csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem& LogSystem, uint64_t NetworkId, const csp::common::String& Name,
+    const csp::multiplayer::SpaceTransform& Transform, bool IsVisible, uint64_t OwnerId, bool IsTransferable, bool IsPersistent,
+    const csp::common::String& AvatarId, csp::multiplayer::AvatarState AvatarState, csp::multiplayer::AvatarPlayMode AvatarPlayMode)
+{
+    auto NewAvatar = std::unique_ptr<csp::multiplayer::SpaceEntity>(new csp::multiplayer::SpaceEntity(
+        nullptr, ScriptRunner, &LogSystem, SpaceEntityType::Avatar, NetworkId, Name, Transform, OwnerId, IsTransferable, IsPersistent));
+
+    auto* AvatarComponent = static_cast<AvatarSpaceComponent*>(NewAvatar->AddComponent(ComponentType::AvatarData));
+    AvatarComponent->SetAvatarId(AvatarId);
+    AvatarComponent->SetState(AvatarState);
+    AvatarComponent->SetAvatarPlayMode(AvatarPlayMode);
+    AvatarComponent->SetUserId(UserId);
+    AvatarComponent->SetIsVisible(IsVisible);
+
+    return NewAvatar;
+}
+
+bool EntityIsInRootHierarchy(csp::common::IRealtimeEngine& RealtimeEngine, SpaceEntity* Entity)
+{
+    for (size_t i = 0; i < RealtimeEngine.GetRootHierarchyEntities()->Size(); ++i)
+    {
+        if ((*RealtimeEngine.GetRootHierarchyEntities())[i]->GetId() == Entity->GetId())
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ResolveEntityHierarchy(csp::common::IRealtimeEngine& RealtimeEngine, csp::common::List<SpaceEntity*>& RootHierarchyEntities, SpaceEntity* Entity)
+{
+    if (Entity->GetParentId().HasValue())
+    {
+        for (size_t i = 0; i < RootHierarchyEntities.Size(); ++i)
+        {
+            if (RootHierarchyEntities[i]->GetId() == Entity->GetId())
+            {
+                RootHierarchyEntities.Remove(i);
+                break;
+            }
+        }
+    }
+    else
+    {
+        if (EntityIsInRootHierarchy(RealtimeEngine, Entity) == false)
+        {
+            RootHierarchyEntities.Append(Entity);
+        }
+    }
+
+    Entity->ResolveParentChildRelationship();
+}
+
+void ResolveParentChildForDeletion(
+    csp::common::IRealtimeEngine& RealtimeEngine, csp::common::List<SpaceEntity*>& RootHierarchyEntities, SpaceEntity* Deletion)
+{
+    if (Deletion->GetParentEntity())
+    {
+        Deletion->RemoveChildEntities();
+    }
+
+    auto ChildEntities = Deletion->GetChildEntities()->ToArray();
+
+    for (size_t i = 0; i < ChildEntities.Size(); ++i)
+    {
+        Deletion->RemoveParentFromChildEntity(i);
+
+        ResolveEntityHierarchy(RealtimeEngine, RootHierarchyEntities, ChildEntities[i]);
+    }
+}
+
+void StartEntityDeletion(
+    csp::common::IRealtimeEngine& RealtimeEngine, csp::common::List<SpaceEntity*>& RootHierarchyEntities, csp::multiplayer::SpaceEntity* Entity)
+{
+    auto EntityComponents = Entity->GetComponents();
+    std::unique_ptr<common::Array<uint16_t>> Keys(const_cast<common::Array<uint16_t>*>(EntityComponents->Keys()));
+
+    for (size_t i = 0; i < Keys->Size(); ++i)
+    {
+        auto EntityComponent = Entity->GetComponent((*Keys)[i]);
+        EntityComponent->OnLocalDelete();
+    }
+
+    csp::common::Array<ComponentUpdateInfo> Info;
+
+    RootHierarchyEntities.RemoveItem(Entity);
+
+    // Manually process the parent updates locally
+    // We want this callback to fire before the deletion so clients can react to children first
+    auto ChildrenToUpdate = Entity->GetChildEntities()->ToArray();
+
+    for (size_t i = 0; i < ChildrenToUpdate.Size(); ++i)
+    {
+        ChildrenToUpdate[i]->RemoveParentId();
+        ResolveEntityHierarchy(RealtimeEngine, RootHierarchyEntities, ChildrenToUpdate[i]);
+
+        if (ChildrenToUpdate[i]->GetEntityUpdateCallback())
+        {
+            ChildrenToUpdate[i]->SetEntityUpdateCallbackParams(ChildrenToUpdate[i], UPDATE_FLAGS_PARENT, Info);
+        }
+    }
+}
+}

--- a/Library/src/Multiplayer/RealtimeEngineUtils.h
+++ b/Library/src/Multiplayer/RealtimeEngineUtils.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "CSP/CSPCommon.h"
+#include "CSP/Common/String.h"
+
+#include <memory>
+
+namespace csp::common
+{
+class IRealtimeEngine;
+class IJSScriptRunner;
+class LogSystem;
+}
+
+/*
+    These functions encapsulate the shared functionality between Online and Offline RealtimeEngine.
+    A better pattern sould be established to ensure shared funcitonality is reused across both versions,
+    as OnlineRealtimeEngine is essentially and extension of Offline, adding replication functionality.
+*/
+
+namespace csp::multiplayer
+{
+class SpaceEntity;
+class SpaceTransform;
+class AvatarSpaceComponent;
+enum class AvatarState;
+enum class AvatarPlayMode;
+
+// Finds a space entity in the Entities container. Returns nullptr if the entity is not found.
+csp::multiplayer::SpaceEntity* FindSpaceEntity(csp::common::IRealtimeEngine& RealtimeEngine, const csp::common::String& Name);
+
+// Finds an avatar entity in the Avatar container. Returns nullptr if the avatar is not found.
+csp::multiplayer::SpaceEntity* FindSpaceAvatar(csp::common::IRealtimeEngine& RealtimeEngine, const csp::common::String& Name);
+
+// Finds an object in the Objects container. Returns nullptr if the object is not found.
+csp::multiplayer::SpaceEntity* FindSpaceObject(csp::common::IRealtimeEngine& RealtimeEngine, const csp::common::String& Name);
+
+// Creates a space entity with an avatar component.
+std::unique_ptr<csp::multiplayer::SpaceEntity> BuildNewAvatar(const csp::common::String& UserId, csp::common::IRealtimeEngine& RealtimeEngine,
+    csp::common::IJSScriptRunner& ScriptRunner, csp::common::LogSystem& LogSystem, uint64_t NetworkId, const csp::common::String& Name,
+    const csp::multiplayer::SpaceTransform& Transform, bool IsVisible, uint64_t OwnerId, bool IsTransferable, bool IsPersistent,
+    const csp::common::String& AvatarId, csp::multiplayer::AvatarState AvatarState, csp::multiplayer::AvatarPlayMode AvatarPlayMode);
+
+// Checks if an entity exists within the root hierarchy array
+bool EntityIsInRootHierarchy(csp::common::IRealtimeEngine& RealtimeEngine, SpaceEntity* Entity);
+
+// Adds or removed entity from the root hierarchy list and calls SpaceEntity::ResolveParentChildRelationship
+void ResolveEntityHierarchy(
+    csp::common::IRealtimeEngine& RealtimeEngine, csp::common::List<SpaceEntity*>& RootHierarchyEntities, SpaceEntity* Entity);
+
+// Unparents any child entities from the entity to be deleted and removed the parent relationship.
+void ResolveParentChildForDeletion(
+    csp::common::IRealtimeEngine& RealtimeEngine, csp::common::List<SpaceEntity*>& RootHierarchyEntities, SpaceEntity* Deletion);
+
+// Ensures compoennts attached to the entitiy are notified of deletion by calling OnLocalDelete.
+// It also fires the entity patch callback, notifying clients that the child entities have been reparented.
+void StartEntityDeletion(
+    csp::common::IRealtimeEngine& RealtimeEngine, csp::common::List<SpaceEntity*>& RootHierarchyEntities, csp::multiplayer::SpaceEntity* Entity);
+}

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -52,6 +52,7 @@
 #include "Multiplayer/Script/EntityScriptBinding.h"
 #include "Multiplayer/Script/EntityScriptInterface.h"
 #include "Multiplayer/SpaceEntityKeys.h"
+#include "RealtimeEngineUtils.h"
 #include "signalrclient/signalr_value.h"
 
 #include <chrono>
@@ -677,8 +678,7 @@ void SpaceEntity::ApplyLocalPatch(bool InvokeUpdateCallback, bool AllowSelfMessa
 
         if (ShouldUpdateParent)
         {
-            // TODO: Replace this with RealtineEngine utils
-            //EntitySystem->ResolveEntityHierarchy(this);
+            EntitySystem->ResolveEntityHierarchy(this);
             UpdateFlags = static_cast<SpaceEntityUpdateFlags>(UpdateFlags | UPDATE_FLAGS_PARENT);
             ShouldUpdateParent = false;
         }
@@ -1334,8 +1334,7 @@ void SpaceEntity::FromObjectPatch(const mcs::ObjectPatch& Patch)
 
     if (ShouldUpdateParent)
     {
-        // TODO: Replace this with RealtineEngine utils
-        //EntitySystem->ResolveEntityHierarchy(this);
+        EntitySystem->ResolveEntityHierarchy(this);
         UpdateFlags = static_cast<SpaceEntityUpdateFlags>(UpdateFlags | UPDATE_FLAGS_PARENT);
         ShouldUpdateParent = false;
     }

--- a/Tests/src/InternalTests/SceneDescriptionTests.cpp
+++ b/Tests/src/InternalTests/SceneDescriptionTests.cpp
@@ -20,7 +20,7 @@
 #include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Multiplayer/CSPSceneDescription.h"
-#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
+#include "CSP/Multiplayer/OfflineRealtimeEngine.h"
 #include "CSP/Systems/CSPSceneData.h"
 #include "Multiplayer/MCS/MCSSceneDescription.h"
 #include "Multiplayer/MCS/MCSTypes.h"
@@ -269,16 +269,15 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeE
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    TestAuthContext AuthContext;
 
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(AuthContext) };
-    csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    CSPSceneDescription SceneDescription { Json.c_str() };
+    csp::multiplayer::OfflineRealtimeEngine Engine { SceneDescription, LogSystem, ScriptRunner };
 
-    CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };
 
-    EXPECT_EQ(SceneDescription.Entities.Size(), 0);
+    auto Entities = SceneDescription.CreateEntities(Engine, LogSystem, ScriptRunner);
+
+    EXPECT_EQ(Entities.Size(), 0);
     EXPECT_EQ(SceneData.AssetCollections.Size(), 0);
     EXPECT_EQ(SceneData.Assets.Size(), 0);
     EXPECT_EQ(SceneData.Sequences.Size(), 0);
@@ -306,13 +305,12 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeT
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    TestAuthContext AuthContext;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(AuthContext) };
-    csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    CSPSceneDescription SceneDescription { Json.c_str() };
+    csp::multiplayer::OfflineRealtimeEngine Engine { SceneDescription, LogSystem, ScriptRunner };
 
-    CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };
+
+    auto Entities = SceneDescription.CreateEntities(Engine, LogSystem, ScriptRunner);
 
     // Test csp scene description values are correct
 
@@ -334,9 +332,9 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionDeserializeT
     EXPECT_TRUE(csp::systems::HasFlag(SceneData.Space.Attributes, csp::systems::SpaceAttributes::RequiresInvite));
 
     // Entities
-    EXPECT_EQ(SceneDescription.Entities.Size(), 74);
+    EXPECT_EQ(Entities.Size(), 74);
 
-    csp::multiplayer::SpaceEntity* SpaceEntity = SceneDescription.Entities[0];
+    csp::multiplayer::SpaceEntity* SpaceEntity = Entities[0];
     EXPECT_EQ(SpaceEntity->GetId(), 1484);
     EXPECT_EQ(SpaceEntity->GetEntityType(), csp::multiplayer::SpaceEntityType::Object);
     EXPECT_EQ(SpaceEntity->IsTransferable, true);
@@ -414,13 +412,12 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeser
 
     MockScriptRunner ScriptRunner;
     csp::common::LogSystem LogSystem;
-    TestAuthContext AuthContext;
-    csp::multiplayer::MultiplayerConnection Connection { LogSystem, *csp::multiplayer::MultiplayerConnection::MakeSignalRConnection(AuthContext) };
-    csp::multiplayer::NetworkEventBus NetworkEventBus { &Connection, LogSystem };
-    csp::multiplayer::OnlineRealtimeEngine EntitySystem(Connection, LogSystem, NetworkEventBus, ScriptRunner);
+    CSPSceneDescription SceneDescription { Json.c_str() };
+    csp::multiplayer::OfflineRealtimeEngine Engine { SceneDescription, LogSystem, ScriptRunner };
 
-    CSPSceneDescription SceneDescription { Json.c_str(), EntitySystem, LogSystem, ScriptRunner };
     CSPSceneData SceneData { Json.c_str() };
+
+    auto Entities = SceneDescription.CreateEntities(Engine, LogSystem, ScriptRunner);
 
     // Test csp scene description values are correct
 
@@ -438,9 +435,9 @@ CSP_INTERNAL_TEST(CSPEngine, SceneDescriptionTests, SceneDescriptionMinimalDeser
     EXPECT_TRUE(csp::systems::HasFlag(SceneData.Space.Attributes, csp::systems::SpaceAttributes::RequiresInvite));
 
     // Entities
-    EXPECT_EQ(SceneDescription.Entities.Size(), 1);
+    EXPECT_EQ(Entities.Size(), 1);
 
-    csp::multiplayer::SpaceEntity* SpaceEntity = SceneDescription.Entities[0];
+    csp::multiplayer::SpaceEntity* SpaceEntity = Entities[0];
     EXPECT_EQ(SpaceEntity->GetId(), 1484);
     EXPECT_EQ(SpaceEntity->GetEntityType(), csp::multiplayer::SpaceEntityType::Object);
     EXPECT_EQ(SpaceEntity->IsTransferable, true);

--- a/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
@@ -1,0 +1,847 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/Common/Systems/Log/LogSystem.h"
+#include "CSP/Multiplayer/CSPSceneDescription.h"
+#include "CSP/Multiplayer/OfflineRealtimeEngine.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Multiplayer/SpaceTransform.h"
+#include "CSP/Systems/Script/ScriptSystem.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
+
+#include "TestHelpers.h"
+
+#include "gtest/gtest.h"
+
+#include <filesystem>
+#include <fstream>
+
+using namespace csp;
+using namespace csp::multiplayer;
+
+/*
+    Checks OfflineRealtimeEngine is returning the correct enum for GetRealtimeEngineType
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, GetRealtimeEngineType)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    EXPECT_EQ(Engine.GetRealtimeEngineType(), csp::common::RealtimeEngineType::Offline);
+}
+
+/*
+    Tests the following behaviour for OfflineRealtimeEngine::CreateAvatar:
+       * A non-null entity is returned from the EntityCreated callback
+       * The local callback fires before the function ends, as the offline realtime engine is synchronous
+       * The EntityCreatedCallback fires before the function ends
+       * Entity properties are populated correctly with the given parameters
+       * An AvatarComponent is created
+       * The avatar component properties are populated correctly with the given parameters
+       * The entity can be retrieved from GetEntities and GetAvatars
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, CreateAvatar)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    bool EntityCreatedCallbackCalled = false;
+    Engine.SetEntityCreatedCallback([&EntityCreatedCallbackCalled](SpaceEntity*) { EntityCreatedCallbackCalled = true; });
+
+    // Create test properties for our avatar.
+    const common::String TestName = "TestName";
+    const SpaceTransform Transform { common::Vector3::One(), common::Vector4::One(), common::Vector3::Zero() };
+    static constexpr const bool IsVisible = false;
+    static constexpr const auto State = AvatarState::Running;
+    const common::String AvatarId = "Id";
+    static constexpr const auto PlayMode = AvatarPlayMode::Creator;
+
+    SpaceEntity* CreatedEntity = nullptr;
+
+    Engine.CreateAvatar(
+        TestName, nullptr, Transform, IsVisible, State, AvatarId, PlayMode, [&CreatedEntity](SpaceEntity* NewEntity) { CreatedEntity = NewEntity; });
+
+    // Callback should be called before the function ends in offline mode, so this should be set.
+    if (CreatedEntity == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_TRUE(EntityCreatedCallbackCalled);
+
+    // Ensure created entity is populated correctly.
+    EXPECT_EQ(CreatedEntity->GetName(), TestName);
+    EXPECT_EQ(CreatedEntity->GetTransform(), Transform);
+    EXPECT_EQ(CreatedEntity->GetParent(), nullptr);
+
+    // Now check our AvatarComponent which should have been created by CreateAvatar.
+    if (CreatedEntity->GetComponents()->Size() != 1)
+    {
+        FAIL();
+    }
+
+    const auto* AvatarComponent = static_cast<AvatarSpaceComponent*>((*CreatedEntity->GetComponents())[0]);
+
+    // Ensure created avatar component is populated correctly.
+    EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
+    EXPECT_EQ(AvatarComponent->GetState(), AvatarState::Running);
+    EXPECT_EQ(AvatarComponent->GetAvatarId(), AvatarId);
+    EXPECT_EQ(AvatarComponent->GetAvatarPlayMode(), PlayMode);
+
+    // Check that our avatar is registered as an entity in the engine.
+    if (Engine.GetNumEntities() != 1)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(Engine.GetEntityByIndex(0)->GetId(), CreatedEntity->GetId());
+
+    // Check our avatar is registered as an avatar in the engine.
+    if (Engine.GetNumAvatars() != 1)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(Engine.GetAvatarByIndex(0)->GetId(), CreatedEntity->GetId());
+
+    // Check our avatar is NOT registered as an object in the engine.
+    EXPECT_EQ(Engine.GetNumObjects(), 0);
+}
+
+/*
+    This tests the behaviour of OfflineRealtimeEngine::CreateEntity.
+    This is very similar to the CreateAvatar test, except an avatar component isn't create by the function.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, CreateEntity)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    bool EntityCreatedCallbackCalled = false;
+    Engine.SetEntityCreatedCallback([&EntityCreatedCallbackCalled](SpaceEntity*) { EntityCreatedCallbackCalled = true; });
+
+    // Create test properties for our entity.
+    const common::String TestName = "TestName";
+    const SpaceTransform Transform { common::Vector3::One(), common::Vector4::One(), common::Vector3::Zero() };
+    static constexpr const bool IsVisible = false;
+    static constexpr const auto State = AvatarState::Running;
+    const common::String AvatarId = "Id";
+    static constexpr const auto PlayMode = AvatarPlayMode::Creator;
+
+    SpaceEntity* CreatedEntity = nullptr;
+
+    Engine.CreateEntity(TestName, Transform, nullptr, [&CreatedEntity](SpaceEntity* NewEntity) { CreatedEntity = NewEntity; });
+
+    // Callback should be called before the function ends in offline mode, so this should be set.
+    if (CreatedEntity == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_TRUE(EntityCreatedCallbackCalled);
+
+    // Ensure created entity is populated correctly.
+    EXPECT_EQ(CreatedEntity->GetName(), TestName);
+    EXPECT_EQ(CreatedEntity->GetTransform(), Transform);
+    EXPECT_EQ(CreatedEntity->GetParent(), nullptr);
+
+    // Check that our entity is registered as an entity in the engine.
+    if (Engine.GetNumEntities() != 1)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(Engine.GetEntityByIndex(0)->GetId(), CreatedEntity->GetId());
+
+    // Check our entity is NOT registered as an avatar in the engine.
+    EXPECT_EQ(Engine.GetNumAvatars(), 0);
+
+    // Check our entity is also registered as an object in the engine.
+    EXPECT_EQ(Engine.GetNumObjects(), 1);
+}
+
+/*
+    This tests the behaviour of OfflineRealtimeEngine::AddEntity
+    by verifying an entity that is created outside of the OfflineRealtimeEngine
+    is added correctly into the engine.
+    The entity should not be added to the entities array until ProcessPendingEntityOperations is called.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, AddEntity)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    auto ExternalEntity = new SpaceEntity { nullptr, *SystemsManager.GetScriptSystem(), SystemsManager.GetLogSystem(), SpaceEntityType::Object, 0,
+        "Name", SpaceTransform {}, 0, false, false };
+    Engine.AddEntity(ExternalEntity);
+
+    // Check that our entity is registered as an entity in the engine.
+    EXPECT_EQ(Engine.GetNumEntities(), 1);
+
+    // Check our entity is NOT registered as an avatar in the engine.
+    EXPECT_EQ(Engine.GetNumAvatars(), 0);
+
+    // Check our entity is also registered as an object in the engine.
+    EXPECT_EQ(Engine.GetNumObjects(), 1);
+}
+
+/*
+    This tests the behaviour of OfflineRealtimeEngine::DestroyEntity
+    by verifying it is removed from the engine when called.
+    It also verifies that the SetDestroyCallback is called correctly.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, DestroyEntity)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    Engine.CreateEntity("", SpaceTransform {}, nullptr, [](SpaceEntity*) {});
+
+    if (Engine.GetNumEntities() != 1)
+    {
+        FAIL();
+    }
+
+    SpaceEntity* CreatedEntity = Engine.GetEntityByIndex(0);
+
+    bool DestroyCalled = false;
+
+    Engine.DestroyEntity(CreatedEntity,
+        [&DestroyCalled](bool Destroyed)
+        {
+            EXPECT_TRUE(Destroyed);
+            DestroyCalled = true;
+        });
+
+    EXPECT_TRUE(DestroyCalled);
+    EXPECT_EQ(Engine.GetNumEntities(), 0);
+}
+
+/*
+    This tests the behaviour of OfflineRealtimeEngine::DestroyEntity for Avatars.
+    This is similar to DestroyEntity test, except it also verifies the avatar is removed
+    from the avatar container.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, DestroyAvatar)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    Engine.CreateAvatar("", nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default, [](SpaceEntity*) {});
+
+    if (Engine.GetNumEntities() != 1)
+    {
+        FAIL();
+    }
+
+    SpaceEntity* CreatedEntity = Engine.GetEntityByIndex(0);
+
+    bool DestroyCalled = false;
+
+    Engine.DestroyEntity(CreatedEntity,
+        [&DestroyCalled](bool Destroyed)
+        {
+            EXPECT_TRUE(Destroyed);
+            DestroyCalled = true;
+        });
+
+    EXPECT_TRUE(DestroyCalled);
+    EXPECT_EQ(Engine.GetNumEntities(), 0);
+    EXPECT_EQ(Engine.GetNumAvatars(), 0);
+}
+
+/*
+    This tests the behaviour AddEntityToSelectedEntities and RemoveEntityFromSelectedEntities
+    by checking if the provided entity gets added and removed from the internal container.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, SelectEntity)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    SpaceEntity* CreatedEntity = nullptr;
+    SpaceEntity* CreatedEntity2 = nullptr;
+
+    Engine.CreateEntity("", SpaceTransform {}, nullptr, [&CreatedEntity](SpaceEntity* NewEntity) { CreatedEntity = NewEntity; });
+    Engine.CreateEntity("", SpaceTransform {}, nullptr, [&CreatedEntity2](SpaceEntity* NewEntity) { CreatedEntity2 = NewEntity; });
+
+    if (CreatedEntity == nullptr)
+    {
+        FAIL();
+    }
+
+    Engine.AddEntityToSelectedEntities(CreatedEntity);
+
+    if (Engine.SelectedEntities.Size() != 1)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(Engine.SelectedEntities[0]->GetId(), CreatedEntity->GetId());
+
+    Engine.AddEntityToSelectedEntities(CreatedEntity2);
+
+    if (Engine.SelectedEntities.Size() != 2)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(Engine.SelectedEntities[1]->GetId(), CreatedEntity2->GetId());
+
+    // Remove the second entity
+    Engine.RemoveEntityFromSelectedEntities(CreatedEntity2);
+
+    EXPECT_EQ(Engine.SelectedEntities.Size(), 1);
+
+    if (Engine.SelectedEntities.Size() != 1)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(Engine.SelectedEntities[0]->GetId(), CreatedEntity->GetId());
+
+    // Remove the first entity
+    Engine.RemoveEntityFromSelectedEntities(CreatedEntity);
+
+    EXPECT_EQ(Engine.SelectedEntities.Size(), 0);
+}
+
+/*
+    This tests the behaviour FindSpaceEntity.
+    by creating 2 different entities and one avatar, checking they can all be retrieved.
+    This alo tests that Avatars are registered as Enities.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, FindSpaceEntity)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String EntityName1 = "Entity1";
+    const csp::common::String EntityName2 = "Entity2";
+    const csp::common::String EntityName3 = "Entity3";
+
+    SpaceEntity* Entity1 = nullptr;
+    SpaceEntity* Entity2 = nullptr;
+    SpaceEntity* Entity3 = nullptr;
+
+    Engine.CreateEntity(EntityName1, SpaceTransform {}, nullptr, [&Entity1](SpaceEntity* NewEntity) { Entity1 = NewEntity; });
+    Engine.CreateAvatar(EntityName2, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Entity2](SpaceEntity* NewEntity) { Entity2 = NewEntity; });
+    Engine.CreateEntity(EntityName3, SpaceTransform {}, nullptr, [&Entity3](SpaceEntity* NewEntity) { Entity3 = NewEntity; });
+
+    SpaceEntity* FoundEntity1 = Engine.FindSpaceEntity(EntityName1);
+    if (FoundEntity1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity1->GetId(), Entity1->GetId());
+
+    SpaceEntity* FoundEntity2 = Engine.FindSpaceEntity(EntityName2);
+    if (FoundEntity2 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity2->GetId(), Entity2->GetId());
+
+    SpaceEntity* FoundEntity3 = Engine.FindSpaceEntity(EntityName3);
+    if (FoundEntity3 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity3->GetId(), Entity3->GetId());
+}
+
+/*
+    This tests the behaviour FindSpaceEntityById
+    by creating 2 different entities and 1 avatar and checking they can all be retrieved.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, FindSpaceEntityById)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String EntityName1 = "Entity1";
+    const csp::common::String EntityName2 = "Entity2";
+    const csp::common::String EntityName3 = "Entity3";
+
+    SpaceEntity* Entity1 = nullptr;
+    SpaceEntity* Entity2 = nullptr;
+    SpaceEntity* Entity3 = nullptr;
+
+    Engine.CreateEntity(EntityName1, SpaceTransform {}, nullptr, [&Entity1](SpaceEntity* NewEntity) { Entity1 = NewEntity; });
+    Engine.CreateAvatar(EntityName2, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Entity2](SpaceEntity* NewEntity) { Entity2 = NewEntity; });
+    Engine.CreateEntity(EntityName3, SpaceTransform {}, nullptr, [&Entity3](SpaceEntity* NewEntity) { Entity3 = NewEntity; });
+
+    SpaceEntity* FoundEntity1 = Engine.FindSpaceEntityById(Entity1->GetId());
+    if (FoundEntity1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity1->GetId(), Entity1->GetId());
+
+    SpaceEntity* FoundEntity2 = Engine.FindSpaceEntityById(Entity2->GetId());
+    if (FoundEntity2 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity2->GetId(), Entity2->GetId());
+
+    SpaceEntity* FoundEntity3 = Engine.FindSpaceEntityById(Entity3->GetId());
+    if (FoundEntity3 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity3->GetId(), Entity3->GetId());
+}
+
+/*
+    This tests the behaviour FindSpaceAvatar
+    by creating 2 avatars and one entity and checking they can all be retrieved.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, FindSpaceAvatar)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String AvatarName1 = "Avatar1";
+    const csp::common::String EntityName1 = "Avatar2";
+    const csp::common::String AvatarName3 = "Avatar3";
+
+    SpaceEntity* Avatar1 = nullptr;
+    SpaceEntity* Entity1 = nullptr;
+    SpaceEntity* Avatar3 = nullptr;
+
+    Engine.CreateAvatar(AvatarName1, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Avatar1](SpaceEntity* NewEntity) { Avatar1 = NewEntity; });
+    Engine.CreateEntity(EntityName1, SpaceTransform {}, nullptr, [&Entity1](SpaceEntity* NewEntity) { Entity1 = NewEntity; });
+    Engine.CreateAvatar(AvatarName3, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Avatar3](SpaceEntity* NewEntity) { Avatar3 = NewEntity; });
+
+    SpaceEntity* FoundAvatar1 = Engine.FindSpaceEntity(AvatarName1);
+    if (FoundAvatar1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundAvatar1->GetId(), Avatar1->GetId());
+
+    // Avatar should still be found using FindSpaceEntity
+    SpaceEntity* FoundEntity1 = Engine.FindSpaceEntity(EntityName1);
+    if (FoundEntity1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity1->GetId(), Entity1->GetId());
+
+    SpaceEntity* FoundAvatar3 = Engine.FindSpaceEntity(AvatarName3);
+    if (FoundAvatar3 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundAvatar3->GetId(), Avatar3->GetId());
+}
+
+/*
+    This tests the behaviour FindSpaceObject by  creating 2 different entities and 1 avatar,
+    checking ONLY the entities can be retieved from this function.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, FindSpaceObject)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String EntityName1 = "Entity1";
+    const csp::common::String EntityName2 = "Entity2";
+    const csp::common::String EntityName3 = "Entity3";
+
+    SpaceEntity* Entity1 = nullptr;
+    SpaceEntity* Entity2 = nullptr;
+    SpaceEntity* Entity3 = nullptr;
+
+    Engine.CreateEntity(EntityName1, SpaceTransform {}, nullptr, [&Entity1](SpaceEntity* NewEntity) { Entity1 = NewEntity; });
+    Engine.CreateAvatar(EntityName2, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Entity2](SpaceEntity* NewEntity) { Entity2 = NewEntity; });
+    Engine.CreateEntity(EntityName3, SpaceTransform {}, nullptr, [&Entity3](SpaceEntity* NewEntity) { Entity3 = NewEntity; });
+
+    SpaceEntity* FoundEntity1 = Engine.FindSpaceObject(Entity1->GetName());
+    if (FoundEntity1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity1->GetName(), Entity1->GetName());
+
+    // Our avatar should not be found.
+    SpaceEntity* FoundEntity2 = Engine.FindSpaceObject(Entity2->GetName());
+    EXPECT_EQ(FoundEntity2, nullptr);
+
+    SpaceEntity* FoundEntity3 = Engine.FindSpaceObject(Entity3->GetName());
+    if (FoundEntity3 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity3->GetName(), Entity3->GetName());
+}
+
+/*
+    This tests the behaviour GetEntityByIndex
+    by creating 2 different entities and 1 avatar and checking they can all be retrieved.
+    This also tests the GetNumX functions.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, GetEntityByIndex)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String EntityName1 = "Entity1";
+    const csp::common::String EntityName2 = "Entity2";
+    const csp::common::String EntityName3 = "Entity3";
+
+    SpaceEntity* Entity1 = nullptr;
+    SpaceEntity* Entity2 = nullptr;
+    SpaceEntity* Entity3 = nullptr;
+
+    Engine.CreateEntity(EntityName1, SpaceTransform {}, nullptr, [&Entity1](SpaceEntity* NewEntity) { Entity1 = NewEntity; });
+    Engine.CreateAvatar(EntityName2, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Entity2](SpaceEntity* NewEntity) { Entity2 = NewEntity; });
+    Engine.CreateEntity(EntityName3, SpaceTransform {}, nullptr, [&Entity3](SpaceEntity* NewEntity) { Entity3 = NewEntity; });
+
+    EXPECT_EQ(Engine.GetNumEntities(), 3);
+    EXPECT_EQ(Engine.GetNumAvatars(), 1);
+    EXPECT_EQ(Engine.GetNumObjects(), 2);
+
+    SpaceEntity* FoundEntity1 = Engine.GetEntityByIndex(0);
+    if (FoundEntity1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity1->GetId(), Entity1->GetId());
+
+    SpaceEntity* FoundEntity2 = Engine.GetEntityByIndex(1);
+    if (FoundEntity2 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity2->GetId(), Entity2->GetId());
+
+    SpaceEntity* FoundEntity3 = Engine.GetEntityByIndex(2);
+    if (FoundEntity3 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity3->GetId(), Entity3->GetId());
+}
+
+/*
+    This tests the behaviour GetAvatarByIndex
+    by creating 2 avatars and one entity and checking they can all be retrieved.
+    This also tests the GetNumX functions.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, GetAvatarByIndex)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String AvatarName1 = "Avatar1";
+    const csp::common::String AvatarName2 = "Avatar2";
+    const csp::common::String AvatarName3 = "Avatar3";
+
+    SpaceEntity* Avatar1 = nullptr;
+    SpaceEntity* Avatar2 = nullptr;
+    SpaceEntity* Avatar3 = nullptr;
+
+    Engine.CreateAvatar(AvatarName1, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Avatar1](SpaceEntity* NewEntity) { Avatar1 = NewEntity; });
+    Engine.CreateEntity(AvatarName2, SpaceTransform {}, nullptr, [&Avatar2](SpaceEntity* NewEntity) { Avatar2 = NewEntity; });
+    Engine.CreateAvatar(AvatarName3, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Avatar3](SpaceEntity* NewEntity) { Avatar3 = NewEntity; });
+
+    EXPECT_EQ(Engine.GetNumEntities(), 3);
+    EXPECT_EQ(Engine.GetNumAvatars(), 2);
+    EXPECT_EQ(Engine.GetNumObjects(), 1);
+
+    SpaceEntity* FoundAvatar1 = Engine.GetAvatarByIndex(0);
+    if (FoundAvatar1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundAvatar1->GetId(), Avatar1->GetId());
+
+    // The second avatar (the one added third) should be found in the second element.
+    SpaceEntity* FoundAvatar2 = Engine.GetAvatarByIndex(1);
+    if (FoundAvatar2 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundAvatar2->GetId(), Avatar3->GetId());
+}
+
+/*
+    This tests the behaviour GetObjectByIndex
+    by creating 2 different entities and 1 avatar and checking they can all be retrieved.
+    This also tests the GetNumX functions.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, GetObjectByIndex)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String EntityName1 = "Entity1";
+    const csp::common::String EntityName2 = "Entity2";
+    const csp::common::String EntityName3 = "Entity3";
+
+    SpaceEntity* Entity1 = nullptr;
+    SpaceEntity* Entity2 = nullptr;
+    SpaceEntity* Entity3 = nullptr;
+
+    Engine.CreateEntity(EntityName1, SpaceTransform {}, nullptr, [&Entity1](SpaceEntity* NewEntity) { Entity1 = NewEntity; });
+    Engine.CreateAvatar(EntityName2, nullptr, SpaceTransform {}, false, AvatarState::Idle, "", AvatarPlayMode::Default,
+        [&Entity2](SpaceEntity* NewEntity) { Entity2 = NewEntity; });
+    Engine.CreateEntity(EntityName3, SpaceTransform {}, nullptr, [&Entity3](SpaceEntity* NewEntity) { Entity3 = NewEntity; });
+
+    EXPECT_EQ(Engine.GetNumEntities(), 3);
+    EXPECT_EQ(Engine.GetNumAvatars(), 1);
+    EXPECT_EQ(Engine.GetNumObjects(), 2);
+
+    SpaceEntity* FoundEntity1 = Engine.GetObjectByIndex(0);
+    if (FoundEntity1 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity1->GetId(), Entity1->GetId());
+
+    // The second entity (the one added third) should be found in the second element.
+    SpaceEntity* FoundEntity2 = Engine.GetObjectByIndex(1);
+    if (FoundEntity2 == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(FoundEntity2->GetId(), Entity3->GetId());
+}
+
+/*
+    This tests the behaviour of correctly setting the ParentId and RootHierarchy entities.
+    We first test that the constuctor is correctly setting these properties, and then ensure
+    the properties are still correrct after aditions and deletions.
+
+    !!! This tests hasn't been ran yet, as it crashes due to the SpaceEntity relying on SpaceEntitySystem instead of IRealtimeEngine.
+    This will only work when we have integrated the OnlineRealtimeEngine refactor changes.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ParentTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String EntityName1 = "Entity1";
+    const csp::common::String EntityName2 = "Entity2";
+    const csp::common::String EntityName3 = "Entity3";
+
+    SpaceEntity* Entity1 = nullptr;
+    SpaceEntity* Entity2 = nullptr;
+    SpaceEntity* Entity3 = nullptr;
+
+    Engine.CreateEntity(EntityName1, SpaceTransform {}, nullptr, [&Entity1](SpaceEntity* NewEntity) { Entity1 = NewEntity; });
+    Engine.CreateEntity(EntityName2, SpaceTransform {}, Entity1->GetId(), [&Entity2](SpaceEntity* NewEntity) { Entity2 = NewEntity; });
+    Engine.CreateEntity(EntityName3, SpaceTransform {}, Entity2->GetId(), [&Entity3](SpaceEntity* NewEntity) { Entity3 = NewEntity; });
+
+    EXPECT_EQ(Entity1->GetParent(), nullptr);
+
+    if (Entity2->GetParent() == nullptr)
+    {
+        FAIL();
+    }
+
+    if (Entity3->GetParent() == nullptr)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ(Entity2->GetParent(), Entity1);
+    EXPECT_EQ(Entity3->GetParent(), Entity2);
+
+    if (Engine.GetRootHierarchyEntities()->Size() != 1)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ((*Engine.GetRootHierarchyEntities())[0]->GetId(), Entity1->GetId());
+
+    // Reparent the third entity to be a child of the first
+    Entity3->SetParentId(Entity1->GetId());
+
+    // Parent shouldn't change yet.
+    EXPECT_EQ(Entity1->GetParent(), nullptr);
+    EXPECT_EQ(Entity2->GetParent(), Entity1);
+    EXPECT_EQ(Entity3->GetParent(), Entity2);
+
+    Entity3->MarkForUpdate();
+    Engine.ProcessPendingEntityOperations();
+
+    // Parent should now have changed
+    EXPECT_EQ(Entity1->GetParent(), nullptr);
+    EXPECT_EQ(Entity2->GetParent(), Entity1);
+    EXPECT_EQ(Entity3->GetParent(), Entity1);
+
+    // Move all entities to the root.
+    Entity2->RemoveParentEntity();
+    Entity3->RemoveParentEntity();
+
+    // Parent shouldn't change yet.
+    EXPECT_EQ(Entity1->GetParent(), nullptr);
+    EXPECT_EQ(Entity2->GetParent(), Entity1);
+    EXPECT_EQ(Entity3->GetParent(), Entity1);
+
+    if (Engine.GetRootHierarchyEntities()->Size() != 1)
+    {
+        FAIL();
+    }
+
+    EXPECT_EQ((*Engine.GetRootHierarchyEntities())[0]->GetId(), Entity1->GetId());
+
+    Entity2->MarkForUpdate();
+    Entity3->MarkForUpdate();
+    Engine.ProcessPendingEntityOperations();
+
+    // Parents should all be null.
+    EXPECT_EQ(Entity1->GetParent(), nullptr);
+    EXPECT_EQ(Entity2->GetParent(), nullptr);
+    EXPECT_EQ(Entity3->GetParent(), nullptr);
+
+    // All entities should be at the root.
+    EXPECT_EQ(Engine.GetRootHierarchyEntities()->Size(), 3);
+
+    // Ensure Root hierarchy is updated if entity is moved from the root.
+    Entity3->SetParentId(Entity1->GetId());
+
+    // Parent shouldn't change yet.
+    EXPECT_EQ(Entity1->GetParent(), nullptr);
+    EXPECT_EQ(Entity2->GetParent(), nullptr);
+    EXPECT_EQ(Entity3->GetParent(), nullptr);
+
+    Entity3->MarkForUpdate();
+    Engine.ProcessPendingEntityOperations();
+
+    EXPECT_EQ(Entity1->GetParent(), nullptr);
+    EXPECT_EQ(Entity2->GetParent(), nullptr);
+    EXPECT_EQ(Entity3->GetParent(), Entity1);
+
+    EXPECT_EQ(Engine.GetRootHierarchyEntities()->Size(), 2);
+}
+
+/*
+    This tests the behaviour of OfflineRealtimeEngine::MarkEntityForUpdate
+    by verifying an entity update is queued when ProcessPendingEntityOperations is called
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, MarkEntityForUpdate)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    CSPSceneDescription SceneDescription;
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    const csp::common::String EntityName = "Entity1";
+    SpaceEntity* Entity = nullptr;
+
+    Engine.CreateEntity(EntityName, SpaceTransform {}, nullptr, [&Entity](SpaceEntity* NewEntity) { Entity = NewEntity; });
+
+    const csp::common::String NewEntityName = "NewEntity1";
+
+    Entity->SetName(NewEntityName);
+
+    // Name should not have been updated yet.
+    EXPECT_EQ(Entity->GetName(), EntityName);
+
+    Engine.MarkEntityForUpdate(Entity);
+    Engine.ProcessPendingEntityOperations();
+
+    EXPECT_EQ(Entity->GetName(), NewEntityName);
+}
+
+/*
+    The CSPSceneDecription has already been thoroughly tested in our SceneDescription tests.
+    This just ensures that the correct amount of objects are populated.
+*/
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructorTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    auto FilePath = std::filesystem::absolute("assets/checkpoint-example.json");
+
+    std::ifstream Stream { FilePath.u8string().c_str() };
+
+    if (!Stream)
+    {
+        FAIL();
+    }
+
+    std::stringstream SStream;
+    SStream << Stream.rdbuf();
+
+    std::string Json = SStream.str();
+
+    CSPSceneDescription SceneDescription { Json.c_str() };
+    OfflineRealtimeEngine Engine { SceneDescription, *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem() };
+
+    EXPECT_EQ(Engine.GetNumEntities(), 74);
+}

--- a/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
@@ -812,7 +812,7 @@ CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, MarkEntityForUpdate)
     // Name should not have been updated yet.
     EXPECT_EQ(Entity->GetName(), EntityName);
 
-    Engine.MarkEntityForUpdate(Entity);
+    Engine.QueueEntityUpdate(Entity);
     Engine.ProcessPendingEntityOperations();
 
     EXPECT_EQ(Entity->GetName(), NewEntityName);


### PR DESCRIPTION
This PR contains the work for implementing the OfflineRealtimeEngine. The implementation is a lot simpler than the Online version, as we don't need to deal with replication, and there is a lot of shared functionality with the Online implementation. Because of this, most of the operations are now synchronous, meaning when Entities are created or destroyed, this happens instantaneously, and isn't deferred until ProcessPendingEntityOperations is called. This function is still in use for Entity and component updates, as this functionality is built into the SpaceEntity itself.

To get around code duplication, a RealtimeEngineUtils has been created. In the future, we likely want to find a better way of handling this, as Online is essentially an extension of the Offline version. To keep this PR simple, and to get around time restraints, this file is a compromise.

This is not in a finished state, as the Online version has not been merged, and this work contains some critical changes for this to work properly. Things that will likely need to change are:

- FetchAllEntitiesAndPopulateBuffers hasn't been implemented yet, as this is called from EnterSpace. We may want to defer the Entity creation until this point, as its currently done in the constructor.
- RealtimeEngineUtils also needs to be used in the Online version to remove duplicated code.
- ParentTest hasn't been successfully run yet, as the current SpaceEntity still relies on a SpaceEntitySystem reference, which has been removed in the online refactor.
- There is a hack in CSPSceneDescription::CreateEntities as I am reinterpret_casting the realtimeengine pointer to a spaceentity system. This is the reason we are getting crashes in the ParentTest, as the SpaceEntity is trying to use this pointer. We can remove this cast after the merge