### PR TITLE
[OF-1739] test: Add batched analytics events

### DIFF
--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -75,13 +75,6 @@ class CSP_API AnalyticsSystem : public SystemBase
 
 public:
     /**
-     * @brief Sets a callback to be executed when a queue of Analytics Records has been sent to the backend services.
-     * This callback will be executed in response both to a call to QueueAnalyticsEvent() as well as to FlushAnalyticsEventsQueue().
-     * @param Callback NullResultCallback : the callback to execute.
-     */
-    CSP_EVENT void SetQueueAnalyticsEventCallback(NullResultCallback Callback);
-
-    /**
      * @brief Constructs an Analytics Record which is added to a queue to be sent to the backend services in a single batch.
      * @details The queue will be sent when one of the following conditions are met:
      * 1. The time since the last batch was sent reaches the AnalyticsQueueSendRate (default 60 seconds).
@@ -146,9 +139,10 @@ public:
      * @brief Trigger immediate dispatch of the Analytics Records queue to the backend services.
      * @note This method should be called as part of client log out or shut down procedure to ensure that any queued analytics records are flushed and
      * sent to the backend services before the user is logged out or the application is shut down.
+     * @param Callback NullResultCallback : the callback to execute on completion of the flush operation.
      * @pre The user must be logged in to send an Analytics Record to the backend services.
      */
-    void FlushAnalyticsEventsQueue();
+    CSP_EVENT void FlushAnalyticsEventsQueue(NullResultCallback Callback);
 
     /**
      * @brief Retrieves the time since the queue was last sent.
@@ -190,8 +184,6 @@ private:
     std::unique_ptr<class AnalyticsQueueEventHandler> EventHandler;
     std::mutex AnalyticsQueueLock;
     std::vector<std::shared_ptr<csp::services::generated::userservice::AnalyticsRecord>> AnalyticsRecordQueue;
-
-    NullResultCallback SendAnalyticsEventQueueCallback;
 
     const csp::ClientUserAgent* UserAgentInfo;
     std::chrono::milliseconds AnalyticsQueueSendRate;

--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -79,19 +79,19 @@ public:
     /**
      * @brief Constructs an Analytics Record which is added to a queue to be sent to MCS in a single batch.
      * @details The batch will be sent when one of the following conditions are met:
-     * 1) The time since the last batch was sent reaches the batch rate (default 60 seconds).
-     * 2) The number of events in the queue reaches the maximum batch size (default 25 events).
-     * 3) The client application calls FlushAnalyticsEvents() as part of their log out or shut down procedure to force the batch to be sent.
-     * For more information about FlushAnalyticsEvents(), see the method documentation @ref AnalyticsSystem::FlushAnalyticsEvents().
+     * 1. The time since the last batch was sent reaches the batch rate (default 60 seconds).
+     * 2. The number of events in the queue reaches the maximum batch size (default 25 events).
+     * 3. The client application calls FlushAnalyticsEvents() as part of their log out or shut down procedure to force the batch to be sent.
+     * For more information about flushing events see the method documentation @ref AnalyticsSystem::FlushAnalyticsEvents().
      *
      * Example: Consider the following user action that is to be captured as an analytics event:
-     *      A [web client] user [clicks] on a [menu] item in the [UI].
+     * A [web client] user [clicks] on a [menu] item in the [UI].
      *
      * In this example:
-     *      [web client] is captured internally.
-     *      [clicks] is the InteractionType.
-     *      [menu] is the Category.
-     *      [UI] is the ProductContextSection.
+     * - [web client] is captured internally.
+     * - [clicks] is the InteractionType.
+     * - [menu] is the Category.
+     * - [UI] is the ProductContextSection.
      *
      * @note The following data is captured internally and included in the analytics record: tenant name, client sku, client version and client build
      * environment.
@@ -102,7 +102,7 @@ public:
      * @param InteractionType const csp::common::String& : The interaction that occurred.
      * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field.
      * @param Metadata const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& : Optional analytics event metadata.
-     * @note Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
+     * Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
      * relevant device specs.
      */
     void BatchAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,
@@ -111,12 +111,10 @@ public:
 
     /**
      * @brief Constructs an Analytics Record which is immediately sent to MCS.
-     * @note: The BatchAnalyticsEvent method should be used by default as it will batch events before sending them.
+     * @note The BatchAnalyticsEvent method should be used by default as it will batch events before sending them.
      * This method will immediately send the analytics event and should therefore only be used when this behaviour is required.
      *
-     * For more information about how the Analytics Record is constructed, see the documentation for @ref AnalyticsSystem::BatchAnalyticsEvent(const
-     csp::common::String&, const csp::common::String&, const csp::common::String&, const csp::common::Optional<csp::common::String>&, const
-     csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>&).
+     * For more information about how the Analytics Record is constructed, see the documentation for @ref AnalyticsSystem::BatchAnalyticsEvent().
      *
      * @pre The user must be logged in to send an Analytics Record to MCS.
      * @param ProductContextSection const csp::common::String& : Section of the client or runtime-context.
@@ -124,7 +122,7 @@ public:
      * @param InteractionType const csp::common::String& : The interaction that occurred.
      * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field.
      * @param Metadata const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& : Optional analytics event metadata.
-     * @note Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
+     * Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
      * relevant device specs.
      */
     void SendAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,

--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -23,7 +23,6 @@
 #include "CSP/Systems/SystemBase.h"
 
 #include <chrono>
-#include <deque>
 #include <mutex>
 
 CSP_START_IGNORE
