### PR TITLE
[nt-0] fix: prevent `is_template` spam

### DIFF
--- a/Tools/WrapperGenerator/MetadataTypes.py
+++ b/Tools/WrapperGenerator/MetadataTypes.py
@@ -175,6 +175,7 @@ class ClassMetadata:
     is_static: bool = False
     is_nested_type: bool = False
     has_nested_types: bool = False
+    is_template: bool = False
     is_template_instance: bool = False
     template_name: str = None
     template_arguments: List[TemplateArgumentMetadata] = None

--- a/Tools/WrapperGenerator/Parser.py
+++ b/Tools/WrapperGenerator/Parser.py
@@ -1729,6 +1729,8 @@ class Parser:
                     self.__find_and_set_templated_type(f.type, c.namespace, types)
         
         for t in self.templates.values():
+            t.definition.is_template = True
+
             for f in t.definition.fields:
                 if any(f.type.name == tp.name for tp in t.template_parameters):
                     f.type.is_template_argument = True


### PR DESCRIPTION
Stop the wrapper generation process from spamming `Could not find key 'is_template'` to the error log.

`ClassMetadata` is used by templates as though it's equivalent to `TypeMetadata`. This change just makes sure that class metadata contains an `is_template` field, which is set when a class is templatized.