### PR TITLE
[OB-4678] Stop SpaceEntity::UpdateCallback firing wven when the value is the same for OfflineEngine.

### DIFF
--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -429,7 +429,7 @@ public:
     // SetPropertyDirect allows us to set all of our replicated property values, without the need for individual setters.
     // We still have to handle ParentId separately, as this is a required MCS object property, and not an MCS component
     // like the rest of our properties.
-    // We also have to handle CSP components separately, as CSP currently replicates them using a different method.
+    // We also have to handle CSP components separately, as CSP currently replicates them by using the whole component as a data container, preventing us from buffering updated state in a patch as you'd expect, as we can't copy whole components. This manifests especially in `UpdateComponentDirect` where the update sequencing happens too early, and is in many ways a bug.
     CSP_NO_EXPORT void SetParentIdDirect(csp::common::Optional<uint64_t> Value, bool CallNotifyingCallback = false);
     CSP_NO_EXPORT bool AddComponentDirect(uint16_t ComponentKey, ComponentBase* Component, bool CallNotifyingCallback = false);
     CSP_NO_EXPORT bool UpdateComponentDirect(uint16_t ComponentKey, ComponentBase* Component, bool CallNotifyingCallback = false);

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -429,7 +429,9 @@ public:
     // SetPropertyDirect allows us to set all of our replicated property values, without the need for individual setters.
     // We still have to handle ParentId separately, as this is a required MCS object property, and not an MCS component
     // like the rest of our properties.
-    // We also have to handle CSP components separately, as CSP currently replicates them by using the whole component as a data container, preventing us from buffering updated state in a patch as you'd expect, as we can't copy whole components. This manifests especially in `UpdateComponentDirect` where the update sequencing happens too early, and is in many ways a bug.
+    // We also have to handle CSP components separately, as CSP currently replicates them by using the whole component as a data container, preventing
+    // us from buffering updated state in a patch as you'd expect, as we can't copy whole components. This manifests especially in
+    // `UpdateComponentDirect` where the update sequencing happens too early, and is in many ways a bug.
     CSP_NO_EXPORT void SetParentIdDirect(csp::common::Optional<uint64_t> Value, bool CallNotifyingCallback = false);
     CSP_NO_EXPORT bool AddComponentDirect(uint16_t ComponentKey, ComponentBase* Component, bool CallNotifyingCallback = false);
     CSP_NO_EXPORT bool UpdateComponentDirect(uint16_t ComponentKey, ComponentBase* Component, bool CallNotifyingCallback = false);
