### PR TITLE
Tests for `Parser.__parse_type()`

### DIFF
--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -262,14 +262,10 @@ class TestParserParseType(unittest.TestCase):
 
     def test_parse_optional_type(self):
         """ Test the special parsing of optional types (using csp::common::Optional). """
-        result = self.__parse_type("csp::common::Optional<int>")
+        result = self.__parse_type("csp::common::Optional<csp::common::String>")
 
-        expected = MetadataTypes.TypeMetadata("", "int")
-        expected.is_const = False
-        expected.is_primitive = True
+        expected = self.__parse_type("csp::common::String")
         expected.is_optional = True
-        expected.template_name = "int"
-        expected.template_arguments = []
 
         self.assertDictEqual(result.__dict__, expected.__dict__)
 

--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -253,3 +253,17 @@ class TestParserParseType(unittest.TestCase):
         expected.template_arguments = []
 
         self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_function_type(self):
+        """ Test parsing a function type. """
+        result = self.__parse_type("std::function<void()>")
+
+        function_metadata = MetadataTypes.FunctionMetadata(None, 0, 0, None, None, None, False, False, [])
+
+        expected = MetadataTypes.TypeMetadata("std", "function")
+        expected.is_function_signature = True
+        expected.function_signature = function_metadata
+        expected.template_arguments = []
+        expected.template_name = "function"
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)

--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -185,6 +185,25 @@ class TestParserParseType(unittest.TestCase):
 
         self.assertDictEqual(result.__dict__, expected.__dict__)
 
+    def test_parse_pointer_const_type_unsupported(self):
+        """ Test that parsing a pointer to a const type is unsupported. """
+        with self.assertRaises(AssertionError):
+            self.__parse_type("int const *")
+
+    def test_parse_const_reference_type(self):
+        """ Test parsing a const reference type. """
+        result = self.__parse_type("const int&")
+
+        expected = MetadataTypes.TypeMetadata("", "int")
+        expected.is_const = True
+        expected.is_reference = True
+        expected.is_pointer_or_reference = True
+        expected.is_primitive = True
+        expected.template_name = "int"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
     def test_parse_template_type(self):
         """ Test parsing a template type. """
         result = self.__parse_type("std::vector<int>")

--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -286,3 +286,39 @@ class TestParserParseType(unittest.TestCase):
         expected.template_name = "function"
 
         self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_function_type_with_args(self):
+        """ Test parsing a function type with arguments. """
+        result = self.__parse_type("std::function<void(int, const std::string&)>")
+
+        int_type = self.__parse_type("int")
+        string_type = self.__parse_type("const std::string&")
+
+        arg0 = MetadataTypes.ParameterMetadata("arg1", int_type, False, False, False)
+        arg1 = MetadataTypes.ParameterMetadata("arg2", string_type, False, False, True)
+
+        function_metadata = MetadataTypes.FunctionMetadata(None, 0, 0, None, None, None, False, True, parameters=[
+            arg0, arg1])
+
+        expected = MetadataTypes.TypeMetadata("std", "function")
+        expected.is_function_signature = True
+        expected.function_signature = function_metadata
+        expected.template_arguments = []
+        expected.template_name = "function"
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_function_with_return_type(self):
+        """ Test parsing a function type with a return type. """
+        result = self.__parse_type("std::function<int()>")
+
+        int_type = self.__parse_type("int")
+        function_metadata = MetadataTypes.FunctionMetadata(None, 0, 0, None, None, int_type, True, False, [])
+
+        expected = MetadataTypes.TypeMetadata("std", "function")
+        expected.is_function_signature = True
+        expected.function_signature = function_metadata
+        expected.template_arguments = []
+        expected.template_name = "function"
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)

--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -139,6 +139,25 @@ class TestParserParseType(unittest.TestCase):
 
         self.assertDictEqual(result.__dict__, expected.__dict__)
 
+    def test_parse_pointer_to_pointer_type(self):
+        """ Test parsing a pointer to pointer type. """
+        result = self.__parse_type("int**")
+
+        expected = self.__parse_type("int")
+        expected.is_pointer = True
+        expected.is_pointer_pointer = True
+        expected.is_pointer_or_reference = True
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_pointer_to_pointer_to_pointer_type_fails(self):
+        """
+        Test parsing a pointer to pointer to pointer type.
+        This test case fails because the parser fails to parse the third * and leaves it as
+        a leftover word.
+        """
+        self.assertRaises(AssertionError, self.__parse_type, "int***")
+
     def test_parse_reference_type(self):
         """ Test parsing a reference type. """
         result = self.__parse_type("int&")

--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -249,3 +249,18 @@ class TestParserParseType(unittest.TestCase):
         expected.template_arguments = []
 
         self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_optional_type(self):
+        """ Test the special parsing of optional types (using csp::common::Optional). """
+        wordreader = WordReader("csp::common::Optional<int>")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("", "int")
+        expected.is_const = False
+        expected.is_primitive = True
+        expected.is_optional = True
+        expected.template_name = "int"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)

--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -4,7 +4,7 @@ from word_reader import WordReader
 import Parser
 import MetadataTypes
 
-class TestParser(unittest.TestCase):
+class TestParserParseEnum(unittest.TestCase):
     def setUp(self):
         self.parser = Parser.Parser(log_file=sys.stdout)
 
