### PR TITLE
[NT-0] style: Remove unused variables

### DIFF
--- a/Tests/src/InternalTests/SceneDescriptionTests.cpp
+++ b/Tests/src/InternalTests/SceneDescriptionTests.cpp
@@ -244,7 +244,7 @@ class MockScriptRunner : public csp::common::IJSScriptRunner
     void* GetModule(int64_t, const csp::common::String&) override { return nullptr; }
     bool CreateContext(int64_t) override { return false; }
     bool DestroyContext(int64_t) override { return false; }
-    void SetModuleSource(csp::common::String ModuleUrl, csp::common::String) override { }
+    void SetModuleSource(csp::common::String, csp::common::String) override { }
     void ClearModuleSource(csp::common::String) override { }
 };
 

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -605,9 +605,9 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
     bool Interrupted = false;
     bool Disconnected = false;
 
-    Connection->SetNetworkInterruptionCallback([&Interrupted](csp::common::String Message) { Interrupted = true; });
+    Connection->SetNetworkInterruptionCallback([&Interrupted](csp::common::String /*Message*/) { Interrupted = true; });
 
-    Connection->SetDisconnectionCallback([&Disconnected](csp::common::String Message) { Disconnected = true; });
+    Connection->SetDisconnectionCallback([&Disconnected](csp::common::String /*Message*/) { Disconnected = true; });
 
     csp::common::String UserName = "Player 1";
     SpaceTransform UserTransform


### PR DESCRIPTION
Was triggering warning as errors on some environments. Not sure why/how these got in there or were missed.
