### PR TITLE
[OF-1741] feat: client applications can express components as holdouts

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -60,9 +60,9 @@ enum class AnimatedModelPropertyKeys
     ThirdPartyComponentRef,
     IsShadowCaster,
     MaterialOverrides,
-    IsVRVisible,
+    IsVirtualVisible,
     ShowAsHoldoutInAR,
-    ShowAsHoldoutInVR,
+    ShowAsHoldoutInVirtual,
     Num
 };
 
@@ -172,10 +172,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef
@@ -200,10 +200,10 @@ public:
     bool GetShowAsHoldoutInAR() const override;
     /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInAR()
     void SetShowAsHoldoutInAR(bool InValue) override;
-    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInVR()
-    bool GetShowAsHoldoutInVR() const override;
-    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInVR()
-    void SetShowAsHoldoutInVR(bool InValue) override;
+    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInVirtual()
+    bool GetShowAsHoldoutInVirtual() const override;
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInVirtual()
+    void SetShowAsHoldoutInVirtual(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -60,9 +60,9 @@ enum class AnimatedModelPropertyKeys
     ThirdPartyComponentRef,
     IsShadowCaster,
     MaterialOverrides,
-    IsVirtualVisible,
+    IsVRVisible,
     ShowAsHoldoutInAR,
-    ShowAsHoldoutInVirtual,
+    ShowAsHoldoutInVR,
     Num
 };
 
@@ -172,10 +172,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef
@@ -200,10 +200,10 @@ public:
     bool GetShowAsHoldoutInAR() const override;
     /// @copydoc IVisibleComponent::SetShowAsHoldoutInAR()
     void SetShowAsHoldoutInAR(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVirtual()
-    bool GetShowAsHoldoutInVirtual() const override;
-    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVirtual()
-    void SetShowAsHoldoutInVirtual(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVR()
+    bool GetShowAsHoldoutInVR() const override;
+    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVR()
+    void SetShowAsHoldoutInVR(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -23,10 +23,10 @@
 #include "CSP/Common/String.h"
 #include "CSP/Multiplayer/ComponentBase.h"
 #include "CSP/Multiplayer/Components/Interfaces/IExternalResourceComponent.h"
+#include "CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IShadowCasterComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IThirdPartyComponentRef.h"
 #include "CSP/Multiplayer/Components/Interfaces/ITransformComponent.h"
-#include "CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
 #include "CSP/Multiplayer/SpaceTransform.h"
 
@@ -61,6 +61,7 @@ enum class AnimatedModelPropertyKeys
     IsShadowCaster,
     MaterialOverrides,
     IsVRVisible,
+    ShowAsHoldout,
     ShowAsHoldoutInAR,
     ShowAsHoldoutInVR,
     Num
@@ -77,7 +78,7 @@ class CSP_API AnimatedModelSpaceComponent : public ComponentBase,
                                             public IExternalResourceComponent,
                                             public IThirdPartyComponentRef,
                                             public IShadowCasterComponent,
-                                            public IVisibilityBehaviourComponent
+                                            public IRenderBehaviourComponent
 {
 public:
     /// @brief Constructs the animated model space component, and associates it with the specified Parent space entity.
@@ -194,15 +195,19 @@ public:
     void SetIsShadowCaster(bool Value) override;
     /// @}
 
-    /// \addtogroup IVisibilityBehaviourComponent
+    /// \addtogroup IRenderBehaviourComponent
     /// @{
-    /// @copydoc IVisibleComponent::GetShowAsHoldoutInAR()
+    /// /// @copydoc IRenderBehaviourComponent::GetShowAsHoldout()
+    bool GetShowAsHoldout() const override;
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldout()
+    void SetShowAsHoldout(bool InValue) override;
+    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInAR()
     bool GetShowAsHoldoutInAR() const override;
-    /// @copydoc IVisibleComponent::SetShowAsHoldoutInAR()
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInAR()
     void SetShowAsHoldoutInAR(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVR()
+    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInVR()
     bool GetShowAsHoldoutInVR() const override;
-    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVR()
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInVR()
     void SetShowAsHoldoutInVR(bool InValue) override;
     /// @}
 };

--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -26,6 +26,7 @@
 #include "CSP/Multiplayer/Components/Interfaces/IShadowCasterComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IThirdPartyComponentRef.h"
 #include "CSP/Multiplayer/Components/Interfaces/ITransformComponent.h"
+#include "CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
 #include "CSP/Multiplayer/SpaceTransform.h"
 
@@ -60,6 +61,8 @@ enum class AnimatedModelPropertyKeys
     IsShadowCaster,
     MaterialOverrides,
     IsVirtualVisible,
+    ShowAsHoldoutInAR,
+    ShowAsHoldoutInVirtual,
     Num
 };
 
@@ -73,7 +76,8 @@ class CSP_API AnimatedModelSpaceComponent : public ComponentBase,
                                             public IVisibleComponent,
                                             public IExternalResourceComponent,
                                             public IThirdPartyComponentRef,
-                                            public IShadowCasterComponent
+                                            public IShadowCasterComponent,
+                                            public IVisibilityBehaviourComponent
 {
 public:
     /// @brief Constructs the animated model space component, and associates it with the specified Parent space entity.
@@ -188,6 +192,18 @@ public:
     bool GetIsShadowCaster() const override;
     /// @copydoc IShadowCasterComponent::SetIsShadowCaster()
     void SetIsShadowCaster(bool Value) override;
+    /// @}
+
+    /// \addtogroup IVisibilityBehaviourComponent
+    /// @{
+    /// @copydoc IVisibleComponent::GetShowAsHoldoutInAR()
+    bool GetShowAsHoldoutInAR() const override;
+    /// @copydoc IVisibleComponent::SetShowAsHoldoutInAR()
+    void SetShowAsHoldoutInAR(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVirtual()
+    bool GetShowAsHoldoutInVirtual() const override;
+    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVirtual()
+    void SetShowAsHoldoutInVirtual(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -59,6 +59,7 @@ enum class AnimatedModelPropertyKeys
     ThirdPartyComponentRef,
     IsShadowCaster,
     MaterialOverrides,
+    IsVirtualVisible,
     Num
 };
 
@@ -167,6 +168,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -61,7 +61,6 @@ enum class AnimatedModelPropertyKeys
     IsShadowCaster,
     MaterialOverrides,
     IsVRVisible,
-    ShowAsHoldout,
     ShowAsHoldoutInAR,
     ShowAsHoldoutInVR,
     Num
@@ -197,10 +196,6 @@ public:
 
     /// \addtogroup IRenderBehaviourComponent
     /// @{
-    /// /// @copydoc IRenderBehaviourComponent::GetShowAsHoldout()
-    bool GetShowAsHoldout() const override;
-    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldout()
-    void SetShowAsHoldout(bool InValue) override;
     /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInAR()
     bool GetShowAsHoldoutInAR() const override;
     /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInAR()

--- a/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
@@ -55,7 +55,7 @@ enum class AvatarComponentPropertyKeys
     LocomotionModel,
     IsVisible,
     IsARVisible,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -256,10 +256,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
@@ -55,7 +55,7 @@ enum class AvatarComponentPropertyKeys
     LocomotionModel,
     IsVisible,
     IsARVisible,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -256,10 +256,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
@@ -55,6 +55,7 @@ enum class AvatarComponentPropertyKeys
     LocomotionModel,
     IsVisible,
     IsARVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -255,6 +256,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
@@ -43,7 +43,7 @@ enum class ButtonPropertyKeys
     IsVisible,
     IsEnabled,
     IsARVisible,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -122,10 +122,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
@@ -43,6 +43,7 @@ enum class ButtonPropertyKeys
     IsVisible,
     IsEnabled,
     IsARVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -121,6 +122,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
@@ -43,7 +43,7 @@ enum class ButtonPropertyKeys
     IsVisible,
     IsEnabled,
     IsARVisible,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -122,10 +122,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
@@ -48,6 +48,7 @@ enum class ExternalLinkPropertyKeys
     IsEnabled,
     IsVisible,
     IsARVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -116,6 +117,10 @@ public:
     virtual bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     virtual void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    virtual bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    virtual void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
@@ -48,7 +48,7 @@ enum class ExternalLinkPropertyKeys
     IsEnabled,
     IsVisible,
     IsARVisible,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -117,10 +117,10 @@ public:
     virtual bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     virtual void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    virtual bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    virtual void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    virtual bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    virtual void SetIsVRVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
@@ -48,7 +48,7 @@ enum class ExternalLinkPropertyKeys
     IsEnabled,
     IsVisible,
     IsARVisible,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -117,10 +117,10 @@ public:
     virtual bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     virtual void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    virtual bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    virtual void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    virtual bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    virtual void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
@@ -39,7 +39,7 @@ enum class FiducialMarkerPropertyKeys
     Scale,
     IsVisible,
     IsARVisible,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -108,10 +108,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
@@ -39,7 +39,7 @@ enum class FiducialMarkerPropertyKeys
     Scale,
     IsVisible,
     IsARVisible,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -108,10 +108,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
@@ -39,6 +39,7 @@ enum class FiducialMarkerPropertyKeys
     Scale,
     IsVisible,
     IsARVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -107,6 +108,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
@@ -45,7 +45,7 @@ enum class FogPropertyKeys
     IsVisible,
     IsARVisible,
     ThirdPartyComponentRef,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -175,10 +175,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
@@ -45,7 +45,7 @@ enum class FogPropertyKeys
     IsVisible,
     IsARVisible,
     ThirdPartyComponentRef,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -175,10 +175,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
@@ -45,6 +45,7 @@ enum class FogPropertyKeys
     IsVisible,
     IsARVisible,
     ThirdPartyComponentRef,
+    IsVirtualVisible,
     Num
 };
 
@@ -174,6 +175,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
@@ -43,7 +43,7 @@ enum class GaussianSplatPropertyKeys
     IsARVisible,
     IsShadowCaster,
     Tint,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -115,10 +115,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IShadowCasterComponent

--- a/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
@@ -43,7 +43,7 @@ enum class GaussianSplatPropertyKeys
     IsARVisible,
     IsShadowCaster,
     Tint,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -115,10 +115,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IShadowCasterComponent

--- a/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
@@ -43,6 +43,7 @@ enum class GaussianSplatPropertyKeys
     IsARVisible,
     IsShadowCaster,
     Tint,
+    IsVirtualVisible,
     Num
 };
 
@@ -114,6 +115,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IShadowCasterComponent

--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -40,7 +40,7 @@ enum class HotspotPropertyKeys
     IsSpawnPoint,
     IsVisible,
     IsARVisible,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -106,10 +106,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -40,6 +40,7 @@ enum class HotspotPropertyKeys
     IsSpawnPoint,
     IsVisible,
     IsARVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -105,6 +106,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -40,7 +40,7 @@ enum class HotspotPropertyKeys
     IsSpawnPoint,
     IsVisible,
     IsARVisible,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -106,10 +106,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
@@ -43,6 +43,7 @@ enum class ImagePropertyKeys
     DisplayMode,
     IsARVisible,
     IsEmissive,
+    IsVirtualVisible,
     Num
 };
 
@@ -143,6 +144,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
@@ -43,7 +43,7 @@ enum class ImagePropertyKeys
     DisplayMode,
     IsARVisible,
     IsEmissive,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -144,10 +144,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
@@ -43,7 +43,7 @@ enum class ImagePropertyKeys
     DisplayMode,
     IsARVisible,
     IsEmissive,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -144,10 +144,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h
@@ -43,17 +43,17 @@ public:
     /// @see HoldoutConcept
     virtual void SetShowAsHoldoutInAR(bool InValue) = 0;
 
-    /// @brief Checks if the component is shown as holdout when in VR and Desktop mode.
-    /// @return True if the component is shown as holdout when in VR and Desktop mode, false otherwise.
+    /// @brief Checks if the component is shown as holdout when in Virtual mode.
+    /// @return True if the component is shown as holdout when in Virtual mode, false otherwise.
     ///
     /// @see HoldoutConcept
-    virtual bool GetShowAsHoldoutInVR() const = 0;
+    virtual bool GetShowAsHoldoutInVirtual() const = 0;
 
-    /// @brief Sets if the component is shown as holdout in VR and Desktop mode.
-    /// @param InValue True if the component is shown as holdout in VR and Desktop mode, false otherwise.
+    /// @brief Sets if the component is shown as holdout in Virtual mode.
+    /// @param InValue True if the component is shown as holdout in Virtual mode, false otherwise.
     ///
     /// @see HoldoutConcept
-    virtual void SetShowAsHoldoutInVR(bool InValue) = 0;
+    virtual void SetShowAsHoldoutInVirtual(bool InValue) = 0;
 
 protected:
     virtual ~IRenderBehaviourComponent() = default;

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/// @file IVisibilityBehaviourComponent.h
+/// @file IRenderBehaviourComponent.h
 /// @brief Holdout visibility control for components.
 
 #pragma once
@@ -23,30 +23,52 @@
 namespace csp::multiplayer
 {
 
-/// @brief Controls the holdout visibility behaviour of the component when in default mode, AR mode or Virtual mode.
-/// A holdout is an object that is rendered as a mask, cutting it out from the final image.
-/// It still participates in depth testing, allowing objects to move behind it, but does not contribute pixels to the final image.
-CSP_INTERFACE class CSP_API IVisibilityBehaviourComponent
+/// @brief Controls rendering behavior properties, such as a holdout state related to display modes, for a component.
+CSP_INTERFACE class CSP_API IRenderBehaviourComponent
 {
 public:
+    /// @defgroup HoldoutConcept Holdouts and Data Access
+    /// A holdout is an object that is rendered as a mask, cutting it out from the final image.
+    /// It still participates in depth testing, allowing objects to move behind it, but does not contribute pixels to the final image.
+
+    /// @brief Checks if the component is shown as holdout when in default mode.
+    /// @return True if the component is shown as holdout when in default mode, false otherwise.
+    ///
+    /// @see HoldoutConcept
+    virtual bool GetShowAsHoldout() const = 0;
+
+    /// @brief Sets if the component is shown as holdout in default mode.
+    /// @param InValue True if the component is shown as holdout in default mode, false otherwise.
+    ///
+    /// @see HoldoutConcept
+    virtual void SetShowAsHoldout(bool InValue) = 0;
+
     /// @brief Checks if the component is shown as holdout when in AR mode.
     /// @return True if the component is shown as holdout when in AR mode, false otherwise.
+    ///
+    /// @see HoldoutConcept
     virtual bool GetShowAsHoldoutInAR() const = 0;
 
     /// @brief Sets if the component is shown as holdout in AR mode.
     /// @param InValue True if the component is shown as holdout in AR mode, false otherwise.
+    ///
+    /// @see HoldoutConcept
     virtual void SetShowAsHoldoutInAR(bool InValue) = 0;
 
     /// @brief Checks if the component is shown as holdout when in VR mode.
     /// @return True if the component is shown as holdout when in VR mode, false otherwise.
+    ///
+    /// @see HoldoutConcept
     virtual bool GetShowAsHoldoutInVR() const = 0;
 
     /// @brief Sets if the component is shown as holdout in VR mode.
     /// @param InValue True if the component is shown as holdout in VR mode, false otherwise.
+    ///
+    /// @see HoldoutConcept
     virtual void SetShowAsHoldoutInVR(bool InValue) = 0;
 
 protected:
-    virtual ~IVisibilityBehaviourComponent() = default;
+    virtual ~IRenderBehaviourComponent() = default;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h
@@ -31,18 +31,6 @@ public:
     /// A holdout is an object that is rendered as a mask, cutting it out from the final image.
     /// It still participates in depth testing, allowing objects to move behind it, but does not contribute pixels to the final image.
 
-    /// @brief Checks if the component is shown as holdout when in default mode.
-    /// @return True if the component is shown as holdout when in default mode, false otherwise.
-    ///
-    /// @see HoldoutConcept
-    virtual bool GetShowAsHoldout() const = 0;
-
-    /// @brief Sets if the component is shown as holdout in default mode.
-    /// @param InValue True if the component is shown as holdout in default mode, false otherwise.
-    ///
-    /// @see HoldoutConcept
-    virtual void SetShowAsHoldout(bool InValue) = 0;
-
     /// @brief Checks if the component is shown as holdout when in AR mode.
     /// @return True if the component is shown as holdout when in AR mode, false otherwise.
     ///
@@ -55,14 +43,14 @@ public:
     /// @see HoldoutConcept
     virtual void SetShowAsHoldoutInAR(bool InValue) = 0;
 
-    /// @brief Checks if the component is shown as holdout when in VR mode.
-    /// @return True if the component is shown as holdout when in VR mode, false otherwise.
+    /// @brief Checks if the component is shown as holdout when in VR and Desktop mode.
+    /// @return True if the component is shown as holdout when in VR and Desktop mode, false otherwise.
     ///
     /// @see HoldoutConcept
     virtual bool GetShowAsHoldoutInVR() const = 0;
 
-    /// @brief Sets if the component is shown as holdout in VR mode.
-    /// @param InValue True if the component is shown as holdout in VR mode, false otherwise.
+    /// @brief Sets if the component is shown as holdout in VR and Desktop mode.
+    /// @param InValue True if the component is shown as holdout in VR and Desktop mode, false otherwise.
     ///
     /// @see HoldoutConcept
     virtual void SetShowAsHoldoutInVR(bool InValue) = 0;

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h
@@ -24,7 +24,7 @@ namespace csp::multiplayer
 {
 
 /// @brief Controls the holdout visibility behaviour of the component when in default mode, AR mode or Virtual mode.
-/// A holdout is an object that is rendered as a “mask”, cutting it out from the final image.
+/// A holdout is an object that is rendered as a mask, cutting it out from the final image.
 /// It still participates in depth testing, allowing objects to move behind it, but does not contribute pixels to the final image.
 CSP_INTERFACE class CSP_API IVisibilityBehaviourComponent
 {
@@ -39,11 +39,11 @@ public:
 
     /// @brief Checks if the component is shown as holdout when in VR mode.
     /// @return True if the component is shown as holdout when in VR mode, false otherwise.
-    virtual bool GetShowAsHoldoutInVirtual() const = 0;
+    virtual bool GetShowAsHoldoutInVR() const = 0;
 
     /// @brief Sets if the component is shown as holdout in VR mode.
     /// @param InValue True if the component is shown as holdout in VR mode, false otherwise.
-    virtual void SetShowAsHoldoutInVirtual(bool InValue) = 0;
+    virtual void SetShowAsHoldoutInVR(bool InValue) = 0;
 
 protected:
     virtual ~IVisibilityBehaviourComponent() = default;

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h
@@ -24,6 +24,8 @@ namespace csp::multiplayer
 {
 
 /// @brief Controls the holdout visibility behaviour of the component when in default mode, AR mode or Virtual mode.
+/// A holdout is an object that is rendered as a “mask”, cutting it out from the final image.
+/// It still participates in depth testing, allowing objects to move behind it, but does not contribute pixels to the final image.
 CSP_INTERFACE class CSP_API IVisibilityBehaviourComponent
 {
 public:
@@ -35,12 +37,12 @@ public:
     /// @param InValue True if the component is shown as holdout in AR mode, false otherwise.
     virtual void SetShowAsHoldoutInAR(bool InValue) = 0;
 
-    /// @brief Checks if the component is shown as holdout when in virtual modalities.
-    /// @return True if the component is shown as holdout when in virtual modalities, false otherwise.
+    /// @brief Checks if the component is shown as holdout when in VR mode.
+    /// @return True if the component is shown as holdout when in VR mode, false otherwise.
     virtual bool GetShowAsHoldoutInVirtual() const = 0;
 
-    /// @brief Sets if the component is shown as holdout in virtual modalities.
-    /// @param InValue True if the component is shown as holdout in virtual modalities, false otherwise.
+    /// @brief Sets if the component is shown as holdout in VR mode.
+    /// @param InValue True if the component is shown as holdout in VR mode, false otherwise.
     virtual void SetShowAsHoldoutInVirtual(bool InValue) = 0;
 
 protected:

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// @file IVisibilityBehaviourComponent.h
+/// @brief Holdout visibility control for components.
+
+#pragma once
+
+#include "CSP/CSPCommon.h"
+
+namespace csp::multiplayer
+{
+
+/// @brief Controls the holdout visibility behaviour of the component when in default mode, AR mode or Virtual mode.
+CSP_INTERFACE class CSP_API IVisibilityBehaviourComponent
+{
+public:
+    /// @brief Checks if the component is shown as holdout when in AR mode.
+    /// @return True if the component is shown as holdout when in AR mode, false otherwise.
+    virtual bool GetShowAsHoldoutInAR() const = 0;
+
+    /// @brief Sets if the component is shown as holdout in AR mode.
+    /// @param InValue True if the component is shown as holdout in AR mode, false otherwise.
+    virtual void SetShowAsHoldoutInAR(bool InValue) = 0;
+
+    /// @brief Checks if the component is shown as holdout when in virtual modalities.
+    /// @return True if the component is shown as holdout when in virtual modalities, false otherwise.
+    virtual bool GetShowAsHoldoutInVirtual() const = 0;
+
+    /// @brief Sets if the component is shown as holdout in virtual modalities.
+    /// @param InValue True if the component is shown as holdout in virtual modalities, false otherwise.
+    virtual void SetShowAsHoldoutInVirtual(bool InValue) = 0;
+
+protected:
+    virtual ~IVisibilityBehaviourComponent() = default;
+};
+
+} // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
@@ -43,6 +43,14 @@ public:
     /// @param InValue True if the component is visible in AR mode, false otherwise.
     virtual void SetIsARVisible(bool InValue) = 0;
 
+    /// @brief Checks if the component is visible when in virtual modalities.
+    /// @return True if the component is visible when in virtual modalities, false otherwise.
+    virtual bool GetIsVirtualVisible() const = 0;
+
+    /// @brief Sets if the component is visible in virtual modalities.
+    /// @param InValue True if the component is visible in virtual modalities, false otherwise.
+    virtual void SetIsVirtualVisible(bool InValue) = 0;
+
 protected:
     virtual ~IVisibleComponent() = default;
 };

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
@@ -43,13 +43,13 @@ public:
     /// @param InValue True if the component is visible in AR mode, false otherwise.
     virtual void SetIsARVisible(bool InValue) = 0;
 
-    /// @brief Checks if the component is visible when in VR mode.
-    /// @return True if the component is visible when in VR mode, false otherwise.
-    virtual bool GetIsVRVisible() const = 0;
+    /// @brief Checks if the component is visible when in Virtual mode.
+    /// @return True if the component is visible when in Virtual mode, false otherwise.
+    virtual bool GetIsVirtualVisible() const = 0;
 
-    /// @brief Sets if the component is visible in VR mode.
-    /// @param InValue True if the component is visible in VR mode, false otherwise.
-    virtual void SetIsVRVisible(bool InValue) = 0;
+    /// @brief Sets if the component is visible in Virtual mode.
+    /// @param InValue True if the component is visible in Virtual mode, false otherwise.
+    virtual void SetIsVirtualVisible(bool InValue) = 0;
 
 protected:
     virtual ~IVisibleComponent() = default;

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
@@ -23,7 +23,7 @@
 namespace csp::multiplayer
 {
 
-/// @brief Controls the visibility of the component when in default mode or in AR mode.
+/// @brief Controls the visibility of the component when in default mode, AR mode or Virtual mode.
 CSP_INTERFACE class CSP_API IVisibleComponent
 {
 public:

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
@@ -43,12 +43,12 @@ public:
     /// @param InValue True if the component is visible in AR mode, false otherwise.
     virtual void SetIsARVisible(bool InValue) = 0;
 
-    /// @brief Checks if the component is visible when in virtual modalities.
-    /// @return True if the component is visible when in virtual modalities, false otherwise.
+    /// @brief Checks if the component is visible when in VR mode.
+    /// @return True if the component is visible when in VR mode, false otherwise.
     virtual bool GetIsVirtualVisible() const = 0;
 
-    /// @brief Sets if the component is visible in virtual modalities.
-    /// @param InValue True if the component is visible in virtual modalities, false otherwise.
+    /// @brief Sets if the component is visible in VR mode.
+    /// @param InValue True if the component is visible in VR mode, false otherwise.
     virtual void SetIsVirtualVisible(bool InValue) = 0;
 
 protected:

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h
@@ -45,11 +45,11 @@ public:
 
     /// @brief Checks if the component is visible when in VR mode.
     /// @return True if the component is visible when in VR mode, false otherwise.
-    virtual bool GetIsVirtualVisible() const = 0;
+    virtual bool GetIsVRVisible() const = 0;
 
     /// @brief Sets if the component is visible in VR mode.
     /// @param InValue True if the component is visible in VR mode, false otherwise.
-    virtual void SetIsVirtualVisible(bool InValue) = 0;
+    virtual void SetIsVRVisible(bool InValue) = 0;
 
 protected:
     virtual ~IVisibleComponent() = default;

--- a/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
@@ -75,6 +75,7 @@ enum class LightPropertyKeys
     IsARVisible,
     ThirdPartyComponentRef,
     LightShadowType,
+    IsVirtualVisible,
     Num
 };
 
@@ -199,6 +200,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
@@ -75,7 +75,7 @@ enum class LightPropertyKeys
     IsARVisible,
     ThirdPartyComponentRef,
     LightShadowType,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -200,10 +200,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
@@ -75,7 +75,7 @@ enum class LightPropertyKeys
     IsARVisible,
     ThirdPartyComponentRef,
     LightShadowType,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -200,10 +200,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
@@ -43,7 +43,7 @@ enum class ScreenSharingPropertyKeys
     DefaultImageCollectionId,
     DefaultImageAssetId,
     AttenuationRadius,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -133,10 +133,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IShadowCasterComponent

--- a/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
@@ -43,7 +43,7 @@ enum class ScreenSharingPropertyKeys
     DefaultImageCollectionId,
     DefaultImageAssetId,
     AttenuationRadius,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -133,10 +133,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IShadowCasterComponent

--- a/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
@@ -43,6 +43,7 @@ enum class ScreenSharingPropertyKeys
     DefaultImageCollectionId,
     DefaultImageAssetId,
     AttenuationRadius,
+    IsVirtualVisible,
     Num
 };
 
@@ -132,6 +133,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IShadowCasterComponent

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -46,9 +46,9 @@ enum class StaticModelPropertyKeys
     ThirdPartyComponentRef,
     IsShadowCaster,
     MaterialOverrides,
-    IsVirtualVisible,
+    IsVRVisible,
     ShowAsHoldoutInAR,
-    ShowAsHoldoutInVirtual,
+    ShowAsHoldoutInVR,
     Num
 };
 
@@ -135,10 +135,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef
@@ -163,10 +163,10 @@ public:
     bool GetShowAsHoldoutInAR() const override;
     /// @copydoc IVisibleComponent::SetShowAsHoldoutInAR()
     void SetShowAsHoldoutInAR(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVirtual()
-    bool GetShowAsHoldoutInVirtual() const override;
-    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVirtual()
-    void SetShowAsHoldoutInVirtual(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVR()
+    bool GetShowAsHoldoutInVR() const override;
+    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVR()
+    void SetShowAsHoldoutInVR(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -45,6 +45,7 @@ enum class StaticModelPropertyKeys
     ThirdPartyComponentRef,
     IsShadowCaster,
     MaterialOverrides,
+    IsVirtualVisible,
     Num
 };
 
@@ -130,6 +131,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -46,9 +46,9 @@ enum class StaticModelPropertyKeys
     ThirdPartyComponentRef,
     IsShadowCaster,
     MaterialOverrides,
-    IsVRVisible,
+    IsVirtualVisible,
     ShowAsHoldoutInAR,
-    ShowAsHoldoutInVR,
+    ShowAsHoldoutInVirtual,
     Num
 };
 
@@ -135,10 +135,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef
@@ -163,10 +163,10 @@ public:
     bool GetShowAsHoldoutInAR() const override;
     /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInAR()
     void SetShowAsHoldoutInAR(bool InValue) override;
-    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInVR()
-    bool GetShowAsHoldoutInVR() const override;
-    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInVR()
-    void SetShowAsHoldoutInVR(bool InValue) override;
+    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInVirtual()
+    bool GetShowAsHoldoutInVirtual() const override;
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInVirtual()
+    void SetShowAsHoldoutInVirtual(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -47,7 +47,6 @@ enum class StaticModelPropertyKeys
     IsShadowCaster,
     MaterialOverrides,
     IsVRVisible,
-    ShowAsHoldout,
     ShowAsHoldoutInAR,
     ShowAsHoldoutInVR,
     Num
@@ -160,10 +159,6 @@ public:
 
     /// \addtogroup IRenderBehaviourComponent
     /// @{
-    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldout()
-    bool GetShowAsHoldout() const override;
-    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldout()
-    void SetShowAsHoldout(bool InValue) override;
     /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInAR()
     bool GetShowAsHoldoutInAR() const override;
     /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInAR()

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -26,6 +26,7 @@
 #include "CSP/Multiplayer/Components/Interfaces/IShadowCasterComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IThirdPartyComponentRef.h"
 #include "CSP/Multiplayer/Components/Interfaces/ITransformComponent.h"
+#include "CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
 
 namespace csp::multiplayer
@@ -46,6 +47,8 @@ enum class StaticModelPropertyKeys
     IsShadowCaster,
     MaterialOverrides,
     IsVirtualVisible,
+    ShowAsHoldoutInAR,
+    ShowAsHoldoutInVirtual,
     Num
 };
 
@@ -59,7 +62,8 @@ class CSP_API StaticModelSpaceComponent : public ComponentBase,
                                           public IShadowCasterComponent,
                                           public IThirdPartyComponentRef,
                                           public ITransformComponent,
-                                          public IVisibleComponent
+                                          public IVisibleComponent,
+                                          public IVisibilityBehaviourComponent
 
 {
 public:
@@ -151,6 +155,18 @@ public:
     bool GetIsShadowCaster() const override;
     /// @copydoc IShadowCasterComponent::SetIsShadowCaster()
     void SetIsShadowCaster(bool Value) override;
+    /// @}
+
+    /// \addtogroup IVisibilityBehaviourComponent
+    /// @{
+    /// @copydoc IVisibleComponent::GetShowAsHoldoutInAR()
+    bool GetShowAsHoldoutInAR() const override;
+    /// @copydoc IVisibleComponent::SetShowAsHoldoutInAR()
+    void SetShowAsHoldoutInAR(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVirtual()
+    bool GetShowAsHoldoutInVirtual() const override;
+    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVirtual()
+    void SetShowAsHoldoutInVirtual(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -23,10 +23,10 @@
 #include "CSP/Common/String.h"
 #include "CSP/Multiplayer/ComponentBase.h"
 #include "CSP/Multiplayer/Components/Interfaces/IExternalResourceComponent.h"
+#include "CSP/Multiplayer/Components/Interfaces/IRenderBehaviourComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IShadowCasterComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IThirdPartyComponentRef.h"
 #include "CSP/Multiplayer/Components/Interfaces/ITransformComponent.h"
-#include "CSP/Multiplayer/Components/Interfaces/IVisibilityBehaviourComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
 
 namespace csp::multiplayer
@@ -47,6 +47,7 @@ enum class StaticModelPropertyKeys
     IsShadowCaster,
     MaterialOverrides,
     IsVRVisible,
+    ShowAsHoldout,
     ShowAsHoldoutInAR,
     ShowAsHoldoutInVR,
     Num
@@ -63,7 +64,7 @@ class CSP_API StaticModelSpaceComponent : public ComponentBase,
                                           public IThirdPartyComponentRef,
                                           public ITransformComponent,
                                           public IVisibleComponent,
-                                          public IVisibilityBehaviourComponent
+                                          public IRenderBehaviourComponent
 
 {
 public:
@@ -157,15 +158,19 @@ public:
     void SetIsShadowCaster(bool Value) override;
     /// @}
 
-    /// \addtogroup IVisibilityBehaviourComponent
+    /// \addtogroup IRenderBehaviourComponent
     /// @{
-    /// @copydoc IVisibleComponent::GetShowAsHoldoutInAR()
+    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldout()
+    bool GetShowAsHoldout() const override;
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldout()
+    void SetShowAsHoldout(bool InValue) override;
+    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInAR()
     bool GetShowAsHoldoutInAR() const override;
-    /// @copydoc IVisibleComponent::SetShowAsHoldoutInAR()
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInAR()
     void SetShowAsHoldoutInAR(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetShowAsHoldoutInVR()
+    /// @copydoc IRenderBehaviourComponent::GetShowAsHoldoutInVR()
     bool GetShowAsHoldoutInVR() const override;
-    /// @copydoc IVisibleComponent::SetShowAsHoldoutInVR()
+    /// @copydoc IRenderBehaviourComponent::SetShowAsHoldoutInVR()
     void SetShowAsHoldoutInVR(bool InValue) override;
     /// @}
 };

--- a/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
@@ -44,7 +44,7 @@ enum class TextPropertyKeys
     BillboardMode,
     IsVisible,
     IsARVisible,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -140,10 +140,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
@@ -44,6 +44,7 @@ enum class TextPropertyKeys
     BillboardMode,
     IsVisible,
     IsARVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -139,6 +140,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
@@ -44,7 +44,7 @@ enum class TextPropertyKeys
     BillboardMode,
     IsVisible,
     IsARVisible,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -140,10 +140,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 };
 

--- a/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
@@ -81,7 +81,7 @@ enum class VideoPlayerPropertyKeys
     IsARVisible,
     MeshComponentId,
     IsEnabled,
-    IsVirtualVisible,
+    IsVRVisible,
     Num
 };
 
@@ -235,10 +235,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
-    bool GetIsVirtualVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
-    void SetIsVirtualVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVRVisible()
+    bool GetIsVRVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVRVisible()
+    void SetIsVRVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IEnableableComponent

--- a/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
@@ -81,6 +81,7 @@ enum class VideoPlayerPropertyKeys
     IsARVisible,
     MeshComponentId,
     IsEnabled,
+    IsVirtualVisible,
     Num
 };
 
@@ -234,6 +235,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IEnableableComponent

--- a/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
@@ -81,7 +81,7 @@ enum class VideoPlayerPropertyKeys
     IsARVisible,
     MeshComponentId,
     IsEnabled,
-    IsVRVisible,
+    IsVirtualVisible,
     Num
 };
 
@@ -235,10 +235,10 @@ public:
     bool GetIsARVisible() const override;
     /// @copydoc IVisibleComponent::SetIsARVisible()
     void SetIsARVisible(bool InValue) override;
-    /// @copydoc IVisibleComponent::GetIsVRVisible()
-    bool GetIsVRVisible() const override;
-    /// @copydoc IVisibleComponent::SetIsVRVisible()
-    void SetIsVRVisible(bool InValue) override;
+    /// @copydoc IVisibleComponent::GetIsVirtualVisible()
+    bool GetIsVirtualVisible() const override;
+    /// @copydoc IVisibleComponent::SetIsVirtualVisible()
+    void SetIsVirtualVisible(bool InValue) override;
     /// @}
 
     /// \addtogroup IEnableableComponent

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -40,6 +40,7 @@ AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)] = true;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new AnimatedModelSpaceComponentScriptInterface(this));
 }
@@ -183,6 +184,16 @@ void AnimatedModelSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_
 bool AnimatedModelSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible)); }
 
 void AnimatedModelSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible), Value); }
