### PR TITLE
[OB-4051] fix: Change default property values for CSP Fog Space Component

### DIFF
--- a/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
@@ -70,7 +70,7 @@ public:
     /// @return The modality of fog currently used by this component.
     FogMode GetFogMode() const;
 
-    /// @brief Sets the type of fog currently to be used by this fog component.
+    /// @brief Sets the type of fog to be used by this fog component.
     /// @param Value The modality of fog to be used by this component.
     void SetFogMode(FogMode Value);
 
@@ -94,75 +94,74 @@ public:
     void SetTransform(const SpaceTransform& InValue) override;
     /// @}
 
-    /// @brief Get start sistance
+    /// @brief Gets start distance
     /// Note: Distance from camera that the fog will start.
     /// Note: 0 = this property has no effect.
     /// @return Current start distance
     float GetStartDistance() const;
 
-    /// @brief Set Current start distance
+    /// @brief Sets start distance
     /// Note: Distance from camera that the fog will start.
     /// Note: 0 = this property has no effect.
-    /// @param Value float : Current start distance
+    /// @param Value float : Start distance
     void SetStartDistance(float Value);
 
-    /// @brief Get Current end distance
+    /// @brief Gets end distance
     /// Note: objects passed this distance will not be affected by fog.
     /// Note: 0 = this property has no effect.
     /// @return Current end distance
     float GetEndDistance() const;
 
-    /// @brief Set Current end distance
+    /// @brief Sets end distance
     /// Note: objects passed this distance will not be affected by fog.
     /// Note: 0 = this property has no effect.
-    /// @param Value float : Current end distance
+    /// @param Value float : End distance
     void SetEndDistance(float Value);
 
-    /// @brief Get fog color
+    /// @brief Gets fog color
     /// @return Current fog color
     const csp::common::Vector3& GetColor() const;
 
-    /// @brief Set Current fog color
-    /// @param Value float : Current fog color
+    /// @brief Sets fog color
+    /// @param Value float : Fog color
     void SetColor(const csp::common::Vector3& Value);
 
-    /// @brief Get Global density factor
-    /// Note: Global density factor
-    /// @return Current Global density factor
+    /// @brief Gets global density factor
+    /// @return Current global density factor
     float GetDensity() const;
 
-    /// @brief Set Global density factor
-    /// Note: Global density factor
+    /// @brief Sets global density factor
     /// @param Value float : Global density factor
     void SetDensity(float Value);
 
-    /// @brief Get Height density factor
+    /// @brief Gets Height density factor
     /// Note: Height density factor, controls how the density increases and height decreases. Smaller values make the visible transition larger.
-    /// @return Current Height density factor
+    /// @return Current height density factor
     float GetHeightFalloff() const;
 
-    /// @brief Set Height density factor
+    /// @brief Sets Height density factor
     /// Note: Height density factor, controls how the density increases and height decreases. Smaller values make the visible transition larger.
     /// @param Value float : Height density factor
     void SetHeightFalloff(float Value);
 
-    /// @brief Get Maximum opacity of the Fog.
-    /// Maximum opacity of the Fog.
+    /// @brief Gets maximum opacity of the fog.
     /// Note: 1 = fog becomes fully opaque at a distance and replaces the scene colour completely.
     /// Note: 0 = fog colour will have no impact.
-    /// @return Current Maximum opacity of the Fog
+    /// @return Current maximum opacity
     float GetMaxOpacity() const;
 
-    /// @brief Set Maximum opacity of the Fog.
-    /// @param Value float : Maximum opacity of the Fog.
+    /// @brief Sets maximum opacity of the fog.
+    /// Note: 1 = fog becomes fully opaque at a distance and replaces the scene colour completely.
+    /// Note: 0 = fog colour will have no impact.
+    /// @param Value float : Maximum opacity of the fog.
     void SetMaxOpacity(float Value);
 
-    /// @brief Get Is Fog Volumetric.
-    /// @param Value float : Fog Volumetric Flag
+    /// @brief Gets IsFogVolumetric.
+    /// @return Current fog volumetric flag
     bool GetIsVolumetric() const;
 
-    /// @brief Set Is Fog Volumetric
-    /// @param Value float : Is Fog Volumetric Flag
+    /// @brief Sets IsFogVolumetric
+    /// @param Value float : Fog Volumetric Flag
     void SetIsVolumetric(bool Value);
 
     /// \addtogroup IVisibleComponent

