### PR TITLE
[OF-1754] test: Skip application settings tests when no admin login is set

### DIFF
--- a/Tests/src/PublicAPITests/ApplicationSettingsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ApplicationSettingsSystemTests.cpp
@@ -53,6 +53,11 @@ ApplicationSettings GetApplicationSettingsTestData(const csp::common::String& Co
 
 CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, CreateSettingsByContextTest)
 {
+    if (std::string(AdminAccountEmail()).empty())
+    {
+        GTEST_SKIP() << "Admin account email not set. This test cannot be run.";
+    }
+
     SetRandSeed();
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -92,6 +97,11 @@ CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, CreateSettingsByConte
 
 CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, CreateAnonymousSettingsByContextTest)
 {
+    if (std::string(AdminAccountEmail()).empty())
+    {
+        GTEST_SKIP() << "Admin account email not set. This test cannot be run.";
+    }
+
     SetRandSeed();
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -131,6 +141,11 @@ CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, CreateAnonymousSettin
 
 CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, GetSettingsByContextTest)
 {
+    if (std::string(AdminAccountEmail()).empty())
+    {
+        GTEST_SKIP() << "Admin account email not set. This test cannot be run.";
+    }
+
     SetRandSeed();
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -185,6 +200,11 @@ CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, GetSettingsByContextT
 
 CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, GetSettingsByContextWithKeysTest)
 {
+    if (std::string(AdminAccountEmail()).empty())
+    {
+        GTEST_SKIP() << "Admin account email not set. This test cannot be run.";
+    }
+
     SetRandSeed();
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -276,6 +296,11 @@ CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, GetInvalidSettingsByC
 
 CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, GetSettingsByContextAnonymousTest)
 {
+    if (std::string(AdminAccountEmail()).empty())
+    {
+        GTEST_SKIP() << "Admin account email not set. This test cannot be run.";
+    }
+
     SetRandSeed();
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -323,6 +348,11 @@ CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, GetSettingsByContextA
 
 CSP_PUBLIC_TEST(CSPEngine, ApplicationSettingsSystemTests, GetSettingsByContextAnonymousWithKeysTest)
 {
+    if (std::string(AdminAccountEmail()).empty())
+    {
+        GTEST_SKIP() << "Admin account email not set. This test cannot be run.";
+    }
+
     SetRandSeed();
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();


### PR DESCRIPTION
These tests fail out of the box and should not run in contexts where they cannot pass.

We set the admin email/password on teamcity, so this effectively makes these tests run on CI, or locally only if you have set the environment variable (which we probably will never do, but that's fine).