### PR TITLE
[OB-4420] Add catch-all to allow Unity iOS to load old incompatible spaces

### DIFF
--- a/Library/src/Multiplayer/MCS/MCSTypes.cpp
+++ b/Library/src/Multiplayer/MCS/MCSTypes.cpp
@@ -147,6 +147,15 @@ namespace
                 catch (const std::exception&)
                 {
                 }
+                catch(...)
+                {
+                    /* This sort of exception management isn't really advisable, we need to emit a callback when we find old data, 
+                       it's a serious compatibility issue. This catch block is added just to unblock Unity, which has done something
+                       funky with sentry integration making derived exceptions not catch for them on iOS.
+                       Sort of good it happened though, as it revealed the poor error management here:
+                         - This is only one path of potentially many, why is there a special catch here?
+                         - Just swallowing errors and loading the rest of a space is surely a recipe for terrifying bugs. */
+                }
             }
 
             Deserializer.EndReadUintMap();


### PR DESCRIPTION
This is not at all a real fix, it's just a patch we can choose to apply that will allow Unity ios to load old spaces in the same way the other clients currently can.

Testing this would imply either threading the log system down, inventing a whole new callback pattern, or even just moving this catch, which isn't something I'm willing to do for an off book fix like this. 

We should discuss this in standup, not sure if we should merge this or not, just putting it up to have it ready.

See [here ](https://magnopus.atlassian.net/browse/OB-4420?focusedCommentId=412476)for more.