### PR TITLE
[OF-1511] Update ReplicatedValue to use a variant internally

### DIFF
--- a/Library/include/CSP/Common/ReplicatedValue.h
+++ b/Library/include/CSP/Common/ReplicatedValue.h
@@ -21,10 +21,16 @@
 #include "CSP/Common/String.h"
 #include "CSP/Common/Vector.h"
 
-#include <functional>
+#include <variant>
 
 namespace csp::common
 {
+
+CSP_START_IGNORE
+class ReplicatedValue;
+using ReplicatedValueImplType = std::variant<bool, float, int64_t, csp::common::String, csp::common::Vector2, csp::common::Vector3,
+    csp::common::Vector4, csp::common::Map<csp::common::String, ReplicatedValue>>;
+CSP_END_IGNORE
 
 /// @brief Enum representing the type of a replicated value.
 /// These values are serialized and stored as integers.
@@ -48,9 +54,27 @@ class CSP_API ReplicatedValue
 {
 public:
     /// @brief A default ReplicatedValue will not have a valid type ("ReplicatedValueType::InvalidType"), and will have no internal value associated.
-    ///
-    /// Do not use this constructor unless you know what you are doing!
+    /// This constuctor will create the value in an invalid state. Do not use unless you know what you are doing!
     ReplicatedValue();
+
+    CSP_START_IGNORE
+
+    // Internal templated constructor
+    CSP_NO_EXPORT template <class T>
+    inline ReplicatedValue(const T& InValue)
+        : Value { InValue }
+    {
+    }
+
+    // Internal templated setter.
+    CSP_NO_EXPORT template <class T> inline void Set(const T& InValue) { Value = InValue; }
+    // Internal templated setter.
+    CSP_NO_EXPORT template <class T> inline const T& Get() const { return std::get<T>(Value); }
+
+    // Internal getter for variant.
+    CSP_NO_EXPORT const ReplicatedValueImplType& GetValue() const { return Value; };
+
+    CSP_END_IGNORE
 
     /// @brief Construct a ReplicatedValue based on a bool type.
     /// @param InBoolValue bool : Initial value.
@@ -85,35 +109,35 @@ public:
     ReplicatedValue(const csp::common::Vector4& InVector4Value);
 
     /// @brief Construct a ReplicatedValue based on an csp::common::Map type with a string value as the key.
-    /// @param InMapValue csp::common::Map : Initial value.
-    ReplicatedValue(const csp::common::Map<csp::common::String, ReplicatedValue>& InMapValue);
-
-    /// @brief Copy constructor
-    /// @param Other csp::multiplayer::ReplicatedValue& : The value to copy.
-    ReplicatedValue(const ReplicatedValue& Other);
+    /// @param InValue csp::common::Map : Initial value.
+    ReplicatedValue(const csp::common::Map<csp::common::String, ReplicatedValue>& InValue);
 
     /// @brief Destroys the replicated value instance.
     ~ReplicatedValue();
 
-    /// @brief Assignment operator overload.
-    /// @param InValue ReplicatedValue : Other replicated value to set this one to.
-    ReplicatedValue& operator=(const ReplicatedValue& InValue);
+    /// @brief Copy constructor
+    /// @param Other csp::common::ReplicatedValue& : The value to copy.
+    CSP_NO_EXPORT ReplicatedValue(const ReplicatedValue& Other);
+
+    /// @brief Move constructor
+    /// @param Other csp::common::ReplicatedValue& : The value to move.
+    CSP_NO_EXPORT ReplicatedValue(ReplicatedValue&& Other);
+
+    /// @brief Copy assignment operator overload.
+    /// @param InValue ReplicatedValue : Other replicated value to set from.
+    CSP_NO_EXPORT ReplicatedValue& operator=(const ReplicatedValue& Other);
+
+    /// @brief Move assignment operator overload.
+    /// @param InValue ReplicatedValue : Other replicated value to move from.
+    CSP_NO_EXPORT ReplicatedValue& operator=(ReplicatedValue&& Other);
 
     /// @brief Equality operator overload.
     /// @param ReplicatedValue : Other value to compare to.
-    bool operator==(const ReplicatedValue& OtherValue) const;
+    CSP_NO_EXPORT bool operator==(const ReplicatedValue& OtherValue) const;
 
-    /// @brief Non equality operator overload.
+    /// @brief Inequality operator overload.
     /// @param ReplicatedValue : Other value to compare to.
-    bool operator!=(const ReplicatedValue& OtherValue) const;
-
-    /// @brief Less than operator overload.
-    /// @param ReplicatedValue : Other value to compare to.
-    bool operator<(const ReplicatedValue& OtherValue) const;
-
-    /// @brief Greater than operator overload.
-    /// @param ReplicatedValue : Other value to compare to.
-    bool operator>(const ReplicatedValue& OtherValue) const;
+    CSP_NO_EXPORT bool operator!=(const ReplicatedValue& OtherValue) const;
 
     /// @brief Gets the type of replicated value.
     /// @return ReplicatedValueType: Enum representing all supported replication base types.
@@ -124,9 +148,6 @@ public:
     void SetBool(bool InValue);
 
     /// @brief Get a bool value from this replicated value, will assert if not a bool type.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return bool
     bool GetBool() const;
 
@@ -135,9 +156,6 @@ public:
     void SetFloat(float InValue);
 
     /// @brief Get a float value from this replicated value, will assert if not a float type.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return float value
     float GetFloat() const;
 
@@ -146,9 +164,6 @@ public:
     void SetInt(int64_t InValue);
 
     /// @brief Get a int64 value from this replicated value, will assert if not a int64 type.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return int64 value
     int64_t GetInt() const;
 
@@ -159,9 +174,6 @@ public:
     void SetString(const csp::common::String& InValue);
 
     /// @brief Get a csp::common::String& value from this replicated value, will assert if not a csp::common::String type.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return csp::common::String&
     const csp::common::String& GetString() const;
 
@@ -173,9 +185,6 @@ public:
     void SetVector2(const csp::common::Vector2& InValue);
 
     /// @brief Get a csp::common::Vector2 value from this replicated value, will assert if not a csp::common::Vector2 type.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return csp::common::Vector2
     const csp::common::Vector2& GetVector2() const;
 
@@ -187,9 +196,6 @@ public:
     void SetVector3(const csp::common::Vector3& InValue);
 
     /// @brief Get a csp::common::Vector3 value from this replicated value, will assert if not a csp::common::Vector3 type.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return csp::common::Vector3
     const csp::common::Vector3& GetVector3() const;
 
@@ -201,9 +207,6 @@ public:
     void SetVector4(const csp::common::Vector4& InValue);
 
     /// @brief Get a csp::common::Vector4 value from this replicated value, will assert if not a csp::common::Vector4 type.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return csp::common::Vector4
     const csp::common::Vector4& GetVector4() const;
 
@@ -213,9 +216,6 @@ public:
 
     /// @brief Get a csp::common::Map value with a string value as the key.
     /// This will assert if not a csp::common::Map type with a string value as the key.
-    ///
-    /// Use ReplicatedValue::GetReplicatedValueType to ensure type before accessing.
-    ///
     /// @return csp::common::Map
     const csp::common::Map<csp::common::String, ReplicatedValue>& GetStringMap() const;
 
@@ -226,31 +226,12 @@ public:
     /// @return The default StringMap.
     CSP_NO_EXPORT static const csp::common::Map<csp::common::String, ReplicatedValue>& GetDefaultStringMap();
 
-    /// @brief returns the size of the stored internal value.
-    /// @return size_t size of the internal value.
-    CSP_NO_EXPORT static size_t GetSizeOfInternalValue();
-
 private:
-    ReplicatedValueType ReplicatedType;
-
     CSP_START_IGNORE
-    union InternalValue
-    {
-        InternalValue();
-        ~InternalValue();
-
-        bool Bool;
-        float Float;
-        int64_t Int;
-        csp::common::String String;
-        csp::common::Vector2 Vector2;
-        csp::common::Vector3 Vector3;
-        csp::common::Vector4 Vector4;
-        csp::common::Map<csp::common::String, ReplicatedValue> StringMap;
-    };
-
-    InternalValue Value;
+    ReplicatedValueImplType Value;
     CSP_END_IGNORE
+
+    ReplicatedValueType ReplicatedType;
 };
 
-} // namespace csp::multiplayer
+} // namespace csp::common