@@ -58,8 +57,8 @@ namespace csp::systems
 {
 
 /// @ingroup Analytics System
-/// @brief Public facing system that allows AnalyticsRecords to be sent to MCS.
-/// @invariant Users must be logged in to send AnalyticsRecords to MCS.
+/// @brief Public facing system that allows AnalyticsRecords to be sent to the backend services.
+/// @invariant Users must be logged in to send AnalyticsRecords to the backend services.
 class CSP_API AnalyticsSystem : public SystemBase
 {
     CSP_START_IGNORE
@@ -76,22 +75,23 @@ class CSP_API AnalyticsSystem : public SystemBase
 
 public:
     /**
-     * @brief Sets a callback to be executed when a queue of Ananlytics Records has been sent to backend services.
-     * This callback will be executed in response to both a call to QueueAnalyticsEvent() as well as FlushAnalyticsEventsQueue().
+     * @brief Sets a callback to be executed when a queue of Analytics Records has been sent to the backend services.
+     * This callback will be executed in response both to a call to QueueAnalyticsEvent() as well as to FlushAnalyticsEventsQueue().
      * @param Callback NullResultCallback : the callback to execute.
      */
     CSP_EVENT void SetQueueAnalyticsEventCallback(NullResultCallback Callback);
 
     /**
-     * @brief Constructs an Analytics Record which is added to a queue to be sent to MCS in a single batch.
-     * @details The batch will be sent when one of the following conditions are met:
-     * 1. The time since the last batch was sent reaches the batch rate (default 60 seconds).
-     * 2. The number of events in the queue reaches the maximum batch size (default 25 events).
-     * 3. The client application calls FlushAnalyticsEventsQueue() as part of their log out or shut down procedure to force the batch to be sent.
-     * For more information about flushing events see the method documentation @ref AnalyticsSystem::FlushAnalyticsEventsQueue().
+     * @brief Constructs an Analytics Record which is added to a queue to be sent to the backend services in a single batch.
+     * @details The queue will be sent when one of the following conditions are met:
+     * 1. The time since the last batch was sent reaches the AnalyticsQueueSendRate (default 60 seconds).
+     * 2. The number of events in the queue reaches the MaxQueueSize threshhold (default 25 events).
+     * 3. The client application calls FlushAnalyticsEventsQueue(). Clients should call this as part of their log out or shut down procedure to force
+     * the queue to be sent. For more information about flushing events see the method documentation @ref
+     * AnalyticsSystem::FlushAnalyticsEventsQueue().
      *
      * Example: Consider the following user action that is to be captured as an analytics event:
-     * A [web client] user [clicks] on a [menu] item in the [UI].
+     * - A [web client] user [clicks] on a [menu] item in the [UI].
      *
      * In this example:
      * - [web client] is captured internally.
@@ -99,16 +99,19 @@ public:
      * - [menu] is the Category.
      * - [UI] is the ProductContextSection.
      *
-     * @note The following data is captured internally and included in the analytics record: tenant name, client sku, client version and client build
-     * environment.
+     * @note The following data is captured internally and included in the analytics record:
+     * - tenant name, client sku, client version and client build environment.
      *
-     * @pre The user must be logged in to send Analytics Records to MCS.
-     * @param ProductContextSection const csp::common::String& : Section of the client or runtime-context.
-     * @param Category const csp::common::String& : Categorization field.
-     * @param InteractionType const csp::common::String& : The interaction that occurred.
-     * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field.
+     * @pre The user must be logged in to send Analytics Records to the backend services.
+     * @param ProductContextSection const csp::common::String& : The specific, high-level functional area or context within the product where the
+     * event occurred. This field acts as a primary identifier for the part of the application or system the user is interacting with.
+     * @param Category const csp::common::String& : Categorization field which acts as a namespace for the InteractionType. It provides a means of
+     * grouping similar events, which makes it easier to analyze and filter analytics data.
+     * @param InteractionType const csp::common::String& : Describes the precise and specific interaction that is being tracked. This field identifies
+     * what the user did or what happened within the product at a specific moment in time.
+     * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field to provide additional context if required.
      * @param Metadata const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& : Optional analytics event metadata.
-     * Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
+     * Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region, as well as
      * relevant device specs.
      */
     void QueueAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,
@@ -116,41 +119,45 @@ public:
         const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata);
 
     /**
-     * @brief Constructs an Analytics Record which is immediately sent to MCS.
-     * @note The QueueAnalyticsEvent method should be used by default as it will batch events before sending them.
-     * This method will immediately send the analytics event and should therefore only be used when this behaviour is required.
+     * @brief Constructs an Analytics Record which is immediately sent to the backend services.
+     * @note The QueueAnalyticsEvent method should be used by default as it will queue events before sending them. This method will immediately send
+     * the analytics event and should therefore only be used when this behaviour is required.
      *
      * For more information about how the Analytics Record is constructed, see the documentation for @ref AnalyticsSystem::QueueAnalyticsEvent().
      *
-     * @pre The user must be logged in to send an Analytics Record to MCS.
-     * @param ProductContextSection const csp::common::String& : Section of the client or runtime-context.
-     * @param Category const csp::common::String& : Categorization field.
-     * @param InteractionType const csp::common::String& : The interaction that occurred.
-     * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field.
+     * @pre The user must be logged in to send Analytics Records to the backend services.
+     * @param ProductContextSection const csp::common::String& : The specific, high-level functional area or context within the product where the
+     * event occurred. This field acts as a primary identifier for the part of the application or system the user is interacting with.
+     * @param Category const csp::common::String& : Categorization field which acts as a namespace for the InteractionType. It provides a means of
+     * grouping similar events, which makes it easier to analyze and filter analytics data.
+     * @param InteractionType const csp::common::String& : Describes the precise and specific interaction that is being tracked. This field identifies
+     * what the user did or what happened within the product at a specific moment in time.
+     * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field to provide additional context if required.
      * @param Metadata const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& : Optional analytics event metadata.
-     * Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
+     * Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region, as well as
      * relevant device specs.
+     * @param Callback NullResultCallback : the callback to execute on completion of the send operation.
      */
     void SendAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,
         const csp::common::String& InteractionType, const csp::common::Optional<csp::common::String>& SubCategory,
         const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata, NullResultCallback Callback);
 
     /**
-     * @brief Trigger immediate dispatch of the Analytics Records queue to MCS.
-     * @note This method is designed to be called as part of a client applications log out and shutdown procedures to ensure that any queued analytics
-     * records are flushed and sent to MCS before the user is logged out or the application is shut down.
-     * @pre The user must be logged in to send an Analytics Record to MCS.
+     * @brief Trigger immediate dispatch of the Analytics Records queue to the backend services.
+     * @note This method should be called as part of client log out or shut down procedure to ensure that any queued analytics records are flushed and
+     * sent to the backend services before the user is logged out or the application is shut down.
+     * @pre The user must be logged in to send an Analytics Record to the backend services.
      */
     void FlushAnalyticsEventsQueue();
 
     /**
-     * @brief Retrieves the time the last batch was sent.
+     * @brief Retrieves the time since the queue was last sent.
      * @return std::chrono::milliseconds : time since epoch in milliseconds.
      */
-    CSP_NO_EXPORT std::chrono::milliseconds GetTimeOfLastBatchSend() const { return TimeOfLastBatchSend; }
+    CSP_NO_EXPORT std::chrono::milliseconds GetTimeSinceLastQueueSend() const { return TimeSinceLastQueueSend; }
 
     /**
-     * @brief Retrieves the rate at which the queued Analytics Records are sent as a batch.
+     * @brief Retrieves the rate at which the queued Analytics Records are sent.
      * @return std::chrono::milliseconds : send rate in milliseconds.
      */
     CSP_NO_EXPORT std::chrono::milliseconds GetQueueSendRate() const { return AnalyticsQueueSendRate; }
@@ -159,12 +166,12 @@ public:
      * @brief Retrieves the current size of the Analytics Records queue.
      * @return size_t : the queue size.
      */
