### PR TITLE
[NT-0] fix: Resolve initialization ordering issue

### DIFF
--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -315,6 +315,11 @@ private:
     UserSystem(csp::web::WebClient* InWebClient, csp::multiplayer::NetworkEventBus* InEventBus, csp::common::LogSystem& LogSystem);
     ~UserSystem();
 
+    // Emergency Fix: We have a circular dependency issue due to SignalR requiring the AuthContext for construction. To get around this
+    // we pass nullptr to the UserSystem ctor for the NetworkEventBus, and then call this method to set it after the NetworkEventBus has been
+    // constructed.
+    void SetNetworkEventBus(csp::multiplayer::NetworkEventBus* EventBus);
+
     [[nodiscard]] bool EmailCheck(const std::string& Email) const;
 
     void NotifyRefreshTokenHasChanged();

--- a/Library/src/Systems/SystemBase.cpp
+++ b/Library/src/Systems/SystemBase.cpp
@@ -33,7 +33,6 @@ SystemBase::SystemBase(csp::web::WebClient* InWebClient, csp::multiplayer::Netwo
     , EventBusPtr(InEventBus)
     , LogSystem(LogSystem)
 {
-    RegisterSystemCallback();
 }
 
 SystemBase::SystemBase(csp::multiplayer::NetworkEventBus* InEventBus, csp::common::LogSystem* LogSystem)
@@ -41,7 +40,6 @@ SystemBase::SystemBase(csp::multiplayer::NetworkEventBus* InEventBus, csp::commo
     , EventBusPtr(InEventBus)
     , LogSystem(LogSystem)
 {
-    RegisterSystemCallback();
 }
 
 SystemBase::~SystemBase()

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -199,7 +199,7 @@ UserSystem::UserSystem(csp::web::WebClient* InWebClient, csp::multiplayer::Netwo
     , Auth { AuthenticationAPI, CurrentLoginState }
 {
 
-    RegisterSystemCallback();
+    // RegisterSystemCallback();
 }
 
 UserSystem::~UserSystem()
@@ -211,6 +211,13 @@ UserSystem::~UserSystem()
     delete (StripeAPI);
 
     DeregisterSystemCallback();
+}
+
+void UserSystem::SetNetworkEventBus(csp::multiplayer::NetworkEventBus* EventBus)
+{
+    EventBusPtr = EventBus;
+
+    RegisterSystemCallback();
 }
 
 const csp::common::LoginState& UserSystem::GetLoginState() const { return CurrentLoginState; }

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -198,8 +198,6 @@ UserSystem::UserSystem(csp::web::WebClient* InWebClient, csp::multiplayer::Netwo
     , RefreshTokenChangedCallback(nullptr)
     , Auth { AuthenticationAPI, CurrentLoginState }
 {
-
-    // RegisterSystemCallback();
 }
 
 UserSystem::~UserSystem()


### PR DESCRIPTION
We had a circular dependency issue in the SystemsManager due to SignalR requiring the AuthContext from the UserSystem for construction. To get around this we pass nullptr to the UserSystem ctor for the NetworkEventBus, and then call a newly introduced  method to set it after the NetworkEventBus has been constructed.