--- a/Library/include/CSP/Common/ReplicatedValue.h
+++ b/Library/include/CSP/Common/ReplicatedValue.h
@@ -66,6 +66,7 @@ public:
     {
     }
 
+    // These are great for certain scenarios such as serialization/deserialization, as we can avoid conditionals.
     // Internal templated setter.
     CSP_NO_EXPORT template <class T> inline void Set(const T& InValue) { Value = InValue; }
     // Internal templated setter.

--- a/Library/src/Common/ReplicatedValue.cpp
+++ b/Library/src/Common/ReplicatedValue.cpp
@@ -24,303 +24,149 @@ static const csp::common::Map<csp::common::String, ReplicatedValue> InvalidStrin
 
 ReplicatedValue::ReplicatedValue() { ReplicatedType = ReplicatedValueType::InvalidType; }
 
-ReplicatedValue::~ReplicatedValue()
-{
-    if (ReplicatedType == ReplicatedValueType::String)
-    {
-        Value.String.~String();
-    }
-    else if (ReplicatedType == ReplicatedValueType::StringMap)
-    {
-        Value.StringMap.~Map();
-    }
-}
+ReplicatedValue::~ReplicatedValue() { }
 
 ReplicatedValue::ReplicatedValue(bool InValue)
-    : ReplicatedType(ReplicatedValueType::Boolean)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::Boolean)
+
 {
-    Value.Bool = InValue;
 }
 
 ReplicatedValue::ReplicatedValue(float InValue)
