### PR TITLE
[OF-1728] feat!: user settings support avatar visibility information

### DIFF
--- a/Library/include/CSP/Systems/Settings/SettingsCollection.h
+++ b/Library/include/CSP/Systems/Settings/SettingsCollection.h
@@ -92,34 +92,36 @@ class CSP_API AvatarInfoResult : public csp::systems::ResultBase
     /** @endcond */
 
 public:
-    /// @brief A getter which returns the String passed via the result.
+    /// @brief Returns the type of avatar selected by the user.
     [[nodiscard]] AvatarType GetAvatarType() const;
+    /// @brief Returns the string used to identify or locate the avatar.
     [[nodiscard]] const csp::common::String& GetAvatarIdentifier() const;
-    [[nodiscard]] const bool GetAvatarSelected() const;
+    /// @brief Returns whether or not the user's avatar is intended to be visible or not.
+    [[nodiscard]] const bool GetAvatarVisible() const;
 
     CSP_NO_EXPORT AvatarInfoResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
         : csp::systems::ResultBase(ResCode, HttpResCode)
         , Type(AvatarType::None)
-        , AvatarSelected(false) {};
+        , AvatarVisible(false) {};
 
 private:
     AvatarInfoResult()
         : Type(AvatarType::None)
-        , AvatarSelected(false) {};
+        , AvatarVisible(false) {};
     AvatarInfoResult(void*)
         : Type(AvatarType::None)
-        , AvatarSelected(false) {};
+        , AvatarVisible(false) {};
 
     void SetAvatarType(AvatarType InValue);
     void SetAvatarIdentifier(const csp::common::String& InValue);
-    void SetAvatarSelected(const bool InValue);
+    void SetAvatarVisible(const bool InValue);
 
     /// @brief The type of avatar (predefined, Ready Player Me, or custom).
     AvatarType Type;
     /// @brief A string used to identify or locate the avatar.
     csp::common::String Identifier;
-    /// @brief Represents whether the avatar has been selected by the user previously.
-    bool AvatarSelected;
+    /// @brief Represents whether the user's avatar is intended to be visible.
+    bool AvatarVisible;
 };
 
 /// @brief Callback containing Settings collection.

--- a/Library/include/CSP/Systems/Settings/SettingsCollection.h
+++ b/Library/include/CSP/Systems/Settings/SettingsCollection.h
@@ -95,22 +95,31 @@ public:
     /// @brief A getter which returns the String passed via the result.
     [[nodiscard]] AvatarType GetAvatarType() const;
     [[nodiscard]] const csp::common::String& GetAvatarIdentifier() const;
+    [[nodiscard]] const bool GetAvatarSelected() const;
 
     CSP_NO_EXPORT AvatarInfoResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
         : csp::systems::ResultBase(ResCode, HttpResCode)
-        , Type(AvatarType::None) {};
+        , Type(AvatarType::None)
+        , AvatarSelected(false) {};
 
 private:
     AvatarInfoResult()
-        : Type(AvatarType::None) {};
+        : Type(AvatarType::None)
+        , AvatarSelected(false) {};
     AvatarInfoResult(void*)
-        : Type(AvatarType::None) {};
+        : Type(AvatarType::None)
+        , AvatarSelected(false) {};
 
     void SetAvatarType(AvatarType InValue);
     void SetAvatarIdentifier(const csp::common::String& InValue);
+    void SetAvatarSelected(const bool InValue);
 
+    /// @brief The type of avatar (predefined, Ready Player Me, or custom).
     AvatarType Type;
+    /// @brief A string used to identify or locate the avatar.
     csp::common::String Identifier;
+    /// @brief Represents whether the avatar has been selected by the user previously.
+    bool AvatarSelected;
 };
 
 /// @brief Callback containing Settings collection.

--- a/Library/include/CSP/Systems/Settings/SettingsCollection.h
+++ b/Library/include/CSP/Systems/Settings/SettingsCollection.h
@@ -102,15 +102,15 @@ public:
     CSP_NO_EXPORT AvatarInfoResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
         : csp::systems::ResultBase(ResCode, HttpResCode)
         , Type(AvatarType::None)
-        , AvatarVisible(false) {};
+        , AvatarVisible(true) {};
 
 private:
     AvatarInfoResult()
         : Type(AvatarType::None)
-        , AvatarVisible(false) {};
+        , AvatarVisible(true) {};
     AvatarInfoResult(void*)
         : Type(AvatarType::None)