-    CSP_NO_EXPORT size_t GetCurrentQueueSize() const { return AnalyticsRecordBatch.size(); }
+    CSP_NO_EXPORT size_t GetCurrentQueueSize() const { return AnalyticsRecordQueue.size(); }
 
     /**
      * @brief Retrieves the max permitted size of the Analytics Records queue.
-     * If the queue size reaches this value, the queue will be sent as a batch to the backend services.
-     * @return size_t : the queue size at which a bacth will be sent.
+     * If the queue size reaches this value, the queue will be sent as a single batch to the backend services.
+     * @return size_t : the queue size at which a batch will be sent.
      */
     CSP_NO_EXPORT size_t GetMaxQueueSize() const { return MaxQueueSize; }
 
@@ -173,22 +180,22 @@ private:
     CSP_NO_EXPORT AnalyticsSystem(csp::web::WebClient* InWebClient, const csp::ClientUserAgent* AgentInfo, common::LogSystem& LogSystem);
     ~AnalyticsSystem();
 
-    void SetTimeOfLastBatchSend(std::chrono::milliseconds NewTimeOfLastBatch);
+    void SetTimeSinceLastQueueSend(std::chrono::milliseconds NewTimeSinceLastQueueSend);
 
-    // This is a utility function to allow us to test the batching functionality in a reasonable time frame.
-    void SetQueueBatchRateAndSize(std::chrono::milliseconds NewSendRate, size_t NewQueueSize);
+    // This is a utility function to allow us to test the queueing functionality in a reasonable time frame.
+    void __SetQueueSendRateAndMaxSize(std::chrono::milliseconds NewSendRate, size_t NewQueueSize);
 
     std::unique_ptr<csp::services::ApiBase> AnalyticsApi;
 
-    std::unique_ptr<class AnalyticsBatchEventHandler> EventHandler;
-    std::recursive_mutex AnalyticsBatchLock;
-    std::vector<std::shared_ptr<csp::services::generated::userservice::AnalyticsRecord>> AnalyticsRecordBatch;
+    std::unique_ptr<class AnalyticsQueueEventHandler> EventHandler;
+    std::recursive_mutex AnalyticsQueueLock;
+    std::vector<std::shared_ptr<csp::services::generated::userservice::AnalyticsRecord>> AnalyticsRecordQueue;
 
-    NullResultCallback BatchAnalyticsEventCallback;
+    NullResultCallback SendAnalyticsEventQueueCallback;
 
     const csp::ClientUserAgent* UserAgentInfo;
     std::chrono::milliseconds AnalyticsQueueSendRate;
-    std::chrono::milliseconds TimeOfLastBatchSend;
+    std::chrono::milliseconds TimeSinceLastQueueSend;
     size_t MaxQueueSize;
 };
 

--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -28,9 +28,9 @@
 
 CSP_START_IGNORE
 #ifdef CSP_TESTS
-class CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchRateTest_Test;
-class CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchSizeTest_Test;
-class CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsBatchTest_Test;
+class CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSendRateTest_Test;
+class CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSizeTest_Test;
+class CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsQueueTest_Test;
 #endif
 CSP_END_IGNORE
 
@@ -65,24 +65,30 @@ class CSP_API AnalyticsSystem : public SystemBase
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
     friend class SystemsManager;
-    friend class AnalyticsBatchEventHandler;
 
 #ifdef CSP_TESTS
-    friend class ::CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchRateTest_Test;
-    friend class ::CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchSizeTest_Test;
-    friend class ::CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsBatchTest_Test;
+    friend class ::CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSendRateTest_Test;
+    friend class ::CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSizeTest_Test;
+    friend class ::CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsQueueTest_Test;
 #endif
     /** @endcond */
     CSP_END_IGNORE
 
 public:
     /**
+     * @brief Sets a callback to be executed when a queue of Ananlytics Records has been sent to backend services.
+     * This callback will be executed in response to both a call to QueueAnalyticsEvent() as well as FlushAnalyticsEventsQueue().
+     * @param Callback NullResultCallback : the callback to execute.
+     */
+    CSP_EVENT void SetQueueAnalyticsEventCallback(NullResultCallback Callback);
+
+    /**
      * @brief Constructs an Analytics Record which is added to a queue to be sent to MCS in a single batch.
      * @details The batch will be sent when one of the following conditions are met:
      * 1. The time since the last batch was sent reaches the batch rate (default 60 seconds).
      * 2. The number of events in the queue reaches the maximum batch size (default 25 events).
-     * 3. The client application calls FlushAnalyticsEvents() as part of their log out or shut down procedure to force the batch to be sent.
-     * For more information about flushing events see the method documentation @ref AnalyticsSystem::FlushAnalyticsEvents().
+     * 3. The client application calls FlushAnalyticsEventsQueue() as part of their log out or shut down procedure to force the batch to be sent.
+     * For more information about flushing events see the method documentation @ref AnalyticsSystem::FlushAnalyticsEventsQueue().
      *
      * Example: Consider the following user action that is to be captured as an analytics event:
      * A [web client] user [clicks] on a [menu] item in the [UI].
@@ -105,16 +111,16 @@ public:
      * Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
      * relevant device specs.
      */
-    void BatchAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,
+    void QueueAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,
         const csp::common::String& InteractionType, const csp::common::Optional<csp::common::String>& SubCategory,
         const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata);
 
     /**
      * @brief Constructs an Analytics Record which is immediately sent to MCS.
-     * @note The BatchAnalyticsEvent method should be used by default as it will batch events before sending them.
+     * @note The QueueAnalyticsEvent method should be used by default as it will batch events before sending them.
      * This method will immediately send the analytics event and should therefore only be used when this behaviour is required.
      *
-     * For more information about how the Analytics Record is constructed, see the documentation for @ref AnalyticsSystem::BatchAnalyticsEvent().
+     * For more information about how the Analytics Record is constructed, see the documentation for @ref AnalyticsSystem::QueueAnalyticsEvent().
      *
      * @pre The user must be logged in to send an Analytics Record to MCS.
      * @param ProductContextSection const csp::common::String& : Section of the client or runtime-context.
@@ -135,33 +141,55 @@ public:
      * records are flushed and sent to MCS before the user is logged out or the application is shut down.
      * @pre The user must be logged in to send an Analytics Record to MCS.
      */