-    : ReplicatedType(ReplicatedValueType::Float)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::Float)
 {
-    Value.Float = InValue;
 }
 
 ReplicatedValue::ReplicatedValue(int64_t InValue)
-    : ReplicatedType(ReplicatedValueType::Integer)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::Integer)
 {
-    Value.Int = InValue;
 }
 
 ReplicatedValue::ReplicatedValue(const char* InValue)
-    : ReplicatedType(ReplicatedValueType::String)
+    : Value { csp::common::String { InValue } }
+    , ReplicatedType(ReplicatedValueType::String)
 {
-    Value.String = InValue;
 }
 
 ReplicatedValue::ReplicatedValue(const csp::common::String& InValue)
-    : ReplicatedType(ReplicatedValueType::String)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::String)
 {
-    Value.String = InValue;
 }
 
 ReplicatedValue::ReplicatedValue(const csp::common::Vector2& InValue)
-    : ReplicatedType(ReplicatedValueType::Vector2)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::Vector2)
 {
-    Value.Vector2 = InValue;
 }
 
 ReplicatedValue::ReplicatedValue(const csp::common::Vector3& InValue)
-    : ReplicatedType(ReplicatedValueType::Vector3)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::Vector3)
 {
-    Value.Vector3 = InValue;
 }
 
 ReplicatedValue::ReplicatedValue(const csp::common::Vector4& InValue)
-    : ReplicatedType(ReplicatedValueType::Vector4)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::Vector4)
 {
-    Value.Vector4 = InValue;
 }
 
-ReplicatedValue::ReplicatedValue(const csp::common::Map<csp::common::String, ReplicatedValue>& InMapValue)
-    : ReplicatedType(ReplicatedValueType::StringMap)
+ReplicatedValue::ReplicatedValue(const csp::common::Map<csp::common::String, ReplicatedValue>& InValue)
+    : Value { InValue }
+    , ReplicatedType(ReplicatedValueType::StringMap)
 {
-    Value.StringMap = InMapValue;
 }
 
-ReplicatedValue::ReplicatedValue(const ReplicatedValue& OtherValue) { *this = OtherValue; }
-
-ReplicatedValue& ReplicatedValue::operator=(const ReplicatedValue& InValue)
+ReplicatedValue::ReplicatedValue(const ReplicatedValue& Other)
 {
-    switch (InValue.GetReplicatedValueType())
-    {
-    case ReplicatedValueType::Boolean:
-    {
-        SetBool(InValue.GetBool());
-        break;
-    }
-    case ReplicatedValueType::Integer:
-    {
-        SetInt(InValue.GetInt());
-        break;
-    }
-    case ReplicatedValueType::Float:
-    {
-        SetFloat(InValue.GetFloat());
-        break;
-    }
-    case ReplicatedValueType::String:
-    {
-        SetString(InValue.GetString());
-        break;
-    }
-    case ReplicatedValueType::Vector2:
-    {
-        SetVector2(InValue.GetVector2());
-        break;
-    }
-    case ReplicatedValueType::Vector3:
-    {
-        SetVector3(InValue.GetVector3());
-        break;
-    }
-    case ReplicatedValueType::Vector4:
-    {
-        SetVector4(InValue.GetVector4());
-        break;
-    }
-    case ReplicatedValueType::StringMap:
-    {
-        SetStringMap(InValue.GetStringMap());
-        break;
-    }
-    case ReplicatedValueType::InvalidType:
-    {
-        ReplicatedType = ReplicatedValueType::InvalidType;
-        break;
-    }
-    default:
-    {
-        assert(0 && "Unhandled replicated value type!");
-        break;
-    }
-    }
+    Value = Other.Value;
+    this->ReplicatedType = Other.ReplicatedType;
+}
+
+ReplicatedValue::ReplicatedValue(ReplicatedValue&& Other)
+{
+    this->Value = std::move(Other.Value);
+
+    this->ReplicatedType = std::move(Other.ReplicatedType);
+    Other.ReplicatedType = ReplicatedValueType::InvalidType;
+}
+
+ReplicatedValue& ReplicatedValue::operator=(const ReplicatedValue& Other)
+{
+    this->Value = Other.Value;
+    this->ReplicatedType = Other.ReplicatedType;
+    return *this;
+}
+
+ReplicatedValue& ReplicatedValue::operator=(ReplicatedValue&& Other)
+{
+    this->Value = std::move(Other.Value);
+
+    this->ReplicatedType = std::move(Other.ReplicatedType);
+    Other.ReplicatedType = ReplicatedValueType::InvalidType;
 
     return *this;
 }
 