@@ -520,6 +522,10 @@ template <typename P, typename V>
 void SpaceEntity::SetPropertyDirect(P& Property, const V& Value, SpaceEntityUpdateFlags Flag, bool CallNotifyingCallback)
 {
     std::scoped_lock PropertiesLocker(PropertiesLock);
+
+    // We cast the value to the property type to get around issues with type <-> ReplicatedValue conversions,
+    // as ReplicatedValues can only hold specific types.
+    // This is quite brittle, so we are finding a better way to handle this.
     Property = static_cast<P>(Value);
     if (CallNotifyingCallback && EntityUpdateCallback)
     {

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -411,7 +411,8 @@ public:
     // The state patcher. This is the object that handles dirty/pending properties,
     // another way of thinking about this is the "network patch manager" or something like that.
     // If this is null, then the space entity does immediate updates without any deferred patching.
-    CSP_NO_EXPORT const std::unique_ptr<SpaceEntityStatePatcher>& GetStatePatcher();
+    CSP_NO_EXPORT const std::unique_ptr<SpaceEntityStatePatcher>& GetStatePatcher() const;
+    CSP_NO_EXPORT std::unique_ptr<SpaceEntityStatePatcher>& GetStatePatcher();
 
     /// @brief Update after the property of a component was changed
     /// @param DirtyComponent ComponentBase* : the dirty component to update
@@ -424,23 +425,21 @@ public:
     /// @brief Sets the internal ParentId to nullptr
     CSP_NO_EXPORT void RemoveParentId();
 
-    // Direct setters that bypass any patching behaviour or conditionals
-    // Non-ideal, here because the responsibility for managing network behaviour is massively munged into SpaceEntity, so it's doing two things at
-    // once. At least with these, we can move the logic out to another type and quarantine the complexity.
-    // These should really be the only things SpaceEntity has. Neither the network management, nor really the locking, should matter to what is
-    // essentially a data-type.
-    CSP_NO_EXPORT void SetNameDirect(const csp::common::String& Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetPositionDirect(const csp::common::Vector3& Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetRotationDirect(const csp::common::Vector4& Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetScaleDirect(const csp::common::Vector3& Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetThirdPartyRefDirect(const csp::common::String& Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetThirdPartyPlatformDirect(const csp::systems::EThirdPartyPlatform Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetEntityLockDirect(LockType Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetSelectedIdDirect(uint64_t Value, bool CallNotifyingCallback = false);
-    CSP_NO_EXPORT void SetParentIdDirect(csp::common::Optional<uint64_t> Value, bool CallNotifyingCallback);
+    // Direct setters that bypass any patching behaviour or conditionals.
+    // SetPropertyDirect allows us to set all of our replicated property values, without the need for individual setters.
+    // We still have to handle ParentId separately, as this is a required MCS object property, and not an MCS component
+    // like the rest of our properties.
+    // We also have to handle CSP components separately, as CSP currently replicates them using a different method.
+    CSP_NO_EXPORT void SetParentIdDirect(csp::common::Optional<uint64_t> Value, bool CallNotifyingCallback = false);
     CSP_NO_EXPORT bool AddComponentDirect(uint16_t ComponentKey, ComponentBase* Component, bool CallNotifyingCallback = false);
     CSP_NO_EXPORT bool UpdateComponentDirect(uint16_t ComponentKey, ComponentBase* Component, bool CallNotifyingCallback = false);
     CSP_NO_EXPORT bool RemoveComponentDirect(uint16_t ComponentKey, bool CallNotifyingCallback = false);
+
+    CSP_START_IGNORE
+    template <typename P, typename V>
+    void SetPropertyDirect(P& Property, const V& Value, SpaceEntityUpdateFlags Flag, bool CallNotifyingCallback = false);
+    CSP_END_IGNORE
+
     /// @brief Setter for the owner ID
     /// @param InOwnerId uint64_t : the owner ID to set
     CSP_NO_EXPORT void SetOwnerId(const uint64_t InOwnerId);
@@ -515,5 +514,19 @@ private:
     /// @return bool : the selection state of the entity
     bool InternalSetSelectionStateOfEntity(const bool SelectedState);
 };
+
+CSP_START_IGNORE
+template <typename P, typename V>
+void SpaceEntity::SetPropertyDirect(P& Property, const V& Value, SpaceEntityUpdateFlags Flag, bool CallNotifyingCallback)
+{
+    std::scoped_lock PropertiesLocker(PropertiesLock);
+    Property = static_cast<P>(Value);
+    if (CallNotifyingCallback && EntityUpdateCallback)
+    {
+        csp::common::Array<ComponentUpdateInfo> Empty;
+        EntityUpdateCallback(this, Flag, Empty);
+    }
+}
+CSP_END_IGNORE
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/PatchUtils.h
+++ b/Library/src/Multiplayer/PatchUtils.h
@@ -10,7 +10,7 @@ namespace csp::multiplayer
 // This needs to live in a private include, as it relies on other non-exported includes.
 template <typename P, typename V>
 static bool SetProperty(
-    SpaceEntity* Entity, P& Property, const V& Value, SpaceEntityComponentKey Key, SpaceEntityUpdateFlags Flag, csp::common::LogSystem* LogSystem)
+    SpaceEntity& Entity, P& Property, const V& Value, SpaceEntityComponentKey Key, SpaceEntityUpdateFlags Flag, csp::common::LogSystem* LogSystem)
 {
     if (!Entity.IsModifiable())
     {
@@ -19,23 +19,23 @@ static bool SetProperty(
             LogSystem->LogMsg(csp::common::LogLevel::Error,
                 fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
                             "owner of. Entity name: {}",
-                    Entity->GetName())
+                    Entity.GetName())
                     .c_str());
         }
 
         return false;
     }
 
-    if (Entity->GetStatePatcher())
+    if (Entity.GetStatePatcher())
     {
-        return Entity->GetStatePatcher()->SetDirtyProperty(Key, Property, Value);
+        return Entity.GetStatePatcher()->SetDirtyProperty(Key, Property, Value);
     }
     else
     {
         // We need this logic here and in SetDirtyProperty to prevent callbacks from firing if the values are the same.
         if (Property != static_cast<P>(Value))
         {
-            Entity->SetPropertyDirect(Property, Value, Flag, true);
+            Entity.SetPropertyDirect(Property, Value, Flag, true);
             return true;
         }
         return false;

--- a/Library/src/Multiplayer/PatchUtils.h
+++ b/Library/src/Multiplayer/PatchUtils.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CSP/Common/Systems/Log/LogSystem.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "SpaceEntityStatePatcher.h"
+
+namespace csp::multiplayer
+{
+// Helper function to generically set entity properties without duplicating a bunch of logic.
+// This needs to live in a private include, as it relies on other non-exported includes.
+template <typename P, typename V>
+static bool SetProperty(
+    SpaceEntity* Entity, P& Property, const V& Value, SpaceEntityComponentKey Key, SpaceEntityUpdateFlags Flag, csp::common::LogSystem* LogSystem)
+{
+    if (!Entity.IsModifiable())
+    {
+        if (LogSystem)
+        {
+            LogSystem->LogMsg(csp::common::LogLevel::Error,
+                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
+                            "owner of. Entity name: {}",
+                    Entity->GetName())
+                    .c_str());
+        }
+
+        return false;
+    }
+
+    if (Entity->GetStatePatcher())
+    {
+        return Entity->GetStatePatcher()->SetDirtyProperty(Key, Property, Value);
+    }
+    else
+    {
+        // We need this logic here and in SetDirtyProperty to prevent callbacks from firing if the values are the same.
+        if (Property != static_cast<P>(Value))
+        {
+            Entity->SetPropertyDirect(Property, Value, Flag, true);
+            return true;
+        }
+        return false;
+    }
+}
+}

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -176,7 +176,7 @@ const csp::common::String& SpaceEntity::GetName() const { return Name; }
 
 bool SpaceEntity::SetName(const csp::common::String& Value)
 {
-    return SetProperty(this, Name, Value, SpaceEntityComponentKey::Name, UPDATE_FLAGS_NAME, LogSystem);
+    return SetProperty(*this, Name, Value, SpaceEntityComponentKey::Name, UPDATE_FLAGS_NAME, LogSystem);
 }
 
 const SpaceTransform& SpaceEntity::GetTransform() const { return Transform; }
@@ -212,7 +212,7 @@ csp::common::Vector3 SpaceEntity::GetGlobalPosition() const
 
 bool SpaceEntity::SetPosition(const csp::common::Vector3& Value)
 {
-    return SetProperty(this, Transform.Position, Value, SpaceEntityComponentKey::Position, UPDATE_FLAGS_POSITION, LogSystem);
+    return SetProperty(*this, Transform.Position, Value, SpaceEntityComponentKey::Position, UPDATE_FLAGS_POSITION, LogSystem);
 }
 
 const csp::common::Vector4& SpaceEntity::GetRotation() const { return Transform.Rotation; }
@@ -234,7 +234,7 @@ csp::common::Vector4 SpaceEntity::GetGlobalRotation() const
 
 bool SpaceEntity::SetRotation(const csp::common::Vector4& Value)
 {
-    return SetProperty(this, Transform.Rotation, Value, SpaceEntityComponentKey::Rotation, UPDATE_FLAGS_ROTATION, LogSystem);
+    return SetProperty(*this, Transform.Rotation, Value, SpaceEntityComponentKey::Rotation, UPDATE_FLAGS_ROTATION, LogSystem);
 }
 
 const csp::common::Vector3& SpaceEntity::GetScale() const { return Transform.Scale; }
@@ -248,7 +248,7 @@ csp::common::Vector3 SpaceEntity::GetGlobalScale() const
 
 bool SpaceEntity::SetScale(const csp::common::Vector3& Value)
 {
-    return SetProperty(this, Transform.Scale, Value, SpaceEntityComponentKey::Scale, UPDATE_FLAGS_SCALE, LogSystem);
+    return SetProperty(*this, Transform.Scale, Value, SpaceEntityComponentKey::Scale, UPDATE_FLAGS_SCALE, LogSystem);
 }
 
 bool SpaceEntity::GetIsTransient() const { return !IsPersistent; }
@@ -257,12 +257,12 @@ const csp::common::String& SpaceEntity::GetThirdPartyRef() const { return ThirdP
 
 bool SpaceEntity::SetThirdPartyRef(const csp::common::String& InThirdPartyRef)
 {
-    return SetProperty(this, ThirdPartyRef, InThirdPartyRef, SpaceEntityComponentKey::ThirdPartyRef, UPDATE_FLAGS_THIRD_PARTY_REF, LogSystem);
+    return SetProperty(*this, ThirdPartyRef, InThirdPartyRef, SpaceEntityComponentKey::ThirdPartyRef, UPDATE_FLAGS_THIRD_PARTY_REF, LogSystem);
 }
 
 bool SpaceEntity::SetThirdPartyPlatformType(const csp::systems::EThirdPartyPlatform InThirdPartyPlatformType)
 {
-    return SetProperty(this, ThirdPartyPlatform, static_cast<int64_t>(InThirdPartyPlatformType), SpaceEntityComponentKey::ThirdPartyPlatform,
+    return SetProperty(*this, ThirdPartyPlatform, static_cast<int64_t>(InThirdPartyPlatformType), SpaceEntityComponentKey::ThirdPartyPlatform,
         UPDATE_FLAGS_THIRD_PARTY_PLATFORM, LogSystem);
 }
 
@@ -667,7 +667,7 @@ bool SpaceEntity::Lock()
     }
 
     return SetProperty(
-        this, EntityLock, static_cast<int64_t>(LockType::UserAgnostic), SpaceEntityComponentKey::LockType, UPDATE_FLAGS_LOCK_TYPE, LogSystem);
+        *this, EntityLock, static_cast<int64_t>(LockType::UserAgnostic), SpaceEntityComponentKey::LockType, UPDATE_FLAGS_LOCK_TYPE, LogSystem);
 }
 
 bool SpaceEntity::Unlock()

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "CSP/Multiplayer/SpaceEntity.h"
-
 #include "CSP/Common/Interfaces/IRealtimeEngine.h"
 #include "CSP/Common/StringFormat.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
@@ -49,6 +48,7 @@
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "Multiplayer/MCS/MCSTypes.h"
 #include "Multiplayer/MCSComponentPacker.h"
+#include "Multiplayer/PatchUtils.h"
 #include "Multiplayer/Script/EntityScriptBinding.h"
 #include "Multiplayer/Script/EntityScriptInterface.h"
 #include "Multiplayer/SpaceEntityKeys.h"
@@ -176,25 +176,7 @@ const csp::common::String& SpaceEntity::GetName() const { return Name; }
 
 bool SpaceEntity::SetName(const csp::common::String& Value)
 {
-    if (!IsModifiable())
-    {
-        if (LogSystem != nullptr)
-        {
-            LogSystem->LogMsg(csp::common::LogLevel::Error,
-                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
-                            "owner of. Entity name: {}",
-                    Name)
-                    .c_str());
-        }
-        return false;
-    }
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::Name, GetName(), Value)
-                                   : [this, &Value]()
-    {
-        SetNameDirect(Value, true);
-        return true;
-    }();
+    return SetProperty(this, Name, Value, SpaceEntityComponentKey::Name, UPDATE_FLAGS_NAME, LogSystem);
 }
 
 const SpaceTransform& SpaceEntity::GetTransform() const { return Transform; }
@@ -230,25 +212,7 @@ csp::common::Vector3 SpaceEntity::GetGlobalPosition() const
 
 bool SpaceEntity::SetPosition(const csp::common::Vector3& Value)
 {
-    if (!IsModifiable())
-    {
-        if (LogSystem != nullptr)
-        {
-            LogSystem->LogMsg(csp::common::LogLevel::Error,
-                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
-                            "owner of. Entity name: {}",
-                    Name)
-                    .c_str());
-        }
-        return false;
-    }
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::Position, GetPosition(), Value)
-                                   : [this, &Value]()
-    {
-        SetPositionDirect(Value, true);
-        return true;
-    }();
+    return SetProperty(this, Transform.Position, Value, SpaceEntityComponentKey::Position, UPDATE_FLAGS_POSITION, LogSystem);
 }
 
 const csp::common::Vector4& SpaceEntity::GetRotation() const { return Transform.Rotation; }
@@ -270,25 +234,7 @@ csp::common::Vector4 SpaceEntity::GetGlobalRotation() const
 
 bool SpaceEntity::SetRotation(const csp::common::Vector4& Value)
 {
-    if (!IsModifiable())
-    {
-        if (LogSystem != nullptr)
-        {
-            LogSystem->LogMsg(csp::common::LogLevel::Error,
-                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
-                            "owner of. Entity name: {}",
-                    Name)
-                    .c_str());
-        }
-        return false;
-    }
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::Rotation, GetRotation(), Value)
-                                   : [this, &Value]()
-    {
-        SetRotationDirect(Value, true);
-        return true;
-    }();
+    return SetProperty(this, Transform.Rotation, Value, SpaceEntityComponentKey::Rotation, UPDATE_FLAGS_ROTATION, LogSystem);
 }
 
 const csp::common::Vector3& SpaceEntity::GetScale() const { return Transform.Scale; }