+
+bool AnimatedModelSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible));
+}
+
+void AnimatedModelSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible), Value);
+}
 
 /* IThirdPartyRefComponent */
 

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -41,7 +41,6 @@ AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible)] = true;
-    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldout)] = false;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR)] = false;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR)] = false;
 
@@ -217,16 +216,6 @@ void AnimatedModelSpaceComponent::SetIsShadowCaster(bool Value)
 }
 
 /* IRenderBehaviourComponent */
-
-bool AnimatedModelSpaceComponent::GetShowAsHoldout() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldout));
-}
-
-void AnimatedModelSpaceComponent::SetShowAsHoldout(bool Value)
-{
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldout), Value);
-}
 
 bool AnimatedModelSpaceComponent::GetShowAsHoldoutInAR() const
 {

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -41,6 +41,7 @@ AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldout)] = false;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR)] = false;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR)] = false;
 
@@ -215,7 +216,17 @@ void AnimatedModelSpaceComponent::SetIsShadowCaster(bool Value)
     SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster), Value);
 }
 
-/* IVisibilityBehaviourComponent */
+/* IRenderBehaviourComponent */
+
+bool AnimatedModelSpaceComponent::GetShowAsHoldout() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldout));
+}
+
+void AnimatedModelSpaceComponent::SetShowAsHoldout(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldout), Value);
+}
 
 bool AnimatedModelSpaceComponent::GetShowAsHoldoutInAR() const
 {

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -40,9 +40,9 @@ AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)] = true;
-    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR)] = false;
-    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual)] = false;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR)] = false;
 
     SetScriptInterface(new AnimatedModelSpaceComponentScriptInterface(this));
 }
@@ -187,15 +187,9 @@ bool AnimatedModelSpaceComponent::GetIsARVisible() const { return GetBooleanProp
 
 void AnimatedModelSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible), Value); }
 
-bool AnimatedModelSpaceComponent::GetIsVirtualVisible() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible));
-}
+bool AnimatedModelSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible)); }
 
-void AnimatedModelSpaceComponent::SetIsVirtualVisible(bool Value)
-{
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible), Value);
-}
+void AnimatedModelSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible), Value); }
 
 /* IThirdPartyRefComponent */
 
@@ -233,14 +227,14 @@ void AnimatedModelSpaceComponent::SetShowAsHoldoutInAR(bool Value)
     SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR), Value);
 }
 
-bool AnimatedModelSpaceComponent::GetShowAsHoldoutInVirtual() const
+bool AnimatedModelSpaceComponent::GetShowAsHoldoutInVR() const
 {
-    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual));
+    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR));
 }
 
-void AnimatedModelSpaceComponent::SetShowAsHoldoutInVirtual(bool Value)
+void AnimatedModelSpaceComponent::SetShowAsHoldoutInVR(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual), Value);
+    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -40,9 +40,9 @@ AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)] = true;
-    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR)] = false;
-    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR)] = false;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual)] = false;
 
     SetScriptInterface(new AnimatedModelSpaceComponentScriptInterface(this));
 }
@@ -187,9 +187,15 @@ bool AnimatedModelSpaceComponent::GetIsARVisible() const { return GetBooleanProp
 
 void AnimatedModelSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible), Value); }
 
-bool AnimatedModelSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible)); }
+bool AnimatedModelSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible));
+}
 
-void AnimatedModelSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVRVisible), Value); }
+void AnimatedModelSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible), Value);
+}
 
 /* IThirdPartyRefComponent */
 
@@ -227,14 +233,14 @@ void AnimatedModelSpaceComponent::SetShowAsHoldoutInAR(bool Value)
     SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR), Value);
 }
 
-bool AnimatedModelSpaceComponent::GetShowAsHoldoutInVR() const
+bool AnimatedModelSpaceComponent::GetShowAsHoldoutInVirtual() const
 {
-    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR));
+    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual));
 }
 
-void AnimatedModelSpaceComponent::SetShowAsHoldoutInVR(bool Value)
+void AnimatedModelSpaceComponent::SetShowAsHoldoutInVirtual(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVR), Value);
+    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -41,6 +41,8 @@ AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR)] = false;
+    Properties[static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual)] = false;
 
     SetScriptInterface(new AnimatedModelSpaceComponentScriptInterface(this));
 }
@@ -217,6 +219,28 @@ bool AnimatedModelSpaceComponent::GetIsShadowCaster() const
 void AnimatedModelSpaceComponent::SetIsShadowCaster(bool Value)
 {
     SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster), Value);
+}
+
+/* IVisibilityBehaviourComponent */
+
+bool AnimatedModelSpaceComponent::GetShowAsHoldoutInAR() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR));
+}
+
+void AnimatedModelSpaceComponent::SetShowAsHoldoutInAR(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR), Value);
+}
+
+bool AnimatedModelSpaceComponent::GetShowAsHoldoutInVirtual() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual));
+}
+
+void AnimatedModelSpaceComponent::SetShowAsHoldoutInVirtual(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
@@ -40,7 +40,7 @@ AvatarSpaceComponent::AvatarSpaceComponent(csp::common::LogSystem* LogSystem, Sp
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::LocomotionModel)] = static_cast<int64_t>(LocomotionModel::Grounded);
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new AvatarSpaceComponentScriptInterface(this));
 }
@@ -200,8 +200,14 @@ bool AvatarSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(st
 
 void AvatarSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible), InValue); }
 
-bool AvatarSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVRVisible)); }
+bool AvatarSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible));
+}
 
-void AvatarSpaceComponent::SetIsVRVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVRVisible), InValue); }
+void AvatarSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible), InValue);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
@@ -40,7 +40,7 @@ AvatarSpaceComponent::AvatarSpaceComponent(csp::common::LogSystem* LogSystem, Sp
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::LocomotionModel)] = static_cast<int64_t>(LocomotionModel::Grounded);
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new AvatarSpaceComponentScriptInterface(this));
 }
@@ -200,14 +200,8 @@ bool AvatarSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(st
 
 void AvatarSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible), InValue); }
 
-bool AvatarSpaceComponent::GetIsVirtualVisible() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible));
-}
+bool AvatarSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVRVisible)); }
 
-void AvatarSpaceComponent::SetIsVirtualVisible(bool InValue)
-{
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible), InValue);
-}
+void AvatarSpaceComponent::SetIsVRVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVRVisible), InValue); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
@@ -40,6 +40,7 @@ AvatarSpaceComponent::AvatarSpaceComponent(csp::common::LogSystem* LogSystem, Sp
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::LocomotionModel)] = static_cast<int64_t>(LocomotionModel::Grounded);
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible)] = true;
+    Properties[static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new AvatarSpaceComponentScriptInterface(this));
 }
@@ -198,5 +199,15 @@ void AvatarSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static_cast<
 bool AvatarSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible)); }
 
 void AvatarSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible), InValue); }
+
+bool AvatarSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible));
+}
+
+void AvatarSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible), InValue);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
@@ -32,7 +32,7 @@ ButtonSpaceComponent::ButtonSpaceComponent(csp::common::LogSystem* LogSystem, Sp
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsEnabled)] = true;
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ButtonSpaceComponentScriptInterface(this));
 }
@@ -120,8 +120,8 @@ bool ButtonSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(st
 
 void ButtonSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible), Value); }
 
-bool ButtonSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVRVisible)); }
+bool ButtonSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible)); }
 
-void ButtonSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVRVisible), Value); }
+void ButtonSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
@@ -32,7 +32,7 @@ ButtonSpaceComponent::ButtonSpaceComponent(csp::common::LogSystem* LogSystem, Sp
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsEnabled)] = true;
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new ButtonSpaceComponentScriptInterface(this));
 }
@@ -120,8 +120,8 @@ bool ButtonSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(st
 
 void ButtonSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible), Value); }
 
-bool ButtonSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible)); }
+bool ButtonSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVRVisible)); }
 
-void ButtonSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible), Value); }
+void ButtonSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVRVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
@@ -32,6 +32,7 @@ ButtonSpaceComponent::ButtonSpaceComponent(csp::common::LogSystem* LogSystem, Sp
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsEnabled)] = true;
     Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible)] = true;
+    Properties[static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ButtonSpaceComponentScriptInterface(this));
 }
@@ -118,5 +119,9 @@ void ButtonSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<ui
 bool ButtonSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible)); }
 
 void ButtonSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible), Value); }
+
+bool ButtonSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible)); }
+
+void ButtonSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
@@ -32,7 +32,7 @@ ExternalLinkSpaceComponent::ExternalLinkSpaceComponent(csp::common::LogSystem* L
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsEnabled)] = true;
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ExternalLinkSpaceComponentScriptInterface(this));
 }
@@ -130,8 +130,14 @@ bool ExternalLinkSpaceComponent::GetIsARVisible() const { return GetBooleanPrope
 
 void ExternalLinkSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible), InValue); }
 
-bool ExternalLinkSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVRVisible)); }
+bool ExternalLinkSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible));
+}
 
-void ExternalLinkSpaceComponent::SetIsVRVisible(bool InValue) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVRVisible), InValue); }
+void ExternalLinkSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible), InValue);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
@@ -32,7 +32,7 @@ ExternalLinkSpaceComponent::ExternalLinkSpaceComponent(csp::common::LogSystem* L
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsEnabled)] = true;
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new ExternalLinkSpaceComponentScriptInterface(this));
 }
@@ -130,14 +130,8 @@ bool ExternalLinkSpaceComponent::GetIsARVisible() const { return GetBooleanPrope
 
 void ExternalLinkSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible), InValue); }
 
-bool ExternalLinkSpaceComponent::GetIsVirtualVisible() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible));
-}
+bool ExternalLinkSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVRVisible)); }
 
-void ExternalLinkSpaceComponent::SetIsVirtualVisible(bool InValue)
-{
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible), InValue);
-}
+void ExternalLinkSpaceComponent::SetIsVRVisible(bool InValue) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVRVisible), InValue); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
@@ -32,6 +32,7 @@ ExternalLinkSpaceComponent::ExternalLinkSpaceComponent(csp::common::LogSystem* L
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsEnabled)] = true;
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible)] = true;
+    Properties[static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ExternalLinkSpaceComponentScriptInterface(this));
 }
@@ -128,5 +129,15 @@ void ExternalLinkSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static
 bool ExternalLinkSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible)); }
 
 void ExternalLinkSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible), InValue); }
+
+bool ExternalLinkSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible));
+}
+
+void ExternalLinkSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible), InValue);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
@@ -32,6 +32,7 @@ FiducialMarkerSpaceComponent::FiducialMarkerSpaceComponent(csp::common::LogSyste
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::Scale)] = csp::common::Vector3::One();
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible)] = true;
+    Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new FiducialMarkerSpaceComponentScriptInterface(this));
 }
@@ -127,4 +128,15 @@ bool FiducialMarkerSpaceComponent::GetIsARVisible() const
 }
 
 void FiducialMarkerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible), Value); }
+
+bool FiducialMarkerSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible));
+}
+
+void FiducialMarkerSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible), Value);
+}
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
@@ -32,7 +32,7 @@ FiducialMarkerSpaceComponent::FiducialMarkerSpaceComponent(csp::common::LogSyste
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::Scale)] = csp::common::Vector3::One();
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new FiducialMarkerSpaceComponentScriptInterface(this));
 }
@@ -129,11 +129,14 @@ bool FiducialMarkerSpaceComponent::GetIsARVisible() const
 
 void FiducialMarkerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible), Value); }
 
-bool FiducialMarkerSpaceComponent::GetIsVRVisible() const
+bool FiducialMarkerSpaceComponent::GetIsVirtualVisible() const
 {
-    return GetBooleanProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVRVisible));
+    return GetBooleanProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible));
 }
 