-bool ReplicatedValue::operator==(const ReplicatedValue& OtherValue) const
-{
-    bool IsEqual = GetReplicatedValueType() == OtherValue.GetReplicatedValueType();
-    if (IsEqual)
-    {
-        switch (OtherValue.GetReplicatedValueType())
-        {
-        case ReplicatedValueType::Boolean:
-        {
-            IsEqual = GetBool() == OtherValue.GetBool();
-            break;
-        }
-        case ReplicatedValueType::Integer:
-        {
-            IsEqual = GetInt() == OtherValue.GetInt();
-            break;
-        }
-        case ReplicatedValueType::Float:
-        {
-            IsEqual = GetFloat() == OtherValue.GetFloat();
-            break;
-        }
-        case ReplicatedValueType::String:
-        {
-            IsEqual = GetString() == OtherValue.GetString();
-            break;
-        }
-        case ReplicatedValueType::Vector2:
-        {
-            IsEqual = GetVector2() == OtherValue.GetVector2();
-            break;
-        }
-        case ReplicatedValueType::Vector3:
-        {
-            IsEqual = GetVector3() == OtherValue.GetVector3();
-            break;
-        }
-        case ReplicatedValueType::Vector4:
-        {
-            IsEqual = GetVector4() == OtherValue.GetVector4();
-            break;
-        }
-        case ReplicatedValueType::StringMap:
-        {
-            IsEqual = GetStringMap() == OtherValue.GetStringMap();
-            break;
-        }
-        default:
-        {
-            assert(0 && "Unhandled replicated value type!");
-            break;
-        }
-        }
-    }
-    return IsEqual;
-}
+bool ReplicatedValue::operator==(const ReplicatedValue& OtherValue) const { return (Value) == OtherValue.Value; }
 bool ReplicatedValue::operator!=(const ReplicatedValue& OtherValue) const { return (*this == OtherValue) == false; }
-
-bool ReplicatedValue::operator<(const ReplicatedValue& OtherValue) const
-{
-    switch (OtherValue.GetReplicatedValueType())
-    {
-    case ReplicatedValueType::Boolean:
-    {
-        return GetBool() < OtherValue.GetBool();
-    }
-    case ReplicatedValueType::Integer:
-    {
-        return GetInt() < OtherValue.GetInt();
-    }
-    case ReplicatedValueType::Float:
-    {
-        return GetFloat() < OtherValue.GetFloat();
-    }
-    case ReplicatedValueType::String:
-    {
-        return GetString() < OtherValue.GetString();
-    }
-    default:
-    {
-        assert(0 && "Unhandled replicated value type!");
-        break;
-    }
-    }
-
-    return false;
-}
-
-bool ReplicatedValue::operator>(const ReplicatedValue& OtherValue) const
-{
-    switch (OtherValue.GetReplicatedValueType())
-    {
-    case ReplicatedValueType::Boolean:
-    {
-        return GetBool() > OtherValue.GetBool();
-    }
-    case ReplicatedValueType::Integer:
-    {
-        return GetInt() > OtherValue.GetInt();
-    }
-    case ReplicatedValueType::Float:
-    {
-        return GetFloat() > OtherValue.GetFloat();
-    }
-    case ReplicatedValueType::String:
-    {
-        return GetString() > OtherValue.GetString();
-    }
-    default:
-    {
-        assert(0 && "Unhandled replicated value type!");
-        break;
-    }
-    }
-
-    return false;
-}
 
 void ReplicatedValue::SetBool(bool InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::Boolean;
-    Value.Bool = InValue;
 }
 
 bool ReplicatedValue::GetBool() const
 {
     assert(ReplicatedType == ReplicatedValueType::Boolean);
-    return Value.Bool;
+    return Get<bool>();
 }
 
 void ReplicatedValue::SetFloat(float InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::Float;
-    Value.Float = InValue;
 }
 
 float ReplicatedValue::GetFloat() const
 {
     assert(ReplicatedType == ReplicatedValueType::Float);
-    return Value.Float;
+    return Get<float>();
 }
 
 void ReplicatedValue::SetInt(int64_t InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::Integer;
-    Value.Int = InValue;
 }
 
 int64_t ReplicatedValue::GetInt() const
 {
     assert(ReplicatedType == ReplicatedValueType::Integer);
-    return Value.Int;
+    return Get<int64_t>();
 }
 
 void ReplicatedValue::SetString(const char* InValue)
 {
+    Value = csp::common::String { InValue };
     ReplicatedType = ReplicatedValueType::String;
-    Value.String = InValue;
 }
 
 void ReplicatedValue::SetString(const csp::common::String& InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::String;
-    Value.String = InValue;
 }
 
 const csp::common::String& ReplicatedValue::GetString() const
 {
     assert(ReplicatedType == ReplicatedValueType::String);
-    return Value.String;
+    return Get<csp::common::String>();
 }
 
 const csp::common::String& ReplicatedValue::GetDefaultString()