@@ -302,25 +248,7 @@ csp::common::Vector3 SpaceEntity::GetGlobalScale() const
 
 bool SpaceEntity::SetScale(const csp::common::Vector3& Value)
 {
-    if (!IsModifiable())
-    {
-        if (LogSystem != nullptr)
-        {
-            LogSystem->LogMsg(csp::common::LogLevel::Error,
-                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
-                            "owner of. Entity name: {}",
-                    Name)
-                    .c_str());
-        }
-        return false;
-    }
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::Scale, GetScale(), Value)
-                                   : [this, &Value]()
-    {
-        SetScaleDirect(Value, true);
-        return true;
-    }();
+    return SetProperty(this, Transform.Scale, Value, SpaceEntityComponentKey::Scale, UPDATE_FLAGS_SCALE, LogSystem);
 }
 
 bool SpaceEntity::GetIsTransient() const { return !IsPersistent; }
@@ -329,49 +257,13 @@ const csp::common::String& SpaceEntity::GetThirdPartyRef() const { return ThirdP
 
 bool SpaceEntity::SetThirdPartyRef(const csp::common::String& InThirdPartyRef)
 {
-    if (!IsModifiable())
-    {
-        if (LogSystem != nullptr)
-        {
-            LogSystem->LogMsg(csp::common::LogLevel::Error,
-                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
-                            "owner of. Entity name: {}",
-                    Name)
-                    .c_str());
-        }
-        return false;
-    }
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::ThirdPartyRef, GetThirdPartyRef(), InThirdPartyRef)
-                                   : [this, &InThirdPartyRef]()
-    {
-        SetThirdPartyRefDirect(InThirdPartyRef, true);
-        return true;
-    }();
+    return SetProperty(this, ThirdPartyRef, InThirdPartyRef, SpaceEntityComponentKey::ThirdPartyRef, UPDATE_FLAGS_THIRD_PARTY_REF, LogSystem);
 }
 
 bool SpaceEntity::SetThirdPartyPlatformType(const csp::systems::EThirdPartyPlatform InThirdPartyPlatformType)
 {
-    if (!IsModifiable())
-    {
-        if (LogSystem != nullptr)
-        {
-            LogSystem->LogMsg(csp::common::LogLevel::Error,
-                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
-                            "owner of. Entity name: {}",
-                    Name)
-                    .c_str());
-        }
-        return false;
-    }
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(
-               SpaceEntityComponentKey::ThirdPartyPlatform, GetThirdPartyPlatformType(), static_cast<int64_t>(InThirdPartyPlatformType))
-                                   : [this, &InThirdPartyPlatformType]()
-    {
-        SetThirdPartyPlatformDirect(InThirdPartyPlatformType, true);
-        return true;
-    }();
+    return SetProperty(this, ThirdPartyPlatform, static_cast<int64_t>(InThirdPartyPlatformType), SpaceEntityComponentKey::ThirdPartyPlatform,
+        UPDATE_FLAGS_THIRD_PARTY_PLATFORM, LogSystem);
 }
 
 csp::systems::EThirdPartyPlatform SpaceEntity::GetThirdPartyPlatformType() const { return ThirdPartyPlatform; }