-void FiducialMarkerSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVRVisible), Value); }
+void FiducialMarkerSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible), Value);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
@@ -32,7 +32,7 @@ FiducialMarkerSpaceComponent::FiducialMarkerSpaceComponent(csp::common::LogSyste
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::Scale)] = csp::common::Vector3::One();
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new FiducialMarkerSpaceComponentScriptInterface(this));
 }
@@ -129,14 +129,11 @@ bool FiducialMarkerSpaceComponent::GetIsARVisible() const
 
 void FiducialMarkerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible), Value); }
 
-bool FiducialMarkerSpaceComponent::GetIsVirtualVisible() const
+bool FiducialMarkerSpaceComponent::GetIsVRVisible() const
 {
-    return GetBooleanProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible));
+    return GetBooleanProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVRVisible));
 }
 
-void FiducialMarkerSpaceComponent::SetIsVirtualVisible(bool Value)
-{
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible), Value);
-}
+void FiducialMarkerSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVRVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
@@ -37,7 +37,7 @@ FogSpaceComponent::FogSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEnt
     Properties[static_cast<uint32_t>(FogPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(FogPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(FogPropertyKeys::ThirdPartyComponentRef)] = "";
-    Properties[static_cast<uint32_t>(FogPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new FogSpaceComponentScriptInterface(this));
 }
@@ -115,9 +115,9 @@ bool FogSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(stati
 
 void FogSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsARVisible), Value); }
 
-bool FogSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVRVisible)); }
+bool FogSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible)); }
 
-void FogSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVRVisible), Value); }
+void FogSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible), Value); }
 
 const csp::common::String& FogSpaceComponent::GetThirdPartyComponentRef() const
 {

--- a/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
@@ -37,6 +37,7 @@ FogSpaceComponent::FogSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEnt
     Properties[static_cast<uint32_t>(FogPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(FogPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(FogPropertyKeys::ThirdPartyComponentRef)] = "";
+    Properties[static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new FogSpaceComponentScriptInterface(this));
 }
@@ -113,6 +114,10 @@ void FogSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint3
 bool FogSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsARVisible)); }
 
 void FogSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsARVisible), Value); }
+
+bool FogSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible)); }
+
+void FogSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible), Value); }
 
 const csp::common::String& FogSpaceComponent::GetThirdPartyComponentRef() const
 {

--- a/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
@@ -37,7 +37,7 @@ FogSpaceComponent::FogSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEnt
     Properties[static_cast<uint32_t>(FogPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(FogPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(FogPropertyKeys::ThirdPartyComponentRef)] = "";
-    Properties[static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(FogPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new FogSpaceComponentScriptInterface(this));
 }
@@ -115,9 +115,9 @@ bool FogSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(stati
 
 void FogSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsARVisible), Value); }
 
-bool FogSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible)); }
+bool FogSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVRVisible)); }
 
-void FogSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible), Value); }
+void FogSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVRVisible), Value); }
 
 const csp::common::String& FogSpaceComponent::GetThirdPartyComponentRef() const
 {

--- a/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
@@ -33,7 +33,7 @@ GaussianSplatSpaceComponent::GaussianSplatSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint)] = csp::common::Vector3::One();
-    Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new GaussianSplatSpaceComponentScriptInterface(this));
 }
@@ -122,11 +122,14 @@ void GaussianSplatSpaceComponent::SetIsARVisible(bool InValue)
     SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible), InValue);
 }
 
-bool GaussianSplatSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVRVisible)); }
-
-void GaussianSplatSpaceComponent::SetIsVRVisible(bool InValue)
+bool GaussianSplatSpaceComponent::GetIsVirtualVisible() const
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVRVisible), InValue);
+    return GetBooleanProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible));
+}
+
+void GaussianSplatSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible), InValue);
 }
 
 bool GaussianSplatSpaceComponent::GetIsShadowCaster() const

--- a/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
@@ -33,7 +33,7 @@ GaussianSplatSpaceComponent::GaussianSplatSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint)] = csp::common::Vector3::One();
-    Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new GaussianSplatSpaceComponentScriptInterface(this));
 }
@@ -122,14 +122,11 @@ void GaussianSplatSpaceComponent::SetIsARVisible(bool InValue)
     SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible), InValue);
 }
 
-bool GaussianSplatSpaceComponent::GetIsVirtualVisible() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible));
-}
+bool GaussianSplatSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVRVisible)); }
 
-void GaussianSplatSpaceComponent::SetIsVirtualVisible(bool InValue)
+void GaussianSplatSpaceComponent::SetIsVRVisible(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible), InValue);
+    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVRVisible), InValue);
 }
 
 bool GaussianSplatSpaceComponent::GetIsShadowCaster() const

--- a/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
@@ -33,6 +33,7 @@ GaussianSplatSpaceComponent::GaussianSplatSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint)] = csp::common::Vector3::One();
+    Properties[static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new GaussianSplatSpaceComponentScriptInterface(this));
 }
@@ -119,6 +120,16 @@ bool GaussianSplatSpaceComponent::GetIsARVisible() const { return GetBooleanProp
 void GaussianSplatSpaceComponent::SetIsARVisible(bool InValue)
 {
     SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible), InValue);
+}
+
+bool GaussianSplatSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible));
+}
+
+void GaussianSplatSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible), InValue);
 }
 
 bool GaussianSplatSpaceComponent::GetIsShadowCaster() const

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -31,6 +31,7 @@ HotspotSpaceComponent::HotspotSpaceComponent(csp::common::LogSystem* LogSystem, 
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint)] = false;
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible)] = true;
+    Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new HotspotSpaceComponentScriptInterface(this));
 }
@@ -95,5 +96,9 @@ void HotspotSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<u
 bool HotspotSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible)); }
 
 void HotspotSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible), Value); }
+
+bool HotspotSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible)); }
+
+void HotspotSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -31,7 +31,7 @@ HotspotSpaceComponent::HotspotSpaceComponent(csp::common::LogSystem* LogSystem, 
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint)] = false;
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new HotspotSpaceComponentScriptInterface(this));
 }
@@ -97,8 +97,8 @@ bool HotspotSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(s
 
 void HotspotSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible), Value); }
 
-bool HotspotSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVRVisible)); }
+bool HotspotSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible)); }
 
-void HotspotSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVRVisible), Value); }
+void HotspotSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -31,7 +31,7 @@ HotspotSpaceComponent::HotspotSpaceComponent(csp::common::LogSystem* LogSystem, 
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint)] = false;
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(HotspotPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new HotspotSpaceComponentScriptInterface(this));
 }
@@ -97,8 +97,8 @@ bool HotspotSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(s
 
 void HotspotSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible), Value); }
 
-bool HotspotSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible)); }
+bool HotspotSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVRVisible)); }
 
-void HotspotSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible), Value); }
+void HotspotSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVRVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
@@ -34,6 +34,7 @@ ImageSpaceComponent::ImageSpaceComponent(csp::common::LogSystem* LogSystem, Spac
     Properties[static_cast<uint32_t>(ImagePropertyKeys::DisplayMode)] = static_cast<int64_t>(DisplayMode::DoubleSided);
     Properties[static_cast<uint32_t>(ImagePropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(ImagePropertyKeys::IsEmissive)] = false;
+    Properties[static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ImageSpaceComponentScriptInterface(this));
 }
@@ -115,6 +116,10 @@ void ImageSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uin
 bool ImageSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsARVisible)); }
 
 void ImageSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsARVisible), Value); }
+
+bool ImageSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible)); }
+
+void ImageSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible), Value); }
 
 BillboardMode ImageSpaceComponent::GetBillboardMode() const
 {

--- a/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
@@ -34,7 +34,7 @@ ImageSpaceComponent::ImageSpaceComponent(csp::common::LogSystem* LogSystem, Spac
     Properties[static_cast<uint32_t>(ImagePropertyKeys::DisplayMode)] = static_cast<int64_t>(DisplayMode::DoubleSided);
     Properties[static_cast<uint32_t>(ImagePropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(ImagePropertyKeys::IsEmissive)] = false;
-    Properties[static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(ImagePropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new ImageSpaceComponentScriptInterface(this));
 }
@@ -117,9 +117,9 @@ bool ImageSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(sta
 
 void ImageSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsARVisible), Value); }
 
-bool ImageSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible)); }
+bool ImageSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVRVisible)); }
 
-void ImageSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible), Value); }
+void ImageSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVRVisible), Value); }
 
 BillboardMode ImageSpaceComponent::GetBillboardMode() const
 {

--- a/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
@@ -34,7 +34,7 @@ ImageSpaceComponent::ImageSpaceComponent(csp::common::LogSystem* LogSystem, Spac
     Properties[static_cast<uint32_t>(ImagePropertyKeys::DisplayMode)] = static_cast<int64_t>(DisplayMode::DoubleSided);
     Properties[static_cast<uint32_t>(ImagePropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(ImagePropertyKeys::IsEmissive)] = false;
-    Properties[static_cast<uint32_t>(ImagePropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ImageSpaceComponentScriptInterface(this));
 }
@@ -117,9 +117,9 @@ bool ImageSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(sta
 
 void ImageSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsARVisible), Value); }
 
-bool ImageSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVRVisible)); }
+bool ImageSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible)); }
 
-void ImageSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVRVisible), Value); }
+void ImageSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible), Value); }
 
 BillboardMode ImageSpaceComponent::GetBillboardMode() const
 {

--- a/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
@@ -38,6 +38,7 @@ LightSpaceComponent::LightSpaceComponent(csp::common::LogSystem* LogSystem, Spac
     Properties[static_cast<uint32_t>(LightPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(LightPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(LightPropertyKeys::LightShadowType)] = static_cast<int64_t>(LightShadowType::None);
+    Properties[static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new LightSpaceComponentScriptInterface(this));
 }
@@ -99,6 +100,10 @@ void LightSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uin
 bool LightSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsARVisible)); }
 
 void LightSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsARVisible), Value); }
+
+bool LightSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible)); }
+
+void LightSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible), Value); }
 
 const csp::common::String& LightSpaceComponent::GetLightCookieAssetId() const
 {

--- a/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
@@ -38,7 +38,7 @@ LightSpaceComponent::LightSpaceComponent(csp::common::LogSystem* LogSystem, Spac
     Properties[static_cast<uint32_t>(LightPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(LightPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(LightPropertyKeys::LightShadowType)] = static_cast<int64_t>(LightShadowType::None);
-    Properties[static_cast<uint32_t>(LightPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new LightSpaceComponentScriptInterface(this));
 }
@@ -101,9 +101,9 @@ bool LightSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(sta
 
 void LightSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsARVisible), Value); }
 
-bool LightSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsVRVisible)); }
+bool LightSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible)); }
 
-void LightSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsVRVisible), Value); }
+void LightSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible), Value); }
 
 const csp::common::String& LightSpaceComponent::GetLightCookieAssetId() const
 {

--- a/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
@@ -38,7 +38,7 @@ LightSpaceComponent::LightSpaceComponent(csp::common::LogSystem* LogSystem, Spac
     Properties[static_cast<uint32_t>(LightPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(LightPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(LightPropertyKeys::LightShadowType)] = static_cast<int64_t>(LightShadowType::None);
-    Properties[static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(LightPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new LightSpaceComponentScriptInterface(this));
 }
@@ -101,9 +101,9 @@ bool LightSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(sta
 
 void LightSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsARVisible), Value); }
 
-bool LightSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible)); }
+bool LightSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsVRVisible)); }
 
-void LightSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible), Value); }
+void LightSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsVRVisible), Value); }
 
 const csp::common::String& LightSpaceComponent::GetLightCookieAssetId() const
 {

--- a/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
@@ -39,7 +39,7 @@ ScreenSharingSpaceComponent::ScreenSharingSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageCollectionId)] = "";
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageAssetId)] = "";
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::AttenuationRadius)] = DefaultAttenuationRadius;
-    Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ScreenSharingSpaceComponentScriptInterface(this));
 }
@@ -143,9 +143,15 @@ bool ScreenSharingSpaceComponent::GetIsARVisible() const { return GetBooleanProp
 
 void ScreenSharingSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsARVisible), Value); }
 
-bool ScreenSharingSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVRVisible)); }
+bool ScreenSharingSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible));
+}
 
-void ScreenSharingSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVRVisible), Value); }
+void ScreenSharingSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible), Value);
+}
 
 /* IShadowCaster */
 

--- a/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
@@ -39,6 +39,7 @@ ScreenSharingSpaceComponent::ScreenSharingSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageCollectionId)] = "";
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageAssetId)] = "";
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::AttenuationRadius)] = DefaultAttenuationRadius;
+    Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new ScreenSharingSpaceComponentScriptInterface(this));
 }
@@ -141,6 +142,16 @@ void ScreenSharingSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_
 bool ScreenSharingSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsARVisible)); }
 
 void ScreenSharingSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsARVisible), Value); }
+
+bool ScreenSharingSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible));
+}
+
+void ScreenSharingSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible), Value);
+}
 
 /* IShadowCaster */
 

--- a/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
@@ -39,7 +39,7 @@ ScreenSharingSpaceComponent::ScreenSharingSpaceComponent(csp::common::LogSystem*
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageCollectionId)] = "";
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageAssetId)] = "";
     Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::AttenuationRadius)] = DefaultAttenuationRadius;
-    Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new ScreenSharingSpaceComponentScriptInterface(this));
 }
@@ -143,15 +143,9 @@ bool ScreenSharingSpaceComponent::GetIsARVisible() const { return GetBooleanProp
 
 void ScreenSharingSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsARVisible), Value); }
 
-bool ScreenSharingSpaceComponent::GetIsVirtualVisible() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible));
-}
+bool ScreenSharingSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVRVisible)); }
 
-void ScreenSharingSpaceComponent::SetIsVirtualVisible(bool Value)
-{
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible), Value);
-}
+void ScreenSharingSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVRVisible), Value); }
 
 /* IShadowCaster */
 

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -37,7 +37,6 @@ StaticModelSpaceComponent::StaticModelSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible)] = true;
-    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldout)] = false;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR)] = false;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR)] = false;
 
@@ -184,13 +183,6 @@ bool StaticModelSpaceComponent::GetIsShadowCaster() const
 void StaticModelSpaceComponent::SetIsShadowCaster(bool Value) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster), Value); }
 
 /* IRenderBehaviourComponent */
-
-bool StaticModelSpaceComponent::GetShowAsHoldout() const { return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldout)); }
-
-void StaticModelSpaceComponent::SetShowAsHoldout(bool InValue)
-{
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldout), InValue);
-}
 
 bool StaticModelSpaceComponent::GetShowAsHoldoutInAR() const
 {

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -36,9 +36,9 @@ StaticModelSpaceComponent::StaticModelSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)] = true;
-    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR)] = false;
-    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR)] = false;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual)] = false;
 
     SetScriptInterface(new StaticModelSpaceComponentScriptInterface(this));
 }
@@ -161,9 +161,15 @@ bool StaticModelSpaceComponent::GetIsARVisible() const { return GetBooleanProper
 
 void StaticModelSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible), InValue); }
 
-bool StaticModelSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible)); }
+bool StaticModelSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible));
+}
 
-void StaticModelSpaceComponent::SetIsVRVisible(bool InValue) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible), InValue); }
+void StaticModelSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible), InValue);
+}
 
 const csp::common::String& StaticModelSpaceComponent::GetThirdPartyComponentRef() const
 {
@@ -194,14 +200,14 @@ void StaticModelSpaceComponent::SetShowAsHoldoutInAR(bool InValue)
     SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR), InValue);
 }
 
-bool StaticModelSpaceComponent::GetShowAsHoldoutInVR() const
+bool StaticModelSpaceComponent::GetShowAsHoldoutInVirtual() const
 {
-    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR));
+    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual));
 }
 
-void StaticModelSpaceComponent::SetShowAsHoldoutInVR(bool InValue)
+void StaticModelSpaceComponent::SetShowAsHoldoutInVirtual(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR), InValue);
+    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -37,6 +37,7 @@ StaticModelSpaceComponent::StaticModelSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldout)] = false;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR)] = false;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR)] = false;
 
@@ -182,7 +183,14 @@ bool StaticModelSpaceComponent::GetIsShadowCaster() const
 
 void StaticModelSpaceComponent::SetIsShadowCaster(bool Value) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster), Value); }
 
-/* IVisibilityBehaviourComponent */
+/* IRenderBehaviourComponent */
+
+bool StaticModelSpaceComponent::GetShowAsHoldout() const { return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldout)); }
+
+void StaticModelSpaceComponent::SetShowAsHoldout(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldout), InValue);
+}
 
 bool StaticModelSpaceComponent::GetShowAsHoldoutInAR() const
 {

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -36,9 +36,9 @@ StaticModelSpaceComponent::StaticModelSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)] = true;
-    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR)] = false;
-    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual)] = false;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR)] = false;
 
     SetScriptInterface(new StaticModelSpaceComponentScriptInterface(this));
 }
@@ -161,15 +161,9 @@ bool StaticModelSpaceComponent::GetIsARVisible() const { return GetBooleanProper
 
 void StaticModelSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible), InValue); }
 
-bool StaticModelSpaceComponent::GetIsVirtualVisible() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible));
-}
+bool StaticModelSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible)); }
 
-void StaticModelSpaceComponent::SetIsVirtualVisible(bool InValue)
-{
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible), InValue);
-}
+void StaticModelSpaceComponent::SetIsVRVisible(bool InValue) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVRVisible), InValue); }
 
 const csp::common::String& StaticModelSpaceComponent::GetThirdPartyComponentRef() const
 {
@@ -200,14 +194,14 @@ void StaticModelSpaceComponent::SetShowAsHoldoutInAR(bool InValue)
     SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR), InValue);
 }
 
-bool StaticModelSpaceComponent::GetShowAsHoldoutInVirtual() const
+bool StaticModelSpaceComponent::GetShowAsHoldoutInVR() const
 {
-    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual));
+    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR));
 }
 
-void StaticModelSpaceComponent::SetShowAsHoldoutInVirtual(bool InValue)
+void StaticModelSpaceComponent::SetShowAsHoldoutInVR(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual), InValue);
+    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVR), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -37,6 +37,8 @@ StaticModelSpaceComponent::StaticModelSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR)] = false;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual)] = false;
 
     SetScriptInterface(new StaticModelSpaceComponentScriptInterface(this));
 }
@@ -185,5 +187,27 @@ bool StaticModelSpaceComponent::GetIsShadowCaster() const
 }
 
 void StaticModelSpaceComponent::SetIsShadowCaster(bool Value) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster), Value); }
+
+/* IVisibilityBehaviourComponent */
+
+bool StaticModelSpaceComponent::GetShowAsHoldoutInAR() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR));
+}
+
+void StaticModelSpaceComponent::SetShowAsHoldoutInAR(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR), InValue);
+}
+
+bool StaticModelSpaceComponent::GetShowAsHoldoutInVirtual() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual));
+}
+
+void StaticModelSpaceComponent::SetShowAsHoldoutInVirtual(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual), InValue);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -36,6 +36,7 @@ StaticModelSpaceComponent::StaticModelSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef)] = "";
     Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster)] = true;
+    Properties[static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new StaticModelSpaceComponentScriptInterface(this));
 }
@@ -157,6 +158,16 @@ void StaticModelSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static_
 bool StaticModelSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible)); }
 
 void StaticModelSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible), InValue); }
+
+bool StaticModelSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible));
+}
+
+void StaticModelSpaceComponent::SetIsVirtualVisible(bool InValue)
+{
+    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible), InValue);
+}
 
 const csp::common::String& StaticModelSpaceComponent::GetThirdPartyComponentRef() const
 {

--- a/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
@@ -35,7 +35,7 @@ TextSpaceComponent::TextSpaceComponent(csp::common::LogSystem* LogSystem, SpaceE
     Properties[static_cast<uint32_t>(TextPropertyKeys::BillboardMode)] = static_cast<int64_t>(BillboardMode::Off);
     Properties[static_cast<uint32_t>(TextPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(TextPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(TextPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new TextSpaceComponentScriptInterface(this));
 }
@@ -114,9 +114,9 @@ bool TextSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(stat
 
 void TextSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsARVisible), Value); }
 
-bool TextSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible)); }
+bool TextSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsVRVisible)); }
 
-void TextSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible), Value); }
+void TextSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsVRVisible), Value); }
 
 BillboardMode TextSpaceComponent::GetBillboardMode() const
 {

--- a/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
@@ -35,6 +35,7 @@ TextSpaceComponent::TextSpaceComponent(csp::common::LogSystem* LogSystem, SpaceE
     Properties[static_cast<uint32_t>(TextPropertyKeys::BillboardMode)] = static_cast<int64_t>(BillboardMode::Off);
     Properties[static_cast<uint32_t>(TextPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(TextPropertyKeys::IsARVisible)] = true;
+    Properties[static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new TextSpaceComponentScriptInterface(this));
 }
@@ -112,6 +113,10 @@ void TextSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint
 bool TextSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsARVisible)); }
 
 void TextSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsARVisible), Value); }
+
+bool TextSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible)); }
+
+void TextSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible), Value); }
 
 BillboardMode TextSpaceComponent::GetBillboardMode() const
 {

--- a/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
@@ -35,7 +35,7 @@ TextSpaceComponent::TextSpaceComponent(csp::common::LogSystem* LogSystem, SpaceE
     Properties[static_cast<uint32_t>(TextPropertyKeys::BillboardMode)] = static_cast<int64_t>(BillboardMode::Off);
     Properties[static_cast<uint32_t>(TextPropertyKeys::IsVisible)] = true;
     Properties[static_cast<uint32_t>(TextPropertyKeys::IsARVisible)] = true;
-    Properties[static_cast<uint32_t>(TextPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new TextSpaceComponentScriptInterface(this));
 }
@@ -114,9 +114,9 @@ bool TextSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(stat
 
 void TextSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsARVisible), Value); }
 
-bool TextSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsVRVisible)); }
+bool TextSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible)); }
 
-void TextSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsVRVisible), Value); }
+void TextSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible), Value); }
 
 BillboardMode TextSpaceComponent::GetBillboardMode() const
 {

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -50,7 +50,7 @@ VideoPlayerSpaceComponent::VideoPlayerSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId)] = static_cast<int64_t>(0);
     Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsEnabled)] = true;
-    Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVRVisible)] = true;
+    Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new VideoPlayerSpaceComponentScriptInterface(this));
 }
@@ -217,9 +217,15 @@ bool VideoPlayerSpaceComponent::GetIsARVisible() const { return GetBooleanProper
 
 void VideoPlayerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible), Value); }
 
-bool VideoPlayerSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVRVisible)); }
+bool VideoPlayerSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible));
+}
 
-void VideoPlayerSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVRVisible), Value); }
+void VideoPlayerSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible), Value);
+}
 
 /* IEnableableComponent */
 

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -50,7 +50,7 @@ VideoPlayerSpaceComponent::VideoPlayerSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId)] = static_cast<int64_t>(0);
     Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsEnabled)] = true;
-    Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible)] = true;
+    Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVRVisible)] = true;
 
     SetScriptInterface(new VideoPlayerSpaceComponentScriptInterface(this));
 }
@@ -217,15 +217,9 @@ bool VideoPlayerSpaceComponent::GetIsARVisible() const { return GetBooleanProper
 
 void VideoPlayerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible), Value); }
 
-bool VideoPlayerSpaceComponent::GetIsVirtualVisible() const
-{
-    return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible));
-}
+bool VideoPlayerSpaceComponent::GetIsVRVisible() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVRVisible)); }
 