--- a/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
@@ -23,7 +23,7 @@ namespace csp::multiplayer
 FogSpaceComponent::FogSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
     : ComponentBase(ComponentType::Fog, LogSystem, Parent)
 {
-    Properties[static_cast<uint32_t>(FogPropertyKeys::FogMode)] = static_cast<int64_t>(FogMode::Linear);
+    Properties[static_cast<uint32_t>(FogPropertyKeys::FogMode)] = static_cast<int64_t>(FogMode::Exponential);
     Properties[static_cast<uint32_t>(FogPropertyKeys::Position)] = csp::common::Vector3 { 0, 0, 0 };
     Properties[static_cast<uint32_t>(FogPropertyKeys::Rotation)] = csp::common::Vector4 { 0, 0, 0, 1 };
     Properties[static_cast<uint32_t>(FogPropertyKeys::Scale)] = csp::common::Vector3 { 1, 1, 1 };

--- a/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
@@ -30,7 +30,7 @@ FogSpaceComponent::FogSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEnt
     Properties[static_cast<uint32_t>(FogPropertyKeys::StartDistance)] = 0.f;
     Properties[static_cast<uint32_t>(FogPropertyKeys::EndDistance)] = 0.f;
     Properties[static_cast<uint32_t>(FogPropertyKeys::Color)] = csp::common::Vector3 { 0.8f, 0.9f, 1.0f };
-    Properties[static_cast<uint32_t>(FogPropertyKeys::Density)] = 0.2f;
+    Properties[static_cast<uint32_t>(FogPropertyKeys::Density)] = 0.4f;
     Properties[static_cast<uint32_t>(FogPropertyKeys::HeightFalloff)] = 0.2f;
     Properties[static_cast<uint32_t>(FogPropertyKeys::MaxOpacity)] = 1.f;
     Properties[static_cast<uint32_t>(FogPropertyKeys::IsVolumetric)] = false;

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -77,7 +77,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
     auto* FogComponent = static_cast<FogSpaceComponent*>(CreatedObject->AddComponent(ComponentType::Fog));
 
     // Ensure defaults are set
-    EXPECT_EQ(FogComponent->GetFogMode(), FogMode::Linear);
+    EXPECT_EQ(FogComponent->GetFogMode(), FogMode::Exponential);
     EXPECT_EQ(FogComponent->GetPosition(), csp::common::Vector3::Zero());
     EXPECT_EQ(FogComponent->GetRotation(), csp::common::Vector4(0, 0, 0, 1));
     EXPECT_EQ(FogComponent->GetScale(), csp::common::Vector3::One());

--- a/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FogComponentTests.cpp
@@ -84,7 +84,7 @@ CSP_PUBLIC_TEST(CSPEngine, FogTests, FogComponentTest)
     EXPECT_FLOAT_EQ(FogComponent->GetStartDistance(), 0.f);
     EXPECT_FLOAT_EQ(FogComponent->GetEndDistance(), 0.f);
     EXPECT_EQ(FogComponent->GetColor(), csp::common::Vector3({ 0.8f, 0.9f, 1.0f }));
-    EXPECT_FLOAT_EQ(FogComponent->GetDensity(), 0.2f);
+    EXPECT_FLOAT_EQ(FogComponent->GetDensity(), 0.4f);
     EXPECT_FLOAT_EQ(FogComponent->GetHeightFalloff(), 0.2f);
     EXPECT_FLOAT_EQ(FogComponent->GetMaxOpacity(), 1.f);
     EXPECT_FALSE(FogComponent->GetIsVolumetric());


### PR DESCRIPTION
## Jira ticket link: [OB-4051](https://magnopus.atlassian.net/browse/OB-4051)

This ticket is part of a bigger work on the OKO UE side, for which a PR has already been submitted [here](https://github.com/magnopus/oko-unreal-plugin/pull/337) (changes are "summarised" [here](https://magnopus.atlassian.net/browse/OB-4051?focusedCommentId=412430)).

This PR on the CSP side aims for a consistent value to initialise each Fog property in CSP so Component variants are consistent across all OKO clients:
- CSP `FogMode` property was set to `Linear` by default. This led to a significant shift in visuals when converting an Unreal Exponential Height Fog component (the only fog mode supported by Unreal being `Exponential`) to an OKO Fog component, as `GetCSPData()` would be called first for OKO component at initialisation time, setting its fog mode to `Linear` as well,
- CSP `Density` property was set to 0.2f while it was set to 0.4f on the Web client. As I set up the Unreal value to be 0.4f as well, conducting the same change here.
- Also took this opportunity to format comments more consistently in the header file.

12 succeeded, 1 failed (error C1083: Cannot open include file: 'process.hpp': No such file or directory - was already there before the change), so I assume the one concerning the CSP Fog component passed. Waiting for the CI tests to run as part of this draft PR now before turning it into a normal one.