-    void FlushAnalyticsEvents();
+    void FlushAnalyticsEventsQueue();
+
+    /**
+     * @brief Retrieves the time the last batch was sent.
+     * @return std::chrono::milliseconds : time since epoch in milliseconds.
+     */
+    CSP_NO_EXPORT std::chrono::milliseconds GetTimeOfLastBatchSend() const { return TimeOfLastBatchSend; }
+
+    /**
+     * @brief Retrieves the rate at which the queued Analytics Records are sent as a batch.
+     * @return std::chrono::milliseconds : send rate in milliseconds.
+     */
+    CSP_NO_EXPORT std::chrono::milliseconds GetQueueSendRate() const { return AnalyticsQueueSendRate; }
+
+    /**
+     * @brief Retrieves the current size of the Analytics Records queue.
+     * @return size_t : the queue size.
+     */
+    CSP_NO_EXPORT size_t GetCurrentQueueSize() const { return AnalyticsRecordBatch.size(); }
+
+    /**
+     * @brief Retrieves the max permitted size of the Analytics Records queue.
+     * If the queue size reaches this value, the queue will be sent as a batch to the backend services.
+     * @return size_t : the queue size at which a bacth will be sent.
+     */
+    CSP_NO_EXPORT size_t GetMaxQueueSize() const { return MaxQueueSize; }
 
 private:
     AnalyticsSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
     CSP_NO_EXPORT AnalyticsSystem(csp::web::WebClient* InWebClient, const csp::ClientUserAgent* AgentInfo, common::LogSystem& LogSystem);
     ~AnalyticsSystem();
 
-    // Method called on Tick. This will send batched Analytics Records if the batch rate or size have been met.
-    void ProcessBatchedAnalyticsRecords();
-
-    std::chrono::milliseconds GetTimeOfLastBatch() const;
-    void SetTimeOfLastBatch(std::chrono::milliseconds NewTimeOfLastBatch);
+    void SetTimeOfLastBatchSend(std::chrono::milliseconds NewTimeOfLastBatch);
 
     // This is a utility function to allow us to test the batching functionality in a reasonable time frame.
-    void SetBatchRateAndSize(std::chrono::milliseconds NewBatchRate, size_t NewBatchSize);
-
-    class AnalyticsBatchEventHandler* EventHandler;
-    std::recursive_mutex* AnalyticsBatchLock;
+    void SetQueueBatchRateAndSize(std::chrono::milliseconds NewSendRate, size_t NewQueueSize);
 
     std::unique_ptr<csp::services::ApiBase> AnalyticsApi;
 
-    std::deque<std::shared_ptr<csp::services::generated::userservice::AnalyticsRecord>>* AnalyticsRecordBatch;
+    std::unique_ptr<class AnalyticsBatchEventHandler> EventHandler;
+    std::recursive_mutex AnalyticsBatchLock;
+    std::vector<std::shared_ptr<csp::services::generated::userservice::AnalyticsRecord>> AnalyticsRecordBatch;
+
+    NullResultCallback BatchAnalyticsEventCallback;
+
     const csp::ClientUserAgent* UserAgentInfo;
-    std::chrono::milliseconds AnalyticsBatchRate;
-    std::chrono::milliseconds TimeOfLastBatch;
-    size_t MaxBatchSize;
-    bool IsFlushingAnalyticsEvents;
+    std::chrono::milliseconds AnalyticsQueueSendRate;
+    std::chrono::milliseconds TimeOfLastBatchSend;
+    size_t MaxQueueSize;
 };
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -22,6 +22,18 @@
 #include "CSP/Common/String.h"
 #include "CSP/Systems/SystemBase.h"
 
+#include <chrono>
+#include <deque>
+#include <mutex>
+
+CSP_START_IGNORE
+#ifdef CSP_TESTS
+class CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchRateTest_Test;
+class CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchSizeTest_Test;
+class CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsBatchTest_Test;
+#endif
+CSP_END_IGNORE
+
 namespace csp
 {
 class ClientUserAgent;
@@ -37,24 +49,40 @@ namespace csp::web
 class WebClient;
 } // namespace csp::web
 