-void VideoPlayerSpaceComponent::SetIsVirtualVisible(bool Value)
-{
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible), Value);
-}
+void VideoPlayerSpaceComponent::SetIsVRVisible(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVRVisible), Value); }
 
 /* IEnableableComponent */
 

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -15,8 +15,8 @@
  */
 #include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
 
-#include "CSP/Multiplayer/SpaceEntity.h"
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
 #include "Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h"
 
 namespace
@@ -50,6 +50,7 @@ VideoPlayerSpaceComponent::VideoPlayerSpaceComponent(csp::common::LogSystem* Log
     Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible)] = true;
     Properties[static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId)] = static_cast<int64_t>(0);
     Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsEnabled)] = true;
+    Properties[static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible)] = true;
 
     SetScriptInterface(new VideoPlayerSpaceComponentScriptInterface(this));
 }
@@ -215,6 +216,16 @@ void VideoPlayerSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_ca
 bool VideoPlayerSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible)); }
 
 void VideoPlayerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible), Value); }
+
+bool VideoPlayerSpaceComponent::GetIsVirtualVisible() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible));
+}
+
+void VideoPlayerSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible), Value);
+}
 
 /* IEnableableComponent */
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
@@ -40,6 +40,8 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsLoopPlayb
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsPlaying);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, int32_t, int32_t, AnimationIndex);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
@@ -43,6 +43,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsARVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVRVisible);
 
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldout);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
@@ -43,7 +43,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsARVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVRVisible);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldout);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
@@ -41,10 +41,10 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsPlaying);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVRVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
-DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInVirtual);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, int32_t, int32_t, AnimationIndex);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
@@ -43,6 +43,9 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsARVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVirtualVisible);
 
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInVirtual);
+
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, int32_t, int32_t, AnimationIndex);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.cpp
@@ -41,10 +41,10 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsPlaying);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
-DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
+DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, bool, bool, ShowAsHoldoutInVirtual);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(AnimatedModelSpaceComponent, int32_t, int32_t, AnimationIndex);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
@@ -42,6 +42,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsPlaying);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(int32_t, AnimationIndex);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
@@ -45,6 +45,9 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVirtual);
+
     DECLARE_SCRIPT_PROPERTY(int32_t, AnimationIndex);
 };
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
@@ -45,7 +45,6 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
-    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldout);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
@@ -43,10 +43,10 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
-    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVirtual);
 
     DECLARE_SCRIPT_PROPERTY(int32_t, AnimationIndex);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
@@ -45,6 +45,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldout);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h
@@ -43,10 +43,10 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
-    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVirtual);
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
 
     DECLARE_SCRIPT_PROPERTY(int32_t, AnimationIndex);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
@@ -44,5 +44,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarPlayMo
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::LocomotionModel, int32_t, LocomotionModel);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
@@ -44,6 +44,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarPlayMo
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::LocomotionModel, int32_t, LocomotionModel);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVRVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.cpp
@@ -44,6 +44,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::AvatarPlayMo
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, csp::multiplayer::LocomotionModel, int32_t, LocomotionModel);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(AvatarSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
@@ -46,7 +46,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(int32_t, LocomotionModel);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
@@ -46,6 +46,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(int32_t, LocomotionModel);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h
@@ -46,7 +46,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(int32_t, LocomotionModel);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.cpp
@@ -38,7 +38,7 @@ DEFINE_SCRIPT_PROPERTY_VEC4(ButtonSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVirtualVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsEnabled);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.cpp
@@ -37,6 +37,8 @@ DEFINE_SCRIPT_PROPERTY_VEC3(ButtonSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(ButtonSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVirtualVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsEnabled);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.cpp
@@ -38,7 +38,7 @@ DEFINE_SCRIPT_PROPERTY_VEC4(ButtonSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsVRVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ButtonSpaceComponent, bool, bool, IsEnabled);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.h
@@ -39,6 +39,9 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
 };
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.h
@@ -40,7 +40,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ButtonSpaceComponentScriptInterface.h
@@ -40,7 +40,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.cpp
@@ -39,5 +39,6 @@ DEFINE_SCRIPT_PROPERTY_VEC4(ExternalLinkSpaceComponent, Rotation);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsEnabled);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.cpp
@@ -39,6 +39,6 @@ DEFINE_SCRIPT_PROPERTY_VEC4(ExternalLinkSpaceComponent, Rotation);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsEnabled);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVRVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.cpp
@@ -39,6 +39,6 @@ DEFINE_SCRIPT_PROPERTY_VEC4(ExternalLinkSpaceComponent, Rotation);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsEnabled);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ExternalLinkSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.h
@@ -41,6 +41,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.h
@@ -41,7 +41,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ExternalLinkSpaceComponentScriptInterface.h
@@ -41,7 +41,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.cpp
@@ -37,6 +37,6 @@ DEFINE_SCRIPT_PROPERTY_VEC4(FiducialMarkerSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.cpp
@@ -37,6 +37,6 @@ DEFINE_SCRIPT_PROPERTY_VEC4(FiducialMarkerSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVRVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.cpp
@@ -36,5 +36,7 @@ DEFINE_SCRIPT_PROPERTY_VEC3(FiducialMarkerSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(FiducialMarkerSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FiducialMarkerSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.h
@@ -39,7 +39,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.h
@@ -39,7 +39,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FiducialMarkerSpaceComponentScriptInterface.h
@@ -38,6 +38,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
@@ -47,6 +47,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVolumetric);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVRVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
@@ -47,6 +47,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVolumetric);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.cpp
@@ -46,5 +46,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, float, float, MaxOpacity);
 DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVolumetric);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(FogSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
@@ -46,7 +46,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
@@ -45,6 +45,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsVolumetric);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/FogSpaceComponentScriptInterface.h
@@ -46,7 +46,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
@@ -38,7 +38,7 @@ DEFINE_SCRIPT_PROPERTY_VEC4(GaussianSplatSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_VEC3(GaussianSplatSpaceComponent, Tint);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
@@ -38,7 +38,7 @@ DEFINE_SCRIPT_PROPERTY_VEC4(GaussianSplatSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVRVisible);
 
 DEFINE_SCRIPT_PROPERTY_VEC3(GaussianSplatSpaceComponent, Tint);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.cpp
@@ -38,6 +38,7 @@ DEFINE_SCRIPT_PROPERTY_VEC4(GaussianSplatSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(GaussianSplatSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_VEC3(GaussianSplatSpaceComponent, Tint);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
@@ -40,6 +40,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(Vector3, Tint);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
@@ -40,7 +40,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
     DECLARE_SCRIPT_PROPERTY(Vector3, Tint);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/GaussianSplatSpaceComponentScriptInterface.h
@@ -40,7 +40,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(Vector3, Tint);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
@@ -41,5 +41,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsSpawnPoint);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
@@ -41,6 +41,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsSpawnPoint);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVRVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.cpp
@@ -41,6 +41,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsSpawnPoint);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(HotspotSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
@@ -39,7 +39,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsSpawnPoint);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
@@ -39,6 +39,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsSpawnPoint);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h
@@ -39,7 +39,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsSpawnPoint);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
@@ -41,6 +41,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, csp::multiplayer::DisplayMode, 
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsEmissive);
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
@@ -40,5 +40,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, csp::multiplayer::DisplayMode, 
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsEmissive);
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.cpp
@@ -41,6 +41,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, csp::multiplayer::DisplayMode, 
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsEmissive);
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ImageSpaceComponent, bool, bool, IsVRVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
@@ -42,6 +42,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsEmissive);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
@@ -43,7 +43,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ImageSpaceComponentScriptInterface.h
@@ -43,7 +43,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
@@ -41,7 +41,7 @@ DEFINE_SCRIPT_PROPERTY_VEC4(LightSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_STRING(LightSpaceComponent, LightCookieAssetId);
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, csp::multiplayer::LightCookieType, int32_t, LightCookieType);

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
@@ -40,6 +40,8 @@ DEFINE_SCRIPT_PROPERTY_VEC3(LightSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(LightSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_STRING(LightSpaceComponent, LightCookieAssetId);
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, csp::multiplayer::LightCookieType, int32_t, LightCookieType);

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.cpp
@@ -41,7 +41,7 @@ DEFINE_SCRIPT_PROPERTY_VEC4(LightSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, bool, bool, IsVRVisible);
 
 DEFINE_SCRIPT_PROPERTY_STRING(LightSpaceComponent, LightCookieAssetId);
 DEFINE_SCRIPT_PROPERTY_TYPE(LightSpaceComponent, csp::multiplayer::LightCookieType, int32_t, LightCookieType);

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
@@ -42,7 +42,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(std::string, LightCookieAssetId);
     DECLARE_SCRIPT_PROPERTY(int32_t, LightCookieType);

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
@@ -42,7 +42,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
     DECLARE_SCRIPT_PROPERTY(std::string, LightCookieAssetId);
     DECLARE_SCRIPT_PROPERTY(int32_t, LightCookieType);

--- a/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/LightSpaceComponentScriptInterface.h
@@ -41,6 +41,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(std::string, LightCookieAssetId);
     DECLARE_SCRIPT_PROPERTY(int32_t, LightCookieType);

--- a/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.cpp
@@ -40,7 +40,7 @@ DEFINE_SCRIPT_PROPERTY_VEC3(ScreenSharingSpaceComponent, Scale);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVirtualVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsShadowCaster);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.cpp
@@ -40,7 +40,7 @@ DEFINE_SCRIPT_PROPERTY_VEC3(ScreenSharingSpaceComponent, Scale);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVRVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsShadowCaster);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.cpp
@@ -40,6 +40,7 @@ DEFINE_SCRIPT_PROPERTY_VEC3(ScreenSharingSpaceComponent, Scale);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsVirtualVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(ScreenSharingSpaceComponent, bool, bool, IsShadowCaster);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.h
@@ -41,6 +41,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsShadowCaster);
 };
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.h
@@ -41,7 +41,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsShadowCaster);
 };
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/ScreenSharingSpaceComponentScriptInterface.h
@@ -41,7 +41,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsShadowCaster);
 };
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
@@ -40,6 +40,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsARVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVRVisible);
 
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldout);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
@@ -40,7 +40,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsARVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVRVisible);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldout);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
@@ -37,5 +37,7 @@ DEFINE_SCRIPT_PROPERTY_VEC3(StaticModelSpaceComponent, Position);
 DEFINE_SCRIPT_PROPERTY_VEC4(StaticModelSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
@@ -40,4 +40,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsARVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVirtualVisible);
 
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInVirtual);
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
@@ -38,9 +38,9 @@ DEFINE_SCRIPT_PROPERTY_VEC4(StaticModelSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
-DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInVirtual);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.cpp
@@ -38,9 +38,9 @@ DEFINE_SCRIPT_PROPERTY_VEC4(StaticModelSpaceComponent, Rotation);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, IsVRVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInAR);
-DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInVirtual);
+DEFINE_SCRIPT_PROPERTY_TYPE(StaticModelSpaceComponent, bool, bool, ShowAsHoldoutInVR);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
@@ -42,7 +42,6 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
-    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldout);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
@@ -40,10 +40,10 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
-    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVirtual);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
@@ -39,6 +39,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
@@ -41,6 +41,9 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVirtual);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
@@ -40,10 +40,10 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
-    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVirtual);
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/StaticModelSpaceComponentScriptInterface.h
@@ -42,6 +42,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
+    DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldout);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInAR);
     DECLARE_SCRIPT_PROPERTY(bool, ShowAsHoldoutInVR);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
@@ -43,5 +43,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Width);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Height);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
@@ -43,6 +43,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Width);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Height);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVRVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.cpp
@@ -43,6 +43,6 @@ DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Width);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, float, uint32_t, Height);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(TextSpaceComponent, bool, bool, IsVirtualVisible);
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
@@ -41,6 +41,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(int32_t, BillboardMode);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
@@ -41,7 +41,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(int32_t, BillboardMode);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/TextSpaceComponentScriptInterface.h
@@ -41,7 +41,7 @@ public:
     DECLARE_SCRIPT_PROPERTY(int32_t, BillboardMode);
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
@@ -52,7 +52,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::VideoPl
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVRVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsEnabled);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
@@ -51,6 +51,8 @@ DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, float, float, TimeSincePl
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::VideoPlayerSourceType, int32_t, VideoPlayerSourceType);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsARVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVirtualVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsEnabled);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
@@ -52,7 +52,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::VideoPl
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVisible);
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsARVisible);
-DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVirtualVisible);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVRVisible);
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsEnabled);
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
@@ -54,7 +54,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
@@ -53,6 +53,8 @@ public:
     DECLARE_SCRIPT_PROPERTY(int32_t, VideoPlayerSourceType);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
 };

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
@@ -54,7 +54,7 @@ public:
 
     DECLARE_SCRIPT_PROPERTY(bool, IsVisible);
     DECLARE_SCRIPT_PROPERTY(bool, IsARVisible);
-    DECLARE_SCRIPT_PROPERTY(bool, IsVRVisible);
+    DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
 };

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -19,8 +19,8 @@
 #include "CSP/Common//Systems/Log/LogSystem.h"
 #include "CSP/Common/List.h"
 #include "CSP/Common/Vector.h"
-#include "CSP/Multiplayer/SpaceEntity.h"
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
 #include "Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h"
@@ -278,6 +278,8 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ButtonSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(ButtonSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(ButtonSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(ButtonSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsEnabled, "isEnabled");
 
     Module->class_<LightSpaceComponentScriptInterface>("LightSpaceComponent")
@@ -292,6 +294,8 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(LightSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(LightSpaceComponent, Color, "color")
         .PROPERTY_GET_SET(LightSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(LightSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(LightSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(LightSpaceComponent, LightCookieAssetId, "cookieAssetId")
         .PROPERTY_GET_SET(LightSpaceComponent, LightCookieType, "lightCookieType");
 
@@ -308,6 +312,8 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsLoopPlayback, "isLoopPlayback")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsPlaying, "isPlaying")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, AnimationIndex, "animationIndex");
 
     Module->class_<VideoPlayerSpaceComponentScriptInterface>("VideoPlayerSpaceComponent")
@@ -328,6 +334,8 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, TimeSincePlay, "timeSincePlay")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, VideoPlayerSourceType, "videoPlayerSourceType")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsEnabled, "isEnabled");
 
     Module->class_<AvatarSpaceComponentScriptInterface>("AvatarSpaceComponent")
@@ -348,7 +356,8 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AvatarSpaceComponent, AvatarPlayMode, "avatarPlayMode")
         .PROPERTY_GET_SET(AvatarSpaceComponent, LocomotionModel, "locomotionModel")
         .PROPERTY_GET_SET(AvatarSpaceComponent, IsVisible, "isVisible")
-        .PROPERTY_GET_SET(AvatarSpaceComponent, IsARVisible, "isARVisible");
+        .PROPERTY_GET_SET(AvatarSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(AvatarSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<ExternalLinkSpaceComponentScriptInterface>("ExternalLinkSpaceComponent")
         .constructor<>()
@@ -360,7 +369,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsEnabled, "isEnabled")
-        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVisible, "isVisible");
+        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<FogSpaceComponentScriptInterface>("FogSpaceComponent")
         .constructor<>()
@@ -375,7 +386,10 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(FogSpaceComponent, Density, "density")
         .PROPERTY_GET_SET(FogSpaceComponent, HeightFalloff, "heightFalloff")
         .PROPERTY_GET_SET(FogSpaceComponent, MaxOpacity, "maxOpacity")
-        .PROPERTY_GET_SET(FogSpaceComponent, IsVolumetric, "isVolumetric");
+        .PROPERTY_GET_SET(FogSpaceComponent, IsVolumetric, "isVolumetric")
+        .PROPERTY_GET_SET(FogSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(FogSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(FogSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<CinematicCameraSpaceComponentScriptInterface>("CinematicCameraSpaceComponent")
         .constructor<>()
@@ -405,7 +419,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ImageSpaceComponent, BillboardMode, "billboardMode")
         .PROPERTY_GET_SET(ImageSpaceComponent, DisplayMode, "displayMode")
         .PROPERTY_GET_SET(ImageSpaceComponent, IsEmissive, "isEmissive")
-        .PROPERTY_GET_SET(ImageSpaceComponent, IsVisible, "isVisible");
+        .PROPERTY_GET_SET(ImageSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(ImageSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(ImageSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<TextSpaceComponentScriptInterface>("TextSpaceComponent")
         .constructor<>()
@@ -421,7 +437,8 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(TextSpaceComponent, Height, "height")
         .PROPERTY_GET_SET(TextSpaceComponent, BillboardMode, "billboardMode")
         .PROPERTY_GET_SET(TextSpaceComponent, IsVisible, "isVisible")
-        .PROPERTY_GET_SET(TextSpaceComponent, IsARVisible, "isARVisible");
+        .PROPERTY_GET_SET(TextSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(TextSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<StaticModelSpaceComponentScriptInterface>("StaticModelSpaceComponent")
         .constructor<>()
@@ -433,7 +450,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(StaticModelSpaceComponent, Position, "position")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, Rotation, "rotation")
-        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible");
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<PortalSpaceComponentScriptInterface>("PortalSpaceComponent")
         .constructor<>()
@@ -500,7 +519,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, Position, "position")
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, Rotation, "rotation")
-        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVisible, "isVisible");
+        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVisible, "isVisible")
+        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<GaussianSplatSpaceComponentScriptInterface>("GaussianSplatSpaceComponent")
         .constructor<>()
@@ -512,6 +533,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, Tint, "tint");
 
     Module->class_<HotspotSpaceComponentScriptInterface>("HotspotSpaceComponent")
@@ -522,6 +544,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(HotspotSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(HotspotSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsTeleportPoint, "isTeleportPoint")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsSpawnPoint, "isSpawnPoint");
 
@@ -537,6 +560,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsARVisible, "isARVisible")
+        .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsShadowCaster, "isShadowCaster");
 }
 

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -314,6 +314,8 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsARVisible, "isARVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInVirtual, "showAsHoldoutInVirtual")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, AnimationIndex, "animationIndex");
 
     Module->class_<VideoPlayerSpaceComponentScriptInterface>("VideoPlayerSpaceComponent")
@@ -452,7 +454,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(StaticModelSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVirtualVisible, "isVirtualVisible");
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInVirtual, "showAsHoldoutInVirtual");
 
     Module->class_<PortalSpaceComponentScriptInterface>("PortalSpaceComponent")
         .constructor<>()

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -314,6 +314,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsARVisible, "isARVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldout, "showAsHoldout")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, AnimationIndex, "animationIndex");
@@ -455,6 +456,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsARVisible, "isARVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldout, "showAsHoldout")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR");
 

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -314,7 +314,6 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsARVisible, "isARVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVRVisible, "isVRVisible")
-        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldout, "showAsHoldout")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, AnimationIndex, "animationIndex");
@@ -456,7 +455,6 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsARVisible, "isARVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVRVisible, "isVRVisible")
-        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldout, "showAsHoldout")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR");
 

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -279,7 +279,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ButtonSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ButtonSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(ButtonSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsEnabled, "isEnabled");
 
     Module->class_<LightSpaceComponentScriptInterface>("LightSpaceComponent")
@@ -295,7 +295,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(LightSpaceComponent, Color, "color")
         .PROPERTY_GET_SET(LightSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(LightSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(LightSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(LightSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(LightSpaceComponent, LightCookieAssetId, "cookieAssetId")
         .PROPERTY_GET_SET(LightSpaceComponent, LightCookieType, "lightCookieType");
 
@@ -313,9 +313,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsPlaying, "isPlaying")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
-        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInVirtual, "showAsHoldoutInVirtual")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, AnimationIndex, "animationIndex");
 
     Module->class_<VideoPlayerSpaceComponentScriptInterface>("VideoPlayerSpaceComponent")
@@ -337,7 +337,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, VideoPlayerSourceType, "videoPlayerSourceType")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsEnabled, "isEnabled");
 
     Module->class_<AvatarSpaceComponentScriptInterface>("AvatarSpaceComponent")
