### PR TITLE
[OF-1738] feat: Implementation of the AnalyticsSystem

### DIFF
--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "CSP/CSPCommon.h"
+#include "CSP/Common/CancellationToken.h"
+#include "CSP/Common/Optional.h"
+#include "CSP/Common/String.h"
+#include "CSP/Systems/SystemBase.h"
+
+namespace csp
+{
+class ClientUserAgent;
+} // namespace csp
+
+namespace csp::services
+{
+class ApiBase;
+} // namespace csp::services
+
+namespace csp::web
+{
+class WebClient;
+} // namespace csp::web
+
+namespace csp::systems
+{
+
+/// @ingroup Analytics System
+/// @brief Public facing system that allows AnalyticsRecords to be sent to MCS.
+class CSP_API AnalyticsSystem : public SystemBase
+{
+    CSP_START_IGNORE
+    /** @cond DO_NOT_DOCUMENT */
+    friend class SystemsManager;
+    /** @endcond */
+    CSP_END_IGNORE
+
+public:
+    /**
+     * @brief Sends an analytics event to the Analytics service.
+     * @details Please note: The BatchAnalyticsEvent method should be used by default as it will batch events before sending them.
+     * This method will immediately send the analytics event and should therefore only be used when this behaviour is required.
+     * Constructs an Analytics Record with the following format:
+     *      {ProductIdentifer}.{ProductContext}.{Tenant}.{ProductContextSection}.{Category}.{InteractionType}.{SubCategory}
+     *      csp.web-client-x.CLIENT_TENANT_X.UI.menus.click
+     * @param ProductContextSection const csp::common::String& : Section of the client or runtime-context - 'UI' in the example provided above.
+     * @param Category const csp::common::String& : Categorization field - 'menus' in the example provided above.
+     * @param InteractionType const csp::common::String& : The interaction that occurred - 'click' in the example provided above.
+     * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field - not used in the example provided above.
+     * @param Metadata const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& : Optional analytics event metadata -
+     * not used in the example provided above.
+     */
+    void SendAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,
+        const csp::common::String& InteractionType, const csp::common::Optional<csp::common::String>& SubCategory,
+        const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata, NullResultCallback Callback);
+
+private:
+    AnalyticsSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
+    CSP_NO_EXPORT AnalyticsSystem(csp::web::WebClient* InWebClient, const csp::ClientUserAgent* AgentInfo, common::LogSystem& LogSystem);
+    ~AnalyticsSystem();
+
+    csp::services::ApiBase* AnalyticsApi;
+
+    const csp::ClientUserAgent* UserAgentInfo;
+};
+
+} // namespace csp::systems

--- a/Library/include/CSP/Systems/SystemsManager.h
+++ b/Library/include/CSP/Systems/SystemsManager.h
@@ -51,6 +51,7 @@ class QuotaSystem;
 class SequenceSystem;
 class HotspotSequenceSystem;
 class ConversationSystemInternal;
+class AnalyticsSystem;
 
 } // namespace csp::systems
 
@@ -159,6 +160,10 @@ public:
     /// @return HotspotSequenceSystem : pointer to the HotspotSequenceSystem system class
     HotspotSequenceSystem* GetHotspotSequenceSystem();
 
+    /// @brief Retrieves the AnalyticsSystem system.
+    /// @return AnalyticsSystem : pointer to the AnalyticsSystem system class
+    AnalyticsSystem* GetAnalyticsSystem();
+
     csp::multiplayer::MultiplayerConnection* GetMultiplayerConnection();
 
     csp::multiplayer::NetworkEventBus* GetEventBus();
@@ -208,6 +213,7 @@ private:
     SequenceSystem* SequenceSystem;
     HotspotSequenceSystem* HotspotSequenceSystem;
     ConversationSystemInternal* ConversationSystem;
+    AnalyticsSystem* AnalyticsSystem;
 };
 
 } // namespace csp::systems

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -417,12 +417,12 @@ bool CSPFoundation::InitialiseWithInject(const csp::common::String& EndpointRoot
     DeviceId = new csp::common::String("");
     ClientUserAgentString = new csp::common::String("");
 
+    SetClientUserAgentInfo(ClientUserAgentHeader);
+
     csp::systems::SystemsManager::Instantiate(SignalRInject);
 
     *DeviceId = LoadDeviceId().c_str();
     IsInitialised = true;
-
-    SetClientUserAgentInfo(ClientUserAgentHeader);
 
     return true;
 }

