### PR TITLE
[NT-0] fix: Update DWARF info file path to Debug

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -320,7 +320,7 @@ if not Project then
             linkoptions {
                 "-gdwarf-5",
                 "-gseparate-dwarf", -- preserve debug information (DWARF)
-                "-sSEPARATE_DWARF_URL=../debug/ConnectedSpacesPlatform_WASM.wasm.debug.wasm"
+                "-sSEPARATE_DWARF_URL=../Debug/ConnectedSpacesPlatform_WASM.wasm.debug.wasm"
             }
         filter { "platforms:wasm", "configurations:*Release*" }
             -- We want to reduce the size of Release builds as much as possible


### PR DESCRIPTION
[NT-0] fix: Update DWARF info file path to Debug

When attempting to debug and step through the C++ source code of the Wasm build on the web, it was discovered that the path for the DWARF information file is incorrect.
The DWARF debug file (`ConnectedSpacesPlatform_WASM.wasm.debug.wasm`) is located in the `Debug` folder of the NPM package, however it was being searched for in the `debug` folder (note the all-lower case name).
Due to this, the `ConnectedSpacesPlatform_WASM.wasm.debug.wasm` file had to be copied by hand into a new `debug` folder for it to be found.
This PR updates the path where this file is loaded from to be `Debug`, where it is actually located.

See the [Debugging CSP for Web](https://connected-spaces-platform.net/manual/debugging/debugging_web.html) documentation page for more information about debugging the CSP Wasm build with DWARF.