-        , AvatarVisible(false) {};
+        , AvatarVisible(true) {};
 
     void SetAvatarType(AvatarType InValue);
     void SetAvatarIdentifier(const csp::common::String& InValue);

--- a/Library/include/CSP/Systems/Settings/SettingsCollection.h
+++ b/Library/include/CSP/Systems/Settings/SettingsCollection.h
@@ -97,7 +97,7 @@ public:
     /// @brief Returns the string used to identify or locate the avatar.
     [[nodiscard]] const csp::common::String& GetAvatarIdentifier() const;
     /// @brief Returns whether or not the user's avatar is intended to be visible or not.
-    [[nodiscard]] const bool GetAvatarVisible() const;
+    [[nodiscard]] bool GetAvatarVisible() const;
 
     CSP_NO_EXPORT AvatarInfoResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
         : csp::systems::ResultBase(ResCode, HttpResCode)
@@ -114,7 +114,7 @@ private:
 
     void SetAvatarType(AvatarType InValue);
     void SetAvatarIdentifier(const csp::common::String& InValue);
-    void SetAvatarVisible(const bool InValue);
+    void SetAvatarVisible(bool InValue);
 
     /// @brief The type of avatar (predefined, Ready Player Me, or custom).
     AvatarType Type;

--- a/Library/include/CSP/Systems/Settings/SettingsSystem.h
+++ b/Library/include/CSP/Systems/Settings/SettingsSystem.h
@@ -137,10 +137,10 @@ public:
     /// @brief Sets the avatar type and identifier for a user.
     /// @param InType csp::systems::AvatarType : The type of avatar (predefined, Ready Player Me, or custom).
     /// @param InIdentifier csp::common::String : A string used to identify or locate the avatar.
-    /// @param AvatarSelected bool : A bool used to identify if the avatar has been selected by the user previously.
+    /// @param InAvatarVisible bool : A bool used to identify whether the user's avatar should be visible or not.
     /// @param Callback NullResultCallback : Callback to call when task finishes.
     CSP_ASYNC_RESULT void SetAvatarInfo(
-        AvatarType InType, const csp::common::String& InIdentifier, const bool AvatarSelected, NullResultCallback Callback);
+        AvatarType InType, const csp::common::String& InIdentifier, bool InAvatarVisible, NullResultCallback Callback);
 
     /// @brief Retrieves the avatar type and identifier for a user.
     /// @param Callback NullResultCallback : Callback to call when task finishes.

--- a/Library/include/CSP/Systems/Settings/SettingsSystem.h
+++ b/Library/include/CSP/Systems/Settings/SettingsSystem.h
@@ -137,8 +137,10 @@ public:
     /// @brief Sets the avatar type and identifier for a user.
     /// @param InType csp::systems::AvatarType : The type of avatar (predefined, Ready Player Me, or custom).
     /// @param InIdentifier csp::common::String : A string used to identify or locate the avatar.
+    /// @param AvatarSelected bool : A bool used to identify if the avatar has been selected by the user previously.
     /// @param Callback NullResultCallback : Callback to call when task finishes.
-    CSP_ASYNC_RESULT void SetAvatarInfo(AvatarType InType, const csp::common::String& InIdentifier, NullResultCallback Callback);
+    CSP_ASYNC_RESULT void SetAvatarInfo(
+        AvatarType InType, const csp::common::String& InIdentifier, const bool AvatarSelected, NullResultCallback Callback);
 
     /// @brief Retrieves the avatar type and identifier for a user.
     /// @param Callback NullResultCallback : Callback to call when task finishes.

--- a/Library/src/Systems/Settings/SettingsCollection.cpp
+++ b/Library/src/Systems/Settings/SettingsCollection.cpp
@@ -56,13 +56,13 @@ AvatarType AvatarInfoResult::GetAvatarType() const { return Type; }
 
 const csp::common::String& AvatarInfoResult::GetAvatarIdentifier() const { return Identifier; }
 
-const bool AvatarInfoResult::GetAvatarVisible() const { return AvatarVisible; }
+bool AvatarInfoResult::GetAvatarVisible() const { return AvatarVisible; }
 
 void AvatarInfoResult::SetAvatarType(AvatarType InValue) { Type = InValue; }
 
 void AvatarInfoResult::SetAvatarIdentifier(const csp::common::String& InValue) { Identifier = InValue; }
 
-void AvatarInfoResult::SetAvatarVisible(const bool InValue) { AvatarVisible = InValue; }
+void AvatarInfoResult::SetAvatarVisible(bool InValue) { AvatarVisible = InValue; }
 
 const SettingsCollection& SettingsCollectionResult::GetSettingsCollection() const { return SettingsCollection; }
 

