### PR TITLE
[NT-0] fix: Crash on duplication of asset collections

### DIFF
--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -571,14 +571,15 @@ void AssetSystem::CopyAssetCollectionsToSpace(csp::common::Array<AssetCollection
         = PrototypeAPI->CreateHandler<AssetCollectionsResultCallback, AssetCollectionsResult, void, csp::services::DtoArray<chs::PrototypeDto>>(
             Callback, nullptr);
 
-    auto PrototypeFilters = std::shared_ptr<chs::PrototypeFilters>();
+    auto PrototypeFilters = std::shared_ptr<chs::PrototypeFilters>(new chs::PrototypeFilters);
     PrototypeFilters->SetHasGroup(true);
 
-    auto DuplicateGroupPrototypesOptions = std::shared_ptr<chs::DuplicateGroupPrototypesOptions>();
+    auto DuplicateGroupPrototypesOptions = std::shared_ptr<chs::DuplicateGroupPrototypesOptions>(new chs::DuplicateGroupPrototypesOptions);
     DuplicateGroupPrototypesOptions->SetOriginalGroupId(SourceSpaceId);
     DuplicateGroupPrototypesOptions->SetNewGroupId(DestSpaceId);
     DuplicateGroupPrototypesOptions->SetAdditionalFilters(PrototypeFilters);
     DuplicateGroupPrototypesOptions->SetAsyncCall(CopyAsync);
+    DuplicateGroupPrototypesOptions->SetIncludeMusubiGeneratedAssets(true);
 
     // Use `GET /api/v1/prototypes` and only pass asset collection IDs
     static_cast<chs::PrototypeApi*>(PrototypeAPI)


### PR DESCRIPTION
Following an update to the endpoints for duplicating prototypes we updated the corresponding CSP abstraction.

However, as part of that we forgot to allocate memory when declaring shared pointers that we then go on to derefrence, causing a crash.

Fixed by allocating memory and assigning it to the shared pointers when invoking their constructors.