### PR TITLE
[OF-1772] feat: create ai chatbot component

### DIFF
--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -76,6 +76,7 @@ enum class ComponentType
     Hotspot = 26,
     CinematicCamera = 27,
     ScreenSharing = 28,
+    AIChatbot = 29,
     // spare values
     Delete = 56
 };

--- a/Library/include/CSP/Multiplayer/Components/AIChatbotComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AIChatbotComponent.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// @file AIChatbotComponent.h
+/// @brief Definitions and support for AI chatbot components.
+
+#pragma once
+
+#include "CSP/CSPCommon.h"
+#include "CSP/Multiplayer/ComponentBase.h"
+#include "CSP/Multiplayer/Components/Interfaces/ITransformComponent.h"
+
+namespace csp::multiplayer
+{
+
+/// @brief Enumerates the list of properties that can be replicated for a AI chatbot component.
+enum class AIChatbotPropertyKeys
+{
+    Position = 0,
+    Rotation,
+    Scale,
+    ContextAssetId,
+    GuardrailAssetId,
+    VisualState,
+    Num
+};
+
+/// @brief Enumerates the list of potential visual states that can be replicated for a AI chatbot component.
+enum class AIChatbotVisualState
+{
+    None
+};
+
+class CSP_API AIChatbotSpaceComponent : public ComponentBase, public ITransformComponent
+{
+public:
+    AIChatbotSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);
+
+    /// @brief Gets the ID of the context asset associated with this AI chatbot.
+    /// @return The ID of the context asset assicuated with this AI chatbot.
+    const csp::common::String& GetContextAssetId() const;
+
+    /// @brief Sets the ID of the context asset associated with this AI chatbot.
+    /// @param Value The ID of the context asset assicuated with this AI chatbot.
+    void SetContextAssetId(const csp::common::String& Value);
+
+    /// @brief Gets the ID of the guardrail asset associated with this AI chatbot.
+    /// @return The ID of the guardrail asset assicuated with this AI chatbot.
+    const csp::common::String& GetGuardrailAssetId() const;
+
+    /// @brief Sets the ID of the guardrail asset associated with this AI chatbot.
+    /// @param Value The ID of the guardrail asset assicuated with this AI chatbot.
+    void SetGuardrailAssetId(const csp::common::String& Value);
+
+    /// @brief Retrieves the visual state of the AI chatbot for this component.
+    /// @return The playback state of the AI chatbot.
+    AIChatbotVisualState GetVisualState() const;
+
+    /// @brief Sets the visual state of the AI chatbot for this component.
+    /// @param Value The visual state of the AI chatbot.
+    void SetVisualState(AIChatbotVisualState Value);
+
+    /// \addtogroup ITransformComponent
+    /// @{
+    /// @copydoc IPositionComponent::GetPosition()
+    const csp::common::Vector3& GetPosition() const override;
+    /// @copydoc IPositionComponent::SetPosition()
+    void SetPosition(const csp::common::Vector3& InValue) override;
+    /// @copydoc IRotationComponent::GetRotation()
+    const csp::common::Vector4& GetRotation() const override;
+    /// @copydoc IRotationComponent::SetRotation()
+    void SetRotation(const csp::common::Vector4& InValue) override;
+    /// @copydoc IScaleComponent::GetScale()
+    const csp::common::Vector3& GetScale() const override;
+    /// @copydoc IScaleComponent::SetScale()
+    void SetScale(const csp::common::Vector3& InValue) override;
+    /// @copydoc ITransformComponent::GetTransform()
+    SpaceTransform GetTransform() const override;
+    /// @copydoc ITransformComonent::SetTransform()
+    void SetTransform(const SpaceTransform& InValue) override;
+    /// @}
+};
+
+} // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/Components/AIChatbotComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AIChatbotComponent.h
@@ -41,7 +41,12 @@ enum class AIChatbotPropertyKeys
 /// @brief Enumerates the list of potential visual states that can be replicated for a AI chatbot component.
 enum class AIChatbotVisualState
 {
-    None
+    Idle = 0,
+    Listening,
+    Thinking,
+    Speaking,
+    Unknown,
+    Num
 };
 
 class CSP_API AIChatbotSpaceComponent : public ComponentBase, public ITransformComponent

