### PR TITLE
[OF-1796] feat: Generic ExternalService result processing

### DIFF
--- a/Library/include/CSP/Systems/ExternalServices/ExternalServiceInvocation.h
+++ b/Library/include/CSP/Systems/ExternalServices/ExternalServiceInvocation.h
@@ -22,7 +22,7 @@
 namespace csp::systems
 {
 
-/// @brief @brief Data class used to contain information relating to invocations via the external service proxy system.
+/// @brief Data class used to contain information relating to invocations via the external service proxy system.
 class CSP_API ExternalServiceInvocationResult : public StringResult
 {
     /** @cond DO_NOT_DOCUMENT */
@@ -32,11 +32,28 @@ class CSP_API ExternalServiceInvocationResult : public StringResult
     CSP_END_IGNORE
     /** @endcond */
 
-private:
+protected:
     ExternalServiceInvocationResult() = default;
     ExternalServiceInvocationResult(void*) {};
 
-    void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+    virtual void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
+};
+
+/// @brief A specialisation of the result data class that handles respnses from the external service proxy system.
+class CSP_API GetAgoraTokenResult : public ExternalServiceInvocationResult
+{
+    /** @cond DO_NOT_DOCUMENT */
+    CSP_START_IGNORE
+    template <typename T, typename U, typename V, typename W> friend class csp::services::ApiResponseHandler;
+    friend class UserSystem;
+    CSP_END_IGNORE
+    /** @endcond */
+
+protected:
+    GetAgoraTokenResult() = default;
+    GetAgoraTokenResult(void*) {};
+
+    virtual void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 };
 
 } // namespace csp::systems

--- a/Library/include/CSP/Systems/ExternalServices/ExternalServiceProxySystem.h
+++ b/Library/include/CSP/Systems/ExternalServices/ExternalServiceProxySystem.h
@@ -117,8 +117,8 @@ public:
 
     /// @brief Specialised utility function which executes a post call to the external services proxy, specifically to retrieve Agora user token
     /// credentials. A good example for how client applications may wish to use PostServiceProxy.
-    /// @param Params const AgoraUserTokenParams& : Params to configure the User token
-    /// @param Callback StringResultCallback : callback to call when a response is received
+    /// @param Params const AgoraUserTokenParams& : Params to configure the User token.
+    /// @param Callback StringResultCallback : callback to call when a response is received.
     CSP_ASYNC_RESULT void GetAgoraUserToken(const AgoraUserTokenParams& Params, StringResultCallback Callback);
 
 private:


### PR DESCRIPTION
## The Problem
It was pointed to me that we cannot assume any schema in the Json data returned via the external service proxy services.

This is because the proxy service is assumed to simply acts as a router for invoking operations on external services, and it is intended to feed the results of those operations directly back to the caller.

## The Solution
To account for that, this change refactors the result class used by the external service system into two classes. One generic class for returning the result payload with no tampering, and another for the Agora specialization.


### Result Classes

The generic result class is used by `ExternalServiceProxySystem::InvokeOperation`, and returns the full string value of the `operationResult` Json field in the returned payload.

The specialized class is used by `ExternalServiceProxySystem::GetAgoraUserToken`. Since we _can_ assume the schema in this specialized instance, this class takes the raw `operationResult` value, and parses it for the token (this is what the previous implementation did for all operations).

The mock test has been updated to not assume any particular Json format. Instead, it now simply stress tests whether the Json data under the `operationResult` is parsable, and that the string held in the result class is the expected full string.

### ExteralServiceSystem Refactor

One thing that was nice about the previous implementation was how the Agora specialisation of `InvokeOperation` fell through into the generalized function. Since we now need to use different types for handling results, and using templated public API functions is messy/has ABI risks, we now do the next best thing and have both calls go through a templated internal-only function.

> [!NOTE]
> This is not a breaking change, as it does not change the public API, nor the data passed back when retrieving Agora tokens. It _does_ change the data returned by the generic `InvokeOperation` endpoint, but that function has yet to be included in a release.