@@ -359,7 +359,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AvatarSpaceComponent, LocomotionModel, "locomotionModel")
         .PROPERTY_GET_SET(AvatarSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(AvatarSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(AvatarSpaceComponent, IsVRVisible, "isVRVisible");
+        .PROPERTY_GET_SET(AvatarSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<ExternalLinkSpaceComponentScriptInterface>("ExternalLinkSpaceComponent")
         .constructor<>()
@@ -373,7 +373,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsEnabled, "isEnabled")
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVRVisible, "isVRVisible");
+        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<FogSpaceComponentScriptInterface>("FogSpaceComponent")
         .constructor<>()
@@ -391,7 +391,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(FogSpaceComponent, IsVolumetric, "isVolumetric")
         .PROPERTY_GET_SET(FogSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(FogSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(FogSpaceComponent, IsVRVisible, "isVRVisible");
+        .PROPERTY_GET_SET(FogSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<CinematicCameraSpaceComponentScriptInterface>("CinematicCameraSpaceComponent")
         .constructor<>()
@@ -423,7 +423,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ImageSpaceComponent, IsEmissive, "isEmissive")
         .PROPERTY_GET_SET(ImageSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ImageSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ImageSpaceComponent, IsVRVisible, "isVRVisible");
+        .PROPERTY_GET_SET(ImageSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<TextSpaceComponentScriptInterface>("TextSpaceComponent")
         .constructor<>()
@@ -440,7 +440,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(TextSpaceComponent, BillboardMode, "billboardMode")
         .PROPERTY_GET_SET(TextSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(TextSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(TextSpaceComponent, IsVRVisible, "isVRVisible");
+        .PROPERTY_GET_SET(TextSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<StaticModelSpaceComponentScriptInterface>("StaticModelSpaceComponent")
         .constructor<>()
@@ -454,9 +454,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(StaticModelSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
-        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR");
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInVirtual, "showAsHoldoutInVirtual");
 
     Module->class_<PortalSpaceComponentScriptInterface>("PortalSpaceComponent")
         .constructor<>()
@@ -525,7 +525,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVRVisible, "isVRVisible");
+        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVirtualVisible, "isVirtualVisible");
 
     Module->class_<GaussianSplatSpaceComponentScriptInterface>("GaussianSplatSpaceComponent")
         .constructor<>()
@@ -537,7 +537,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, Tint, "tint");
 
     Module->class_<HotspotSpaceComponentScriptInterface>("HotspotSpaceComponent")
@@ -548,7 +548,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(HotspotSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(HotspotSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(HotspotSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsTeleportPoint, "isTeleportPoint")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsSpawnPoint, "isSpawnPoint");
 
@@ -564,7 +564,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVRVisible, "isVRVisible")
+        .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsShadowCaster, "isShadowCaster");
 }
 

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -279,7 +279,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ButtonSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ButtonSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(ButtonSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(ButtonSpaceComponent, IsEnabled, "isEnabled");
 
     Module->class_<LightSpaceComponentScriptInterface>("LightSpaceComponent")
@@ -295,7 +295,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(LightSpaceComponent, Color, "color")
         .PROPERTY_GET_SET(LightSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(LightSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(LightSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(LightSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(LightSpaceComponent, LightCookieAssetId, "cookieAssetId")
         .PROPERTY_GET_SET(LightSpaceComponent, LightCookieType, "lightCookieType");
 
@@ -313,9 +313,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsPlaying, "isPlaying")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
-        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInVirtual, "showAsHoldoutInVirtual")
+        .PROPERTY_GET_SET(AnimatedModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR")
         .PROPERTY_GET_SET(AnimatedModelSpaceComponent, AnimationIndex, "animationIndex");
 
     Module->class_<VideoPlayerSpaceComponentScriptInterface>("VideoPlayerSpaceComponent")
@@ -337,7 +337,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, VideoPlayerSourceType, "videoPlayerSourceType")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsEnabled, "isEnabled");
 
     Module->class_<AvatarSpaceComponentScriptInterface>("AvatarSpaceComponent")
@@ -359,7 +359,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(AvatarSpaceComponent, LocomotionModel, "locomotionModel")
         .PROPERTY_GET_SET(AvatarSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(AvatarSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(AvatarSpaceComponent, IsVirtualVisible, "isVirtualVisible");
+        .PROPERTY_GET_SET(AvatarSpaceComponent, IsVRVisible, "isVRVisible");
 
     Module->class_<ExternalLinkSpaceComponentScriptInterface>("ExternalLinkSpaceComponent")
         .constructor<>()
@@ -373,7 +373,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsEnabled, "isEnabled")
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVirtualVisible, "isVirtualVisible");
+        .PROPERTY_GET_SET(ExternalLinkSpaceComponent, IsVRVisible, "isVRVisible");
 
     Module->class_<FogSpaceComponentScriptInterface>("FogSpaceComponent")
         .constructor<>()
@@ -391,7 +391,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(FogSpaceComponent, IsVolumetric, "isVolumetric")
         .PROPERTY_GET_SET(FogSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(FogSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(FogSpaceComponent, IsVirtualVisible, "isVirtualVisible");
+        .PROPERTY_GET_SET(FogSpaceComponent, IsVRVisible, "isVRVisible");
 
     Module->class_<CinematicCameraSpaceComponentScriptInterface>("CinematicCameraSpaceComponent")
         .constructor<>()
@@ -423,7 +423,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ImageSpaceComponent, IsEmissive, "isEmissive")
         .PROPERTY_GET_SET(ImageSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ImageSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ImageSpaceComponent, IsVirtualVisible, "isVirtualVisible");
+        .PROPERTY_GET_SET(ImageSpaceComponent, IsVRVisible, "isVRVisible");
 
     Module->class_<TextSpaceComponentScriptInterface>("TextSpaceComponent")
         .constructor<>()
@@ -440,7 +440,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(TextSpaceComponent, BillboardMode, "billboardMode")
         .PROPERTY_GET_SET(TextSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(TextSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(TextSpaceComponent, IsVirtualVisible, "isVirtualVisible");
+        .PROPERTY_GET_SET(TextSpaceComponent, IsVRVisible, "isVRVisible");
 
     Module->class_<StaticModelSpaceComponentScriptInterface>("StaticModelSpaceComponent")
         .constructor<>()
@@ -454,9 +454,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(StaticModelSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInAR, "showAsHoldoutInAR")
-        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInVirtual, "showAsHoldoutInVirtual");
+        .PROPERTY_GET_SET(StaticModelSpaceComponent, ShowAsHoldoutInVR, "showAsHoldoutInVR");
 
     Module->class_<PortalSpaceComponentScriptInterface>("PortalSpaceComponent")
         .constructor<>()
@@ -525,7 +525,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVirtualVisible, "isVirtualVisible");
+        .PROPERTY_GET_SET(FiducialMarkerSpaceComponent, IsVRVisible, "isVRVisible");
 
     Module->class_<GaussianSplatSpaceComponentScriptInterface>("GaussianSplatSpaceComponent")
         .constructor<>()
@@ -537,7 +537,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(GaussianSplatSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(GaussianSplatSpaceComponent, Tint, "tint");
 
     Module->class_<HotspotSpaceComponentScriptInterface>("HotspotSpaceComponent")
@@ -548,7 +548,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(HotspotSpaceComponent, Rotation, "rotation")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(HotspotSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(HotspotSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsTeleportPoint, "isTeleportPoint")
         .PROPERTY_GET_SET(HotspotSpaceComponent, IsSpawnPoint, "isSpawnPoint");
 
@@ -564,7 +564,7 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, Scale, "scale")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsARVisible, "isARVisible")
-        .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVirtualVisible, "isVirtualVisible")
+        .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVRVisible, "isVRVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsShadowCaster, "isShadowCaster");
 }
 

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -91,6 +91,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         constexpr const bool TestIsVirtualVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
+        constexpr const bool TestShowAsHoldoutInAR = true;
+        constexpr const bool TestShowAsHoldoutInVirtual = true;
 
         // Test defaults
         EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), "");
@@ -108,6 +110,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), true);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), false);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), false);
 
         AnimatedModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
         AnimatedModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
@@ -123,6 +127,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         AnimatedModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
         AnimatedModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         AnimatedModelComponent->SetIsShadowCaster(TestIsShadowCaster);
+        AnimatedModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
+        AnimatedModelComponent->SetShowAsHoldoutInVirtual(TestShowAsHoldoutInVirtual);
 
         // Test new values
         EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
@@ -140,6 +146,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), TestShowAsHoldoutInVirtual);
 
         // Test transform separately, as this just sets position, rotation, scale
         AnimatedModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
@@ -214,6 +222,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 		model.isVisible = false;
         model.isARVisible = false;
         model.isVirtualVisible = false;
+        model.showAsHoldoutInAR = true;
+        model.showAsHoldoutInVirtual = true;
 		model.animationIndex = 1;
     )xx";
 
@@ -233,6 +243,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), true);
+    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), true);
     EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), 1);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -88,11 +88,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         constexpr const int TestAnimationIndex = 1;
         constexpr const bool TestIsVisible = false;
         constexpr const bool TestIsARVisible = false;
-        constexpr const bool TestIsVirtualVisible = false;
+        constexpr const bool TestIsVRVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
         constexpr const bool TestShowAsHoldoutInAR = true;
-        constexpr const bool TestShowAsHoldoutInVirtual = true;
+        constexpr const bool TestShowAsHoldoutInVR = true;
 
         // Test defaults
         EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), "");
@@ -107,11 +107,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), -1);
         EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), true);
-        EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), true);
+        EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), true);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), false);
-        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), false);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), false);
 
         AnimatedModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
         AnimatedModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
@@ -124,11 +124,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         AnimatedModelComponent->SetAnimationIndex(TestAnimationIndex);
         AnimatedModelComponent->SetIsVisible(TestIsVisible);
         AnimatedModelComponent->SetIsARVisible(TestIsARVisible);
-        AnimatedModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
+        AnimatedModelComponent->SetIsVRVisible(TestIsVRVisible);
         AnimatedModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         AnimatedModelComponent->SetIsShadowCaster(TestIsShadowCaster);
         AnimatedModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
-        AnimatedModelComponent->SetShowAsHoldoutInVirtual(TestShowAsHoldoutInVirtual);
+        AnimatedModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
 
         // Test new values
         EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
@@ -143,11 +143,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), TestAnimationIndex);
         EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), TestIsVisible);
         EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), TestIsARVisible);
-        EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
+        EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), TestIsVRVisible);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
-        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), TestShowAsHoldoutInVirtual);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
 
         // Test transform separately, as this just sets position, rotation, scale
         AnimatedModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
@@ -221,9 +221,9 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 		model.isPlaying = false;
 		model.isVisible = false;
         model.isARVisible = false;
-        model.isVirtualVisible = false;
+        model.isVRVisible = false;
         model.showAsHoldoutInAR = true;
-        model.showAsHoldoutInVirtual = true;
+        model.showAsHoldoutInVR = true;
 		model.animationIndex = 1;
     )xx";
 
@@ -242,9 +242,9 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     EXPECT_EQ(AnimatedModelComponent->GetIsPlaying(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), false);
-    EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), true);
-    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), true);
+    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), true);
     EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), 1);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -88,11 +88,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         constexpr const int TestAnimationIndex = 1;
         constexpr const bool TestIsVisible = false;
         constexpr const bool TestIsARVisible = false;
-        constexpr const bool TestIsVRVisible = false;
+        constexpr const bool TestIsVirtualVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
         constexpr const bool TestShowAsHoldoutInAR = true;
-        constexpr const bool TestShowAsHoldoutInVR = true;
+        constexpr const bool TestShowAsHoldoutInVirtual = true;
 
         // Test defaults
         EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), "");
@@ -107,11 +107,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), -1);
         EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), true);
-        EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), true);
+        EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), true);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), false);
-        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), false);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), false);
 
         AnimatedModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
         AnimatedModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
@@ -124,11 +124,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         AnimatedModelComponent->SetAnimationIndex(TestAnimationIndex);
         AnimatedModelComponent->SetIsVisible(TestIsVisible);
         AnimatedModelComponent->SetIsARVisible(TestIsARVisible);
-        AnimatedModelComponent->SetIsVRVisible(TestIsVRVisible);
+        AnimatedModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
         AnimatedModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         AnimatedModelComponent->SetIsShadowCaster(TestIsShadowCaster);
         AnimatedModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
-        AnimatedModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
+        AnimatedModelComponent->SetShowAsHoldoutInVirtual(TestShowAsHoldoutInVirtual);
 
         // Test new values
         EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
@@ -143,11 +143,11 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), TestAnimationIndex);
         EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), TestIsVisible);
         EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), TestIsARVisible);
-        EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), TestIsVRVisible);
+        EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
-        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), TestShowAsHoldoutInVirtual);
 
         // Test transform separately, as this just sets position, rotation, scale
         AnimatedModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
@@ -221,9 +221,9 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 		model.isPlaying = false;
 		model.isVisible = false;
         model.isARVisible = false;
-        model.isVRVisible = false;
+        model.isVirtualVisible = false;
         model.showAsHoldoutInAR = true;
-        model.showAsHoldoutInVR = true;
+        model.showAsHoldoutInVirtual = true;
 		model.animationIndex = 1;
     )xx";
 
@@ -242,9 +242,9 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     EXPECT_EQ(AnimatedModelComponent->GetIsPlaying(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), false);
-    EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), true);
-    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), true);
+    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVirtual(), true);
     EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), 1);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -91,7 +91,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         constexpr const bool TestIsVRVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
-        constexpr const bool TestShowAsHoldout = true;
         constexpr const bool TestShowAsHoldoutInAR = true;
         constexpr const bool TestShowAsHoldoutInVR = true;
 
@@ -111,7 +110,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), true);
-        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldout(), false);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), false);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), false);
 
@@ -129,7 +127,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         AnimatedModelComponent->SetIsVRVisible(TestIsVRVisible);
         AnimatedModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         AnimatedModelComponent->SetIsShadowCaster(TestIsShadowCaster);
-        AnimatedModelComponent->SetShowAsHoldout(TestShowAsHoldout);
         AnimatedModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
         AnimatedModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
 
@@ -149,7 +146,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), TestIsVRVisible);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
-        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldout(), TestShowAsHoldout);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
 
@@ -226,10 +222,8 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 		model.isVisible = false;
         model.isARVisible = false;
         model.isVRVisible = false;
-        model.showAsHoldout = true;
         model.showAsHoldoutInAR = true;
         model.showAsHoldoutInVR = true;
-        model.showAsHoldoutInXR = true;
 		model.animationIndex = 1;
     )xx";
 
@@ -249,7 +243,6 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), false);
-    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldout(), true);
     EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), true);
     EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), true);
     EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), 1);

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -91,6 +91,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         constexpr const bool TestIsVRVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
+        constexpr const bool TestShowAsHoldout = true;
         constexpr const bool TestShowAsHoldoutInAR = true;
         constexpr const bool TestShowAsHoldoutInVR = true;
 
@@ -110,6 +111,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), true);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldout(), false);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), false);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), false);
 
@@ -127,6 +129,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         AnimatedModelComponent->SetIsVRVisible(TestIsVRVisible);
         AnimatedModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         AnimatedModelComponent->SetIsShadowCaster(TestIsShadowCaster);
+        AnimatedModelComponent->SetShowAsHoldout(TestShowAsHoldout);
         AnimatedModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
         AnimatedModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
 
@@ -146,6 +149,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), TestIsVRVisible);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
+        EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldout(), TestShowAsHoldout);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
         EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
 
@@ -222,8 +226,10 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 		model.isVisible = false;
         model.isARVisible = false;
         model.isVRVisible = false;
+        model.showAsHoldout = true;
         model.showAsHoldoutInAR = true;
         model.showAsHoldoutInVR = true;
+        model.showAsHoldoutInXR = true;
 		model.animationIndex = 1;
     )xx";
 
@@ -243,6 +249,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldout(), true);
     EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInAR(), true);
     EXPECT_EQ(AnimatedModelComponent->GetShowAsHoldoutInVR(), true);
     EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), 1);

--- a/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AnimatedModelComponentTests.cpp
@@ -88,6 +88,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         constexpr const int TestAnimationIndex = 1;
         constexpr const bool TestIsVisible = false;
         constexpr const bool TestIsARVisible = false;
+        constexpr const bool TestIsVirtualVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
 
@@ -104,6 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), -1);
         EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), true);
+        EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), true);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), true);
 
@@ -118,6 +120,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         AnimatedModelComponent->SetAnimationIndex(TestAnimationIndex);
         AnimatedModelComponent->SetIsVisible(TestIsVisible);
         AnimatedModelComponent->SetIsARVisible(TestIsARVisible);
+        AnimatedModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
         AnimatedModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         AnimatedModelComponent->SetIsShadowCaster(TestIsShadowCaster);
 
@@ -134,6 +137,7 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelComponentTest)
         EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), TestAnimationIndex);
         EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), TestIsVisible);
         EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), TestIsARVisible);
+        EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
         EXPECT_EQ(AnimatedModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(AnimatedModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
 
@@ -203,11 +207,13 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
 		model.externalResourceAssetCollectionId = "TestExternalResourceAssetCollectionId";
 		model.externalResourceAssetId = "TestExternalResourceAssetId";
 		model.position = [1, 1, 1];
-		model.rotation = [1, 1, 1, 1];
 		model.scale = [2, 2, 2];
+        model.rotation = [1, 1, 1, 1];
 		model.isLoopPlayback = false;
 		model.isPlaying = false;
 		model.isVisible = false;
+        model.isARVisible = false;
+        model.isVirtualVisible = false;
 		model.animationIndex = 1;
     )xx";
 
@@ -220,11 +226,13 @@ CSP_PUBLIC_TEST(CSPEngine, AnimatedModelTests, AnimatedModelScriptInterfaceTest)
     EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetCollectionId(), "TestExternalResourceAssetCollectionId");
     EXPECT_EQ(AnimatedModelComponent->GetExternalResourceAssetId(), "TestExternalResourceAssetId");
     EXPECT_EQ(AnimatedModelComponent->GetPosition(), csp::common::Vector3::One());
-    EXPECT_EQ(AnimatedModelComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(AnimatedModelComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+    EXPECT_EQ(AnimatedModelComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(AnimatedModelComponent->GetIsLoopPlayback(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsPlaying(), false);
     EXPECT_EQ(AnimatedModelComponent->GetIsVisible(), false);
+    EXPECT_EQ(AnimatedModelComponent->GetIsARVisible(), false);
+    EXPECT_EQ(AnimatedModelComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(AnimatedModelComponent->GetAnimationIndex(), 1);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -105,6 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
@@ -123,6 +124,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     const LocomotionModel NewAvatarLocomotionModel = LocomotionModel::FreeCamera;
     const bool NewIsVisible = true;
     const bool NewIsARVisible = false;
+    const bool NewIsVirtualVisible = false;
     const int64_t NewAvatarMeshIndex = 42;
     const csp::common::String NewAgoraUserId = "AgoraUser123";
     const csp::common::String NewCustomAvatarUrl = "https://example.com/avatar.png";
@@ -140,6 +142,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     AvatarComponent->SetLocomotionModel(NewAvatarLocomotionModel);
     AvatarComponent->SetIsVisible(NewIsVisible);
     AvatarComponent->SetIsARVisible(NewIsARVisible);
+    AvatarComponent->SetIsVirtualVisible(NewIsVirtualVisible);
     AvatarComponent->SetAvatarMeshIndex(NewAvatarMeshIndex);
     AvatarComponent->SetAgoraUserId(NewAgoraUserId);
     AvatarComponent->SetCustomAvatarUrl(NewCustomAvatarUrl);
@@ -158,6 +161,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), NewAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), NewIsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), NewIsARVisible);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), NewIsVirtualVisible);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), NewAvatarMeshIndex);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), NewAgoraUserId);
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), NewCustomAvatarUrl);
@@ -242,6 +246,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
@@ -274,6 +279,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
             avatar.torsoTwistAlpha = 0.5;
             avatar.isVisible = true;
             avatar.isARVisible = false;
+            avatar.isVirtualVisible = false;
 		)xx";
 
     Avatar->GetScript().SetScriptSource(AvatarComponentScriptText.c_str());
@@ -297,6 +303,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     EXPECT_EQ(AvatarComponent->GetTorsoTwistAlpha(), 0.5f);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), true);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), false);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), false);
 
     // Exit space
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -105,7 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
-    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), true);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
@@ -124,7 +124,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     const LocomotionModel NewAvatarLocomotionModel = LocomotionModel::FreeCamera;
     const bool NewIsVisible = true;
     const bool NewIsARVisible = false;
-    const bool NewIsVirtualVisible = false;
+    const bool NewIsVRVisible = false;
     const int64_t NewAvatarMeshIndex = 42;
     const csp::common::String NewAgoraUserId = "AgoraUser123";
     const csp::common::String NewCustomAvatarUrl = "https://example.com/avatar.png";
@@ -142,7 +142,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     AvatarComponent->SetLocomotionModel(NewAvatarLocomotionModel);
     AvatarComponent->SetIsVisible(NewIsVisible);
     AvatarComponent->SetIsARVisible(NewIsARVisible);
-    AvatarComponent->SetIsVirtualVisible(NewIsVirtualVisible);
+    AvatarComponent->SetIsVRVisible(NewIsVRVisible);
     AvatarComponent->SetAvatarMeshIndex(NewAvatarMeshIndex);
     AvatarComponent->SetAgoraUserId(NewAgoraUserId);
     AvatarComponent->SetCustomAvatarUrl(NewCustomAvatarUrl);
@@ -161,7 +161,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), NewAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), NewIsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), NewIsARVisible);
-    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), NewIsVirtualVisible);
+    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), NewIsVRVisible);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), NewAvatarMeshIndex);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), NewAgoraUserId);
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), NewCustomAvatarUrl);
@@ -246,7 +246,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
-    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), true);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
@@ -279,7 +279,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
             avatar.torsoTwistAlpha = 0.5;
             avatar.isVisible = true;
             avatar.isARVisible = false;
-            avatar.isVirtualVisible = false;
+            avatar.isVRVisible = false;
 		)xx";
 
     Avatar->GetScript().SetScriptSource(AvatarComponentScriptText.c_str());
@@ -303,7 +303,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     EXPECT_EQ(AvatarComponent->GetTorsoTwistAlpha(), 0.5f);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), true);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), false);
-    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), false);
 
     // Exit space
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -105,7 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
-    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
@@ -124,7 +124,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     const LocomotionModel NewAvatarLocomotionModel = LocomotionModel::FreeCamera;
     const bool NewIsVisible = true;
     const bool NewIsARVisible = false;
-    const bool NewIsVRVisible = false;
+    const bool NewIsVirtualVisible = false;
     const int64_t NewAvatarMeshIndex = 42;
     const csp::common::String NewAgoraUserId = "AgoraUser123";
     const csp::common::String NewCustomAvatarUrl = "https://example.com/avatar.png";
@@ -142,7 +142,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     AvatarComponent->SetLocomotionModel(NewAvatarLocomotionModel);
     AvatarComponent->SetIsVisible(NewIsVisible);
     AvatarComponent->SetIsARVisible(NewIsARVisible);
-    AvatarComponent->SetIsVRVisible(NewIsVRVisible);
+    AvatarComponent->SetIsVirtualVisible(NewIsVirtualVisible);
     AvatarComponent->SetAvatarMeshIndex(NewAvatarMeshIndex);
     AvatarComponent->SetAgoraUserId(NewAgoraUserId);
     AvatarComponent->SetCustomAvatarUrl(NewCustomAvatarUrl);
@@ -161,7 +161,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), NewAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), NewIsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), NewIsARVisible);
-    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), NewIsVRVisible);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), NewIsVirtualVisible);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), NewAvatarMeshIndex);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), NewAgoraUserId);
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), NewCustomAvatarUrl);
@@ -246,7 +246,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     EXPECT_EQ(AvatarComponent->GetLocomotionModel(), UserAvatarLocomotionModel);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), IsVisible);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), true);
-    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(AvatarComponent->GetAvatarMeshIndex(), -1);
     EXPECT_EQ(AvatarComponent->GetAgoraUserId(), "");
     EXPECT_EQ(AvatarComponent->GetCustomAvatarUrl(), "");
@@ -279,7 +279,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
             avatar.torsoTwistAlpha = 0.5;
             avatar.isVisible = true;
             avatar.isARVisible = false;
-            avatar.isVRVisible = false;
+            avatar.isVirtualVisible = false;
 		)xx";
 
     Avatar->GetScript().SetScriptSource(AvatarComponentScriptText.c_str());
@@ -303,7 +303,7 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
     EXPECT_EQ(AvatarComponent->GetTorsoTwistAlpha(), 0.5f);
     EXPECT_EQ(AvatarComponent->GetIsVisible(), true);
     EXPECT_EQ(AvatarComponent->GetIsARVisible(), false);
-    EXPECT_EQ(AvatarComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(AvatarComponent->GetIsVirtualVisible(), false);
 
     // Exit space
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -179,15 +179,15 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, VirtualVisibleTest)
     {
         auto* VisibleComponent = dynamic_cast<IVisibleComponent*>(Component);
 
-        EXPECT_TRUE(VisibleComponent->GetIsVRVisible());
+        EXPECT_TRUE(VisibleComponent->GetIsVirtualVisible());
     }
 
     for (auto Component : Components)
     {
         auto* VisibleComponent = dynamic_cast<IVisibleComponent*>(Component);
-        VisibleComponent->SetIsVRVisible(false);
+        VisibleComponent->SetIsVirtualVisible(false);
 
-        EXPECT_FALSE(VisibleComponent->GetIsVRVisible());
+        EXPECT_FALSE(VisibleComponent->GetIsVirtualVisible());
 
         delete Component;
     }

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -179,15 +179,15 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, VirtualVisibleTest)
     {
         auto* VisibleComponent = dynamic_cast<IVisibleComponent*>(Component);
 
-        EXPECT_TRUE(VisibleComponent->GetIsVirtualVisible());
+        EXPECT_TRUE(VisibleComponent->GetIsVRVisible());
     }
 
     for (auto Component : Components)
     {
         auto* VisibleComponent = dynamic_cast<IVisibleComponent*>(Component);
-        VisibleComponent->SetIsVirtualVisible(false);
+        VisibleComponent->SetIsVRVisible(false);
 
-        EXPECT_FALSE(VisibleComponent->GetIsVirtualVisible());
+        EXPECT_FALSE(VisibleComponent->GetIsVRVisible());
 
         delete Component;
     }

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -164,6 +164,35 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ARVisibleTest)
     }
 }
 