@@ -774,30 +666,8 @@ bool SpaceEntity::Lock()
         return false;
     }
 
-    if (!IsModifiable())
-    {
-        if (LogSystem != nullptr)
-        {
-            LogSystem->LogMsg(csp::common::LogLevel::Error,
-                fmt::format("Entity is not modifiable, you can only modify entities that have transferable ownership, or which you already are the "
-                            "owner of. Entity name: {}",
-                    Name)
-                    .c_str());
-        }
-        return false;
-    }
-
-    // We do it this way just so we can reuse the `SetDirtyProperty` function. It dosen't really matter that we're not checking if the "true"
-    // old lock is the same before setting the val again.
-    const auto OldLockReplicatedVal = csp::common::ReplicatedValue(static_cast<int64_t>(LockType::None));
-    const auto NewLockReplicatedVal = csp::common::ReplicatedValue(static_cast<int64_t>(LockType::UserAgnostic));
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::LockType, OldLockReplicatedVal, NewLockReplicatedVal)
-                                   : [this]()
-    {
-        SetEntityLockDirect(LockType::UserAgnostic, true);
-        return true;
-    }();
+    return SetProperty(
+        this, EntityLock, static_cast<int64_t>(LockType::UserAgnostic), SpaceEntityComponentKey::LockType, UPDATE_FLAGS_LOCK_TYPE, LogSystem);
 }
 
 bool SpaceEntity::Unlock()