@@ -331,64 +177,60 @@ const csp::common::String& ReplicatedValue::GetDefaultString()
 
 void ReplicatedValue::SetVector2(const csp::common::Vector2& InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::Vector2;
-    Value.Vector2 = InValue;
 }
 
 const csp::common::Vector2& ReplicatedValue::GetVector2() const
 {
     assert(ReplicatedType == ReplicatedValueType::Vector2);
-    return Value.Vector2;
+    return Get<csp::common::Vector2>();
 }
 
 const csp::common::Vector2& ReplicatedValue::GetDefaultVector2() { return InvalidVector2; }
 
 void ReplicatedValue::SetVector3(const csp::common::Vector3& InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::Vector3;
-    Value.Vector3 = InValue;
 }
 
 const csp::common::Vector3& ReplicatedValue::GetVector3() const
 {
     assert(ReplicatedType == ReplicatedValueType::Vector3);
-    return Value.Vector3;
+    return Get<csp::common::Vector3>();
 }
 
 const csp::common::Vector3& ReplicatedValue::GetDefaultVector3() { return InvalidVector3; }
 
 void ReplicatedValue::SetVector4(const csp::common::Vector4& InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::Vector4;
-    Value.Vector4 = InValue;
 }
 
 const csp::common::Vector4& ReplicatedValue::GetVector4() const
 {
     assert(ReplicatedType == ReplicatedValueType::Vector4);
-    return Value.Vector4;
+    return Get<csp::common::Vector4>();
 }
 
 const csp::common::Vector4& ReplicatedValue::GetDefaultVector4() { return InvalidVector4; }
 
+csp::common::Map<csp::common::String, ReplicatedValue> m;
+
 const csp::common::Map<csp::common::String, ReplicatedValue>& ReplicatedValue::GetStringMap() const
 {
     assert(ReplicatedType == ReplicatedValueType::StringMap);
-    return Value.StringMap;
+    return Get<csp::common::Map<csp::common::String, ReplicatedValue>>();
 }
 
 void ReplicatedValue::SetStringMap(const csp::common::Map<csp::common::String, ReplicatedValue>& InValue)
 {
+    Value = InValue;
     ReplicatedType = ReplicatedValueType::StringMap;
-    Value.StringMap = InValue;
 }
 
 const csp::common::Map<csp::common::String, ReplicatedValue>& ReplicatedValue::GetDefaultStringMap() { return InvalidStringMap; }
 
-size_t ReplicatedValue::GetSizeOfInternalValue() { return sizeof(InternalValue); }
-
-ReplicatedValue::InternalValue::InternalValue() { memset(this, 0x0, sizeof(InternalValue)); }
-
-ReplicatedValue::InternalValue::~InternalValue() { }
-
-} // namespace csp::multiplayer
+} // namespace csp::common

--- a/Library/src/Common/ReplicatedValue.cpp
+++ b/Library/src/Common/ReplicatedValue.cpp
@@ -217,8 +217,6 @@ const csp::common::Vector4& ReplicatedValue::GetVector4() const
 
 const csp::common::Vector4& ReplicatedValue::GetDefaultVector4() { return InvalidVector4; }
 