+CSP_PUBLIC_TEST(CSPEngine, ComponentTests, VirtualVisibleTest)
+{
+    SpaceEntity* MySpaceEntity = new SpaceEntity();
+
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
+
+    std::vector<ComponentBase*> Components { new AnimatedModelSpaceComponent(LogSystem, MySpaceEntity),
+        new ButtonSpaceComponent(LogSystem, MySpaceEntity), new ImageSpaceComponent(LogSystem, MySpaceEntity),
+        new LightSpaceComponent(LogSystem, MySpaceEntity), new StaticModelSpaceComponent(LogSystem, MySpaceEntity),
+        new VideoPlayerSpaceComponent(LogSystem, MySpaceEntity) };
+
+    for (auto Component : Components)
+    {
+        auto* VisibleComponent = dynamic_cast<IVisibleComponent*>(Component);
+
+        EXPECT_TRUE(VisibleComponent->GetIsVirtualVisible());
+    }
+
+    for (auto Component : Components)
+    {
+        auto* VisibleComponent = dynamic_cast<IVisibleComponent*>(Component);
+        VisibleComponent->SetIsVirtualVisible(false);
+
+        EXPECT_FALSE(VisibleComponent->GetIsVirtualVisible());
+
+        delete Component;
+    }
+}
+
 CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ThirdPartyComponentRefTest)
 {
     SpaceEntity* MySpaceEntity = new SpaceEntity();

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -129,11 +129,13 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     delete[] UploadFileData;
 
+    EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVirtualVisible(), true);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsARVisible(), true);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVisible(), true);
 
     FiducialMarkerSpaceComponentInstance->SetAssetCollectionId(Asset.AssetCollectionId);
     FiducialMarkerSpaceComponentInstance->SetMarkerAssetId(Asset.Id);
+    FiducialMarkerSpaceComponentInstance->SetIsVirtualVisible(false);
     FiducialMarkerSpaceComponentInstance->SetIsARVisible(false);
 
     auto FiducialMarkerSpaceComponentKey = FiducialMarkerSpaceComponentInstance->GetId();
@@ -141,6 +143,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetAssetCollectionId(), Asset.AssetCollectionId);
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetMarkerAssetId(), Asset.Id);
+    EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsARVisible(), false);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVisible(), true);
 
@@ -196,10 +199,14 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
 
     // Setup script
     const std::string FiducialMarkerScriptText = R"xx(
-	
 		var marker = ThisEntity.getFiducialMarkerComponents()[0];
-		
+		marker.name = "Updated_FiducialMarkerScriptName";
+        marker.position = [1, 1, 1];
+        marker.scale = [2, 2, 2];
+		marker.rotation = [1, 1, 1, 1];
 		marker.isVisible = false;
+        marker.isARVisible = false;
+        marker.isVirtualVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(FiducialMarkerScriptText.c_str());
@@ -210,7 +217,13 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
 
+    EXPECT_EQ(FiducialMarkerComponent->GetName(), "Updated_FiducialMarkerScriptName");
+    EXPECT_EQ(FiducialMarkerComponent->GetPosition(), csp::common::Vector3::One());
+    EXPECT_EQ(FiducialMarkerComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+    EXPECT_EQ(FiducialMarkerComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(FiducialMarkerComponent->GetIsVisible(), false);
+    EXPECT_EQ(FiducialMarkerComponent->GetIsARVisible(), false);
+    EXPECT_EQ(FiducialMarkerComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -129,13 +129,13 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     delete[] UploadFileData;
 
-    EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVirtualVisible(), true);
+    EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVRVisible(), true);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsARVisible(), true);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVisible(), true);
 
     FiducialMarkerSpaceComponentInstance->SetAssetCollectionId(Asset.AssetCollectionId);
     FiducialMarkerSpaceComponentInstance->SetMarkerAssetId(Asset.Id);
-    FiducialMarkerSpaceComponentInstance->SetIsVirtualVisible(false);
+    FiducialMarkerSpaceComponentInstance->SetIsVRVisible(false);
     FiducialMarkerSpaceComponentInstance->SetIsARVisible(false);
 
     auto FiducialMarkerSpaceComponentKey = FiducialMarkerSpaceComponentInstance->GetId();
@@ -143,7 +143,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetAssetCollectionId(), Asset.AssetCollectionId);
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetMarkerAssetId(), Asset.Id);
-    EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsVRVisible(), false);
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsARVisible(), false);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVisible(), true);
 
@@ -206,7 +206,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
 		marker.rotation = [1, 1, 1, 1];
 		marker.isVisible = false;
         marker.isARVisible = false;
-        marker.isVirtualVisible = false;
+        marker.isVRVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(FiducialMarkerScriptText.c_str());
@@ -223,7 +223,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     EXPECT_EQ(FiducialMarkerComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(FiducialMarkerComponent->GetIsVisible(), false);
     EXPECT_EQ(FiducialMarkerComponent->GetIsARVisible(), false);
-    EXPECT_EQ(FiducialMarkerComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(FiducialMarkerComponent->GetIsVRVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -129,13 +129,13 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     delete[] UploadFileData;
 
-    EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVRVisible(), true);
+    EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVirtualVisible(), true);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsARVisible(), true);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVisible(), true);
 
     FiducialMarkerSpaceComponentInstance->SetAssetCollectionId(Asset.AssetCollectionId);
     FiducialMarkerSpaceComponentInstance->SetMarkerAssetId(Asset.Id);
-    FiducialMarkerSpaceComponentInstance->SetIsVRVisible(false);
+    FiducialMarkerSpaceComponentInstance->SetIsVirtualVisible(false);
     FiducialMarkerSpaceComponentInstance->SetIsARVisible(false);
 
     auto FiducialMarkerSpaceComponentKey = FiducialMarkerSpaceComponentInstance->GetId();
@@ -143,7 +143,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerComponentTest)
 
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetAssetCollectionId(), Asset.AssetCollectionId);
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetMarkerAssetId(), Asset.Id);
-    EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(StoredFiducialMarkerSpaceComponent->GetIsARVisible(), false);
     EXPECT_EQ(FiducialMarkerSpaceComponentInstance->GetIsVisible(), true);
 
@@ -206,7 +206,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
 		marker.rotation = [1, 1, 1, 1];
 		marker.isVisible = false;
         marker.isARVisible = false;
-        marker.isVRVisible = false;
+        marker.isVirtualVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(FiducialMarkerScriptText.c_str());
@@ -223,7 +223,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     EXPECT_EQ(FiducialMarkerComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(FiducialMarkerComponent->GetIsVisible(), false);
     EXPECT_EQ(FiducialMarkerComponent->GetIsARVisible(), false);
-    EXPECT_EQ(FiducialMarkerComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(FiducialMarkerComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -176,7 +176,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
 		fog.isVolumetric = true;
         fog.isVisible = false;
         fog.isARVisible = false;
-        fog.isVirtualVisible = false;
+        fog.isVRVisible = false;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(FogScriptText.c_str());
@@ -197,7 +197,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     EXPECT_TRUE(FogComponent->GetIsVolumetric());
     EXPECT_EQ(FogComponent->GetIsVisible(), false);
     EXPECT_EQ(FogComponent->GetIsARVisible(), false);
-    EXPECT_EQ(FogComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(FogComponent->GetIsVRVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -165,8 +165,8 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
 		var fog = ThisEntity.getFogComponents()[0];
 		fog.fogMode = 1;
 		fog.position = [1, 1, 1];
+        fog.scale = [2, 2, 2];
 		fog.rotation = [1, 1, 1, 2];
-		fog.scale = [2, 2, 2];
 		fog.startDistance = 1.1;
 		fog.endDistance = 2.2;
 		fog.color = [1, 1, 1];
@@ -174,6 +174,9 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
 		fog.heightFalloff = 4.4;
 		fog.maxOpacity = 5.5;
 		fog.isVolumetric = true;
+        fog.isVisible = false;
+        fog.isARVisible = false;
+        fog.isVirtualVisible = false;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(FogScriptText.c_str());
@@ -183,8 +186,8 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
 
     EXPECT_EQ(FogComponent->GetFogMode(), FogMode::Exponential);
     EXPECT_EQ(FogComponent->GetPosition(), csp::common::Vector3::One());
-    EXPECT_EQ(FogComponent->GetRotation(), csp::common::Vector4(1, 1, 1, 2));
     EXPECT_EQ(FogComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+    EXPECT_EQ(FogComponent->GetRotation(), csp::common::Vector4(1, 1, 1, 2));
     EXPECT_FLOAT_EQ(FogComponent->GetStartDistance(), 1.1f);
     EXPECT_FLOAT_EQ(FogComponent->GetEndDistance(), 2.2f);
     EXPECT_EQ(FogComponent->GetColor(), csp::common::Vector3::One());
@@ -192,6 +195,9 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     EXPECT_FLOAT_EQ(FogComponent->GetHeightFalloff(), 4.4f);
     EXPECT_FLOAT_EQ(FogComponent->GetMaxOpacity(), 5.5f);
     EXPECT_TRUE(FogComponent->GetIsVolumetric());
+    EXPECT_EQ(FogComponent->GetIsVisible(), false);
+    EXPECT_EQ(FogComponent->GetIsARVisible(), false);
+    EXPECT_EQ(FogComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -176,7 +176,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
 		fog.isVolumetric = true;
         fog.isVisible = false;
         fog.isARVisible = false;
-        fog.isVRVisible = false;
+        fog.isVirtualVisible = false;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(FogScriptText.c_str());
@@ -197,7 +197,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogScriptInterfaceTest)
     EXPECT_TRUE(FogComponent->GetIsVolumetric());
     EXPECT_EQ(FogComponent->GetIsVisible(), false);
     EXPECT_EQ(FogComponent->GetIsARVisible(), false);
-    EXPECT_EQ(FogComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(FogComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -93,6 +93,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     EXPECT_EQ(GaussianSplatComponent->GetScale(), csp::common::Vector3::One());
     EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), true);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), true);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), true);
     EXPECT_EQ(GaussianSplatComponent->GetTint(), csp::common::Vector3::One());
 
@@ -110,6 +111,9 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
 
     GaussianSplatComponent->SetIsARVisible(false);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), false);
+
+    GaussianSplatComponent->SetIsVirtualVisible(false);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), false);
 
     GaussianSplatComponent->SetIsShadowCaster(false);
     EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), false);
@@ -166,9 +170,16 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
 
     // Setup script
     const std::string ScriptSource = R"xx(
-	
 		var splat = ThisEntity.getGaussianSplatComponents()[0];
+        splat.externalResourceAssetCollectionId = "TestExternalResourceAssetCollectionId";
+		splat.externalResourceAssetId = "TestExternalResourceAssetId";
 		splat.tint = [0.0, 0.1, 0.2];
+        splat.position = [1, 1, 1];
+        splat.scale = [2, 2, 2];
+		splat.rotation = [1, 1, 1, 1];
+        splat.isVisible = false;
+        splat.isARVisible = false;
+        splat.isVirtualVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(ScriptSource.c_str());
@@ -179,7 +190,15 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
 
+    EXPECT_EQ(GaussianSplatComponent->GetExternalResourceAssetCollectionId(), "TestExternalResourceAssetCollectionId");
+    EXPECT_EQ(GaussianSplatComponent->GetExternalResourceAssetId(), "TestExternalResourceAssetId");
     EXPECT_EQ(GaussianSplatComponent->GetTint(), csp::common::Vector3(0.0f, 0.1f, 0.2f));
+    EXPECT_EQ(GaussianSplatComponent->GetPosition(), csp::common::Vector3::One());
+    EXPECT_EQ(GaussianSplatComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+    EXPECT_EQ(GaussianSplatComponent->GetRotation(), csp::common::Vector4::One());
+    EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), false);
+    EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), false);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -93,7 +93,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     EXPECT_EQ(GaussianSplatComponent->GetScale(), csp::common::Vector3::One());
     EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), true);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), true);
-    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVRVisible(), true);
     EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), true);
     EXPECT_EQ(GaussianSplatComponent->GetTint(), csp::common::Vector3::One());
 
@@ -112,8 +112,8 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     GaussianSplatComponent->SetIsARVisible(false);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), false);
 
-    GaussianSplatComponent->SetIsVirtualVisible(false);
-    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), false);
+    GaussianSplatComponent->SetIsVRVisible(false);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVRVisible(), false);
 
     GaussianSplatComponent->SetIsShadowCaster(false);
     EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), false);
@@ -179,7 +179,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
 		splat.rotation = [1, 1, 1, 1];
         splat.isVisible = false;
         splat.isARVisible = false;
-        splat.isVirtualVisible = false;
+        splat.isVRVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(ScriptSource.c_str());
@@ -198,7 +198,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
     EXPECT_EQ(GaussianSplatComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), false);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), false);
-    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVRVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/GaussianSplatComponentTests.cpp
@@ -93,7 +93,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     EXPECT_EQ(GaussianSplatComponent->GetScale(), csp::common::Vector3::One());
     EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), true);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), true);
-    EXPECT_EQ(GaussianSplatComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), true);
     EXPECT_EQ(GaussianSplatComponent->GetTint(), csp::common::Vector3::One());
 
@@ -112,8 +112,8 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatTest)
     GaussianSplatComponent->SetIsARVisible(false);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), false);
 
-    GaussianSplatComponent->SetIsVRVisible(false);
-    EXPECT_EQ(GaussianSplatComponent->GetIsVRVisible(), false);
+    GaussianSplatComponent->SetIsVirtualVisible(false);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), false);
 
     GaussianSplatComponent->SetIsShadowCaster(false);
     EXPECT_EQ(GaussianSplatComponent->GetIsShadowCaster(), false);
@@ -179,7 +179,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
 		splat.rotation = [1, 1, 1, 1];
         splat.isVisible = false;
         splat.isARVisible = false;
-        splat.isVRVisible = false;
+        splat.isVirtualVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(ScriptSource.c_str());
@@ -198,7 +198,7 @@ CSP_PUBLIC_TEST(CSPEngine, GaussianSplatTests, GaussianSplatScriptInterfaceTest)
     EXPECT_EQ(GaussianSplatComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(GaussianSplatComponent->GetIsVisible(), false);
     EXPECT_EQ(GaussianSplatComponent->GetIsARVisible(), false);
-    EXPECT_EQ(GaussianSplatComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(GaussianSplatComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -80,7 +80,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     EXPECT_EQ(HotspotComponent->GetPosition().Y, 0.0f);
     EXPECT_EQ(HotspotComponent->GetPosition().Z, 0.0f);
     EXPECT_EQ(HotspotComponent->GetComponentType(), ComponentType::Hotspot);
-    EXPECT_EQ(HotspotComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), true);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), true);
     EXPECT_EQ(HotspotComponent->GetRotation().W, 1);
@@ -105,7 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 
     // Set new values
     HotspotComponent->SetPosition(csp::common::Vector3::One());
-    HotspotComponent->SetIsVRVisible(false);
+    HotspotComponent->SetIsVirtualVisible(false);
     HotspotComponent->SetIsARVisible(false);
     HotspotComponent->SetIsVisible(false);
     HotspotComponent->SetPosition(csp::common::Vector3::One());
@@ -117,7 +117,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().X, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Y, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Z, 1.0f);
-    EXPECT_EQ(HotspotComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), false);
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().W, 1.0f);
@@ -184,7 +184,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
         hotspot.rotation = [1.0, 1.0, 1.0, 1.0];
 		hotspot.isVisible = false;
         hotspot.isARVisible = false;
-        hotspot.isVRVisible = false;
+        hotspot.isVirtualVisible = false;
 		hotspot.isSpawnPoint = true;
 		hotspot.isTeleportPoint = false;
 
@@ -211,7 +211,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Z, 1.0f);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), false);
-    EXPECT_EQ(HotspotComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsSpawnPoint(), true);
     EXPECT_EQ(HotspotComponent->GetIsTeleportPoint(), false);
 

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -80,6 +80,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     EXPECT_EQ(HotspotComponent->GetPosition().Y, 0.0f);
     EXPECT_EQ(HotspotComponent->GetPosition().Z, 0.0f);
     EXPECT_EQ(HotspotComponent->GetComponentType(), ComponentType::Hotspot);
+    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), true);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), true);
     EXPECT_EQ(HotspotComponent->GetRotation().W, 1);
@@ -104,6 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 
     // Set new values
     HotspotComponent->SetPosition(csp::common::Vector3::One());
+    HotspotComponent->SetIsVirtualVisible(false);
     HotspotComponent->SetIsARVisible(false);
     HotspotComponent->SetIsVisible(false);
     HotspotComponent->SetPosition(csp::common::Vector3::One());
@@ -115,6 +117,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().X, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Y, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Z, 1.0f);
+    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), false);
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().W, 1.0f);
@@ -178,9 +181,10 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
 
 		var hotspot = ThisEntity.getHotspotComponents()[0];
 		hotspot.position = [1.0,1.0,1.0];
-		hotspot.isARVisible = false;
+        hotspot.rotation = [1.0, 1.0, 1.0, 1.0];
 		hotspot.isVisible = false;
-		hotspot.rotation = [1.0, 1.0, 1.0, 1.0];
+        hotspot.isARVisible = false;
+        hotspot.isVirtualVisible = false;
 		hotspot.isSpawnPoint = true;
 		hotspot.isTeleportPoint = false;
 
@@ -201,12 +205,13 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().X, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Y, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Z, 1.0f);
-    EXPECT_EQ(HotspotComponent->GetIsARVisible(), false);
-    EXPECT_EQ(HotspotComponent->GetIsVisible(), false);
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().W, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().X, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Y, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Z, 1.0f);
+    EXPECT_EQ(HotspotComponent->GetIsVisible(), false);
+    EXPECT_EQ(HotspotComponent->GetIsARVisible(), false);
+    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsSpawnPoint(), true);
     EXPECT_EQ(HotspotComponent->GetIsTeleportPoint(), false);
 

--- a/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/HotspotComponentTests.cpp
@@ -80,7 +80,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     EXPECT_EQ(HotspotComponent->GetPosition().Y, 0.0f);
     EXPECT_EQ(HotspotComponent->GetPosition().Z, 0.0f);
     EXPECT_EQ(HotspotComponent->GetComponentType(), ComponentType::Hotspot);
-    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(HotspotComponent->GetIsVRVisible(), true);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), true);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), true);
     EXPECT_EQ(HotspotComponent->GetRotation().W, 1);
@@ -105,7 +105,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
 
     // Set new values
     HotspotComponent->SetPosition(csp::common::Vector3::One());
-    HotspotComponent->SetIsVirtualVisible(false);
+    HotspotComponent->SetIsVRVisible(false);
     HotspotComponent->SetIsARVisible(false);
     HotspotComponent->SetIsVisible(false);
     HotspotComponent->SetPosition(csp::common::Vector3::One());
@@ -117,7 +117,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotComponentTest)
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().X, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Y, 1.0f);
     EXPECT_FLOAT_EQ(HotspotComponent->GetPosition().Z, 1.0f);
-    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(HotspotComponent->GetIsVRVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), false);
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().W, 1.0f);
@@ -184,7 +184,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
         hotspot.rotation = [1.0, 1.0, 1.0, 1.0];
 		hotspot.isVisible = false;
         hotspot.isARVisible = false;
-        hotspot.isVirtualVisible = false;
+        hotspot.isVRVisible = false;
 		hotspot.isSpawnPoint = true;
 		hotspot.isTeleportPoint = false;
 
