### PR TITLE
[nt-0] fix: Protect against null pointers

### DIFF
--- a/Library/CSharpWrapper/src/NativeClassWrapper.cs
+++ b/Library/CSharpWrapper/src/NativeClassWrapper.cs
@@ -39,13 +39,41 @@ namespace Csp
 
     public class NativeClassWrapper
     {
-        internal IntPtr _ptr;
+        private IntPtr _ptrValue = IntPtr.Zero;
         internal bool _ownsPtr;
         internal bool _disposed = false;
 
         internal virtual string _safeTypeName { get; }
 
-        public bool PointerIsValid => _ptr != IntPtr.Zero;
+        public bool PointerIsValid => _ptrValue != IntPtr.Zero;
+
+        /// <summary>
+        /// Pointer to the native object.
+        /// </summary>
+        /// <exception cref="NullReferenceException">Thrown if the pointer is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if attempting to change the pointer once it's set to a non-null value.</exception>
+        internal IntPtr _ptr
+        {
+            get
+            {
+                // Prevent accessing the pointer if it's null
+                if (_ptrValue == IntPtr.Zero)
+                {
+                    throw new NullReferenceException($"Attempting to access a null pointer for {_safeTypeName}");
+                }
+                return _ptrValue;
+            }
+            set
+            {
+                // Prevent changing the pointer once it's set to a non-null value
+                if (_ptrValue != IntPtr.Zero && value != IntPtr.Zero)
+                {
+                    throw new InvalidOperationException($"Attempting to change the native pointer for {_safeTypeName} from {_ptrValue} to {value}");
+                }
+
+                _ptrValue = value;
+            }
+        }
 
         public NativeClassWrapper() { }
 

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Method/Destructor.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Class/Method/Destructor.mustache
@@ -9,9 +9,9 @@ void RealDispose() {
     if (_ownsPtr && !_disposed)
     {
         {{ unique_name }}(_ptr);
-        _disposed = true;
     }
 
+    _ptr = IntPtr.Zero;
     _disposed = true;
 }
 

--- a/Tools/WrapperGenerator/Templates/CSharp/Partials/Template/Method/Destructor.mustache
+++ b/Tools/WrapperGenerator/Templates/CSharp/Partials/Template/Method/Destructor.mustache
@@ -8,9 +8,9 @@ void RealDispose() {
     if (_ownsPtr && !_disposed)
     {
         {{ unique_name }}(_ptr);
-        _disposed = true;
     }
 
+    _ptr = IntPtr.Zero;
     _disposed = true;
 }
 

--- a/UnitTesting/include/classes.h
+++ b/UnitTesting/include/classes.h
@@ -24,5 +24,7 @@ class CSP_API SimpleClass
 public:
     SimpleClass();
     ~SimpleClass();
+
+    int GetValue() const;
 };
 }

--- a/UnitTesting/src/classes.cpp
+++ b/UnitTesting/src/classes.cpp
@@ -21,4 +21,7 @@ namespace csp::Tests
 SimpleClass::SimpleClass() { }
 
 SimpleClass::~SimpleClass() { }
-}
+
+int SimpleClass::GetValue() const { return 42; }
+
+} // namespace csp::Tests

--- a/UnitTesting/tests/csharp/Assets/Tests/ClassTests.cs
+++ b/UnitTesting/tests/csharp/Assets/Tests/ClassTests.cs
@@ -15,6 +15,7 @@
  */
 
 using NUnit.Framework;
+using System;
 
 namespace Csp.Tests
 {
@@ -29,13 +30,13 @@ namespace Csp.Tests
 
             // Verify the internal pointer is set.
             // Note that we have to use reflection here to access the internal field.
-            var ptrField = typeof(SimpleClass).GetField("_ptr", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var ptrValue = ptrField.GetValue(simpleClass);
+            var ptrField = typeof(NativeClassWrapper).GetField("_ptrValue", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            IntPtr ptrValue = (IntPtr)ptrField.GetValue(simpleClass);
             Assert.IsNotNull(ptrValue);
 
             // Verify that the instance owns the native pointer.
             // Note that we have to use reflection here to access the internal field.
-            var ownsPtrField = typeof(SimpleClass).GetField("_ownsPtr", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var ownsPtrField = typeof(NativeClassWrapper).GetField("_ownsPtr", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var ownsPtrValue = ownsPtrField.GetValue(simpleClass);
             Assert.IsTrue((bool)ownsPtrValue);
 
@@ -44,14 +45,19 @@ namespace Csp.Tests
             simpleClass.Dispose();
 
             // Once Dispose is called, the internal pointer is no longer valid.
-            // However, Dispose does not null out the pointer so the class is
-            // left in an indeterminate state.
-            // There is also no way to query whether Dispose has been called.
-            Assert.IsTrue(simpleClass.PointerIsValid);
+            Assert.IsFalse(simpleClass.PointerIsValid);
 
-            // Verify the internal pointer is still set.
-            var ptrValueDisposed = ptrField.GetValue(simpleClass);
-            Assert.IsNotNull(ptrValueDisposed);
+            // Verify the internal pointer has been nulled.
+            IntPtr ptrValueDisposed = (IntPtr)ptrField.GetValue(simpleClass);
+            Assert.AreEqual(IntPtr.Zero, ptrValueDisposed);
+        }
+
+        [Test]
+        public void GetValueReturnsCorrectValue()
+        {
+            var simpleClass = new SimpleClass();
+            int value = simpleClass.GetValue();
+            Assert.AreEqual(42, value);
         }
 
         [Test]
@@ -62,6 +68,18 @@ namespace Csp.Tests
             // Call Dispose multiple times and ensure no errors occur.
             simpleClass.Dispose();
             simpleClass.Dispose();
+        }
+
+        [Test]
+        public void AccessAfterDisposeThrows()
+        {
+            var simpleClass = new SimpleClass();
+            simpleClass.Dispose();
+
+            // Accessing the pointer after Dispose should throw a NullReferenceException rather
+            // than creating a segfault.
+            var ex = Assert.Throws<NullReferenceException>(() => { int value = simpleClass.GetValue(); });
+            StringAssert.Contains("Attempting to access a null pointer", ex.Message);
         }
     }
 }


### PR DESCRIPTION
Attempt to prevent the class of native level crash caused by accessing invalid pointers.

* `Dispose()` now sets the internal pointer to zero
* Changes `_ptr` to a property
* Accessing `_ptr` when it's `IntPtr.Zero` throws a NullReferenceException (rather than segfaulting)
* Prevent modification of the underlying pointer for `NativeClassWrapper`

This will catch two common causes of segfaults and instead throw a managed `NullReferenceException`.

* Accessing native code when the pointer is `null_ptr`
* Accessing fields and properties on a `NativeClassWrapper` after `Dispose()` has been called.