-csp::common::Map<csp::common::String, ReplicatedValue> m;
-
 const csp::common::Map<csp::common::String, ReplicatedValue>& ReplicatedValue::GetStringMap() const
 {
     assert(ReplicatedType == ReplicatedValueType::StringMap);

--- a/Library/src/Multiplayer/MCSComponentPacker.cpp
+++ b/Library/src/Multiplayer/MCSComponentPacker.cpp
@@ -178,7 +178,7 @@ mcs::ItemComponentData MCSComponentPacker::CreateItemComponentData(const csp::co
 {
     mcs::ItemComponentData Data;
     // Extract the internal type from the variant and parse using its corrosponding typed CreateItemComponentData.
-    std::visit([&Data, this](auto&& InternalType) { Data = CreateItemComponentData(InternalType); }, Value.GetValue());
+    std::visit([&Data, this](const auto& InternalType) { Data = CreateItemComponentData(InternalType); }, Value.GetValue());
     return Data;
 }
 

--- a/Library/src/Multiplayer/MCSComponentPacker.cpp
+++ b/Library/src/Multiplayer/MCSComponentPacker.cpp
@@ -174,48 +174,12 @@ mcs::ItemComponentData MCSComponentPacker::CreateItemComponentData(ComponentBase
     return mcs::ItemComponentData { ComponentPacker.GetComponents() };
 }
 
-// TODO: We can make a safer version of this function when we convert our ReplicatedValue to use a variant,
-// as we can create compile-time checking by using std::visit and function overloads.
-// This will prevent us forgetting to update this when we add new types.
-// https://magnopus.atlassian.net/browse/OF-1511
 mcs::ItemComponentData MCSComponentPacker::CreateItemComponentData(const csp::common::ReplicatedValue& Value)
 {
-    if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::Boolean)
-    {
-        return CreateItemComponentData(Value.GetBool());
-    }
-    else if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::Integer)
-    {
-        return CreateItemComponentData(Value.GetInt());
-    }
-    else if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::Float)
-    {
-        return CreateItemComponentData(Value.GetFloat());
-    }
-    else if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::String)
-    {
-        return CreateItemComponentData(Value.GetString());
-    }
-    else if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::Vector3)
-    {
-        return CreateItemComponentData(Value.GetVector3());
-    }
-    else if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::Vector4)
-    {
-        return CreateItemComponentData(Value.GetVector4());
-    }
-    else if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::Vector2)
-    {
-        return CreateItemComponentData(Value.GetVector2());
-    }
-    else if (Value.GetReplicatedValueType() == csp::common::ReplicatedValueType::StringMap)
-    {
-        return CreateItemComponentData(Value.GetStringMap());
-    }
-    else
-    {
-        throw std::runtime_error("Invalid ReplicatedValue property");
-    }
+    mcs::ItemComponentData Data;
+    // Extract the internal type from the variant and parse using its corrosponding typed CreateItemComponentData.
+    std::visit([&Data, this](auto&& InternalType) { Data = CreateItemComponentData(InternalType); }, Value.GetValue());
+    return Data;
 }
 
 mcs::ItemComponentData MCSComponentPacker::CreateItemComponentData(bool Value) { return mcs::ItemComponentData { Value }; }