+namespace csp::services::generated::userservice
+{
+class AnalyticsRecord;
+}
+
 namespace csp::systems
 {
 
 /// @ingroup Analytics System
 /// @brief Public facing system that allows AnalyticsRecords to be sent to MCS.
+/// @invariant Users must be logged in to send AnalyticsRecords to MCS.
 class CSP_API AnalyticsSystem : public SystemBase
 {
     CSP_START_IGNORE
     /** @cond DO_NOT_DOCUMENT */
     friend class SystemsManager;
+    friend class AnalyticsBatchEventHandler;
+
+#ifdef CSP_TESTS
+    friend class ::CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchRateTest_Test;
+    friend class ::CSPEngine_AnalyticsSystemTests_BatchSendAnalyticsEventBatchSizeTest_Test;
+    friend class ::CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsBatchTest_Test;
+#endif
     /** @endcond */
     CSP_END_IGNORE
 
 public:
     /**
-     * @brief Sends an analytics event to the Analytics service.
-     * @details Please note: The BatchAnalyticsEvent method should be used by default as it will batch events before sending them.
-     * This method will immediately send the analytics event and should therefore only be used when this behaviour is required.
+     * @brief Constructs an Analytics Record which is added to a queue to be sent to MCS in a single batch.
+     * @details The batch will be sent when one of the following conditions are met:
+     * 1) The time since the last batch was sent reaches the batch rate (default 60 seconds).
+     * 2) The number of events in the queue reaches the maximum batch size (default 25 events).
+     * 3) The client application calls FlushAnalyticsEvents() as part of their log out or shut down procedure to force the batch to be sent.
+     * For more information about FlushAnalyticsEvents(), see the method documentation @ref AnalyticsSystem::FlushAnalyticsEvents().
      *
      * Example: Consider the following user action that is to be captured as an analytics event:
      *      A [web client] user [clicks] on a [menu] item in the [UI].
@@ -68,6 +96,29 @@ public:
      * @note The following data is captured internally and included in the analytics record: tenant name, client sku, client version and client build
      * environment.
      *
+     * @pre The user must be logged in to send Analytics Records to MCS.
+     * @param ProductContextSection const csp::common::String& : Section of the client or runtime-context.
+     * @param Category const csp::common::String& : Categorization field.
+     * @param InteractionType const csp::common::String& : The interaction that occurred.
+     * @param SubCategory const csp::common::Optional<csp::common::String>& : Optional sub-category field.
+     * @param Metadata const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& : Optional analytics event metadata.
+     * @note Metadata is the event payload. It may be used to store such information as the space the user is in, their geographical region as well as
+     * relevant device specs.
+     */
+    void BatchAnalyticsEvent(const csp::common::String& ProductContextSection, const csp::common::String& Category,
+        const csp::common::String& InteractionType, const csp::common::Optional<csp::common::String>& SubCategory,
+        const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata);
+
+    /**
+     * @brief Constructs an Analytics Record which is immediately sent to MCS.
+     * @note: The BatchAnalyticsEvent method should be used by default as it will batch events before sending them.
+     * This method will immediately send the analytics event and should therefore only be used when this behaviour is required.
+     *
+     * For more information about how the Analytics Record is constructed, see the documentation for @ref AnalyticsSystem::BatchAnalyticsEvent(const
+     csp::common::String&, const csp::common::String&, const csp::common::String&, const csp::common::Optional<csp::common::String>&, const
+     csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>&).
+     *
+     * @pre The user must be logged in to send an Analytics Record to MCS.
      * @param ProductContextSection const csp::common::String& : Section of the client or runtime-context.
      * @param Category const csp::common::String& : Categorization field.
      * @param InteractionType const csp::common::String& : The interaction that occurred.
@@ -80,14 +131,39 @@ public:
         const csp::common::String& InteractionType, const csp::common::Optional<csp::common::String>& SubCategory,
         const csp::common::Optional<csp::common::Map<csp::common::String, csp::common::String>>& Metadata, NullResultCallback Callback);
 
+    /**
+     * @brief Trigger immediate dispatch of the Analytics Records queue to MCS.
+     * @note This method is designed to be called as part of a client applications log out and shutdown procedures to ensure that any queued analytics
+     * records are flushed and sent to MCS before the user is logged out or the application is shut down.
+     * @pre The user must be logged in to send an Analytics Record to MCS.
+     */
+    void FlushAnalyticsEvents();
+
 private:
     AnalyticsSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
     CSP_NO_EXPORT AnalyticsSystem(csp::web::WebClient* InWebClient, const csp::ClientUserAgent* AgentInfo, common::LogSystem& LogSystem);
     ~AnalyticsSystem();
 
+    // Method called on Tick. This will send batched Analytics Records if the batch rate or size have been met.
+    void ProcessBatchedAnalyticsRecords();
+
+    std::chrono::milliseconds GetTimeOfLastBatch() const;
+    void SetTimeOfLastBatch(std::chrono::milliseconds NewTimeOfLastBatch);
+
+    // This is a utility function to allow us to test the batching functionality in a reasonable time frame.
+    void SetBatchRateAndSize(std::chrono::milliseconds NewBatchRate, size_t NewBatchSize);
+
+    class AnalyticsBatchEventHandler* EventHandler;
+    std::recursive_mutex* AnalyticsBatchLock;
+
     std::unique_ptr<csp::services::ApiBase> AnalyticsApi;
 
+    std::deque<std::shared_ptr<csp::services::generated::userservice::AnalyticsRecord>>* AnalyticsRecordBatch;
     const csp::ClientUserAgent* UserAgentInfo;
+    std::chrono::milliseconds AnalyticsBatchRate;
+    std::chrono::milliseconds TimeOfLastBatch;
+    size_t MaxBatchSize;
+    bool IsFlushingAnalyticsEvents;
 };
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -188,7 +188,7 @@ private:
     std::unique_ptr<csp::services::ApiBase> AnalyticsApi;
 
     std::unique_ptr<class AnalyticsQueueEventHandler> EventHandler;
-    std::recursive_mutex AnalyticsQueueLock;
+    std::mutex AnalyticsQueueLock;
     std::vector<std::shared_ptr<csp::services::generated::userservice::AnalyticsRecord>> AnalyticsRecordQueue;
 
     NullResultCallback SendAnalyticsEventQueueCallback;

--- a/Library/src/Systems/Analytics/AnalyticsSystem.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsSystem.cpp
@@ -18,6 +18,8 @@
 
 #include "CSP/CSPFoundation.h"
 #include "CallHelpers.h"
+#include "Events/EventListener.h"
+#include "Events/EventSystem.h"
 #include "Services/UserService/Api.h"
 #include "Services/UserService/Dto.h"
 #include "Systems/ResultHelpers.h"
@@ -29,36 +31,12 @@ using namespace csp::common;
 
 namespace chs = csp::services::generated::userservice;
 
-namespace csp::systems
+namespace
 {
 
-AnalyticsSystem::AnalyticsSystem()
-    : SystemBase(nullptr, nullptr, nullptr)
-    , AnalyticsApi(nullptr)
-    , UserAgentInfo(nullptr)
+std::shared_ptr<chs::AnalyticsRecord> CreateAnalyticsRecord(const csp::ClientUserAgent* UserAgentInfo, const String& ProductContextSection,
+    const String& Category, const String& InteractionType, const Optional<String>& SubCategory, const Optional<Map<String, String>>& Metadata)
 {
-}
-
-AnalyticsSystem::AnalyticsSystem(csp::web::WebClient* InWebClient, const csp::ClientUserAgent* AgentInfo, csp::common::LogSystem& LogSystem)
-    : SystemBase(InWebClient, nullptr, &LogSystem)
-{
-    AnalyticsApi = std::unique_ptr<csp::services::ApiBase>(new chs::AnalyticsApi(InWebClient));
-    UserAgentInfo = AgentInfo;
-}
-
-AnalyticsSystem::~AnalyticsSystem() { }
-
-void AnalyticsSystem::SendAnalyticsEvent(const String& ProductContextSection, const String& Category, const String& InteractionType,
-    const Optional<String>& SubCategory, const Optional<Map<String, String>>& Metadata, NullResultCallback Callback)
-{
-    if (ProductContextSection.IsEmpty() || Category.IsEmpty() || InteractionType.IsEmpty())
-    {
-        CSP_LOG_MSG(common::LogLevel::Error, "Missing the required fields for the Analytics Event.");
-        INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
-
-        return;
-    }
-
     // Construct an AnalyticsRecord object
     auto Record = std::make_shared<chs::AnalyticsRecord>();
     Record->SetProductIdentifier("csp");
@@ -89,6 +67,103 @@ void AnalyticsSystem::SendAnalyticsEvent(const String& ProductContextSection, co
 
     Record->SetTimestamp(DateTime::TimeNow().GetUtcString());
 
+    return Record;
+}
+
+}
+
+namespace csp::systems
+{
+
+class AnalyticsBatchEventHandler : public csp::events::EventListener
+{
+public:
+    AnalyticsBatchEventHandler(AnalyticsSystem* AnalyticsSystem);
+
+    void OnEvent(const csp::events::Event& InEvent) override;
+
+private:
+    AnalyticsSystem* _AnalyticsSystem;
+};
+
+AnalyticsBatchEventHandler::AnalyticsBatchEventHandler(AnalyticsSystem* AnalyticsSystem)
+    : _AnalyticsSystem(AnalyticsSystem)
+{
+}
+
+void AnalyticsBatchEventHandler::OnEvent(const csp::events::Event& InEvent)
+{
+    if (InEvent.GetId() == csp::events::FOUNDATION_TICK_EVENT_ID && _AnalyticsSystem != nullptr)
+    {
+        _AnalyticsSystem->ProcessBatchedAnalyticsRecords();
+    }
+}
+
+AnalyticsSystem::AnalyticsSystem()
+    : SystemBase(nullptr, nullptr, nullptr)
+    , EventHandler(nullptr)
+    , AnalyticsBatchLock(new std::recursive_mutex)
+    , AnalyticsApi(nullptr)
+    , AnalyticsRecordBatch(nullptr)
+    , UserAgentInfo(nullptr)
+    , AnalyticsBatchRate(std::chrono::seconds(60))
+    , TimeOfLastBatch(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()))
+    , MaxBatchSize(25)
+    , IsFlushingAnalyticsEvents(false)
+{
+}
+
+AnalyticsSystem::AnalyticsSystem(csp::web::WebClient* InWebClient, const csp::ClientUserAgent* AgentInfo, csp::common::LogSystem& LogSystem)
+    : SystemBase(InWebClient, nullptr, &LogSystem)
+    , EventHandler(new AnalyticsBatchEventHandler(this))
+    , AnalyticsBatchLock(new std::recursive_mutex)
+    , AnalyticsRecordBatch(new(std::deque<std::shared_ptr<chs::AnalyticsRecord>>))
+    , UserAgentInfo(AgentInfo)
+    , AnalyticsBatchRate(std::chrono::seconds(60))
+    , TimeOfLastBatch(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()))
+    , MaxBatchSize(25)
+    , IsFlushingAnalyticsEvents(false)
+{
+    AnalyticsApi = std::unique_ptr<csp::services::ApiBase>(new chs::AnalyticsApi(InWebClient));
+
+    csp::events::EventSystem::Get().RegisterListener(csp::events::FOUNDATION_TICK_EVENT_ID, EventHandler);
+}
+
+AnalyticsSystem::~AnalyticsSystem()
+{
+    csp::events::EventSystem::Get().UnRegisterListener(csp::events::FOUNDATION_TICK_EVENT_ID, EventHandler);
+
+    delete (EventHandler);
+    delete (AnalyticsBatchLock);
+    delete (AnalyticsRecordBatch);
+}
+
+std::chrono::milliseconds AnalyticsSystem::GetTimeOfLastBatch() const { return TimeOfLastBatch; }
+
+void AnalyticsSystem::SetTimeOfLastBatch(std::chrono::milliseconds NewTimeOfLastBatch) { TimeOfLastBatch = NewTimeOfLastBatch; }
+
+// This is a utility function to allow us to test the batching functionality in a reasonable time frame.
+void AnalyticsSystem::SetBatchRateAndSize(std::chrono::milliseconds NewBatchRate, size_t NewBatchSize)
+{
+    std::scoped_lock AnalyticsBatchLocker(*AnalyticsBatchLock);
+
+    AnalyticsBatchRate = NewBatchRate;
+    MaxBatchSize = NewBatchSize;
+}
+
+void AnalyticsSystem::SendAnalyticsEvent(const String& ProductContextSection, const String& Category, const String& InteractionType,
+    const Optional<String>& SubCategory, const Optional<Map<String, String>>& Metadata, NullResultCallback Callback)
+{
+    if (ProductContextSection.IsEmpty() || Category.IsEmpty() || InteractionType.IsEmpty())
+    {
+        CSP_LOG_MSG(common::LogLevel::Error, "Missing the required fields for the Analytics Event.");
+        INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
+
+        return;
+    }
+
+    auto Record = CreateAnalyticsRecord(UserAgentInfo, ProductContextSection, Category, InteractionType, SubCategory, Metadata);
+
     std::vector<std::shared_ptr<chs::AnalyticsRecord>> Records;
     Records.push_back(Record);
 
@@ -118,6 +193,94 @@ void AnalyticsSystem::SendAnalyticsEvent(const String& ProductContextSection, co
 
     csp::services::ResponseHandlerPtr ResponseHandler
         = AnalyticsApi->CreateHandler<NullResultCallback, NullResult, void, chs::AnalyticsRecord>(SendAnalyticsCallback, nullptr);
+
+    static_cast<chs::AnalyticsApi*>(AnalyticsApi.get())->analyticsBulkPost(Records, ResponseHandler);
+}
+
+void AnalyticsSystem::BatchAnalyticsEvent(const String& ProductContextSection, const String& Category, const String& InteractionType,
+    const Optional<String>& SubCategory, const Optional<Map<String, String>>& Metadata)
+{
+    if (ProductContextSection.IsEmpty() || Category.IsEmpty() || InteractionType.IsEmpty())
+    {
+        CSP_LOG_MSG(common::LogLevel::Error, "Missing the required fields for the Analytics Event.");
+
+        return;
+    }
+
+    auto Record = CreateAnalyticsRecord(UserAgentInfo, ProductContextSection, Category, InteractionType, SubCategory, Metadata);
+
+    std::scoped_lock AnalyticsBatchLocker(*AnalyticsBatchLock);
+    AnalyticsRecordBatch->emplace_back(Record);
+}
+
+void AnalyticsSystem::ProcessBatchedAnalyticsRecords()
+{
+    std::scoped_lock AnalyticsBatchLocker(*AnalyticsBatchLock);
+
+    if (AnalyticsRecordBatch->empty())
+    {
+        return;
+    }
+
+    const std::chrono::milliseconds CurrentTime
+        = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+
+    if (CurrentTime - GetTimeOfLastBatch() >= AnalyticsBatchRate)
+    {
+        FlushAnalyticsEvents();
+        return;
+    }
+
+    if (AnalyticsRecordBatch->size() >= MaxBatchSize)
+    {
+        FlushAnalyticsEvents();
+        return;
+    }
+}
+
+void AnalyticsSystem::FlushAnalyticsEvents()
+{
+    std::scoped_lock AnalyticsBatchLocker(*AnalyticsBatchLock);
+
+    if (AnalyticsRecordBatch->empty())
+    {
+        return;
+    }
+
+    const std::chrono::milliseconds CurrentTime
+        = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+
+    SetTimeOfLastBatch(CurrentTime);
+
+    std::vector<std::shared_ptr<chs::AnalyticsRecord>> Records;
+    Records.reserve(AnalyticsRecordBatch->size());
+
+    while (AnalyticsRecordBatch->empty() == false)
+    {
+        auto Record = AnalyticsRecordBatch->front();
+
+        Records.push_back(Record);
+
+        AnalyticsRecordBatch->pop_front();
+    }
+
+    NullResultCallback SendBatchAnalyticsCallback = [LogSystem = this->LogSystem, BatchSize = Records.size()](const NullResult& Result)
+    {
+        if (Result.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            LogSystem->LogMsg(common::LogLevel::Verbose, "Batched Analytics Events sent.");
+        }
+        else if (Result.GetResultCode() == csp::systems::EResultCode::Failed)
+        {
+            LogSystem->LogMsg(common::LogLevel::Error,
+                fmt::format("Failed to send Batch Analytics Event. ResCode: {}, HttpResCode: {}", static_cast<int>(Result.GetResultCode()),
+                    Result.GetHttpResultCode())
+                    .c_str());
+        }
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AnalyticsApi->CreateHandler<NullResultCallback, NullResult, void, chs::AnalyticsRecord>(SendBatchAnalyticsCallback, nullptr);
 
     static_cast<chs::AnalyticsApi*>(AnalyticsApi.get())->analyticsBulkPost(Records, ResponseHandler);
 }

--- a/Tests/src/PublicAPITests/AnalyticsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnalyticsSystemTests.cpp
@@ -36,6 +36,9 @@ bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.Ge
 
 } // namespace
 
+/*
+ * Test that we can successfully send an analytics event
+ */
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, SendAnalyticsEventTest)
 {
     SetRandSeed();
@@ -66,6 +69,9 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, SendAnalyticsEventTest)
     LogOut(UserSystem);
 }
 