--- a/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
+++ b/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
@@ -19,6 +19,8 @@
 
 #include "CSP/Multiplayer/Components/AIChatbotComponent.h"
 
+#include "Multiplayer/Script/ComponentBinding/AIChatbotComponentScriptInterface.h"
+
 namespace csp::multiplayer
 {
 
@@ -31,6 +33,8 @@ csp::multiplayer::AIChatbotSpaceComponent::AIChatbotSpaceComponent(csp::common::
     Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::ContextAssetId)] = "";
     Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::GuardrailAssetId)] = "";
     Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::VisualState)] = static_cast<int64_t>(0);
+
+    SetScriptInterface(new AIChatbotSpaceComponentScriptInterface(this));
 }
 
 const csp::common::String& AIChatbotSpaceComponent::GetContextAssetId() const

--- a/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
+++ b/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// @file AIChatbotComponent.h
+/// @brief Definitions and support for AI chatbot components.
+
+#include "CSP/Multiplayer/Components/AIChatbotComponent.h"
+
+namespace csp::multiplayer
+{
+
+csp::multiplayer::AIChatbotSpaceComponent::AIChatbotSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
+    : ComponentBase(ComponentType::AIChatbot, LogSystem, Parent)
+{
+    Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::Position)] = csp::common::Vector3::Zero();
+    Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::Rotation)] = csp::common::Vector4::Identity();
+    Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::Scale)] = csp::common::Vector3::One();
+    Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::ContextAssetId)] = "";
+    Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::GuardrailAssetId)] = "";
+    Properties[static_cast<uint32_t>(AIChatbotPropertyKeys::VisualState)] = static_cast<int64_t>(0);
+}
+
+const csp::common::String& AIChatbotSpaceComponent::GetContextAssetId() const
+{
+    return GetStringProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::ContextAssetId));
+}
+
+void AIChatbotSpaceComponent::SetContextAssetId(const csp::common::String& Value)
+{
+    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::ContextAssetId), Value);
+}
+
+const csp::common::String& AIChatbotSpaceComponent::GetGuardrailAssetId() const
+{
+    return GetStringProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::GuardrailAssetId));
+}
+
+void AIChatbotSpaceComponent::SetGuardrailAssetId(const csp::common::String& Value)
+{
+    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::GuardrailAssetId), Value);
+}
+
+AIChatbotVisualState AIChatbotSpaceComponent::GetVisualState() const
+{
+    return static_cast<AIChatbotVisualState>(GetIntegerProperty((uint32_t)AIChatbotPropertyKeys::VisualState));
+}
+
+void AIChatbotSpaceComponent::SetVisualState(AIChatbotVisualState Value)
+{
+    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::VisualState), static_cast<int64_t>(Value));
+}
+
+/* ITransformComponent */
+
+const csp::common::Vector3& AIChatbotSpaceComponent::GetPosition() const
+{
+    return GetVector3Property(static_cast<uint32_t>(AIChatbotPropertyKeys::Position));
+}
+
+void AIChatbotSpaceComponent::SetPosition(const csp::common::Vector3& Value)
+{
+    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::Position), Value);
+}
+
+const csp::common::Vector4& AIChatbotSpaceComponent::GetRotation() const
+{
+    return GetVector4Property(static_cast<uint32_t>(AIChatbotPropertyKeys::Rotation));
+}
+
+void AIChatbotSpaceComponent::SetRotation(const csp::common::Vector4& Value)
+{
+    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::Rotation), Value);
+}
+
+const csp::common::Vector3& AIChatbotSpaceComponent::GetScale() const
+{
+    return GetVector3Property(static_cast<uint32_t>(AIChatbotPropertyKeys::Scale));
+}
+
+void AIChatbotSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::Scale), Value); }
+
+SpaceTransform AIChatbotSpaceComponent::GetTransform() const
+{
+    SpaceTransform Transform;
+    Transform.Position = GetPosition();
+    Transform.Rotation = GetRotation();
+    Transform.Scale = GetScale();
+
+    return Transform;
+}
+
+void AIChatbotSpaceComponent::SetTransform(const SpaceTransform& InValue)
+{
+    SetPosition(InValue.Position);
+    SetRotation(InValue.Rotation);
+    SetScale(InValue.Scale);
+}
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AIChatbotComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AIChatbotComponentScriptInterface.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Multiplayer/Script/ComponentBinding/AIChatbotComponentScriptInterface.h"
+
+#include "CSP/Multiplayer/Components/AIChatbotComponent.h"
+
+namespace csp::multiplayer
+{
+
+AIChatbotSpaceComponentScriptInterface::AIChatbotSpaceComponentScriptInterface(AIChatbotSpaceComponent* InComponent)
+    : ComponentScriptInterface(InComponent)
+{
+}
+
+DEFINE_SCRIPT_PROPERTY_VEC3(AIChatbotSpaceComponent, Scale);
+DEFINE_SCRIPT_PROPERTY_VEC3(AIChatbotSpaceComponent, Position);
+DEFINE_SCRIPT_PROPERTY_VEC4(AIChatbotSpaceComponent, Rotation);
+
+DEFINE_SCRIPT_PROPERTY_STRING(AIChatbotSpaceComponent, ContextAssetId);
+DEFINE_SCRIPT_PROPERTY_STRING(AIChatbotSpaceComponent, GuardrailAssetId);
+
+DEFINE_SCRIPT_PROPERTY_TYPE(AIChatbotSpaceComponent, csp::multiplayer::AIChatbotVisualState, int32_t, VisualState);
+
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/AIChatbotComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/AIChatbotComponentScriptInterface.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Multiplayer/Script/ComponentScriptInterface.h"
+
+#include <string>
+#include <vector>
+
+namespace csp::multiplayer
+{
+
+class AIChatbotSpaceComponent;
+
+class AIChatbotSpaceComponentScriptInterface : public ComponentScriptInterface
+{
+public:
+    AIChatbotSpaceComponentScriptInterface(AIChatbotSpaceComponent* InComponent = nullptr);
+
+    DECLARE_SCRIPT_PROPERTY(Vector3, Position);
+    DECLARE_SCRIPT_PROPERTY(Vector3, Scale);
+    DECLARE_SCRIPT_PROPERTY(Vector4, Rotation);
+
+    DECLARE_SCRIPT_PROPERTY(std::string, ContextAssetId);
+    DECLARE_SCRIPT_PROPERTY(std::string, GuardrailAssetId);
+
+    DECLARE_SCRIPT_PROPERTY(int32_t, VisualState);
+};
+
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -21,6 +21,7 @@
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Common/Vector.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
+#include "Multiplayer/Script/ComponentBinding/AIChatbotComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/AnimatedModelSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/AvatarSpaceComponentScriptInterface.h"
@@ -584,6 +585,16 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsARVisible, "isARVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsVirtualVisible, "isVirtualVisible")
         .PROPERTY_GET_SET(ScreenSharingSpaceComponent, IsShadowCaster, "isShadowCaster");
+
+    Module->class_<AIChatbotSpaceComponentScriptInterface>("AIChatbotSpaceComponent")
+        .constructor<>()
+        .base<ComponentScriptInterface>()
+        .PROPERTY_GET_SET(AIChatbotSpaceComponent, Position, "position")
+        .PROPERTY_GET_SET(AIChatbotSpaceComponent, Scale, "scale")
+        .PROPERTY_GET_SET(AIChatbotSpaceComponent, Rotation, "rotation")
+        .PROPERTY_GET_SET(AIChatbotSpaceComponent, ContextAssetId, "contextAssetId")
+        .PROPERTY_GET_SET(AIChatbotSpaceComponent, GuardrailAssetId, "guardrailAssetId")
+        .PROPERTY_GET_SET(AIChatbotSpaceComponent, VisualState, "visualState");
 }
 
 void EntityScriptBinding::Bind(int64_t ContextId, csp::common::IJSScriptRunner& ScriptRunner)
@@ -630,6 +641,7 @@ void EntityScriptBinding::Bind(int64_t ContextId, csp::common::IJSScriptRunner& 
         .fun<&EntityScriptInterface::GetComponentsOfType<HotspotSpaceComponentScriptInterface, ComponentType::Hotspot>>("getHotspotComponents")
         .fun<&EntityScriptInterface::GetComponentsOfType<ScreenSharingSpaceComponentScriptInterface, ComponentType::ScreenSharing>>(
             "getScreenSharingComponents")
+        .fun<&EntityScriptInterface::GetComponentsOfType<AIChatbotSpaceComponentScriptInterface, ComponentType::AIChatbot>>("getAIChatbotComponents")
         .fun<&EntityScriptInterface::RemoveParentEntity>("removeParentEntity")
         .property<&EntityScriptInterface::GetPosition, &EntityScriptInterface::SetPosition>("position")
         .property<&EntityScriptInterface::GetGlobalPosition>("globalPosition")

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -18,6 +18,7 @@
 #include "CSP/Common/StringFormat.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Common/fmt_Formatters.h"
+#include "CSP/Multiplayer/Components/AIChatbotComponent.h"
 #include "CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h"
 #include "CSP/Multiplayer/Components/AudioSpaceComponent.h"
 #include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
@@ -576,6 +577,9 @@ ComponentBase* SpaceEntity::InstantiateComponent(uint16_t InstantiateId, Compone
         break;
     case ComponentType::ScreenSharing:
         Component = new ScreenSharingSpaceComponent(LogSystem, this);
+        break;
+    case ComponentType::AIChatbot:
+        Component = new AIChatbotSpaceComponent(LogSystem, this);
         break;
     default:
     {

--- a/Tests/src/PublicAPITests/ComponentTests/AIChatbotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AIChatbotComponentTests.cpp
@@ -117,3 +117,76 @@ CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentTest)
     // Log out
     LogOut(UserSystem);
 }
+
+CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentScriptTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    // Log in
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Create space
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+
+    EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    RealtimeEngine->SetRemoteEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    // Create parent Space Entity
+    csp::common::String ObjectName = "Object 1";
+    SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
+
+    // Create ai chatbot component
+    auto* AIChatbotComponent = (AIChatbotSpaceComponent*)CreatedObject->AddComponent(ComponentType::AIChatbot);
+
+    CreatedObject->QueueUpdate();
+    RealtimeEngine->ProcessPendingEntityOperations();
+
+    // Setup script
+    const std::string ScreenSharingScriptText = R"xx(
+		var component = ThisEntity.getAIChatbotComponents()[0];
+
+		component.attenuationRadius = 22.0;
+		component.position = [1, 1, 1];
+		component.rotation = [1, 1, 1, 1];
+        component.scale = [0, 0, 0];
+        component.contextAssetId = "TEST_CONTEXT_ASSET_ID";
+        component.guardrailAssetId = "TEST_GUARDRAIL_ASSET_ID";
+        component.visualState = 0;
+    )xx";
+
+    CreatedObject->GetScript().SetScriptSource(ScreenSharingScriptText.c_str());
+    CreatedObject->GetScript().Invoke();
+
+    RealtimeEngine->ProcessPendingEntityOperations();
+
+    // Ensure values are set correctly
+    EXPECT_EQ(AIChatbotComponent->GetPosition(), csp::common::Vector3::One());
+    EXPECT_EQ(AIChatbotComponent->GetRotation(), csp::common::Vector4::One());
+    EXPECT_EQ(AIChatbotComponent->GetScale(), csp::common::Vector3::Zero());
+
+    EXPECT_EQ(AIChatbotComponent->GetContextAssetId(), "TEST_CONTEXT_ASSET_ID");
+    EXPECT_EQ(AIChatbotComponent->GetGuardrailAssetId(), "TEST_GUARDRAIL_ASSET_ID");
+
+    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::None);
+
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+    // Delete space
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    // Log out
+    LogOut(UserSystem);
+}