--- a/Tests/src/PublicAPITests/ReplicatedValueTests.cpp
+++ b/Tests/src/PublicAPITests/ReplicatedValueTests.cpp
@@ -20,14 +20,14 @@
 
 using namespace csp::multiplayer;
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, InvalidTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, InvalidTest)
 {
     csp::common::ReplicatedValue MyValue;
 
     EXPECT_TRUE(MyValue.GetReplicatedValueType() == csp::common::ReplicatedValueType::InvalidType);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, BoolConstructorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, BoolConstructorTest)
 {
     csp::common::ReplicatedValue MyValue(true);
 
@@ -35,7 +35,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, BoolConstructorTest)
     EXPECT_TRUE(MyValue.GetBool() == true);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetBoolTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, SetBoolTest)
 {
     csp::common::ReplicatedValue MyValue;
     MyValue.SetBool(true);
@@ -44,7 +44,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetBoolTest)
     EXPECT_TRUE(MyValue.GetBool() == true);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, BoolAssignmentTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, BoolAssignmentTest)
 {
     csp::common::ReplicatedValue MyValue;
     MyValue = true;
@@ -53,7 +53,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, BoolAssignmentTest)
     EXPECT_TRUE(MyValue.GetBool() == true);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, IntConstructorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, IntConstructorTest)
 {
     const int64_t MyInt = 42;
     csp::common::ReplicatedValue MyValue(MyInt);
@@ -62,7 +62,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, IntConstructorTest)
     EXPECT_TRUE(MyValue.GetInt() == 42);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetIntTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, SetIntTest)
 {
     const int64_t MyInt = 42;
     csp::common::ReplicatedValue MyValue;
@@ -72,7 +72,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetIntTest)
     EXPECT_TRUE(MyValue.GetInt() == 42);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, IntAssignmentTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, IntAssignmentTest)
 {
     const int64_t MyInt = 42;
     csp::common::ReplicatedValue MyValue;
@@ -82,7 +82,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, IntAssignmentTest)
     EXPECT_TRUE(MyValue.GetInt() == 42);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, FloatConstructorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, FloatConstructorTest)
 {
     csp::common::ReplicatedValue MyValue(12345.6789f);
 
@@ -90,7 +90,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, FloatConstructorTest)
     EXPECT_TRUE(MyValue.GetFloat() == 12345.6789f);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetFloatTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, SetFloatTest)
 {
     csp::common::ReplicatedValue MyValue;
     MyValue.SetFloat(12345.6789f);
@@ -99,7 +99,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetFloatTest)
     EXPECT_TRUE(MyValue.GetFloat() == 12345.6789f);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, FloatAssignmentTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, FloatAssignmentTest)
 {
     csp::common::ReplicatedValue MyValue;
     MyValue = 12345.6789f;
@@ -108,7 +108,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, FloatAssignmentTest)
     EXPECT_TRUE(MyValue.GetFloat() == 12345.6789f);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, Vector3ConstructorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, Vector3ConstructorTest)
 {
     const csp::common::Vector3 Vector3(5.0f, 1.0f, 3.0f);
     csp::common::ReplicatedValue MyValue(Vector3);
@@ -117,7 +117,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, Vector3ConstructorTest)
     EXPECT_TRUE(MyValue.GetVector3() == Vector3);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetVector3Test)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, SetVector3Test)
 {
     const csp::common::Vector3 Vector3(5.0f, 1.0f, 3.0f);
     csp::common::ReplicatedValue MyValue;
@@ -127,7 +127,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetVector3Test)
     EXPECT_TRUE(MyValue.GetVector3() == Vector3);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringConstructorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, StringConstructorTest)
 {
     const csp::common::String MyString("This is a string");
 
@@ -137,7 +137,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringConstructorTest)
     EXPECT_TRUE(MyValue.GetString() == MyString);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetStringTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, SetStringTest)
 {
     const csp::common::String MyString("This is a string");
 
@@ -148,7 +148,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetStringTest)
     EXPECT_TRUE(MyValue.GetString() == MyString);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringAssignmentTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, StringAssignmentTest)
 {
     const csp::common::String MyString("This is a string");
 
@@ -159,7 +159,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringAssignmentTest)
     EXPECT_TRUE(MyValue.GetString() == MyString);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringLiteralConstructorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, StringLiteralConstructorTest)
 {
     csp::common::ReplicatedValue MyValue("This is a string");
 
@@ -167,7 +167,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringLiteralConstructorTest)
     EXPECT_TRUE(MyValue.GetString() == "This is a string");
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetStringLiteralTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, SetStringLiteralTest)
 {
     csp::common::ReplicatedValue MyValue;
     MyValue.SetString("This is a string");
@@ -176,7 +176,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetStringLiteralTest)
     EXPECT_TRUE(MyValue.GetString() == "This is a string");
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringLiteralAssignmentTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, StringLiteralAssignmentTest)
 {
     csp::common::ReplicatedValue MyValue;
     MyValue = "This is a string";
@@ -185,7 +185,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, StringLiteralAssignmentTest)
     EXPECT_TRUE(MyValue.GetString() == "This is a string");
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapConstructorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, MapConstructorTest)
 {
     csp::common::Map<csp::common::String, csp::common::ReplicatedValue> MyMap;
     MyMap["Key1"] = "Test1";
@@ -198,7 +198,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapConstructorTest)
     EXPECT_TRUE(MyValue.GetStringMap() == MyMap);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetMapTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, SetMapTest)
 {
     csp::common::ReplicatedValue MyValue;
     csp::common::Map<csp::common::String, csp::common::ReplicatedValue> MyMap;
@@ -212,7 +212,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, SetMapTest)
     EXPECT_TRUE(MyValue.GetStringMap() == MyMap);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapAssignmentTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, MapAssignmentTest)
 {
     csp::common::ReplicatedValue MyValue;
     csp::common::Map<csp::common::String, csp::common::ReplicatedValue> MyMap;
@@ -227,7 +227,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapAssignmentTest)
 }
 
 // Tests move logic with a basic type
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveConstructorIntTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, MoveConstructorIntTest)
 {
     csp::common::ReplicatedValue Value { 10ll };
     csp::common::ReplicatedValue NewValue { std::move(Value) };
@@ -239,7 +239,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveConstructorIntTest)
 }
 
 // Tests move logic with a more complex type
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveConstructorStringTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, MoveConstructorStringTest)
 {
     csp::common::ReplicatedValue Value { "Test" };
     csp::common::ReplicatedValue NewValue { std::move(Value) };
@@ -250,7 +250,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveConstructorStringTest)
     EXPECT_EQ(Value.GetReplicatedValueType(), csp::common::ReplicatedValueType::InvalidType);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveAssignmentIntTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, MoveAssignmentIntTest)
 {
     csp::common::ReplicatedValue Value { 10ll };
     csp::common::ReplicatedValue NewValue { 5ll };
@@ -263,7 +263,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveAssignmentIntTest)
     EXPECT_EQ(Value.GetReplicatedValueType(), csp::common::ReplicatedValueType::InvalidType);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveAssignmentStringTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, MoveAssignmentStringTest)
 {
     csp::common::ReplicatedValue Value { "Test" };
     csp::common::ReplicatedValue NewValue { "Other" };
@@ -276,7 +276,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveAssignmentStringTest)
     EXPECT_EQ(Value.GetReplicatedValueType(), csp::common::ReplicatedValueType::InvalidType);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, EqualityOperatorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, EqualityOperatorTest)
 {
     csp::common::ReplicatedValue Value { "Test" };
     csp::common::ReplicatedValue Value2 { "Test" };
@@ -292,7 +292,7 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, EqualityOperatorTest)
     EXPECT_FALSE(Value == Value2);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, InequalityOperatorTest)
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, InequalityOperatorTest)
 {
     csp::common::ReplicatedValue Value { "Test" };
     csp::common::ReplicatedValue Value2 { "Test" };

--- a/Tests/src/PublicAPITests/ReplicatedValueTests2.cpp
+++ b/Tests/src/PublicAPITests/ReplicatedValueTests2.cpp
@@ -225,3 +225,85 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MapAssignmentTest)
     EXPECT_TRUE(MyValue.GetReplicatedValueType() == csp::common::ReplicatedValueType::StringMap);
     EXPECT_TRUE(MyValue.GetStringMap() == MyMap);
 }