@@ -211,7 +211,7 @@ CSP_PUBLIC_TEST(CSPEngine, HotspotTests, HotspotSpaceComponentScriptInterfaceTes
     EXPECT_FLOAT_EQ(HotspotComponent->GetRotation().Z, 1.0f);
     EXPECT_EQ(HotspotComponent->GetIsVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsARVisible(), false);
-    EXPECT_EQ(HotspotComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(HotspotComponent->GetIsVRVisible(), false);
     EXPECT_EQ(HotspotComponent->GetIsSpawnPoint(), true);
     EXPECT_EQ(HotspotComponent->GetIsTeleportPoint(), false);
 

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -132,6 +132,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     EXPECT_EQ(ImageSpaceComponentInstance->GetBillboardMode(), BillboardMode::Off);
     EXPECT_EQ(ImageSpaceComponentInstance->GetDisplayMode(), DisplayMode::DoubleSided);
     EXPECT_EQ(ImageSpaceComponentInstance->GetIsARVisible(), true);
+    EXPECT_EQ(ImageSpaceComponentInstance->GetIsVirtualVisible(), true);
     EXPECT_EQ(ImageSpaceComponentInstance->GetIsEmissive(), false);
 
     ImageSpaceComponentInstance->SetAssetCollectionId(Asset.AssetCollectionId);
@@ -139,6 +140,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     ImageSpaceComponentInstance->SetBillboardMode(BillboardMode::YawLockedBillboard);
     ImageSpaceComponentInstance->SetDisplayMode(DisplayMode::SingleSided);
     ImageSpaceComponentInstance->SetIsARVisible(false);
+    ImageSpaceComponentInstance->SetIsVirtualVisible(false);
     ImageSpaceComponentInstance->SetIsEmissive(true);
 
     auto ImageSpaceComponentKey = ImageSpaceComponentInstance->GetId();
@@ -149,6 +151,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     EXPECT_EQ(StoredImageSpaceComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
     EXPECT_EQ(StoredImageSpaceComponent->GetDisplayMode(), DisplayMode::SingleSided);
     EXPECT_EQ(StoredImageSpaceComponent->GetIsARVisible(), false);
+    EXPECT_EQ(StoredImageSpaceComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(StoredImageSpaceComponent->GetIsEmissive(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -198,20 +201,32 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     CreatedObject->QueueUpdate();
     RealtimeEngine->ProcessPendingEntityOperations();
 
-    EXPECT_EQ(ImageComponent->GetIsVisible(), true);
-    EXPECT_EQ(ImageComponent->GetIsEmissive(), false);
-    EXPECT_EQ(ImageComponent->GetDisplayMode(), DisplayMode::DoubleSided);
+    EXPECT_EQ(ImageComponent->GetName(), "");
+    EXPECT_EQ(ImageComponent->GetImageAssetId(), "");
+    EXPECT_EQ(ImageComponent->GetPosition(), csp::common::Vector3::Zero());
+    EXPECT_EQ(ImageComponent->GetScale(), csp::common::Vector3::One());
+    EXPECT_EQ(ImageComponent->GetRotation(), csp::common::Vector4::Identity());
     EXPECT_EQ(ImageComponent->GetBillboardMode(), BillboardMode::Off);
+    EXPECT_EQ(ImageComponent->GetDisplayMode(), DisplayMode::DoubleSided);
+    EXPECT_EQ(ImageComponent->GetIsEmissive(), false);
+    EXPECT_EQ(ImageComponent->GetIsVisible(), true);
+    EXPECT_EQ(ImageComponent->GetIsARVisible(), true);
+    EXPECT_EQ(ImageComponent->GetIsVirtualVisible(), true);
 
     // Setup script
     const std::string ImageScriptText = R"xx(
-	
 		var image = ThisEntity.getImageComponents()[0];
-		
-		image.isVisible = false;
-		image.isEmissive = true;
-		image.displayMode = 2;
+        image.name = "TestName";
+        image.imageAssetId = "TestImageAssetId";
+        image.position = [1, 1, 1];
+        image.scale = [2, 2, 2];
+		image.rotation = [1, 1, 1, 1];
 		image.billboardMode = 1;
+        image.displayMode = 2;
+		image.isEmissive = true;
+        image.isVisible = false;
+        image.isARVisible = false;
+        image.isVirtualVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(ImageScriptText.c_str());
@@ -222,10 +237,17 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
 
-    EXPECT_EQ(ImageComponent->GetIsVisible(), false);
-    EXPECT_EQ(ImageComponent->GetIsEmissive(), true);
-    EXPECT_EQ(ImageComponent->GetDisplayMode(), DisplayMode::DoubleSidedReversed);
+    EXPECT_EQ(ImageComponent->GetName(), "TestName");
+    EXPECT_EQ(ImageComponent->GetImageAssetId(), "TestImageAssetId");
+    EXPECT_EQ(ImageComponent->GetPosition(), csp::common::Vector3::One());
+    EXPECT_EQ(ImageComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+    EXPECT_EQ(ImageComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(ImageComponent->GetBillboardMode(), BillboardMode::Billboard);
+    EXPECT_EQ(ImageComponent->GetDisplayMode(), DisplayMode::DoubleSidedReversed);
+    EXPECT_EQ(ImageComponent->GetIsEmissive(), true);
+    EXPECT_EQ(ImageComponent->GetIsVisible(), false);
+    EXPECT_EQ(ImageComponent->GetIsARVisible(), false);
+    EXPECT_EQ(ImageComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -132,7 +132,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     EXPECT_EQ(ImageSpaceComponentInstance->GetBillboardMode(), BillboardMode::Off);
     EXPECT_EQ(ImageSpaceComponentInstance->GetDisplayMode(), DisplayMode::DoubleSided);
     EXPECT_EQ(ImageSpaceComponentInstance->GetIsARVisible(), true);
-    EXPECT_EQ(ImageSpaceComponentInstance->GetIsVirtualVisible(), true);
+    EXPECT_EQ(ImageSpaceComponentInstance->GetIsVRVisible(), true);
     EXPECT_EQ(ImageSpaceComponentInstance->GetIsEmissive(), false);
 
     ImageSpaceComponentInstance->SetAssetCollectionId(Asset.AssetCollectionId);
@@ -140,7 +140,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     ImageSpaceComponentInstance->SetBillboardMode(BillboardMode::YawLockedBillboard);
     ImageSpaceComponentInstance->SetDisplayMode(DisplayMode::SingleSided);
     ImageSpaceComponentInstance->SetIsARVisible(false);
-    ImageSpaceComponentInstance->SetIsVirtualVisible(false);
+    ImageSpaceComponentInstance->SetIsVRVisible(false);
     ImageSpaceComponentInstance->SetIsEmissive(true);
 
     auto ImageSpaceComponentKey = ImageSpaceComponentInstance->GetId();
@@ -151,7 +151,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     EXPECT_EQ(StoredImageSpaceComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
     EXPECT_EQ(StoredImageSpaceComponent->GetDisplayMode(), DisplayMode::SingleSided);
     EXPECT_EQ(StoredImageSpaceComponent->GetIsARVisible(), false);
-    EXPECT_EQ(StoredImageSpaceComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(StoredImageSpaceComponent->GetIsVRVisible(), false);
     EXPECT_EQ(StoredImageSpaceComponent->GetIsEmissive(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -211,7 +211,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     EXPECT_EQ(ImageComponent->GetIsEmissive(), false);
     EXPECT_EQ(ImageComponent->GetIsVisible(), true);
     EXPECT_EQ(ImageComponent->GetIsARVisible(), true);
-    EXPECT_EQ(ImageComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(ImageComponent->GetIsVRVisible(), true);
 
     // Setup script
     const std::string ImageScriptText = R"xx(
@@ -226,7 +226,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
 		image.isEmissive = true;
         image.isVisible = false;
         image.isARVisible = false;
-        image.isVirtualVisible = false;
+        image.isVRVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(ImageScriptText.c_str());
@@ -247,7 +247,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     EXPECT_EQ(ImageComponent->GetIsEmissive(), true);
     EXPECT_EQ(ImageComponent->GetIsVisible(), false);
     EXPECT_EQ(ImageComponent->GetIsARVisible(), false);
-    EXPECT_EQ(ImageComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(ImageComponent->GetIsVRVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -132,7 +132,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     EXPECT_EQ(ImageSpaceComponentInstance->GetBillboardMode(), BillboardMode::Off);
     EXPECT_EQ(ImageSpaceComponentInstance->GetDisplayMode(), DisplayMode::DoubleSided);
     EXPECT_EQ(ImageSpaceComponentInstance->GetIsARVisible(), true);
-    EXPECT_EQ(ImageSpaceComponentInstance->GetIsVRVisible(), true);
+    EXPECT_EQ(ImageSpaceComponentInstance->GetIsVirtualVisible(), true);
     EXPECT_EQ(ImageSpaceComponentInstance->GetIsEmissive(), false);
 
     ImageSpaceComponentInstance->SetAssetCollectionId(Asset.AssetCollectionId);
@@ -140,7 +140,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     ImageSpaceComponentInstance->SetBillboardMode(BillboardMode::YawLockedBillboard);
     ImageSpaceComponentInstance->SetDisplayMode(DisplayMode::SingleSided);
     ImageSpaceComponentInstance->SetIsARVisible(false);
-    ImageSpaceComponentInstance->SetIsVRVisible(false);
+    ImageSpaceComponentInstance->SetIsVirtualVisible(false);
     ImageSpaceComponentInstance->SetIsEmissive(true);
 
     auto ImageSpaceComponentKey = ImageSpaceComponentInstance->GetId();
@@ -151,7 +151,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageComponentTest)
     EXPECT_EQ(StoredImageSpaceComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
     EXPECT_EQ(StoredImageSpaceComponent->GetDisplayMode(), DisplayMode::SingleSided);
     EXPECT_EQ(StoredImageSpaceComponent->GetIsARVisible(), false);
-    EXPECT_EQ(StoredImageSpaceComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(StoredImageSpaceComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(StoredImageSpaceComponent->GetIsEmissive(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -211,7 +211,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     EXPECT_EQ(ImageComponent->GetIsEmissive(), false);
     EXPECT_EQ(ImageComponent->GetIsVisible(), true);
     EXPECT_EQ(ImageComponent->GetIsARVisible(), true);
-    EXPECT_EQ(ImageComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(ImageComponent->GetIsVirtualVisible(), true);
 
     // Setup script
     const std::string ImageScriptText = R"xx(
@@ -226,7 +226,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
 		image.isEmissive = true;
         image.isVisible = false;
         image.isARVisible = false;
-        image.isVRVisible = false;
+        image.isVirtualVisible = false;
     )xx";
 
     ScriptComponent->SetScriptSource(ImageScriptText.c_str());
@@ -247,7 +247,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     EXPECT_EQ(ImageComponent->GetIsEmissive(), true);
     EXPECT_EQ(ImageComponent->GetIsVisible(), false);
     EXPECT_EQ(ImageComponent->GetIsARVisible(), false);
-    EXPECT_EQ(ImageComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(ImageComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
@@ -286,7 +286,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightSpaceScriptInterfaceTest)
     EXPECT_EQ(LightComponent->GetColor(), csp::common::Vector3(255, 255, 255));
     EXPECT_EQ(LightComponent->GetIsVisible(), true);
     EXPECT_EQ(LightComponent->GetIsARVisible(), true);
-    EXPECT_EQ(LightComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(LightComponent->GetIsVRVisible(), true);
     EXPECT_EQ(LightComponent->GetLightCookieAssetId(), "");
     EXPECT_EQ(LightComponent->GetLightCookieType(), LightCookieType::NoCookie);
 
@@ -305,7 +305,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightSpaceScriptInterfaceTest)
         light.color = [0, 0, 0];
 		light.isVisible = false;
         light.isARVisible = false;
-        light.isVirtualVisible = false;
+        light.isVRVisible = false;
         light.cookieAssetId = "TestLightCookieAssetId";
         light.lightCookieType = 0;
 
@@ -329,7 +329,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightSpaceScriptInterfaceTest)
     EXPECT_EQ(LightComponent->GetColor(), csp::common::Vector3(0, 0, 0));
     EXPECT_EQ(LightComponent->GetIsVisible(), false);
     EXPECT_EQ(LightComponent->GetIsARVisible(), false);
-    EXPECT_EQ(LightComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(LightComponent->GetIsVRVisible(), false);
     EXPECT_EQ(LightComponent->GetLightCookieAssetId(), "TestLightCookieAssetId");
     EXPECT_EQ(LightComponent->GetLightCookieType(), LightCookieType::ImageCookie);
 

--- a/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LightComponentTests.cpp
@@ -286,7 +286,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightSpaceScriptInterfaceTest)
     EXPECT_EQ(LightComponent->GetColor(), csp::common::Vector3(255, 255, 255));
     EXPECT_EQ(LightComponent->GetIsVisible(), true);
     EXPECT_EQ(LightComponent->GetIsARVisible(), true);
-    EXPECT_EQ(LightComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(LightComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(LightComponent->GetLightCookieAssetId(), "");
     EXPECT_EQ(LightComponent->GetLightCookieType(), LightCookieType::NoCookie);
 
@@ -305,7 +305,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightSpaceScriptInterfaceTest)
         light.color = [0, 0, 0];
 		light.isVisible = false;
         light.isARVisible = false;
-        light.isVRVisible = false;
+        light.isVirtualVisible = false;
         light.cookieAssetId = "TestLightCookieAssetId";
         light.lightCookieType = 0;
 
@@ -329,7 +329,7 @@ CSP_PUBLIC_TEST(CSPEngine, LightTests, LightSpaceScriptInterfaceTest)
     EXPECT_EQ(LightComponent->GetColor(), csp::common::Vector3(0, 0, 0));
     EXPECT_EQ(LightComponent->GetIsVisible(), false);
     EXPECT_EQ(LightComponent->GetIsARVisible(), false);
-    EXPECT_EQ(LightComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(LightComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(LightComponent->GetLightCookieAssetId(), "TestLightCookieAssetId");
     EXPECT_EQ(LightComponent->GetLightCookieType(), LightCookieType::ImageCookie);
 

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -21,6 +21,7 @@
 #include "CSP/CSPFoundation.h"
 #include "CSP/Common/Optional.h"
 #include "CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h"
+#include "CSP/Multiplayer/Components/ScriptSpaceComponent.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
 #include "CSP/Systems/SystemsManager.h"
@@ -120,8 +121,109 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
 
         EXPECT_EQ(ExternalLinkComponent->GetIsARVisible(), IsARVisible);
 
+        bool IsVirtualVisible = false;
+        ExternalLinkComponent->SetIsVirtualVisible(IsVirtualVisible);
+
+        EXPECT_EQ(ExternalLinkComponent->GetIsVirtualVisible(), IsVirtualVisible);
+
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
+
+    // Delete space
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    // Log in
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Create space
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+
+    EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    RealtimeEngine->SetEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    // Create parent entity
+    csp::common::String ObjectName = "Object 1";
+    SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
+
+    // Create external link component
+    auto* LinkComponent = (ExternalLinkSpaceComponent*)CreatedObject->AddComponent(ComponentType::ExternalLink);
+
+    // Create script component
+    auto* ScriptComponent = (ScriptSpaceComponent*)CreatedObject->AddComponent(ComponentType::ScriptData);
+
+    CreatedObject->QueueUpdate();
+    RealtimeEngine->ProcessPendingEntityOperations();
+
+    EXPECT_EQ(LinkComponent->GetName(), "");
+    EXPECT_EQ(LinkComponent->GetLinkUrl(), "");
+    EXPECT_EQ(LinkComponent->GetDisplayText(), "");
+    EXPECT_EQ(LinkComponent->GetPosition(), csp::common::Vector3::Zero());
+    EXPECT_EQ(LinkComponent->GetScale(), csp::common::Vector3::One());
+    EXPECT_EQ(LinkComponent->GetRotation(), csp::common::Vector4::Identity());
+    EXPECT_EQ(LinkComponent->GetIsEnabled(), true);
+    EXPECT_EQ(LinkComponent->GetIsVisible(), true);
+    EXPECT_EQ(LinkComponent->GetIsARVisible(), true);
+    EXPECT_EQ(LinkComponent->GetIsVirtualVisible(), true);
+
+    // Setup script
+    const std::string ExternalLinkScriptText = R"xx(
+
+		var link = ThisEntity.getExternalLinkComponents()[0];
+
+        link.name = "TestName";
+        link.linkUrl = "http://youtube.com/avideo";
+        link.displayText = "TestDisplayText";
+        link.position = [1, 1, 1];
+        link.scale = [2, 2, 2];
+		link.rotation = [1, 1, 1, 1];
+        link.isEnabled = false;
+		link.isVisible = false;
+        link.isARVisible = false;
+        link.isVirtualVisible = false;
+
+    )xx";
+
+    ScriptComponent->SetScriptSource(ExternalLinkScriptText.c_str());
+    CreatedObject->GetScript().Invoke();
+
+    RealtimeEngine->ProcessPendingEntityOperations();
+
+    const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
+    EXPECT_FALSE(ScriptHasErrors);
+
+    EXPECT_EQ(LinkComponent->GetName(), "TestName");
+    EXPECT_EQ(LinkComponent->GetLinkUrl(), "http://youtube.com/avideo");
+    EXPECT_EQ(LinkComponent->GetDisplayText(), "TestDisplayText");
+    EXPECT_EQ(LinkComponent->GetPosition(), csp::common::Vector3::One());
+    EXPECT_EQ(LinkComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+    EXPECT_EQ(LinkComponent->GetRotation(), csp::common::Vector4::One());
+    EXPECT_EQ(LinkComponent->GetIsEnabled(), false);
+    EXPECT_EQ(LinkComponent->GetIsVisible(), false);
+    EXPECT_EQ(LinkComponent->GetIsARVisible(), false);
+    EXPECT_EQ(LinkComponent->GetIsVirtualVisible(), false);
+
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -121,10 +121,10 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
 
         EXPECT_EQ(ExternalLinkComponent->GetIsARVisible(), IsARVisible);
 
-        bool IsVRVisible = false;
-        ExternalLinkComponent->SetIsVRVisible(IsVRVisible);
+        bool IsVirtualVisible = false;
+        ExternalLinkComponent->SetIsVirtualVisible(IsVirtualVisible);
 
-        EXPECT_EQ(ExternalLinkComponent->GetIsVRVisible(), IsVRVisible);
+        EXPECT_EQ(ExternalLinkComponent->GetIsVirtualVisible(), IsVirtualVisible);
 
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
@@ -184,7 +184,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
     EXPECT_EQ(LinkComponent->GetIsEnabled(), true);
     EXPECT_EQ(LinkComponent->GetIsVisible(), true);
     EXPECT_EQ(LinkComponent->GetIsARVisible(), true);
-    EXPECT_EQ(LinkComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(LinkComponent->GetIsVirtualVisible(), true);
 
     // Setup script
     const std::string ExternalLinkScriptText = R"xx(
@@ -200,7 +200,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
         link.isEnabled = false;
 		link.isVisible = false;
         link.isARVisible = false;
-        link.isVRVisible = false;
+        link.isVirtualVisible = false;
 
     )xx";
 
@@ -221,7 +221,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
     EXPECT_EQ(LinkComponent->GetIsEnabled(), false);
     EXPECT_EQ(LinkComponent->GetIsVisible(), false);
     EXPECT_EQ(LinkComponent->GetIsARVisible(), false);
-    EXPECT_EQ(LinkComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(LinkComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -121,10 +121,10 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkComponentTest)
 
         EXPECT_EQ(ExternalLinkComponent->GetIsARVisible(), IsARVisible);
 
-        bool IsVirtualVisible = false;
-        ExternalLinkComponent->SetIsVirtualVisible(IsVirtualVisible);
+        bool IsVRVisible = false;
+        ExternalLinkComponent->SetIsVRVisible(IsVRVisible);
 
-        EXPECT_EQ(ExternalLinkComponent->GetIsVirtualVisible(), IsVirtualVisible);
+        EXPECT_EQ(ExternalLinkComponent->GetIsVRVisible(), IsVRVisible);
 
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     }
@@ -184,7 +184,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
     EXPECT_EQ(LinkComponent->GetIsEnabled(), true);
     EXPECT_EQ(LinkComponent->GetIsVisible(), true);
     EXPECT_EQ(LinkComponent->GetIsARVisible(), true);
-    EXPECT_EQ(LinkComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(LinkComponent->GetIsVRVisible(), true);
 
     // Setup script
     const std::string ExternalLinkScriptText = R"xx(
@@ -200,7 +200,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
         link.isEnabled = false;
 		link.isVisible = false;
         link.isARVisible = false;
-        link.isVirtualVisible = false;
+        link.isVRVisible = false;
 
     )xx";
 
@@ -221,7 +221,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
     EXPECT_EQ(LinkComponent->GetIsEnabled(), false);
     EXPECT_EQ(LinkComponent->GetIsVisible(), false);
     EXPECT_EQ(LinkComponent->GetIsARVisible(), false);
-    EXPECT_EQ(LinkComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(LinkComponent->GetIsVRVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/ScreenSharingComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ScreenSharingComponentTests.cpp
@@ -85,6 +85,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), true);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), true);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), false);
 
     CreatedObject->QueueUpdate();
@@ -107,6 +108,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     ScreenSharingComponent->SetIsVisible(false);
     ScreenSharingComponent->SetIsARVisible(false);
+    ScreenSharingComponent->SetIsVirtualVisible(false);
     ScreenSharingComponent->SetIsShadowCaster(true);
 
     // Ensure values are set correctly
@@ -121,6 +123,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), false);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -180,6 +183,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentScriptTest)
 		component.scale = [0, 0, 0];
 		component.isVisible = false;
 		component.isARVisible = false;
+        component.isVirtualVisible = false;
 		component.isShadowCaster = true;
     )xx";
 
@@ -200,6 +204,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentScriptTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), false);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/ScreenSharingComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ScreenSharingComponentTests.cpp
@@ -85,7 +85,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), true);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), true);
-    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVRVisible(), true);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), false);
 
     CreatedObject->QueueUpdate();
@@ -108,7 +108,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     ScreenSharingComponent->SetIsVisible(false);
     ScreenSharingComponent->SetIsARVisible(false);
-    ScreenSharingComponent->SetIsVirtualVisible(false);
+    ScreenSharingComponent->SetIsVRVisible(false);
     ScreenSharingComponent->SetIsShadowCaster(true);
 
     // Ensure values are set correctly
@@ -123,7 +123,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), false);
-    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVRVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -183,7 +183,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentScriptTest)
 		component.scale = [0, 0, 0];
 		component.isVisible = false;
 		component.isARVisible = false;
-        component.isVirtualVisible = false;
+        component.isVRVisible = false;
 		component.isShadowCaster = true;
     )xx";
 
@@ -204,7 +204,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentScriptTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), false);
-    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVRVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/ScreenSharingComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ScreenSharingComponentTests.cpp
@@ -85,7 +85,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), true);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), true);
-    EXPECT_EQ(ScreenSharingComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), false);
 
     CreatedObject->QueueUpdate();
@@ -108,7 +108,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     ScreenSharingComponent->SetIsVisible(false);
     ScreenSharingComponent->SetIsARVisible(false);
-    ScreenSharingComponent->SetIsVRVisible(false);
+    ScreenSharingComponent->SetIsVirtualVisible(false);
     ScreenSharingComponent->SetIsShadowCaster(true);
 
     // Ensure values are set correctly
@@ -123,7 +123,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), false);
-    EXPECT_EQ(ScreenSharingComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -183,7 +183,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentScriptTest)
 		component.scale = [0, 0, 0];
 		component.isVisible = false;
 		component.isARVisible = false;
-        component.isVRVisible = false;
+        component.isVirtualVisible = false;
 		component.isShadowCaster = true;
     )xx";
 
@@ -204,7 +204,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScreenSharingTests, ScreenSharingComponentScriptTest)
 
     EXPECT_EQ(ScreenSharingComponent->GetIsVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsARVisible(), false);
-    EXPECT_EQ(ScreenSharingComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(ScreenSharingComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(ScreenSharingComponent->GetIsShadowCaster(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -87,6 +87,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         constexpr const bool TestIsVRVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
+        constexpr const bool TestShowAsHoldout = true;
         constexpr const bool TestShowAsHoldoutInAR = true;
         constexpr const bool TestShowAsHoldoutInVR = true;
 
@@ -103,6 +104,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), true);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldout(), false);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), false);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), false);
 
@@ -117,6 +119,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         StaticModelComponent->SetIsVRVisible(TestIsVRVisible);
         StaticModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         StaticModelComponent->SetIsShadowCaster(TestIsShadowCaster);
+        StaticModelComponent->SetShowAsHoldout(TestShowAsHoldout);
         StaticModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
         StaticModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
 
@@ -133,6 +136,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), TestIsVRVisible);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldout(), TestShowAsHoldout);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
 
@@ -207,6 +211,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 		model.isVisible = false;
         model.isARVisible = false;
         model.isVRVisible = false;
+        model.showAsHoldout = true;
         model.showAsHoldoutInAR = true;
         model.showAsHoldoutInVR = true;
     )xx";
@@ -225,6 +230,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     EXPECT_EQ(StaticModelComponent->GetIsVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsARVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(StaticModelComponent->GetShowAsHoldout(), true);
     EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), true);
     EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), true);
 

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -84,11 +84,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         const SpaceTransform TestTransform(TestPosition, TestRotation, TestScale);
         constexpr const bool TestIsVisible = false;
         constexpr const bool TestIsARVisible = false;
-        constexpr const bool TestIsVirtualVisible = false;
+        constexpr const bool TestIsVRVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
         constexpr const bool TestShowAsHoldoutInAR = true;
-        constexpr const bool TestShowAsHoldoutInVirtual = true;
+        constexpr const bool TestShowAsHoldoutInVR = true;
 
         // Test defaults
         EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), "");
@@ -100,11 +100,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetTransform(), csp::multiplayer::SpaceTransform());
         EXPECT_EQ(StaticModelComponent->GetIsVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetIsARVisible(), true);
-        EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), true);
+        EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), true);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), false);
-        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), false);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), false);
 
         StaticModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
         StaticModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
@@ -114,11 +114,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         StaticModelComponent->SetScale(TestScale);
         StaticModelComponent->SetIsVisible(TestIsVisible);
         StaticModelComponent->SetIsARVisible(TestIsARVisible);
-        StaticModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
+        StaticModelComponent->SetIsVRVisible(TestIsVRVisible);
         StaticModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         StaticModelComponent->SetIsShadowCaster(TestIsShadowCaster);
         StaticModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
-        StaticModelComponent->SetShowAsHoldoutInVirtual(TestShowAsHoldoutInVirtual);
+        StaticModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
 
         // Test new values
         EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
@@ -130,11 +130,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetScale(), TestScale);
         EXPECT_EQ(StaticModelComponent->GetIsVisible(), TestIsVisible);
         EXPECT_EQ(StaticModelComponent->GetIsARVisible(), TestIsARVisible);
-        EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
+        EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), TestIsVRVisible);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
-        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), TestShowAsHoldoutInVirtual);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
 
         // Test transform separately, as this just sets position, rotation, scale
         StaticModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
@@ -206,9 +206,9 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 		model.rotation = [1, 1, 1, 1];
 		model.isVisible = false;
         model.isARVisible = false;
-        model.isVirtualVisible = false;
+        model.isVRVisible = false;
         model.showAsHoldoutInAR = true;
-        model.showAsHoldoutInVirtual = true;
+        model.showAsHoldoutInVR = true;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(StaticModelScriptText.c_str());
@@ -224,9 +224,9 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     EXPECT_EQ(StaticModelComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(StaticModelComponent->GetIsVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsARVisible(), false);
-    EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), true);
-    EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), true);
+    EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -87,6 +87,8 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         constexpr const bool TestIsVirtualVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
+        constexpr const bool TestShowAsHoldoutInAR = true;
+        constexpr const bool TestShowAsHoldoutInVirtual = true;
 
         // Test defaults
         EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), "");
@@ -101,6 +103,8 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), true);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), false);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), false);
 
         StaticModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
         StaticModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
@@ -113,6 +117,8 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         StaticModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
         StaticModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         StaticModelComponent->SetIsShadowCaster(TestIsShadowCaster);
+        StaticModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
+        StaticModelComponent->SetShowAsHoldoutInVirtual(TestShowAsHoldoutInVirtual);
 
         // Test new values
         EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
@@ -127,6 +133,8 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), TestShowAsHoldoutInVirtual);
 
         // Test transform separately, as this just sets position, rotation, scale
         StaticModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