@@ -811,17 +681,16 @@ bool SpaceEntity::Unlock()
         return false;
     }
 
-    // We do it this way just so we can reuse the `SetDirtyProperty` function. It dosen't really matter that we're not checking if the "true"
-    // old lock is the same before setting the val again.
-    const auto OldLockReplicatedVal = csp::common::ReplicatedValue(static_cast<int64_t>(LockType::UserAgnostic));
-    const auto NewLockReplicatedVal = csp::common::ReplicatedValue(static_cast<int64_t>(LockType::None));
-
-    return StatePatcher != nullptr ? StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::LockType, OldLockReplicatedVal, NewLockReplicatedVal)
-                                   : [this]()
+    // We don't call "SetProperty" here, because the internal IsModifiable check will always fail due to the entity being locked.
+    if (StatePatcher)
     {
-        SetEntityLockDirect(LockType::None, true);
+        return StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::LockType, EntityLock, static_cast<int64_t>(LockType::None));
+    }
+    else
+    {
+        SetPropertyDirect(EntityLock, LockType::None, UPDATE_FLAGS_LOCK_TYPE, true);
         return true;
-    }();
+    }
 }
 
 csp::multiplayer::LockType SpaceEntity::GetLockType() const { return EntityLock; }
@@ -859,7 +728,7 @@ bool SpaceEntity::InternalSetSelectionStateOfEntity(const bool SelectedState)
             bool Added = EntitySystem->AddEntityToSelectedEntities(this);
             if (Added)
             {
-                SetSelectedIdDirect(LocalClientId, true);
+                SetPropertyDirect(SelectedId, LocalClientId, UPDATE_FLAGS_SELECTION_ID, true);
                 return true;
             }
         }
