### PR TITLE
[NT-0] test: Remove LocalMCS skip

### DIFF
--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -1223,13 +1223,6 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetCheckoutSessionUrlTest)
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DefaultApplicationSettingsTest)
 {
-    if (std::string(EndpointBaseURI()).find(":8081") != std::string::npos)
-    {
-        // Skip if we're running on Local MCS. This is hopefully a temporary hack as CHS do intend that this data be seeded in local MCS, it just
-        // hasn't managed to take quite yet. Doing this to unblock the work.
-        GTEST_SKIP() << "Default application settings not seeded on local MCS";
-    }
-
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
 


### PR DESCRIPTION
This wasn't actually a global problem, was an issue on machines that had a local mongo instance installed, to the surprise of everyone.