### PR TITLE
[NT-0] fix: Add chs database write to sequence persistence test

### DIFF
--- a/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CustomComponentTests.cpp
@@ -180,8 +180,6 @@ CSP_PUBLIC_TEST(CSPEngine, CustomTests, CustomComponentTest)
         std::this_thread::sleep_for(7s);
     }
 
-    std::this_thread::sleep_for(std::chrono::seconds(7));
-
     // Re-Enter space and verify contents
     {
         // Retrieve all entities

--- a/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
+++ b/Tests/src/PublicAPITests/HotspotSequenceTests.cpp
@@ -914,6 +914,11 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotSequenceTests, SequencePersistenceTest)
 
     // Exit the space
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+    // Ensure data has been written to database by chs before entering the space again
+    // This is due to an enforced 2 second chs database write delay
+    std::this_thread::sleep_for(7s);
+
     // Reenter the space
     auto [ReEnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 


### PR DESCRIPTION
We're not 100% sure if this change is the cause of the flakey test, but it should be there anyway. I also removed a duplicate delay from the custom component test.