--- a/Tests/src/PublicAPITests/ComponentTests/AIChatbotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AIChatbotComponentTests.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../SpaceSystemTestHelpers.h"
+#include "../UserSystemTestHelpers.h"
+#include "Awaitable.h"
+#include "CSP/CSPFoundation.h"
+#include "CSP/Common/Optional.h"
+#include "CSP/Multiplayer/Components/AIChatbotComponent.h"
+#include "CSP/Multiplayer/MultiPlayerConnection.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
+#include "TestHelpers.h"
+
+#include "gtest/gtest.h"
+#include <chrono>
+#include <thread>
+
+using namespace csp::multiplayer;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+bool RequestPredicate(const csp::systems::ResultBase& Result) { return Result.GetResultCode() != csp::systems::EResultCode::InProgress; }
+
+} // namespace
+
+CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    // Log in
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    // Create space
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+
+    EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    RealtimeEngine->SetRemoteEntityCreatedCallback([](csp::multiplayer::SpaceEntity* /*Entity*/) {});
+
+    // Create parent Space Entity
+    csp::common::String ObjectName = "Object 1";
+    SpaceTransform ObjectTransform = { csp::common::Vector3::Zero(), csp::common::Vector4::Zero(), csp::common::Vector3::One() };
+    auto [CreatedObject] = AWAIT(RealtimeEngine.get(), CreateEntity, ObjectName, ObjectTransform, csp::common::Optional<uint64_t> {});
+
+    // Create ai chatbot component
+    auto* AIChatbotComponent = static_cast<AIChatbotSpaceComponent*>(CreatedObject->AddComponent(ComponentType::AIChatbot));
+
+    // Ensure defaults are set
+    EXPECT_EQ(AIChatbotComponent->GetPosition(), csp::common::Vector3::Zero());
+    EXPECT_EQ(AIChatbotComponent->GetRotation(), csp::common::Vector4::Identity());
+    EXPECT_EQ(AIChatbotComponent->GetScale(), csp::common::Vector3::One());
+
+    EXPECT_EQ(AIChatbotComponent->GetContextAssetId(), "");
+    EXPECT_EQ(AIChatbotComponent->GetGuardrailAssetId(), "");
+
+    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::None);
+
+    CreatedObject->QueueUpdate();
+    RealtimeEngine->ProcessPendingEntityOperations();
+
+    // Set new values
+    csp::common::String ContextAssetId = "TEST_CONTEXT_ASSET_ID";
+    csp::common::String GuardrailAssetId = "TEST_GUARDRAIL_ASSET_ID";
+
+    AIChatbotComponent->SetPosition(csp::common::Vector3::One());
+    AIChatbotComponent->SetRotation(csp::common::Vector4::One());
+    AIChatbotComponent->SetScale(csp::common::Vector3::Zero());
+
+    AIChatbotComponent->SetContextAssetId(ContextAssetId);
+    AIChatbotComponent->SetGuardrailAssetId(GuardrailAssetId);
+
+    AIChatbotComponent->SetVisualState(AIChatbotVisualState::None);
+
+    // Ensure values are set correctly
+    EXPECT_EQ(AIChatbotComponent->GetPosition(), csp::common::Vector3::One());
+    EXPECT_EQ(AIChatbotComponent->GetRotation(), csp::common::Vector4::One());
+    EXPECT_EQ(AIChatbotComponent->GetScale(), csp::common::Vector3::Zero());
+
+    EXPECT_EQ(AIChatbotComponent->GetContextAssetId(), ContextAssetId);
+    EXPECT_EQ(AIChatbotComponent->GetGuardrailAssetId(), GuardrailAssetId);
+
+    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::None);
+
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+
+    // Delete space
+    DeleteSpace(SpaceSystem, Space.Id);
+
+    // Log out
+    LogOut(UserSystem);
+}