@@ -78,3 +78,161 @@ class TestParser(unittest.TestCase):
         self.assertEqual(result.is_flags, False)
         self.assertEqual(result.is_nested_type, False)
         self.assertEqual(result.doc_comments, None)
+
+
+class TestParserParseType(unittest.TestCase):
+    def setUp(self):
+        self.parser = Parser.Parser(log_file=sys.stdout)
+        self.maxDiff = None
+
+    def test_parse_primitive_type(self):
+        """ Test parsing a simple type. """
+        wordreader = WordReader("int")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("", "int")
+        expected.is_primitive = True
+        expected.template_name = "int"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_const_simple_type(self):
+        """ Test parsing a simple type. """
+        wordreader = WordReader("const int")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("", "int")
+        expected.is_const = True
+        expected.is_primitive = True
+        expected.template_name = "int"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_namespaced_type(self):
+        """ Test parsing a namespaced type. """
+        wordreader = WordReader("eggs::and::bacon")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("eggs::and", "bacon")
+        expected.template_name = "bacon"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_pointer_type(self):
+        """ Test parsing a pointer type. """
+        wordreader = WordReader("int*")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("", "int")
+        expected.is_pointer = True
+        expected.is_pointer_or_reference = True
+        expected.is_primitive = True
+        expected.template_name = "int"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_reference_type(self):
+        """ Test parsing a reference type. """
+        wordreader = WordReader("int&")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("", "int")
+        expected.is_reference = True
+        expected.is_pointer_or_reference = True
+        expected.is_primitive = True
+        expected.template_name = "int"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_const_pointer_type(self):
+        """ Test parsing a const pointer type. """
+        wordreader = WordReader("const int*")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("", "int")
+        expected.is_const = True
+        expected.is_pointer = True
+        expected.is_pointer_or_reference = True
+        expected.is_primitive = True
+        expected.template_name = "int"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_template_type(self):
+        """ Test parsing a template type. """
+        wordreader = WordReader("std::vector<int>")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("std", "vector")
+        expected.is_template = True
+        expected.template_name = "vector"
+        expected.template_arguments = [
+            MetadataTypes.TemplateArgumentMetadata(
+                type=MetadataTypes.TypeMetadata("", "int", template_name="int", template_arguments=[], is_primitive=True),
+                is_last=True
+            )
+        ]
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_multi_template_type(self):
+        """ Test parsing a template type with two arguments to the template. """
+        wordreader = WordReader("std::map<int, std::string>")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("std", "map")
+        expected.is_template = True
+        expected.template_name = "map"
+        expected.template_arguments = [
+            MetadataTypes.TemplateArgumentMetadata(
+                type=MetadataTypes.TypeMetadata("", "int", template_name="int", template_arguments=[], is_primitive=True),
+                is_last=False
+            ),
+            MetadataTypes.TemplateArgumentMetadata(
+                type=MetadataTypes.TypeMetadata("std", "string", template_name="string", template_arguments=[]),
+                is_last=True
+            )
+        ]
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_nested_template_type(self):
+        """ Test parsing a template type with a nested template argument. """
+        wordreader = WordReader("std::map<int, std::vector<std::string>>")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("std", "map")
+        expected.is_template = True
+        expected.template_name = "map"
+        expected.template_arguments = [
+            MetadataTypes.TemplateArgumentMetadata(
+                type=MetadataTypes.TypeMetadata("", "int", template_name="int", template_arguments=[], is_primitive=True),
+                is_last=False
+            ),
+            MetadataTypes.TemplateArgumentMetadata(
+                type=MetadataTypes.TypeMetadata("std", "vector", is_template=True, template_name="vector", template_arguments=[
+                    MetadataTypes.TemplateArgumentMetadata(
+                        type=MetadataTypes.TypeMetadata("std", "string", template_name="string", template_arguments=[]),
+                        is_last=True
+                    )
+                ]),
+                is_last=True
+            )
+        ]
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)

--- a/Tools/WrapperGenerator/tests/test_parser.py
+++ b/Tools/WrapperGenerator/tests/test_parser.py
@@ -236,3 +236,16 @@ class TestParserParseType(unittest.TestCase):
         ]
 
         self.assertDictEqual(result.__dict__, expected.__dict__)
+
+    def test_parse_forward_declared_type(self):
+        """ Test parsing a forward-declared type. """
+        wordreader = WordReader("class Foo")
+        word = wordreader.next_word()
+        result, word = self.parser._Parser__parse_type(wordreader, word)
+
+        expected = MetadataTypes.TypeMetadata("", "Foo")
+        expected.is_inline_forward = True
+        expected.template_name = "Foo"
+        expected.template_arguments = []
+
+        self.assertDictEqual(result.__dict__, expected.__dict__)


### PR DESCRIPTION
Added fairly thorough tests for the `__parse_type()` function. These tests cover _almost_ every line of the function.

These tests build on each other, starting from checking simple types (e.g. `test_parse_primitive_type`), then using the parser to construct tests for templated types (`test_parse_template_type`) to finally checking templated `std::function<>` types with templated arguments.

`test_parse_pointer_to_pointer_to_pointer_type_fails` demonstrates that there are certain edge case types (`int***`) that the parser handles incorrectly.