@@ -880,7 +749,7 @@ bool SpaceEntity::InternalSetSelectionStateOfEntity(const bool SelectedState)
             bool Removed = EntitySystem->RemoveEntityFromSelectedEntities(this);
             if (Removed)
             {
-                SetSelectedIdDirect(0, true);
+                SetPropertyDirect(SelectedId, 0, UPDATE_FLAGS_SELECTION_ID, true);
                 return true;
             }
         }
@@ -896,94 +765,6 @@ std::chrono::milliseconds SpaceEntity::GetTimeOfLastPatch() { return StatePatche
 // Not dirtyable because it is a mandatory type in ObjectMessage. It's sent no matter what.
 // It may still be nicer to make this in-pattern and do loopbacks like the dirtyable props, but no formal need.
 void SpaceEntity::SetOwnerId(uint64_t InOwnerId) { OwnerId = InOwnerId; }
-
-void SpaceEntity::SetNameDirect(const csp::common::String& Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    Name = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_NAME, Empty);
-    }
-}
-
-void SpaceEntity::SetPositionDirect(const csp::common::Vector3& Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    Transform.Position = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_POSITION, Empty);
-    }
-}
-
-void SpaceEntity::SetRotationDirect(const csp::common::Vector4& Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    Transform.Rotation = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_ROTATION, Empty);
-    }
-}
-
-void SpaceEntity::SetScaleDirect(const csp::common::Vector3& Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    Transform.Scale = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_SCALE, Empty);
-    }
-}
-
-void SpaceEntity::SetThirdPartyRefDirect(const csp::common::String& Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    ThirdPartyRef = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_THIRD_PARTY_REF, Empty);
-    }
-}
-
-void SpaceEntity::SetThirdPartyPlatformDirect(const csp::systems::EThirdPartyPlatform Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    ThirdPartyPlatform = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_THIRD_PARTY_PLATFORM, Empty);
-    }
-}
-
-void SpaceEntity::SetEntityLockDirect(LockType Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    EntityLock = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_LOCK_TYPE, Empty);
-    }
-}
-
-void SpaceEntity::SetSelectedIdDirect(uint64_t Value, bool CallNotifyingCallback)
-{
-    std::scoped_lock PropertiesLocker(PropertiesLock);
-    SelectedId = Value;
-    if (CallNotifyingCallback && EntityUpdateCallback)
-    {
-        csp::common::Array<ComponentUpdateInfo> Empty;
-        EntityUpdateCallback(this, UPDATE_FLAGS_SELECTION_ID, Empty);
-    }
-}
 
 void SpaceEntity::SetParentIdDirect(csp::common::Optional<uint64_t> Value, bool CallNotifyingCallback)
 {
@@ -1146,7 +927,9 @@ void SpaceEntity::ResolveParentChildRelationship()
     }
 }
 