--- a/Library/src/Systems/Settings/SettingsCollection.cpp
+++ b/Library/src/Systems/Settings/SettingsCollection.cpp
@@ -56,13 +56,13 @@ AvatarType AvatarInfoResult::GetAvatarType() const { return Type; }
 
 const csp::common::String& AvatarInfoResult::GetAvatarIdentifier() const { return Identifier; }
 
-const bool AvatarInfoResult::GetAvatarSelected() const { return AvatarSelected; }
+const bool AvatarInfoResult::GetAvatarVisible() const { return AvatarVisible; }
 
 void AvatarInfoResult::SetAvatarType(AvatarType InValue) { Type = InValue; }
 
 void AvatarInfoResult::SetAvatarIdentifier(const csp::common::String& InValue) { Identifier = InValue; }
 
-void AvatarInfoResult::SetAvatarSelected(const bool InValue) { AvatarSelected = InValue; }
+void AvatarInfoResult::SetAvatarVisible(const bool InValue) { AvatarVisible = InValue; }
 
 const SettingsCollection& SettingsCollectionResult::GetSettingsCollection() const { return SettingsCollection; }
 

--- a/Library/src/Systems/Settings/SettingsCollection.cpp
+++ b/Library/src/Systems/Settings/SettingsCollection.cpp
@@ -56,9 +56,13 @@ AvatarType AvatarInfoResult::GetAvatarType() const { return Type; }
 
 const csp::common::String& AvatarInfoResult::GetAvatarIdentifier() const { return Identifier; }
 
+const bool AvatarInfoResult::GetAvatarSelected() const { return AvatarSelected; }
+
 void AvatarInfoResult::SetAvatarType(AvatarType InValue) { Type = InValue; }
 
 void AvatarInfoResult::SetAvatarIdentifier(const csp::common::String& InValue) { Identifier = InValue; }
+
+void AvatarInfoResult::SetAvatarSelected(const bool InValue) { AvatarSelected = InValue; }
 
 const SettingsCollection& SettingsCollectionResult::GetSettingsCollection() const { return SettingsCollection; }
 

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -824,13 +824,14 @@ void SettingsSystem::RemoveAvatarPortrait(NullResultCallback Callback)
     GetAvatarPortraitAssetCollection(UserId, PortraitAvatarAssetCollCallback);
 }
 
-void SettingsSystem::SetAvatarInfo(AvatarType InType, const String& InIdentifier, NullResultCallback Callback)
+void SettingsSystem::SetAvatarInfo(AvatarType InType, const String& InIdentifier, const bool AvatarSelected, NullResultCallback Callback)
 {
     rapidjson::Document Json;
     Json.SetObject();
     Json.AddMember("type", static_cast<int>(InType), Json.GetAllocator());
     Json.AddMember(
         "identifier", rapidjson::Value(InIdentifier.c_str(), static_cast<rapidjson::SizeType>(InIdentifier.Length())), Json.GetAllocator());
+    Json.AddMember("avatarSelected", AvatarSelected, Json.GetAllocator());
     rapidjson::StringBuffer Buffer;
     rapidjson::Writer<rapidjson::StringBuffer> Writer(Buffer);
     Json.Accept(Writer);
@@ -872,7 +873,7 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
         rapidjson::Document Json;
         Json.Parse(Value.c_str());
 
-        if (!Json.HasMember("type") || !Json.HasMember("identifier"))
+        if (!Json.HasMember("type") || !Json.HasMember("identifier") || !Json.HasMember("avatarSelected"))
         {
             CSP_LOG_ERROR_MSG("Invalid avatar info!");
 
@@ -908,6 +909,20 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
         else
         {
             CSP_LOG_ERROR_MSG("Invalid identifier type!");
+
+            Callback(InternalResult);
+
+            return;
+        }
+
+        if (!Json.HasMember("avatarSelectedType") || (static_cast<VariantType>(Json["avatarSelectedType"].GetBool()) == VariantType::Boolean))
+        {
+            InternalResult.SetAvatarSelected(Json["avatarSelected"].GetBool());
+            Callback(InternalResult);
+        }
+        else
+        {
+            CSP_LOG_ERROR_MSG("Invalid avatar selected type!");
 
             Callback(InternalResult);
 

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -906,9 +906,9 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
         }
 
         // Avatar visibility
-        if (Json.HasMember("avatarSelected") && Json["avatarSelected"].IsBool())
+        if (Json.HasMember("avatarVisible") && Json["avatarVisible"].IsBool())
         {
-            InternalResult.SetAvatarVisible(Json["avatarSelected"].GetBool());
+            InternalResult.SetAvatarVisible(Json["avatarVisible"].GetBool());
         }
 
         Callback(InternalResult);

--- a/Tests/src/PublicAPITests/SettingsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SettingsSystemTests.cpp
@@ -458,6 +458,15 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, AvatarInfoTest)
     // Log in
     LogInAsNewTestUser(UserSystem, UserId);
 
+    // Get default avatar info (without the user ever having set it)
+    {
+        auto [Result] = AWAIT(SettingsSystem, GetAvatarInfo);
+
+        EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+        EXPECT_EQ(Result.GetAvatarType(), csp::systems::AvatarType::None);
+        EXPECT_EQ(Result.GetAvatarVisible(), true);
+    }
+
     auto Type = csp::systems::AvatarType::Custom;
     csp::common::String Identifier = "https://notarealweb.site/my_cool_avatar.glb";
 
@@ -474,7 +483,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, AvatarInfoTest)
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
         EXPECT_EQ(Result.GetAvatarType(), Type);
