### PR TITLE
[OF-1727] fix: remove redundant getspace call from enterspace flow

### DIFF
--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -232,7 +232,12 @@ public:
     /// @param UserId csp::common::String : unique ID of user
     /// @param Callback SpaceResultCallback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void AddUserToSpace(const csp::common::String& SpaceId, const csp::common::String& UserId, SpaceResultCallback Callback);
-    CSP_NO_EXPORT async::task<SpaceResult> AddUserToSpace(const SpaceResult& Space, const csp::common::String& UserId);
+
+    /// @brief Adds a user to a space.
+    /// @param Result SpaceResult : result object of the space to which the user will be added
+    /// @param UserId csp::common::String : unique ID of user
+    /// @return async::task<SpaceResult> : a task containing the result of the operation
+    CSP_NO_EXPORT async::task<SpaceResult> AddUserToSpace(const SpaceResult& Result, const csp::common::String& UserId);
 
     /// @brief Creates new Site information and associates it with the Space.
     /// @param SpaceId csp::common::String : Space ID to associate the Site information with

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -867,13 +867,13 @@ void SpaceSystem::AddUserToSpace(const csp::common::String& SpaceId, const Strin
         });
 }
 
-async::task<SpaceResult> SpaceSystem::AddUserToSpace(const SpaceResult& Space, const String& UserId)
+async::task<SpaceResult> SpaceSystem::AddUserToSpace(const SpaceResult& Result, const String& UserId)
 {
     // Because we react in a continuation, we need to keep the event alive, hence shared ptr.
     std::shared_ptr<async::event_task<SpaceResult>> OnCompleteEvent = std::make_shared<async::event_task<SpaceResult>>();
     async::task<SpaceResult> OnCompleteTask = OnCompleteEvent->get_task();
 
-    const csp::common::String& SpaceCode = Space.GetSpaceCode();
+    const csp::common::String& SpaceCode = Result.GetSpaceCode();
 
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(
         [](const SpaceResult&) {}, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(*OnCompleteEvent.get()));


### PR DESCRIPTION
This PR removes the redundant MCS call from EnterSpace flow. 

> [!NOTE]
> The public API has not been modified, hence the change has not been marked as breaking. 