-const std::unique_ptr<SpaceEntityStatePatcher>& SpaceEntity::GetStatePatcher() { return StatePatcher; }
+const std::unique_ptr<SpaceEntityStatePatcher>& SpaceEntity::GetStatePatcher() const { return StatePatcher; }
+
+std::unique_ptr<SpaceEntityStatePatcher>& SpaceEntity::GetStatePatcher() { return StatePatcher; }
 
 void SpaceEntity::AddComponentFromItemComponentData(uint16_t ComponentId, const mcs::ItemComponentData& ComponentData)
 {
@@ -1268,42 +1051,42 @@ csp::common::Array<EntityProperty> SpaceEntity::CreateReplicatedProperties()
         { 
             SpaceEntityComponentKey::Name, UPDATE_FLAGS_NAME, 
             [&Name = Name]() { return csp::common::ReplicatedValue { Name }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetNameDirect(Value.GetString()); } 
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(Name, Value.GetString(), UPDATE_FLAGS_NAME); } 
         },
         {
             SpaceEntityComponentKey::Position, UPDATE_FLAGS_POSITION,
             [&Position = Transform.Position]() { return csp::common::ReplicatedValue { Position }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetPositionDirect(Value.GetVector3()); }
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(Transform.Position, Value.GetVector3(), UPDATE_FLAGS_POSITION); }
         },
         { 
             SpaceEntityComponentKey::Rotation, UPDATE_FLAGS_ROTATION,
             [&Rotation = Transform.Rotation]() { return csp::common::ReplicatedValue { Rotation }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetRotationDirect(Value.GetVector4()); }
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(Transform.Rotation, Value.GetVector4(), UPDATE_FLAGS_ROTATION); }
         },
         {
             SpaceEntityComponentKey::Scale, UPDATE_FLAGS_SCALE,
             [&Scale = Transform.Scale]() { return csp::common::ReplicatedValue { Scale }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetScaleDirect(Value.GetVector3()); }
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(Transform.Scale, Value.GetVector3(), UPDATE_FLAGS_SCALE); }
         },
         {
             SpaceEntityComponentKey::SelectedClientId, UPDATE_FLAGS_SELECTION_ID,
             [&SelectedId = SelectedId]() { return csp::common::ReplicatedValue { static_cast<int64_t>(SelectedId) }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetSelectedIdDirect(Value.GetInt()); }
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(SelectedId, Value.GetInt(), UPDATE_FLAGS_SELECTION_ID); }
         },
         {
             SpaceEntityComponentKey::ThirdPartyRef, UPDATE_FLAGS_THIRD_PARTY_REF,
             [&ThirdPartyRef = ThirdPartyRef]() { return csp::common::ReplicatedValue { ThirdPartyRef }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetThirdPartyRefDirect(Value.GetString()); }
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(ThirdPartyRef, Value.GetString(), UPDATE_FLAGS_THIRD_PARTY_REF); }
         },
         {
             SpaceEntityComponentKey::ThirdPartyPlatform, UPDATE_FLAGS_THIRD_PARTY_PLATFORM,
             [&ThirdPartyPlatform = ThirdPartyPlatform]() { return csp::common::ReplicatedValue { static_cast<int64_t>(ThirdPartyPlatform) }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetThirdPartyPlatformDirect(static_cast<systems::EThirdPartyPlatform>(Value.GetInt())); }
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(ThirdPartyPlatform, static_cast<systems::EThirdPartyPlatform>(Value.GetInt()), UPDATE_FLAGS_THIRD_PARTY_PLATFORM); }
         },
         {
             SpaceEntityComponentKey::LockType, UPDATE_FLAGS_LOCK_TYPE,
             [&EntityLock = EntityLock]() { return csp::common::ReplicatedValue { static_cast<int64_t>(EntityLock) }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetEntityLockDirect(static_cast<LockType>(Value.GetInt())); }
+            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(EntityLock, static_cast<LockType>(Value.GetInt()), UPDATE_FLAGS_LOCK_TYPE); }
         }
 
     };

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -682,6 +682,8 @@ bool SpaceEntity::Unlock()
     }
 
     // We don't call "SetProperty" here, because the internal IsModifiable check will always fail due to the entity being locked.