--- a/Library/src/Systems/Analytics/AnalyticsSystem.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsSystem.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/Systems/Analytics/AnalyticsSystem.h"
+
+#include "CSP/CSPFoundation.h"
+#include "CallHelpers.h"
+#include "Services/UserService/Api.h"
+#include "Services/UserService/Dto.h"
+#include "Systems/ResultHelpers.h"
+
+#include <fmt/format.h>
+
+using namespace csp;
+using namespace csp::common;
+
+namespace chs = csp::services::generated::userservice;
+
+namespace csp::systems
+{
+
+AnalyticsSystem::AnalyticsSystem()
+    : SystemBase(nullptr, nullptr, nullptr)
+    , AnalyticsApi(nullptr)
+    , UserAgentInfo(nullptr)
+{
+}
+
+AnalyticsSystem::AnalyticsSystem(csp::web::WebClient* InWebClient, const csp::ClientUserAgent* AgentInfo, csp::common::LogSystem& LogSystem)
+    : SystemBase(InWebClient, nullptr, &LogSystem)
+{
+    AnalyticsApi = new chs::AnalyticsApi(InWebClient);
+    UserAgentInfo = AgentInfo;
+}
+
+AnalyticsSystem::~AnalyticsSystem() { delete (AnalyticsApi); }
+
+void AnalyticsSystem::SendAnalyticsEvent(const String& ProductContextSection, const String& Category, const String& InteractionType,
+    const Optional<String>& SubCategory, const Optional<Map<String, String>>& Metadata, NullResultCallback Callback)
+{
+    if (ProductContextSection.IsEmpty() || Category.IsEmpty() || InteractionType.IsEmpty())
+    {
+        CSP_LOG_MSG(common::LogLevel::Error, "Missing the required fields for the Analytics Event.");
+        INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
+
+        return;
+    }
+
+    // Construct an AnalyticsRecord object
+    auto Record = std::make_shared<chs::AnalyticsRecord>();
+    Record->SetProductIdentifier("csp");
+    Record->SetProductContext(UserAgentInfo->ClientSKU);
+    Record->SetTenantName(CSPFoundation::GetTenant());
+    Record->SetProductContextSection(ProductContextSection);
+    Record->SetCategory(Category);
+    Record->SetInteractionType(InteractionType);
+
+    if (SubCategory.HasValue())
+    {
+        Record->SetSubCategory(*SubCategory);
+    }
+
+    String ClientVersion
+        = fmt::format("{}/{}({})", UserAgentInfo->ClientSKU.c_str(), UserAgentInfo->ClientVersion.c_str(), UserAgentInfo->ClientEnvironment.c_str())
+              .c_str();
+    String CSPVersion = fmt::format("CSP/{}({})", CSPFoundation::GetVersion().c_str(), CSPFoundation::GetBuildType().c_str()).c_str();
+
+    std::vector<String> VersionsMatrix { ClientVersion, CSPVersion };
+    Record->SetVersionMatrix(VersionsMatrix);
+
+    if (Metadata.HasValue())
+    {
+        std::map<String, String> AnalyticsRecordMetadata;
+
+        auto* Keys = Metadata->Keys();
+
+        for (size_t idx = 0; idx < Keys->Size(); ++idx)
+        {
+            auto Key = Keys->operator[](idx);
+            auto Value = Metadata->operator[](Key);
+            AnalyticsRecordMetadata.insert(std::pair<String, String>(Key, Value));
+        }
+
+        Record->SetMetadata(AnalyticsRecordMetadata);
+    }
+
+    Record->SetTimestamp(DateTime::TimeNow().GetUtcString());
+
+    std::vector<std::shared_ptr<chs::AnalyticsRecord>> Records;
+    Records.push_back(Record);
+
+    NullResultCallback SendAnalyticsCallback = [Callback](const NullResult& Result)
+    {
+        if (Result.GetResultCode() == csp::systems::EResultCode::InProgress)
+        {
+            return;
+        }
+
+        if (Result.GetResultCode() == csp::systems::EResultCode::Failed)
+        {
+            CSP_LOG_FORMAT(common::LogLevel::Error, "Failed to send Analytics Event. ResCode: %d, HttpResCode: %d",
+                static_cast<int>(Result.GetResultCode()), Result.GetHttpResultCode());
+
+            NullResult ErrorResult(Result.GetResultCode(), Result.GetHttpResultCode());
+            Callback(ErrorResult);
+
+            return;
+        }
+
+        NullResult SuccessResult(Result.GetResultCode(), Result.GetHttpResultCode());
+        Callback(SuccessResult);
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AnalyticsApi->CreateHandler<NullResultCallback, NullResult, void, chs::AnalyticsRecord>(SendAnalyticsCallback, nullptr);
+
+    static_cast<chs::AnalyticsApi*>(AnalyticsApi)->analyticsBulkPost(Records, ResponseHandler);
+}
+
+} // namespace csp::systems

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -15,10 +15,12 @@
  */
 #include "CSP/Systems/SystemsManager.h"
 
+#include "CSP/CSPFoundation.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/OfflineRealtimeEngine.h"
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
+#include "CSP/Systems/Analytics/AnalyticsSystem.h"
 #include "CSP/Systems/Assets/AssetSystem.h"
 #include "CSP/Systems/ECommerce/ECommerceSystem.h"
 #include "CSP/Systems/EventTicketing/EventTicketingSystem.h"
@@ -93,6 +95,8 @@ SequenceSystem* SystemsManager::GetSequenceSystem() { return SequenceSystem; }
 
 HotspotSequenceSystem* SystemsManager::GetHotspotSequenceSystem() { return HotspotSequenceSystem; }
 
+AnalyticsSystem* SystemsManager::GetAnalyticsSystem() { return AnalyticsSystem; }
+
 csp::multiplayer::MultiplayerConnection* SystemsManager::GetMultiplayerConnection() { return MultiplayerConnection; }
 
 csp::multiplayer::NetworkEventBus* SystemsManager::GetEventBus() { return NetworkEventBus; }
@@ -142,6 +146,7 @@ SystemsManager::SystemsManager()
     , QuotaSystem(nullptr)
     , SequenceSystem(nullptr)
     , HotspotSequenceSystem(nullptr)
+    , AnalyticsSystem(nullptr)
 {
 }
 
@@ -192,12 +197,14 @@ void SystemsManager::CreateSystems(csp::multiplayer::ISignalRConnection* SignalR
     SequenceSystem = new csp::systems::SequenceSystem(WebClient, NetworkEventBus, *LogSystem);
     HotspotSequenceSystem = new csp::systems::HotspotSequenceSystem(SequenceSystem, SpaceSystem, NetworkEventBus, *LogSystem);
     ConversationSystem = new csp::systems::ConversationSystemInternal(AssetSystem, SpaceSystem, UserSystem, NetworkEventBus, *LogSystem);
+    AnalyticsSystem = new csp::systems::AnalyticsSystem(WebClient, &(csp::CSPFoundation::GetClientUserAgentInfo()), *LogSystem);
 }
 
 void SystemsManager::DestroySystems()
 {
     // Systems must be shut down in reverse order to CreateSystems() to ensure that any
     // dependencies continue to exist until each system is successfully shut down.
+    delete AnalyticsSystem;
     delete ConversationSystem;
     delete HotspotSequenceSystem;
     delete SequenceSystem;

--- a/Tests/src/PublicAPITests/AnalyticsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnalyticsSystemTests.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "Awaitable.h"
+#include "CSP/CSPFoundation.h"
+#include "CSP/Common/SharedEnums.h"
+#include "CSP/Common/Systems/Log/LogSystem.h"
+#include "CSP/Systems/Analytics/AnalyticsSystem.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "Common/Web/HttpPayload.h"
+#include "RAIIMockLogger.h"
+#include "TestHelpers.h"
+#include "UserSystemTestHelpers.h"
+
+#include "gtest/gtest.h"
+
+using namespace csp::common;
+using namespace csp::systems;
+
+namespace
+{
+
+bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
+
+} // namespace
+
+CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, SendAnalyticsEventTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* AnalyticsSystem = SystemsManager.GetAnalyticsSystem();
+
+    String UserId;
+
+    // Log in
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Analytics Data
+    const auto TestProductContextSection = String("Event_ProductContextSection");
+    const auto TestCategory = String("Event_Category");
+    const auto TestInteractionType = String("Event_InteractionType");
+    const auto TestSubCategory = String("Event_SubCategory");
+    const Map<String, String> TestMetadata = { { "Key1", "Value1" }, { "Key2", "Value2" } };
+
+    auto [Result] = AWAIT_PRE(AnalyticsSystem, SendAnalyticsEvent, RequestPredicate, TestProductContextSection, TestCategory, TestInteractionType,
+        TestSubCategory, TestMetadata);
+
+    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+    EXPECT_EQ(Result.GetHttpResultCode(), 201);
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, SendAnalyticsEventMissingFieldsTest)
+{
+    SetRandSeed();
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* AnalyticsSystem = SystemsManager.GetAnalyticsSystem();
+    auto& LogSystem = *SystemsManager.GetLogSystem();
+
+    // We are only concerned with error logs in this test
+    LogSystem.SetSystemLevel(csp::common::LogLevel::Error);
+
+    String UserId;
+
+    // Log in
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Analytics Data
+    // Passing an empty string for a required field
+    const auto TestProductContextSection = String("");
+    const auto TestCategory = String("Event_Category");
+    const auto TestInteractionType = String("Event_InteractionType");
+    const auto TestSubCategory = String("Event_SubCategory");
+    const Map<String, String> TestMetadata = { { "Key1", "Value1" }, { "Key2", "Value2" } };
+
+    // Ensure the required fields error message is logged when we try to send an analytics event with a required field missing
+    const csp::common::String LockErrorMsg = "Missing the required fields for the Analytics Event.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(LockErrorMsg)).Times(1);
+
+    auto [Result] = AWAIT_PRE(AnalyticsSystem, SendAnalyticsEvent, RequestPredicate, TestProductContextSection, TestCategory, TestInteractionType,
+        TestSubCategory, TestMetadata);
+
+    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+    EXPECT_EQ(Result.GetHttpResultCode(), 0);
+
+    // Log out
+    LogOut(UserSystem);
+}


### PR DESCRIPTION
This work involves the introduction of a new Analytics System, which wraps a single MCS Analytics endpoint on the User Service - `POST /analytics/bulk`.

This PR introduces a single public system method - AnalyticsSystem::SendAnalyticsEvent().

A subsequent PR will add a second method to this system for the batching of analytics events - AnalyticsSystem::BatchAnalyticsEvent().