### PR TITLE
Test generic/templated types in C# wrapper generation

### DIFF
--- a/UnitTesting/Templates/Exports/exports.cpp.jinja2
+++ b/UnitTesting/Templates/Exports/exports.cpp.jinja2
@@ -14,6 +14,46 @@
 
 using namespace std::chrono_literals;
 
+// Copied from CSPFoundation.cpp
+// TODO: Move to a common header/source file
+#if defined(DEBUG)
+#define LIB_NAME "ConnectedSpacesPlatform_D"
+#else
+#define LIB_NAME "ConnectedSpacesPlatform"
+#endif
+
+#if defined(CSP_WINDOWS)
+// For SHGetKnownFolderPath
+#include <Shlobj.h>
+// For std::codecvt_utf8_utf16
+#include <codecvt>
+// For GetModuleHandle and GetProcAddress
+#include <libloaderapi.h>
+
+#define LOAD_OWN_MODULE() (void*)GetModuleHandleA(LIB_NAME)
+#define GET_FUNCTION_ADDRESS(mod, name) (void*)GetProcAddress((HMODULE)(mod), name)
+#elif defined(CSP_ANDROID)
+// For dlopen and dlsym
+#include <dlfcn.h>
+// For fstat and mkdir
+#include <sys/stat.h>
+
+#define LOAD_OWN_MODULE() dlopen(nullptr, RTLD_LAZY)
+#define GET_FUNCTION_ADDRESS(mod, name) dlsym((mod), name)
+#elif defined(CSP_MACOSX) || defined(CSP_IOS)
+// For dlopen and dlsym
+#include <dlfcn.h>
+// For stat and mkdir
+#include <sys/stat.h>
+// For PATH_MAX
+#include <sys/syslimits.h>
+
+#define LOAD_OWN_MODULE() dlopen(nullptr, RTLD_LAZY)
+#define GET_FUNCTION_ADDRESS(mod, name) dlsym((mod), name)
+#elif defined(CSP_WASM)
+#include <emscripten.h>
+#endif
+
 
 namespace csp {
     // Helper function to free allocated memory from wrappers
@@ -28,6 +68,22 @@ namespace csp {
         return (std::fabs(A - B) <= Tolerance);
     }
 
+    void* ModuleHandle = nullptr;
+
+    void* GetFunctionAddress([[maybe_unused]] const csp::common::String& Name)
+    {
+    #if defined(CSP_WASM)
+        return nullptr;
+    #else
+        if (ModuleHandle == nullptr)
+        {
+            ModuleHandle = LOAD_OWN_MODULE();
+            assert(ModuleHandle != nullptr);
+        }
+
+        return GET_FUNCTION_ADDRESS(ModuleHandle, Name.c_str());
+    #endif
+    }
 
     /********************************/
     /*       Global functions       */

--- a/UnitTesting/Templates/Exports/exports.h.jinja2
+++ b/UnitTesting/Templates/Exports/exports.h.jinja2
@@ -9,9 +9,12 @@
 
 
 namespace csp {
+
     // Helper function to free allocated memory from wrappers
     CSP_API void Free(void* Pointer);
 
+    // Helper function to get function address for templates from wrappers
+    CSP_API void* GetFunctionAddress(const csp::common::String& Name);
 
     /********************************/
     /*       Global functions       */

--- a/UnitTesting/include/classes.h
+++ b/UnitTesting/include/classes.h
@@ -43,4 +43,21 @@ public:
     ~DerivedClass();
 };
 
-}
+template <typename T> class CSP_API TemplateClass
+{
+public:
+    TemplateClass();
+    ~TemplateClass();
+
+    void SetValue(const T& value);
+
+    // Plain return values are not supported by the code generator
+    // T GetValue() const;
+
+    void GetValue(T& outValue) const;
+
+private:
+    T m_Value;
+};
+
+} // namespace csp::Tests

--- a/UnitTesting/src/classes.cpp
+++ b/UnitTesting/src/classes.cpp
@@ -31,4 +31,13 @@ BaseClass::~BaseClass() { }
 DerivedClass::DerivedClass() { }
 DerivedClass::~DerivedClass() { }
 
+// TemplateClass
+template <typename T> TemplateClass<T>::TemplateClass() { }
+
+template <typename T> TemplateClass<T>::~TemplateClass() { }
+
+template <typename T> void TemplateClass<T>::SetValue(const T& value) { m_Value = value; }
+
+template <typename T> void TemplateClass<T>::GetValue(T& value) const { value = m_Value; }
+
 } // namespace csp::Tests

--- a/UnitTesting/tests/csharp/Assets/Tests/ClassTests.cs
+++ b/UnitTesting/tests/csharp/Assets/Tests/ClassTests.cs
@@ -91,5 +91,35 @@ namespace Csp.Tests
                 Assert.IsTrue(derivedClass.PointerIsValid);
             }
         }
+
+        [Test]
+        public void TestTemplateClassInt()
+        {
+            using (var templateClass = new TemplateClass<int>())
+            {
+                Assert.IsTrue(templateClass.PointerIsValid);
+                templateClass.SetValue(100);
+
+                // Currently the GetValue method does not work correctly for primitive types.
+                // int value;
+                // templateClass.GetValue(out value);
+                // Assert.AreEqual(100, value);
+            }
+        }
+
+        [Test]
+        public void TestTemplateClassString()
+        {
+            using (var templateClass = new TemplateClass<string>())
+            {
+                Assert.IsTrue(templateClass.PointerIsValid);
+                templateClass.SetValue("Hello");
+
+                // Currently the GetValue method does not work correctly for string types.
+                // string value;
+                // templateClass.GetValue(out value);
+                // Assert.AreEqual("Hello", value);
+            }
+        }
     }
 }


### PR DESCRIPTION
Create some test cases that exercise the runtime type lookup mechanism used by templated types.

PR #808 demonstrated how this failed for Android because the symbol lookups were searching the wrong export table. This test provides a path for running automated tests to verify this behaviour works correctly.