+    // We do it this way just so we can reuse the `SetDirtyProperty` function. It dosen't really matter that we're not checking if the "true"
+    // old lock is the same before setting the val again.
     if (StatePatcher)
     {
         return StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::LockType, EntityLock, static_cast<int64_t>(LockType::None));

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -682,8 +682,6 @@ bool SpaceEntity::Unlock()
     }
 
     // We don't call "SetProperty" here, because the internal IsModifiable check will always fail due to the entity being locked.
-    // We do it this way just so we can reuse the `SetDirtyProperty` function. It dosen't really matter that we're not checking if the "true"
-    // old lock is the same before setting the val again.
     if (StatePatcher)
     {
         return StatePatcher->SetDirtyProperty(SpaceEntityComponentKey::LockType, EntityLock, static_cast<int64_t>(LockType::None));

--- a/Library/src/Multiplayer/SpaceEntityStatePatcher.h
+++ b/Library/src/Multiplayer/SpaceEntityStatePatcher.h
@@ -135,6 +135,8 @@ public:
     {
         std::scoped_lock<std::mutex> PropertiesLocker(DirtyPropertiesLock);
 
+        // This erase is useful for a very specific case where a value was changed, and before a patch is sent, the value is set back to its original
+        // value. This will prevent a redundant patch from being sent.
         DirtyProperties.erase(PropertyKey);
 
         if (NewValue != static_cast<U>(PriorValue))
@@ -216,4 +218,5 @@ private:
     csp::multiplayer::SpaceEntity& SpaceEntity;
     PatchSentCallback EntityPatchSentCallback;
 };
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/SpaceEntityStatePatcher.h
+++ b/Library/src/Multiplayer/SpaceEntityStatePatcher.h
@@ -135,8 +135,10 @@ public:
     {
         std::scoped_lock<std::mutex> PropertiesLocker(DirtyPropertiesLock);
 
-        // This erase is useful for a very specific case where a value was changed, and before a patch is sent, the value is set back to its original
-        // value. This will prevent a redundant patch from being sent.
+        // We're not 100% sure, but this erase was likely put here for a very specific case where:
+        // A value was changed, but before a patch is sent,
+        // the value is set back to its original value.
+        // This will prevent a redundant patch from being sent.
         DirtyProperties.erase(PropertyKey);
 
         if (NewValue != static_cast<U>(PriorValue))


### PR DESCRIPTION
I would advise reviewing [OF-1761](https://github.com/magnopus-opensource/connected-spaces-platform/pull/792) first, as this merges into that branch.

We were only checking if the values were the same in our StatePatcher::SetDirtyProperty, which isn't used on the offline version.
Instead of adding a conditional check in every setter, I created a generic, templated setter with this extra conditional in. This cuts out a lot of code from SpaceEntity.

[OF-1761]: https://magnopus.atlassian.net/browse/OF-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