--- a/Tests/src/PublicAPITests/ComponentTests/AIChatbotComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AIChatbotComponentTests.cpp
@@ -81,7 +81,7 @@ CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentTest)
     EXPECT_EQ(AIChatbotComponent->GetContextAssetId(), "");
     EXPECT_EQ(AIChatbotComponent->GetGuardrailAssetId(), "");
 
-    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::None);
+    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::Idle);
 
     CreatedObject->QueueUpdate();
     RealtimeEngine->ProcessPendingEntityOperations();
@@ -97,7 +97,7 @@ CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentTest)
     AIChatbotComponent->SetContextAssetId(ContextAssetId);
     AIChatbotComponent->SetGuardrailAssetId(GuardrailAssetId);
 
-    AIChatbotComponent->SetVisualState(AIChatbotVisualState::None);
+    AIChatbotComponent->SetVisualState(AIChatbotVisualState::Listening);
 
     // Ensure values are set correctly
     EXPECT_EQ(AIChatbotComponent->GetPosition(), csp::common::Vector3::One());
@@ -107,7 +107,7 @@ CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentTest)
     EXPECT_EQ(AIChatbotComponent->GetContextAssetId(), ContextAssetId);
     EXPECT_EQ(AIChatbotComponent->GetGuardrailAssetId(), GuardrailAssetId);
 