+
+// Tests move logic with a basic type
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveConstructorIntTest)
+{
+    csp::common::ReplicatedValue Value { 10ll };
+    csp::common::ReplicatedValue NewValue { std::move(Value) };
+
+    EXPECT_EQ(NewValue.GetReplicatedValueType(), csp::common::ReplicatedValueType::Integer);
+    EXPECT_EQ(NewValue.GetInt(), 10ll);
+
+    EXPECT_EQ(Value.GetReplicatedValueType(), csp::common::ReplicatedValueType::InvalidType);
+}
+
+// Tests move logic with a more complex type
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveConstructorStringTest)
+{
+    csp::common::ReplicatedValue Value { "Test" };
+    csp::common::ReplicatedValue NewValue { std::move(Value) };
+
+    EXPECT_EQ(NewValue.GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(NewValue.GetString(), "Test");
+
+    EXPECT_EQ(Value.GetReplicatedValueType(), csp::common::ReplicatedValueType::InvalidType);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveAssignmentIntTest)
+{
+    csp::common::ReplicatedValue Value { 10ll };
+    csp::common::ReplicatedValue NewValue { 5ll };
+
+    NewValue = std::move(Value);
+
+    EXPECT_EQ(NewValue.GetReplicatedValueType(), csp::common::ReplicatedValueType::Integer);
+    EXPECT_EQ(NewValue.GetInt(), 10ll);
+
+    EXPECT_EQ(Value.GetReplicatedValueType(), csp::common::ReplicatedValueType::InvalidType);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, MoveAssignmentStringTest)
+{
+    csp::common::ReplicatedValue Value { "Test" };
+    csp::common::ReplicatedValue NewValue { "Other" };
+
+    NewValue = std::move(Value);
+
+    EXPECT_EQ(NewValue.GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(NewValue.GetString(), "Test");
+
+    EXPECT_EQ(Value.GetReplicatedValueType(), csp::common::ReplicatedValueType::InvalidType);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, EqualityOperatorTest)
+{
+    csp::common::ReplicatedValue Value { "Test" };
+    csp::common::ReplicatedValue Value2 { "Test" };
+
+    EXPECT_TRUE(Value == Value2);
+
+    Value2.SetString("Test2");
+
+    EXPECT_FALSE(Value == Value2);
+
+    Value2.SetInt(5);
+
+    EXPECT_FALSE(Value == Value2);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTestsv2, InequalityOperatorTest)
+{
+    csp::common::ReplicatedValue Value { "Test" };
+    csp::common::ReplicatedValue Value2 { "Test" };
+
+    EXPECT_FALSE(Value != Value2);
+
+    Value2.SetString("Test2");
+
+    EXPECT_TRUE(Value != Value2);
+
+    Value2.SetInt(5);
+
+    EXPECT_TRUE(Value != Value2);
+}


### PR DESCRIPTION
This refactors our ReplicatedValue implementation use a std::variant instead of a union. This gives us a lot more power when using this type from within CSP, as we can use visit/compile-time type checking instead of runtime conditionals. An example of this exists in this PR when updating MCSComponentPacker::CreateItemComponentData to use std::visit. 

This change will also allow us to further streamline our ReplicatedValue conversions, as we now have access to templated setters and getters.