+/*
+ * Test that we get an error when sending an analytics event with a required field missing
+ */
 CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, SendAnalyticsEventMissingFieldsTest)
 {
     SetRandSeed();
@@ -75,15 +81,18 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, SendAnalyticsEventMissingFields
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
     auto* AnalyticsSystem = SystemsManager.GetAnalyticsSystem();
-    auto& LogSystem = *SystemsManager.GetLogSystem();
-
-    // We are only concerned with error logs in this test
-    LogSystem.SetSystemLevel(csp::common::LogLevel::Error);
 
     String UserId;
 
     // Log in
     LogInAsNewTestUser(UserSystem, UserId);
+
+    // Ensure the MockLogger will ignore all logs except the one we care about
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(::testing::_)).Times(::testing::AnyNumber());
+
+    // Ensure the required fields error message is logged when we try to send an analytics event with a required field missing
+    const csp::common::String AnalyticsErrorMsg = "Missing the required fields for the Analytics Event.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(AnalyticsErrorMsg)).Times(1);
 
     // Analytics Data
     // Passing an empty string for a required field
@@ -93,15 +102,284 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, SendAnalyticsEventMissingFields
     const auto TestSubCategory = String("Event_SubCategory");
     const Map<String, String> TestMetadata = { { "Key1", "Value1" }, { "Key2", "Value2" } };
 
