### PR TITLE
[NT-0] test: Add new exportID to test data

### DIFF
--- a/Tests/assets/checkpoint-basic.json
+++ b/Tests/assets/checkpoint-basic.json
@@ -3,6 +3,7 @@
     "checkpointTimestamp": "2025-08-27T14:33:22.7204028+00:00",
     "spaceId": "68af162f015bb6793cacf4a2",
     "tenantName": "OKO_TESTS",
+    "exportId": "679aba06b50e18a31a050532",
     "data": {
         "group": {
             "id": "68af162f015bb6793cacf4a2",

--- a/Tests/assets/checkpoint-empty.json
+++ b/Tests/assets/checkpoint-empty.json
@@ -3,6 +3,7 @@
     "checkpointTimestamp": "2025-08-26T16:15:24.6191891+00:00",
     "spaceId": "68addce4985d7612f76b9461",
     "tenantName": "OKO_TESTS",
+    "exportId": "679aba06b50e18a31a050532",
     "data": {
         "group": {
             "id": "68addce4985d7612f76b9461",

--- a/Tests/assets/checkpoint-material.json
+++ b/Tests/assets/checkpoint-material.json
@@ -3,6 +3,7 @@
     "checkpointTimestamp": "2025-08-29T15:39:23.415991+00:00",
     "spaceId": "68b1c760015bb6793cad24a7",
     "tenantName": "OKO_TESTS",
+    "exportId": "679aba06b50e18a31a050532",
     "data": {
         "group": {
             "id": "68b1c760015bb6793cad24a7",

--- a/Tests/assets/checkpoint-parents.json
+++ b/Tests/assets/checkpoint-parents.json
@@ -3,6 +3,7 @@
   "checkpointTimestamp": "2025-10-02T08:10:09.1072167+00:00",
   "spaceId": "68de3196d71222a39de853da",
   "tenantName": "TEST_01",
+  "exportId": "679aba06b50e18a31a050532",
   "data": {
     "group": {
       "id": "68de3196d71222a39de853da",


### PR DESCRIPTION
New data was added when these files are generated, just mirror/add it to our test data to ensure we stay able to parse.

We are btw, we don't really care about data outside the "data" field