### PR TITLE
[OF-1649] fix and re enable the poi tests

### DIFF
--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -454,22 +454,28 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
         const csp::common::Array<csp::systems::PointOfInterest>& POIs = GetPOIsResult.GetPOIs();
         EXPECT_GE(POIs.Size(), 1);
 
-        // There may be more than one POI at this location, so we search for the one we have created and expect to find it.
-        bool FoundSpacePOI = false;
-        bool FoundDefaultPOI = false;
+        // Multiple POIs have been created at the same location, so we need to validate that the expected POIs are found.
+        csp::systems::PointOfInterest POITypeDefault;
+        csp::systems::PointOfInterest POITypeSpace;
+
         for (uint32_t i = 0; i < POIs.Size(); i++)
         {
             if (POIs[i].Id == DefaultPOI.Id)
             {
-                FoundDefaultPOI = true;
+                POITypeDefault = POIs[i];
             }
 
             if (POIs[i].SpaceId == Space.Id)
             {
-                FoundSpacePOI = true;
+                POITypeSpace = POIs[i];
             }
         }
-        EXPECT_TRUE(FoundDefaultPOI && FoundSpacePOI);
+
+        EXPECT_NE(POITypeDefault.Id, "");
+        DeletePointOfInterest(POISystem, POITypeDefault);
+
+        EXPECT_NE(POITypeSpace.Id, "");
+        DeletePointOfInterest(POISystem, POITypeSpace);
     }
 
     DeleteSpace(SpaceSystem, Space.Id);

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -208,8 +208,6 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaT
     CreatePointOfInterest(POISystem, nullptr, POILocation, nullptr, PointOfInterest);
 
     // Search for the newly created POI inside a circular area
-    csp::common::Array<csp::systems::PointOfInterest> POICollection;
-
     csp::systems::GeoLocation SearchLocationOrigin;
     SearchLocationOrigin.Latitude = 44.0;
     SearchLocationOrigin.Longitude = 160.0;
@@ -221,16 +219,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaT
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
-    if (Result.GetResultCode() == csp::systems::EResultCode::Success)
-    {
-        const auto& ResultPOIs = Result.GetPOIs();
-        POICollection = csp::common::Array<csp::systems::PointOfInterest>(ResultPOIs.Size());
-
-        for (size_t idx = 0; idx < ResultPOIs.Size(); ++idx)
-        {
-            POICollection[idx] = ResultPOIs[idx];
-        }
-    }
+    const csp::common::Array<csp::systems::PointOfInterest>& POICollection = Result.GetPOIs();
 
     // we should have at least the POI we've created
     EXPECT_TRUE(POICollection.Size() > 0);
@@ -316,8 +305,6 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaE
     CreatePointOfInterest(POISystem, nullptr, OutsidePOILocation, nullptr, OutsidePointOfInterest);
 
     // Search for the newly created POI inside a circular area
-    csp::common::Array<csp::systems::PointOfInterest> POICollection;
-
     csp::systems::GeoLocation SearchLocationOrigin;
     SearchLocationOrigin.Latitude = 44.0;
     SearchLocationOrigin.Longitude = 160.0;
@@ -329,20 +316,10 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaE
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
-    if (Result.GetResultCode() == csp::systems::EResultCode::Success)
-    {
-        const auto& ResultPOIs = Result.GetPOIs();
-        POICollection = csp::common::Array<csp::systems::PointOfInterest>(ResultPOIs.Size());
-
-        for (size_t idx = 0; idx < ResultPOIs.Size(); ++idx)
-        {
-            POICollection[idx] = ResultPOIs[idx];
-        }
-    }
-
     bool InsidePointOfInterestFound = false;
     bool OutsidePointOfInterestFound = false;
 
+    const csp::common::Array<csp::systems::PointOfInterest>& POICollection = Result.GetPOIs();
     for (size_t idx = 0; idx < POICollection.Size(); ++idx)
     {
         if (POICollection[idx].Name == InsidePointOfInterest.Name)

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -189,7 +189,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOIWithTagsTest)
 }
 
 // This test is to be fixed as part of OF-1649.
-CSP_PUBLIC_TEST(DISABLED_CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaTest)
+CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaTest)
 {
     SetRandSeed();
 
@@ -303,7 +303,7 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
 }
 
 // This test is to be fixed as part of OF-1649.
-CSP_PUBLIC_TEST(DISABLED_CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
+CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 {
     SetRandSeed();
 

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -188,7 +188,6 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, CreatePOIWithTagsTest)
     LogOut(UserSystem);
 }
 
-// This test is to be fixed as part of OF-1649.
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaTest)
 {
     SetRandSeed();
@@ -302,7 +301,6 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
     LogOut(UserSystem);
 }
 