-    // Ensure the required fields error message is logged when we try to send an analytics event with a required field missing
-    const csp::common::String LockErrorMsg = "Missing the required fields for the Analytics Event.";
-    EXPECT_CALL(MockLogger.MockLogCallback, Call(LockErrorMsg)).Times(1);
-
     auto [Result] = AWAIT_PRE(AnalyticsSystem, SendAnalyticsEvent, RequestPredicate, TestProductContextSection, TestCategory, TestInteractionType,
         TestSubCategory, TestMetadata);
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
     EXPECT_EQ(Result.GetHttpResultCode(), 0);
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+/*
+ * Test that we can successfully send a batch of analytics events based on batch rate
+ * The batch size has been set high enough that it won't trigger the batch to be sent
+ */
+CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, BatchSendAnalyticsEventBatchRateTest)
+{
+    SetRandSeed();
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* AnalyticsSystem = SystemsManager.GetAnalyticsSystem();
+
+    const std::chrono::milliseconds CurrentTime
+        = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+
+    // Reset time of last batch otherwise the analytics event batch will immediately be sent
+    AnalyticsSystem->SetTimeOfLastBatch(CurrentTime);
+    // The default batch rate and size are too large for testing so set them to something more reasonable
+    AnalyticsSystem->SetBatchRateAndSize(std::chrono::seconds(3), 5);
+
+    String UserId;
+
+    // Log in
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Ensure the MockLogger will ignore all logs except the one we care about
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(::testing::_)).Times(::testing::AnyNumber());
+
+    // We can confirm that the batch has been successfully sent by checking for this success log message
+    const csp::common::String BatchAnalyticsSuccessMsg = "Batched Analytics Events sent.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(BatchAnalyticsSuccessMsg)).Times(1);
+
+    // Analytics Data
+    const auto TestProductContextSection = String("Event_ProductContextSection");
+    const auto TestCategory = String("Event_Category");
+    const auto TestInteractionType = String("Event_InteractionType");
+    const auto TestSubCategory = String("Event_SubCategory");
+    const Map<String, String> TestMetadata = { { "Key1", "Value1" }, { "Key2", "Value2" } };
+
+    // Send two analytics events to be queued for sending later as a batch
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+
+    // The batch rate has been set to 3 seconds so we need to tick foundation for at least that long to allow the batch to be sent
+    auto Start = std::chrono::steady_clock::now();
+    auto Current = std::chrono::steady_clock::now();
+    long long TestTime = 0;
+
+    while (TestTime < 4)
+    {
+        std::this_thread::sleep_for(1s);
+
+        Current = std::chrono::steady_clock::now();
+        TestTime = std::chrono::duration_cast<std::chrono::seconds>(Current - Start).count();
+
+        csp::CSPFoundation::Tick();
+    }
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+/*
+ * Test that we can successfully send a batch of analytics events based on batch size
+ * The batch rate has been set high enough that it won't trigger the batch to be sent
+ */
+CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, BatchSendAnalyticsEventBatchSizeTest)
+{
+    SetRandSeed();
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* AnalyticsSystem = SystemsManager.GetAnalyticsSystem();
+
+    const std::chrono::milliseconds CurrentTime
+        = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+
+    // Reset time of last batch otherwise the analytics event batch will immediately be sent
+    AnalyticsSystem->SetTimeOfLastBatch(CurrentTime);
+    // The default batch rate and size are too large for testing so set them to something more reasonable
+    AnalyticsSystem->SetBatchRateAndSize(std::chrono::seconds(20), 3);
+
+    String UserId;
+
+    // Log in
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Ensure the MockLogger will ignore all logs except the one we care about
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(::testing::_)).Times(::testing::AnyNumber());
+
+    auto SendBatchStart = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point LogTime;
+    bool BatchSent = false;
+    // We can confirm that the batch has been successfully sent by checking for this success log message
+    // We also check that the batch has been sent as a result of batch size rather than batch rate by checking
+    // the elapsed test time is less than the batch rate of 20 seconds
+    const csp::common::String BatchAnalyticsSuccessMsg = "Batched Analytics Events sent.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(BatchAnalyticsSuccessMsg))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const csp::common::String&)
+            {
+                LogTime = std::chrono::steady_clock::now();
+                long long ElapsedTestTime = std::chrono::duration_cast<std::chrono::seconds>(LogTime - SendBatchStart).count();
+                EXPECT_TRUE(ElapsedTestTime < 20);
+                BatchSent = true;
+            }));
+
+    // Analytics Data
+    const auto TestProductContextSection = String("Event_ProductContextSection");
+    const auto TestCategory = String("Event_Category");
+    const auto TestInteractionType = String("Event_InteractionType");
+    const auto TestSubCategory = String("Event_SubCategory");
+    const Map<String, String> TestMetadata = { { "Key1", "Value1" }, { "Key2", "Value2" } };
+
+    // Send three analytics events to be queued for sending later as a batch
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+
+    // The batch rate has been set to 20 seconds so we need to tick foundation for at least that long
+    // We check that the batch is sent as a result of batch size rather than batch rate in the EXPECT_CALL above
+    auto Start = std::chrono::steady_clock::now();
+    auto Current = std::chrono::steady_clock::now();
+    long long TestTime = 0;
+
+    // Once the batch has been set as a result of the BatchSize having been reached, BatchSent will be set to true
+    // in the EXPECT_CALL above and the while loop will exit before the 20 second batch rate is reached. This is
+    // also validated in the EXPECT_CALL above.
+    while (!BatchSent && TestTime < 21)
+    {
+        std::this_thread::sleep_for(1s);
+
+        Current = std::chrono::steady_clock::now();
+        TestTime = std::chrono::duration_cast<std::chrono::seconds>(Current - Start).count();
+
+        csp::CSPFoundation::Tick();
+    }
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+/*
+ * Test that we get an error when attempting to batch send an analytics event with a required field missing
+ */
+CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, BatchSendAnalyticsEventMissingFieldsTest)
+{
+    SetRandSeed();
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* AnalyticsSystem = SystemsManager.GetAnalyticsSystem();
+
+    String UserId;
+
+    // Log in
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Ensure the MockLogger will ignore all logs except the one we care about
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(::testing::_)).Times(::testing::AnyNumber());
+
+    // Ensure the required fields error message is logged when we try to batch send an analytics event with a required field missing
+    const csp::common::String AnalyticsErrorMsg = "Missing the required fields for the Analytics Event.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(AnalyticsErrorMsg)).Times(1);
+
+    // Analytics Data
+    // Passing an empty string for a required field
+    const auto TestProductContextSection = String("");
+    const auto TestCategory = String("Event_Category");
+    const auto TestInteractionType = String("Event_InteractionType");
+    const auto TestSubCategory = String("Event_SubCategory");
+    const Map<String, String> TestMetadata = { { "Key1", "Value1" }, { "Key2", "Value2" } };
+
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+/*
+ * Test that we can successfully flush a batch of analytics events.
+ * The batch rate and size has been set high enough that they won't trigger the batch to be sent.
+ */
+CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, FlushAnalyticsEventsBatchTest)
+{
+    SetRandSeed();
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* AnalyticsSystem = SystemsManager.GetAnalyticsSystem();
+
+    const std::chrono::milliseconds CurrentTime
+        = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+
+    // Reset time of last batch otherwise the analytics event batch will immediately be sent
+    AnalyticsSystem->SetTimeOfLastBatch(CurrentTime);
+    // The default batch rate and size are too large for testing so set them to something more reasonable
+    AnalyticsSystem->SetBatchRateAndSize(std::chrono::seconds(20), 5);
+
+    String UserId;
+
+    // Log in
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Ensure the MockLogger will ignore all logs except the one we care about
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(::testing::_)).Times(::testing::AnyNumber());
+
+    auto SendBatchStart = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point LogTime;
+    bool BatchFlushed = false;
+    // We can confirm that the batch has been successfully flushed by checking for this success log message
+    // We also check that the batch has been sent as a result of flush rather than batch rate by checking that
+    // the elapsed test time is less than the batch rate of 20 seconds
+    const csp::common::String BatchAnalyticsSuccessMsg = "Batched Analytics Events sent.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(BatchAnalyticsSuccessMsg))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const csp::common::String&)
+            {
+                LogTime = std::chrono::steady_clock::now();
+                long long ElapsedTestTime = std::chrono::duration_cast<std::chrono::seconds>(LogTime - SendBatchStart).count();
+                EXPECT_TRUE(ElapsedTestTime < 20);
+                BatchFlushed = true;
+            }));
+
+    // Analytics Data
+    const auto TestProductContextSection = String("Event_ProductContextSection");
+    const auto TestCategory = String("Event_Category");
+    const auto TestInteractionType = String("Event_InteractionType");
+    const auto TestSubCategory = String("Event_SubCategory");
+    const Map<String, String> TestMetadata = { { "Key1", "Value1" }, { "Key2", "Value2" } };
+
+    // Send two analytics events to be queued for sending later as a batch
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+    AnalyticsSystem->BatchAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
+
+    // The batch rate has been set to 20 seconds so we need to tick foundation for at least that long to allow the batch to be sent
+    auto Start = std::chrono::steady_clock::now();
+    auto Current = std::chrono::steady_clock::now();
+    long long TestTime = 0;
+
+    // We will make the call to flush the batch after 3 seconds. If successful BatchFlushed will be set to true
+    // in the EXPECT_CALL above and the while loop will exit before the 20 second batch rate is reached. This is
+    // also validated in the EXPECT_CALL above.
+    while (!BatchFlushed && TestTime < 21)
+    {
+        std::this_thread::sleep_for(1s);
+
+        Current = std::chrono::steady_clock::now();
+        TestTime = std::chrono::duration_cast<std::chrono::seconds>(Current - Start).count();
+
+        if (TestTime == 3)
+        {
+            // Flush the batch of events after 3 seconds
+            AnalyticsSystem->FlushAnalyticsEvents();
+        }
+
+        csp::CSPFoundation::Tick();
+    }
 
     // Log out
     LogOut(UserSystem);