-        EXPECT_EQ(Result.GetAvatarSelected(), true);
+        EXPECT_EQ(Result.GetAvatarVisible(), true);
     }
 
     // Log out

--- a/Tests/src/PublicAPITests/SettingsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SettingsSystemTests.cpp
@@ -463,7 +463,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, AvatarInfoTest)
 
     // Set Avatar info
     {
-        auto [Result] = AWAIT(SettingsSystem, SetAvatarInfo, Type, Identifier);
+        auto [Result] = AWAIT(SettingsSystem, SetAvatarInfo, Type, Identifier, true);
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
     }
@@ -474,6 +474,7 @@ CSP_PUBLIC_TEST(CSPEngine, SettingsSystemTests, AvatarInfoTest)
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
         EXPECT_EQ(Result.GetAvatarType(), Type);
+        EXPECT_EQ(Result.GetAvatarSelected(), true);
     }
 
     // Log out

--- a/Tests/src/PublicTestBase.cpp
+++ b/Tests/src/PublicTestBase.cpp
@@ -127,3 +127,4 @@ template <typename T> void PublicTestBaseWithParam<T>::TearDown()
 
 // Explicit instantiations
 template class PublicTestBaseWithParam<std::tuple<csp::systems::SpaceAttributes, csp::systems::EResultCode, std::string>>;
+template class PublicTestBaseWithParam<std::tuple<csp::systems::AvatarType, csp::common::String, bool>>;

--- a/Tests/src/PublicTestBase.h
+++ b/Tests/src/PublicTestBase.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "CSP/Systems/Settings/SettingsCollection.h"
 #include "CSP/Systems/Spaces/Space.h"
 #include "Mocks/SignalRConnectionMock.h"
 #include <gtest/gtest.h>
@@ -68,3 +69,4 @@ protected:
 
 // If you want to use a new parameterized test structure, you need to explicitly instantiate here (and in the .cpp)
 extern template class PublicTestBaseWithParam<std::tuple<csp::systems::SpaceAttributes, csp::systems::EResultCode, std::string>>;
+extern template class PublicTestBaseWithParam<std::tuple<csp::systems::AvatarType, csp::common::String, bool>>;


### PR DESCRIPTION
## User settings support avatar visibility state information

Currently, clients are unable to discern between "a user that has never set an avatar" and "a user that has explicitly chosen to hide their avatar".

The PR updated the user settings and [SetAvatarInfo](https://github.com/magnopus-opensource/connected-spaces-platform/blob/3897cff42ce745f3088c59585cfdb636019f9eca/Library/include/CSP/Systems/Settings/SettingsSystem.h#L141) API to allow clients to reason about the state of the user. 

The PR contains the following changes: 

- Introduce a new bool to track if the avatar should be visible or not.
- Updated the public API to expose the new bool to clients.
- Included validation for the new property in tests.

## Reviewer Notes

Many approaches could have been taken to resolve this; however, there was a previous discussion as a team for a suitable resolution. Please see the Jira ticket for more information. 

## Breaking Changes

- [SetAvatarInfo](https://github.com/magnopus-opensource/connected-spaces-platform/blob/3897cff42ce745f3088c59585cfdb636019f9eca/Library/include/CSP/Systems/Settings/SettingsSystem.h#L141) introduces a new bool parameter to the function signature 