### PR TITLE
[OF-1524] Cross-thread Callbacks

### DIFF
--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -203,6 +203,7 @@ namespace
         Connection->SetDisconnected(
             [&NetworkInterruptionCallback, &LogSystem](const std::exception_ptr& Except)
             {
+                // We currently detect a connection interrupt if the disconnected callback contains an exception.
                 if (Except)
                 {
                     try
@@ -212,10 +213,9 @@ namespace
                     catch (const std::exception& e)
                     {
                         INVOKE_IF_NOT_NULL(NetworkInterruptionCallback, e.what());
+                        LogSystem.LogMsg(csp::common::LogLevel::Log, "Connection Interrupted.");
                     }
                 }
-
-                LogSystem.LogMsg(csp::common::LogLevel::Log, "Connection Interrupted.");
             });
     }
 }

--- a/Tools/WrapperGenerator/Templates/C/GeneratedWrapper.mustache
+++ b/Tools/WrapperGenerator/Templates/C/GeneratedWrapper.mustache
@@ -12,6 +12,86 @@
 
 #pragma endregion Generated Includes
 
+/*
+    Callback queue designed to push callbacks onto the main thread using the emscripten api.
+    This works because emscriptens threads are just web workers, which allows us to push messages to different workers.
+
+    This is implemented to work around the limitation of callbacks needing to fire on the same thread they were created on.
+*/
+#pragma region Emscripten Callback Queue
+
+#if CSP_WASM
+#include <emscripten.h>
+#include <emscripten/proxying.h>
+#include <emscripten/threading.h>
+#include <pthread.h>
+#include <tuple>
+
+static em_proxying_queue* ProxyQueue = nullptr;
+static pthread_t MainThread = 0;
+
+// Creates an emscripten queue and sets the main thread if we haven't already initialized.
+void Emscripten_InitializeProxyQueue()
+{
+    if (ProxyQueue != nullptr)
+    {
+        return;
+    }
+
+    ProxyQueue = em_proxying_queue_create();
+    MainThread = emscripten_main_runtime_thread_id();
+}
+
+// Structure to hold the callback and arguments.
+template <typename ...T>
+struct CallbackData
+{
+    void (*Callback)(T...);
+    std::tuple<T...> Args;
+ };
+
+// This function is called internally from emscripten_proxy_sync on the main thread.
+template <typename ...T>
+static void Emscripten_CallbackWrapper(void* InData) 
+{
+    auto* Data = static_cast<CallbackData<T...>*>(InData);
+    std::apply(Data->Callback, Data->Args);
+}
+
+// Function that will push the callback to the main thread if we are not on it.
+template <typename ...T>
+static void Emscripten_CallbackOnThread(void (*Callback)(T...), T... Args) 
+{
+    bool OnMainThread = pthread_equal(pthread_self(), emscripten_main_runtime_thread_id());
+    if (OnMainThread)
+    {
+        // We're on the main thread already, just call normally
+        Callback(Args...);
+    }
+    else
+    {
+        Emscripten_InitializeProxyQueue();
+
+        // Pack our data and send to the emscripten queue.
+        CallbackData<T...> Data{Callback, std::make_tuple(Args...)};
+        emscripten_proxy_sync(ProxyQueue, MainThread, Emscripten_CallbackWrapper<T...>, static_cast<void*>(&Data));
+    }
+}
+#endif
+#pragma endregion Emscripten Callback Queue
+
+// Generic callback function which will either call the callback directly, or, 
+// if we're on wasm, push to the main thread if we're not on the main thread.
+template <typename ...T>
+static void CallCallback(void (*Callback)(T...), T... Args)
+{
+#ifdef CSP_WASM
+    Emscripten_CallbackOnThread(Callback, Args...);
+#else
+    Callback(Args...);
+#endif
+}
+
 extern "C"
 {
     typedef struct {

--- a/Tools/WrapperGenerator/Templates/C/Partials/Class/Method/Method.mustache
+++ b/Tools/WrapperGenerator/Templates/C/Partials/Class/Method/Method.mustache
@@ -239,12 +239,10 @@
             {{/ type.is_string }}
           {{/ parameters }}
 
-          {{ name }}(
-            {{ name }}_StateObject,
-
-            {{# parameters }}
+          CallCallback({{ name }}, {{ name }}_StateObject,
+              {{# parameters }}
               {{# type.is_string }}
-                _{{ name }}
+                (const char*)_{{ name }}
               {{/ type.is_string }}
 
               {{^ type.is_string }}

--- a/WasmTesting/csp-wasm.test.ts
+++ b/WasmTesting/csp-wasm.test.ts
@@ -50,9 +50,7 @@ test('Cross Thread Callbacks From Log Callback, OB-3782', async () => {
   console.log(errors);
 
   assert.ok(
-    errors.some(e => e.message.includes('table index is out of bounds')),
-    'Expected cross-thread `table index is out of bounds` error. Message not found, did you fix the bug (OB-3782)? Nice job! ',
-  );
+    !errors.some(e => e.message.includes('table index is out of bounds')));
   
 });
 


### PR DESCRIPTION
CSP sometimes fires certain callbacks on a different thread the function was invoked. This causes crashes in WASM builds due to it not supporting this behaviour.

I decided to fix this at the binding level (wrapper generator), as we only need to fix this on wasm, and not anywhere else. Also, creating a callback queue that needs to be polled may change expected behavior, as clients would need to call CSPFoundation::Tick before logging in to get the callback.

I used the emscripten api to create a callback queue, which pushes callbacks onto the main thread if we are not on main. Doing it here also means we don't have to poll, as Emscripten resolved the inter-thread messaging for us using worker-thread messaging.

I also fixed a small logging issue in the NetworkInterruptionCallback, as we were always logging, even if it was a regular disconnect.

I was unfortunatly unable to reproduce the NetworkInterruptionCallback crash, both via testing and using a web build. Our testing framework crashes when trying to block to wait for the callback, so it isn't easily testable. Also, using a web build showed the callback logs, but no crash.

I also tested my new changes on a local web build to make sure there were no obvious issues/