--- a/Tests/src/PublicAPITests/AnalyticsSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AnalyticsSystemTests.cpp
@@ -159,6 +159,10 @@ CSP_PUBLIC_TEST(CSPEngine, AnalyticsSystemTests, QueueAnalyticsEventQueueSendRat
     AnalyticsSystem->QueueAnalyticsEvent(TestProductContextSection, TestCategory, TestInteractionType, TestSubCategory, TestMetadata);
 
     csp::CSPFoundation::Tick();
+    // It will not process the queue until at least 3 seconds has elapsed since the last send time
+    ASSERT_NE(ResultFuture.wait_for(4s), std::future_status::ready) << "Analytics queue should not yet have been sent.";
+    // Calling tick will check if the queue send rate time has elapsed and send the queued events if it has
+    csp::CSPFoundation::Tick();
 
     // Wait for the callback to be received
     ResultFuture.wait();


### PR DESCRIPTION
Added two new methods to the AnalyticsSystem; `BatchAnalyticsEvent` and `FlushAnalyticsEvents`.

The `BatchAnalyticsEvent` method makes it possible to add an analytic event to a queue to be sent to MCS later as part of a batch.
The queue will be processed when one of the following conditions is met:
1. The time since the last batch was sent reaches the batch rate (default 60 seconds).
2. The number of events in the queue reaches the maximum batch size (default 25 events).
3. The client application calls FlushAnalyticsEvents() as part of their log out or shut down procedure to force the batch to be sent.

The `FlushAnalyticsEvents` method will trigger immediate dispatch of the Analytics Records queue to MCS. This method is designed to be called as part of a client applications log out and shutdown procedures to ensure that any queued analytics records are flushed and sent to MCS before the user is logged out or the application is shut down.