-    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::None);
+    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::Listening);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
@@ -164,7 +164,7 @@ CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentScriptTest)
         component.scale = [0, 0, 0];
         component.contextAssetId = "TEST_CONTEXT_ASSET_ID";
         component.guardrailAssetId = "TEST_GUARDRAIL_ASSET_ID";
-        component.visualState = 0;
+        component.visualState = 1;
     )xx";
 
     CreatedObject->GetScript().SetScriptSource(ScreenSharingScriptText.c_str());
@@ -180,7 +180,7 @@ CSP_PUBLIC_TEST(CSPEngine, AIChatbotTests, AIChatbotSpaceComponentScriptTest)
     EXPECT_EQ(AIChatbotComponent->GetContextAssetId(), "TEST_CONTEXT_ASSET_ID");
     EXPECT_EQ(AIChatbotComponent->GetGuardrailAssetId(), "TEST_GUARDRAIL_ASSET_ID");
 
-    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::None);
+    EXPECT_EQ(AIChatbotComponent->GetVisualState(), AIChatbotVisualState::Listening);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 


### PR DESCRIPTION
CSP will need to provide a new component to hold relevant information for the AI chatbot work. The main interaction with the AI and visual cues will be handled client-side, but some state and related information needs to be replicated between clients. This PR introduces a new AI chatbot component with the following properties: 

- Position: Local position in meters.
- Rotation: Local rotation.
- Scale: Local scale in meters.
- ContextAssetID: The context asset ID represents an MCS prototype storing the LLM context 
- GuardrailAssetID: The Guardrail asset ID represents an MCS prototype storing the user-defined guardrails.
- VisualState: Store the current visual state of the AI (NOTE: the states are gathered from the UI prototype)

These properties have also been exposed through the scripting interface, and tests for both components and scripts have been included. 

> [!NOTE]
This PR has been marked as a draft as guardrails may change based on discussion later today. Following this, I will address any needed changes and/or promote it from draft.