### PR TITLE
[OPE-2742] fix: Use LIB_NAME for Android symbol resolution

### DIFF
--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -51,8 +51,8 @@
 // For fstat and mkdir
 #include <sys/stat.h>
 
-#define LOAD_OWN_MODULE() dlopen(nullptr, RTLD_LAZY)
-#define GET_FUNCTION_ADDRESS(mod, name) dlsym((RTLD_DEFAULT), name)
+#define LOAD_OWN_MODULE() dlopen(LIB_NAME, RTLD_LAZY)
+#define GET_FUNCTION_ADDRESS(mod, name) dlsym((mod), name)
 #elif defined(CSP_MACOSX) || defined(CSP_IOS)
 // For dlopen and dlsym
 #include <dlfcn.h>


### PR DESCRIPTION
Resolving a runtime failure on Android (Unity) Quest 3 (see [this Slack thread](https://magnopus.slack.com/archives/C02TKEGRJE6/p1759241197504239?thread_ts=1759159460.239089&cid=C02TKEGRJE6) for more info).

This change allows our exported functions to be correctly found by Unity, since the previous behavior was limiting the search to the running executable rather than the library, causing a nullptr due to not found signatures.