-// This test is to be fixed as part of OF-1649.
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 {
     SetRandSeed();

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -316,24 +316,10 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaE
 
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
-    bool InsidePointOfInterestFound = false;
-    bool OutsidePointOfInterestFound = false;
-
     const csp::common::Array<csp::systems::PointOfInterest>& POICollection = Result.GetPOIs();
-    for (size_t idx = 0; idx < POICollection.Size(); ++idx)
-    {
-        if (POICollection[idx].Name == InsidePointOfInterest.Name)
-        {
-            InsidePointOfInterestFound = true;
-        }
-        else if (POICollection[idx].Name == OutsidePointOfInterest.Name)
-        {
-            OutsidePointOfInterestFound = true;
-        }
-    }
 
-    EXPECT_TRUE(InsidePointOfInterestFound);
-    EXPECT_FALSE(OutsidePointOfInterestFound);
+    EXPECT_EQ(POICollection.Size(), 1);
+    EXPECT_EQ(POICollection[0].Name, InsidePointOfInterest.Name);
 
     DeletePointOfInterest(POISystem, InsidePointOfInterest);
     DeletePointOfInterest(POISystem, OutsidePointOfInterest);

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -300,22 +300,14 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOI
     auto* POISystem = SystemsManager.GetPointOfInterestSystem();
 
     csp::common::String UserId;
-
     LogInAsNewTestUser(UserSystem, UserId);
 
-    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
-    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
-    const char* TestAssetCollectionName = "CSP-UNITTEST-ASSETCOLLECTION-MAG";
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     char UniqueAssetCollectionName[256];
+    const char* TestAssetCollectionName = "CSP-UNITTEST-ASSETCOLLECTION-MAG";
     SPRINTF(UniqueAssetCollectionName, "%s-%s", TestAssetCollectionName, GetUniqueString().c_str());
-
-    csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     csp::systems::AssetCollection AssetCollection;
     CreateAssetCollection(AssetSystem, Space, UniqueAssetCollectionName, AssetCollection);
@@ -349,18 +341,11 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId);
 
-    const char* TestSpaceName = "CSP-TEST-SPACE";
-    const char* TestSpaceDescription = "CSP-TEST-SPACEDESC";
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
 
     // The default POI we will be using during the test.
     csp::systems::PointOfInterest DefaultPOI;
-
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
-
-    csp::systems::Space Space;
-    CreateSpace(
-        SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Private, nullptr, nullptr, nullptr, nullptr, Space);
 
     csp::systems::GeoLocation SpaceGeolocation;
 

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -440,3 +440,29 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, QuerySpacePOITest)
 
     LogOut(UserSystem);
 }
+
+CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, DeletePOITest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* POISystem = SystemsManager.GetPointOfInterestSystem();
+
+    csp::common::String UserId;
+
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    csp::systems::GeoLocation POILocation;
+    POILocation.Latitude = 45.0;
+    POILocation.Longitude = 160.0;
+
+    csp::systems::PointOfInterest PointOfInterest;
+    CreatePointOfInterest(POISystem, nullptr, POILocation, nullptr, PointOfInterest);
+
+    auto [Result] = Awaitable(&csp::systems::PointOfInterestSystem::DeletePOI, POISystem, PointOfInterest).Await(RequestPredicate);
+
+    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+
+    LogOut(UserSystem);
+}

--- a/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
+++ b/Tests/src/PublicAPITests/PointOfInterestSystemTests.cpp
@@ -253,6 +253,42 @@ CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIInsideCircularAreaT
     LogOut(UserSystem);
 }
 
+CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetPOIOutsideCircularAreaTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* POISystem = SystemsManager.GetPointOfInterestSystem();
+
+    csp::common::String UserId;
+
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    csp::systems::GeoLocation POILocation;
+    POILocation.Latitude = 45.0;
+    POILocation.Longitude = 160.0;
+
+    csp::systems::PointOfInterest PointOfInterest;
+    CreatePointOfInterest(POISystem, nullptr, POILocation, nullptr, PointOfInterest);
+
+    csp::systems::GeoLocation SearchLocationOrigin;
+    SearchLocationOrigin.Latitude = 0;
+    SearchLocationOrigin.Longitude = 0;
+    double SearchRadius = 1000;
+
+    auto [Result] = Awaitable(&csp::systems::PointOfInterestSystem::GetPOIsInArea, POISystem, SearchLocationOrigin, SearchRadius,
+        csp::systems::EPointOfInterestType::DEFAULT)
+                        .Await(RequestPredicate);
+
+    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+    EXPECT_EQ(Result.GetPOIs().Size(), 0);
+
+    DeletePointOfInterest(POISystem, PointOfInterest);
+
+    LogOut(UserSystem);
+}
+
 CSP_PUBLIC_TEST(CSPEngine, PointOfInterestSystemTests, GetAssetCollectionFromPOITest)
 {
     SetRandSeed();


### PR DESCRIPTION
The previous failing test worked out of the box on local CHS; it was likely that, due to confusion around local CHS at the time, this was not supported in the local version on the developer machine, but worked as intended on CI due to the latest version of the services being pulled. 

Following this, I took the opportunity to evaluate the current state of the test and coverage. This highlighted a few separate problems that have been fixed in this PR:
 - Previously disabled tests have been reinstated 
 - We did not have a direct test for the delete operation; this has been added 
 - There were POI artefacts that persisted from the test runs; tests have been updated to remove the created POIs
 - An additional test has been added for testing the negative of `GetPOIInsideCircularAreaTest`

Overall, these changes are relatively minor to improve our current coverage and expectations around POI. 

> [!NOTE]
> During this investigation, I have found some inconsistencies with the API I plan to document and share these; however, they will be external to the current scope. 

> [!IMPORTANT]
> I considered mocking the service at this point; however, due to possible discussions around inconsistencies with API I decided to avoid this at the current time. However happy to reconsider if the team feels this would be a valuable change, considering the API is opinionated. 