@@ -199,6 +207,8 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 		model.isVisible = false;
         model.isARVisible = false;
         model.isVirtualVisible = false;
+        model.showAsHoldoutInAR = true;
+        model.showAsHoldoutInVirtual = true;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(StaticModelScriptText.c_str());
@@ -215,6 +225,8 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     EXPECT_EQ(StaticModelComponent->GetIsVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsARVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), true);
+    EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -84,11 +84,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         const SpaceTransform TestTransform(TestPosition, TestRotation, TestScale);
         constexpr const bool TestIsVisible = false;
         constexpr const bool TestIsARVisible = false;
-        constexpr const bool TestIsVRVisible = false;
+        constexpr const bool TestIsVirtualVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
         constexpr const bool TestShowAsHoldoutInAR = true;
-        constexpr const bool TestShowAsHoldoutInVR = true;
+        constexpr const bool TestShowAsHoldoutInVirtual = true;
 
         // Test defaults
         EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), "");
@@ -100,11 +100,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetTransform(), csp::multiplayer::SpaceTransform());
         EXPECT_EQ(StaticModelComponent->GetIsVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetIsARVisible(), true);
-        EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), true);
+        EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), true);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), false);
-        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), false);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), false);
 
         StaticModelComponent->SetExternalResourceAssetCollectionId(TestExternalResourceAssetCollectionId);
         StaticModelComponent->SetExternalResourceAssetId(TestExternalResourceAssetId);
@@ -114,11 +114,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         StaticModelComponent->SetScale(TestScale);
         StaticModelComponent->SetIsVisible(TestIsVisible);
         StaticModelComponent->SetIsARVisible(TestIsARVisible);
-        StaticModelComponent->SetIsVRVisible(TestIsVRVisible);
+        StaticModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
         StaticModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         StaticModelComponent->SetIsShadowCaster(TestIsShadowCaster);
         StaticModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
-        StaticModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
+        StaticModelComponent->SetShowAsHoldoutInVirtual(TestShowAsHoldoutInVirtual);
 
         // Test new values
         EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), TestExternalResourceAssetCollectionId);
@@ -130,11 +130,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetScale(), TestScale);
         EXPECT_EQ(StaticModelComponent->GetIsVisible(), TestIsVisible);
         EXPECT_EQ(StaticModelComponent->GetIsARVisible(), TestIsARVisible);
-        EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), TestIsVRVisible);
+        EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
-        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
+        EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), TestShowAsHoldoutInVirtual);
 
         // Test transform separately, as this just sets position, rotation, scale
         StaticModelComponent->SetTransform(csp::multiplayer::SpaceTransform());
@@ -206,9 +206,9 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 		model.rotation = [1, 1, 1, 1];
 		model.isVisible = false;
         model.isARVisible = false;
-        model.isVRVisible = false;
+        model.isVirtualVisible = false;
         model.showAsHoldoutInAR = true;
-        model.showAsHoldoutInVR = true;
+        model.showAsHoldoutInVirtual = true;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(StaticModelScriptText.c_str());
@@ -224,9 +224,9 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     EXPECT_EQ(StaticModelComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(StaticModelComponent->GetIsVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsARVisible(), false);
-    EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), true);
-    EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), true);
+    EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVirtual(), true);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -87,7 +87,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         constexpr const bool TestIsVRVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
-        constexpr const bool TestShowAsHoldout = true;
         constexpr const bool TestShowAsHoldoutInAR = true;
         constexpr const bool TestShowAsHoldoutInVR = true;
 
@@ -104,7 +103,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), true);
-        EXPECT_EQ(StaticModelComponent->GetShowAsHoldout(), false);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), false);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), false);
 
@@ -119,7 +117,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         StaticModelComponent->SetIsVRVisible(TestIsVRVisible);
         StaticModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         StaticModelComponent->SetIsShadowCaster(TestIsShadowCaster);
-        StaticModelComponent->SetShowAsHoldout(TestShowAsHoldout);
         StaticModelComponent->SetShowAsHoldoutInAR(TestShowAsHoldoutInAR);
         StaticModelComponent->SetShowAsHoldoutInVR(TestShowAsHoldoutInVR);
 
@@ -136,7 +133,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), TestIsVRVisible);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
-        EXPECT_EQ(StaticModelComponent->GetShowAsHoldout(), TestShowAsHoldout);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), TestShowAsHoldoutInAR);
         EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), TestShowAsHoldoutInVR);
 
@@ -211,7 +207,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 		model.isVisible = false;
         model.isARVisible = false;
         model.isVRVisible = false;
-        model.showAsHoldout = true;
         model.showAsHoldoutInAR = true;
         model.showAsHoldoutInVR = true;
     )xx";
@@ -230,7 +225,6 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     EXPECT_EQ(StaticModelComponent->GetIsVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsARVisible(), false);
     EXPECT_EQ(StaticModelComponent->GetIsVRVisible(), false);
-    EXPECT_EQ(StaticModelComponent->GetShowAsHoldout(), true);
     EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInAR(), true);
     EXPECT_EQ(StaticModelComponent->GetShowAsHoldoutInVR(), true);
 

--- a/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/StaticModelComponentTests.cpp
@@ -84,6 +84,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         const SpaceTransform TestTransform(TestPosition, TestRotation, TestScale);
         constexpr const bool TestIsVisible = false;
         constexpr const bool TestIsARVisible = false;
+        constexpr const bool TestIsVirtualVisible = false;
         constexpr const char* TestThirdPartyComponentRef = "TestThirdPartyComponentRef";
         constexpr const bool TestIsShadowCaster = false;
 
@@ -97,6 +98,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetTransform(), csp::multiplayer::SpaceTransform());
         EXPECT_EQ(StaticModelComponent->GetIsVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetIsARVisible(), true);
+        EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), true);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), "");
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), true);
 
@@ -108,6 +110,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         StaticModelComponent->SetScale(TestScale);
         StaticModelComponent->SetIsVisible(TestIsVisible);
         StaticModelComponent->SetIsARVisible(TestIsARVisible);
+        StaticModelComponent->SetIsVirtualVisible(TestIsVirtualVisible);
         StaticModelComponent->SetThirdPartyComponentRef(TestThirdPartyComponentRef);
         StaticModelComponent->SetIsShadowCaster(TestIsShadowCaster);
 
@@ -121,6 +124,7 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelComponentTest)
         EXPECT_EQ(StaticModelComponent->GetScale(), TestScale);
         EXPECT_EQ(StaticModelComponent->GetIsVisible(), TestIsVisible);
         EXPECT_EQ(StaticModelComponent->GetIsARVisible(), TestIsARVisible);
+        EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), TestIsVirtualVisible);
         EXPECT_EQ(StaticModelComponent->GetThirdPartyComponentRef(), TestThirdPartyComponentRef);
         EXPECT_EQ(StaticModelComponent->GetIsShadowCaster(), TestIsShadowCaster);
 
@@ -190,9 +194,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
 		model.externalResourceAssetCollectionId = "TestExternalResourceAssetCollectionId";
 		model.externalResourceAssetId = "TestExternalResourceAssetId";
 		model.position = [1, 1, 1];
+        model.scale = [2, 2, 2];
 		model.rotation = [1, 1, 1, 1];
-		model.scale = [2, 2, 2];
 		model.isVisible = false;
+        model.isARVisible = false;
+        model.isVirtualVisible = false;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(StaticModelScriptText.c_str());
@@ -204,9 +210,11 @@ CSP_PUBLIC_TEST(CSPEngine, StaticModelTests, StaticModelScriptInterfaceTest)
     EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetCollectionId(), "TestExternalResourceAssetCollectionId");
     EXPECT_EQ(StaticModelComponent->GetExternalResourceAssetId(), "TestExternalResourceAssetId");
     EXPECT_EQ(StaticModelComponent->GetPosition(), csp::common::Vector3::One());
-    EXPECT_EQ(StaticModelComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(StaticModelComponent->GetScale(), csp::common::Vector3(2, 2, 2));
+    EXPECT_EQ(StaticModelComponent->GetRotation(), csp::common::Vector4::One());
     EXPECT_EQ(StaticModelComponent->GetIsVisible(), false);
+    EXPECT_EQ(StaticModelComponent->GetIsARVisible(), false);
+    EXPECT_EQ(StaticModelComponent->GetIsVirtualVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -85,6 +85,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::Off);
     EXPECT_EQ(TextComponent->GetComponentType(), ComponentType::Text);
     EXPECT_EQ(TextComponent->GetHeight(), 1.0f);
+    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(TextComponent->GetIsARVisible(), true);
     EXPECT_EQ(TextComponent->GetIsVisible(), true);
     EXPECT_EQ(TextComponent->GetRotation().W, 1);
@@ -105,6 +106,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     TextComponent->SetHeight(2.0f);
     TextComponent->SetWidth(2.0f);
     TextComponent->SetBillboardMode(BillboardMode::YawLockedBillboard);
+    TextComponent->SetIsVirtualVisible(false);
     TextComponent->SetIsARVisible(false);
     TextComponent->SetIsVisible(false);
     TextComponent->SetBackgroundColor(csp::common::Vector3::One());
@@ -124,6 +126,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().Z, 1.0f);
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
     EXPECT_FLOAT_EQ(TextComponent->GetHeight(), 2.0f);
+    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(TextComponent->GetIsARVisible(), false);
     EXPECT_EQ(TextComponent->GetIsVisible(), false);
     EXPECT_FLOAT_EQ(TextComponent->GetRotation().W, 1.0f);
@@ -193,18 +196,20 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
 		const assetCollectionId = "TEST_COLLECTION_ID";
 
 		var text = ThisEntity.getTextComponents()[0];
+        text.text = "Text";
 		text.position = [1.0,1.0,1.0];
+        text.scale = [2.0, 2.0, 2.0];
+        text.rotation = [1.0, 1.0, 1.0, 1.0];
+        text.textColor = [0.0,0.0,0.0];
+        text.backgroundColor = [1.0,1.0,1.0];
+        text.isBackgroundVisible = false;
+        text.width = 2.0;
 		text.height = 2.0;
-		text.width = 2.0;
 		text.billboardMode = 2;
-		text.isARVisible = false;
 		text.isVisible = false;
-		text.backgroundColor = [1.0,1.0,1.0];
-		text.textColor = [0.0,0.0,0.0];
-		text.rotation = [1.0, 1.0, 1.0, 1.0];
-		text.text = "Text";
-		text.scale = [2.0, 2.0, 2.0];
-		text.isBackgroundVisible = false;
+		text.isARVisible = false;
+		text.isVirtualVisible = false;
+
     )xx";
 
     ScriptComponent->SetScriptSource(TextScriptText.c_str());
@@ -214,28 +219,41 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
     RealtimeEngine->ProcessPendingEntityOperations();
 
     // Ensure values are set correctly
+    EXPECT_EQ(TextComponent->GetText(), "Text");
+
     EXPECT_FLOAT_EQ(TextComponent->GetPosition().X, 1.0f);
     EXPECT_FLOAT_EQ(TextComponent->GetPosition().Y, 1.0f);
     EXPECT_FLOAT_EQ(TextComponent->GetPosition().Z, 1.0f);
-    EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().X, 1.0f);
-    EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().Y, 1.0f);
-    EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().Z, 1.0f);
-    EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
-    EXPECT_FLOAT_EQ(TextComponent->GetHeight(), 2.0f);
-    EXPECT_EQ(TextComponent->GetIsARVisible(), false);
-    EXPECT_EQ(TextComponent->GetIsVisible(), false);
+
+    EXPECT_FLOAT_EQ(TextComponent->GetScale().X, 2.0f);
+    EXPECT_FLOAT_EQ(TextComponent->GetScale().Y, 2.0f);
+    EXPECT_FLOAT_EQ(TextComponent->GetScale().Z, 2.0f);
+
     EXPECT_FLOAT_EQ(TextComponent->GetRotation().W, 1.0f);
     EXPECT_FLOAT_EQ(TextComponent->GetRotation().X, 1.0f);
     EXPECT_FLOAT_EQ(TextComponent->GetRotation().Y, 1.0f);
     EXPECT_FLOAT_EQ(TextComponent->GetRotation().Z, 1.0f);
-    EXPECT_EQ(TextComponent->GetText(), "Text");
+
     EXPECT_FLOAT_EQ(TextComponent->GetTextColor().X, 0.0f);
     EXPECT_FLOAT_EQ(TextComponent->GetTextColor().Y, 0.0f);
     EXPECT_FLOAT_EQ(TextComponent->GetTextColor().Z, 0.0f);
-    EXPECT_FLOAT_EQ(TextComponent->GetScale().X, 2.0f);
-    EXPECT_FLOAT_EQ(TextComponent->GetScale().Y, 2.0f);
-    EXPECT_FLOAT_EQ(TextComponent->GetScale().Z, 2.0f);
+
+    EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().X, 1.0f);
+    EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().Y, 1.0f);
+    EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().Z, 1.0f);
+
+    EXPECT_EQ(TextComponent->GetIsBackgroundVisible(), false);
+
     EXPECT_FLOAT_EQ(TextComponent->GetWidth(), 2.0f);
+
+    EXPECT_FLOAT_EQ(TextComponent->GetHeight(), 2.0f);
+
+    EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
+
+    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(TextComponent->GetIsARVisible(), false);
+    EXPECT_EQ(TextComponent->GetIsVisible(), false);
+
     EXPECT_EQ(TextComponent->GetIsBackgroundVisible(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -85,7 +85,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::Off);
     EXPECT_EQ(TextComponent->GetComponentType(), ComponentType::Text);
     EXPECT_EQ(TextComponent->GetHeight(), 1.0f);
-    EXPECT_EQ(TextComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(TextComponent->GetIsARVisible(), true);
     EXPECT_EQ(TextComponent->GetIsVisible(), true);
     EXPECT_EQ(TextComponent->GetRotation().W, 1);
@@ -106,7 +106,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     TextComponent->SetHeight(2.0f);
     TextComponent->SetWidth(2.0f);
     TextComponent->SetBillboardMode(BillboardMode::YawLockedBillboard);
-    TextComponent->SetIsVRVisible(false);
+    TextComponent->SetIsVirtualVisible(false);
     TextComponent->SetIsARVisible(false);
     TextComponent->SetIsVisible(false);
     TextComponent->SetBackgroundColor(csp::common::Vector3::One());
@@ -126,7 +126,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().Z, 1.0f);
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
     EXPECT_FLOAT_EQ(TextComponent->GetHeight(), 2.0f);
-    EXPECT_EQ(TextComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(TextComponent->GetIsARVisible(), false);
     EXPECT_EQ(TextComponent->GetIsVisible(), false);
     EXPECT_FLOAT_EQ(TextComponent->GetRotation().W, 1.0f);
@@ -208,7 +208,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
 		text.billboardMode = 2;
 		text.isVisible = false;
 		text.isARVisible = false;
-		text.isVRVisible = false;
+		text.isVirtualVisible = false;
 
     )xx";
 
@@ -250,7 +250,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
 
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
 
-    EXPECT_EQ(TextComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(TextComponent->GetIsARVisible(), false);
     EXPECT_EQ(TextComponent->GetIsVisible(), false);
 

--- a/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/TextComponentTests.cpp
@@ -85,7 +85,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::Off);
     EXPECT_EQ(TextComponent->GetComponentType(), ComponentType::Text);
     EXPECT_EQ(TextComponent->GetHeight(), 1.0f);
-    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(TextComponent->GetIsVRVisible(), true);
     EXPECT_EQ(TextComponent->GetIsARVisible(), true);
     EXPECT_EQ(TextComponent->GetIsVisible(), true);
     EXPECT_EQ(TextComponent->GetRotation().W, 1);
@@ -106,7 +106,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     TextComponent->SetHeight(2.0f);
     TextComponent->SetWidth(2.0f);
     TextComponent->SetBillboardMode(BillboardMode::YawLockedBillboard);
-    TextComponent->SetIsVirtualVisible(false);
+    TextComponent->SetIsVRVisible(false);
     TextComponent->SetIsARVisible(false);
     TextComponent->SetIsVisible(false);
     TextComponent->SetBackgroundColor(csp::common::Vector3::One());
@@ -126,7 +126,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextComponentTest)
     EXPECT_FLOAT_EQ(TextComponent->GetBackgroundColor().Z, 1.0f);
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
     EXPECT_FLOAT_EQ(TextComponent->GetHeight(), 2.0f);
-    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(TextComponent->GetIsVRVisible(), false);
     EXPECT_EQ(TextComponent->GetIsARVisible(), false);
     EXPECT_EQ(TextComponent->GetIsVisible(), false);
     EXPECT_FLOAT_EQ(TextComponent->GetRotation().W, 1.0f);
@@ -208,7 +208,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
 		text.billboardMode = 2;
 		text.isVisible = false;
 		text.isARVisible = false;
-		text.isVirtualVisible = false;
+		text.isVRVisible = false;
 
     )xx";
 
@@ -250,7 +250,7 @@ CSP_PUBLIC_TEST(CSPEngine, TextTests, TextSpaceComponentScriptInterfaceTest)
 
     EXPECT_EQ(TextComponent->GetBillboardMode(), BillboardMode::YawLockedBillboard);
 
-    EXPECT_EQ(TextComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(TextComponent->GetIsVRVisible(), false);
     EXPECT_EQ(TextComponent->GetIsARVisible(), false);
     EXPECT_EQ(TextComponent->GetIsVisible(), false);
 

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -89,7 +89,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     EXPECT_EQ(VideoComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::AssetSource);
     EXPECT_EQ(VideoComponent->GetIsVisible(), true);
     EXPECT_EQ(VideoComponent->GetIsARVisible(), true);
-    EXPECT_EQ(VideoComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(VideoComponent->GetIsVRVisible(), true);
     EXPECT_EQ(VideoComponent->GetIsEnabled(), true);
 
     CreatedObject->QueueUpdate();
@@ -113,7 +113,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     VideoComponent->SetVideoPlayerSourceType(VideoPlayerSourceType::URLSource);
     VideoComponent->SetIsVisible(false);
     VideoComponent->SetIsARVisible(false);
-    VideoComponent->SetIsVirtualVisible(false);
+    VideoComponent->SetIsVRVisible(false);
     VideoComponent->SetIsEnabled(false);
 
     // Ensure values are set correctly
@@ -131,7 +131,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     EXPECT_EQ(VideoComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::URLSource);
     EXPECT_EQ(VideoComponent->GetIsVisible(), false);
     EXPECT_EQ(VideoComponent->GetIsARVisible(), false);
-    EXPECT_EQ(VideoComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(VideoComponent->GetIsVRVisible(), false);
     EXPECT_EQ(VideoComponent->GetIsEnabled(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -197,7 +197,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     EXPECT_EQ(VideoPlayerComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::AssetSource);
     EXPECT_EQ(VideoPlayerComponent->GetIsVisible(), true);
     EXPECT_EQ(VideoPlayerComponent->GetIsARVisible(), true);
-    EXPECT_EQ(VideoPlayerComponent->GetIsVirtualVisible(), true);
+    EXPECT_EQ(VideoPlayerComponent->GetIsVRVisible(), true);
     EXPECT_EQ(VideoPlayerComponent->GetIsEnabled(), true);
 
     // Setup script
@@ -220,7 +220,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
         video.videoPlayerSourceType = 0;
 		video.isVisible = false;
         video.isARVisible = false;
-        video.isVirtualVisible = false;
+        video.isVRVisible = false;
         video.isEnabled = false;
 
     )xx";
@@ -248,7 +248,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     EXPECT_EQ(VideoPlayerComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::URLSource);
     EXPECT_EQ(VideoPlayerComponent->GetIsVisible(), false);
     EXPECT_EQ(VideoPlayerComponent->GetIsARVisible(), false);
-    EXPECT_EQ(VideoPlayerComponent->GetIsVirtualVisible(), false);
+    EXPECT_EQ(VideoPlayerComponent->GetIsVRVisible(), false);
     EXPECT_EQ(VideoPlayerComponent->GetIsEnabled(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -89,7 +89,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     EXPECT_EQ(VideoComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::AssetSource);
     EXPECT_EQ(VideoComponent->GetIsVisible(), true);
     EXPECT_EQ(VideoComponent->GetIsARVisible(), true);
-    EXPECT_EQ(VideoComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(VideoComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(VideoComponent->GetIsEnabled(), true);
 
     CreatedObject->QueueUpdate();
@@ -113,7 +113,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     VideoComponent->SetVideoPlayerSourceType(VideoPlayerSourceType::URLSource);
     VideoComponent->SetIsVisible(false);
     VideoComponent->SetIsARVisible(false);
-    VideoComponent->SetIsVRVisible(false);
+    VideoComponent->SetIsVirtualVisible(false);
     VideoComponent->SetIsEnabled(false);
 
     // Ensure values are set correctly
@@ -131,7 +131,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     EXPECT_EQ(VideoComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::URLSource);
     EXPECT_EQ(VideoComponent->GetIsVisible(), false);
     EXPECT_EQ(VideoComponent->GetIsARVisible(), false);
-    EXPECT_EQ(VideoComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(VideoComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(VideoComponent->GetIsEnabled(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -197,7 +197,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     EXPECT_EQ(VideoPlayerComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::AssetSource);
     EXPECT_EQ(VideoPlayerComponent->GetIsVisible(), true);
     EXPECT_EQ(VideoPlayerComponent->GetIsARVisible(), true);
-    EXPECT_EQ(VideoPlayerComponent->GetIsVRVisible(), true);
+    EXPECT_EQ(VideoPlayerComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(VideoPlayerComponent->GetIsEnabled(), true);
 
     // Setup script
@@ -220,7 +220,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
         video.videoPlayerSourceType = 0;
 		video.isVisible = false;
         video.isARVisible = false;
-        video.isVRVisible = false;
+        video.isVirtualVisible = false;
         video.isEnabled = false;
 
     )xx";
@@ -248,7 +248,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     EXPECT_EQ(VideoPlayerComponent->GetVideoPlayerSourceType(), VideoPlayerSourceType::URLSource);
     EXPECT_EQ(VideoPlayerComponent->GetIsVisible(), false);
     EXPECT_EQ(VideoPlayerComponent->GetIsARVisible(), false);
-    EXPECT_EQ(VideoPlayerComponent->GetIsVRVisible(), false);
+    EXPECT_EQ(VideoPlayerComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(VideoPlayerComponent->GetIsEnabled(), false);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);


### PR DESCRIPTION
## Client applications can express components as holdouts

The following PR introduces the following new properties to the existing `IVisibleComponent`:

- `IsVRVisible` - A complement to the current `IsARVisible` flag, allowing applications to express components as visible in AR but not in virtual context.

The following PR introduces the following new properties to the new `IRenderBehaviourComponent`:

- `ShowAsHoldout` - Determines whether the component should render normally (when flag is false) or as a holdout (when true) in default virtual environments.
- `ShowAsHoldoutInAR` - Determines whether the component should render normally (when flag is false) or as a holdout (when true) in AR.
- `ShowAsHoldoutInVR`- Determines whether the component should render normally (when flag is false) or as a holdout (when true) in virtual contexts.

> [!NOTE]
> The original interface has changed due to discussion on the external thread, I have updated the ticket to capture this discussion and linked the original thread. 

The new properties are also included as part of the basic component test and scripting interface test. During development, I noticed a few inconsistencies in the scripting interface, which are included in the changes:

- Not all components that inherit from `IVisibleComponent` expose all methods through the scripting interface 
- Not all components that implement the scripting interface had suitable or missing tests (Added new test and updated existing)
- Scripting interface test properties out of order (changes ordering for readability)