### PR TITLE
[NT-0] test: Mock the Web Client

### DIFF
--- a/Library/src/Common/Web/WebClient.h
+++ b/Library/src/Common/Web/WebClient.h
@@ -84,7 +84,7 @@ public:
     /// @param Payload Headers and body content
     /// @param ResponseCallback Pointer to callback for the response
     /// @param AsyncResponse Flag to indicate if the response should be issued asynchronously as soon as it's received
-    void SendRequest(ERequestVerb Verb, const csp::web::Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* ResponseCallback,
+    virtual void SendRequest(ERequestVerb Verb, const csp::web::Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* ResponseCallback,
         csp::common::CancellationToken& CancellationToken, bool AsyncResponse = true);
 
 #ifndef CSP_WASM
@@ -107,7 +107,7 @@ public:
     /// @details This setter needs to exist due to order of initialization. At the time of writing, the AuthContext has a WebClient dependency,
     /// and the WebClient has an IAuthContext dependency.
     /// @param AuthContext csp::common::IAuthContext& : The AuthContext for this object.
-    void SetAuthContext(csp::common::IAuthContext& AuthContext);
+    virtual void SetAuthContext(csp::common::IAuthContext& AuthContext);
 
 protected:
     /// @brief Send a http request

--- a/Tests/src/InternalTests/WebClientTests.cpp
+++ b/Tests/src/InternalTests/WebClientTests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CSP/CSPFoundation.h"
+#include "CSP/Common/fmt_Formatters.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "CSP/Systems/Users/UserSystem.h"
 #include "Debug/Logging.h"
@@ -22,249 +23,174 @@
 #include "RAIIMockLogger.h"
 #include "TestHelpers.h"
 
-#ifdef CSP_WASM
-#include "Common/Web/EmscriptenWebClient/EmscriptenWebClient.h"
-#else
-#include "Common/Web/POCOWebClient/POCOWebClient.h"
-#endif
-
 #include "gtest/gtest.h"
-#include <atomic>
 #include <chrono>
+#include <future>
 #include <gmock/gmock.h>
 #include <rapidjson/document.h>
 #include <rapidjson/rapidjson.h>
-#include <thread>
+
+#include "Mocks/WebClientMock.h"
 
 using namespace csp::web;
 
-// The WebClientTests will be reviewed as part of OF-1532.
+inline const char* TESTS_PAYLOAD_RESPONSE_CONTENT = "payloadData";
 
-class ResponseReceiver : public ResponseWaiter, public csp::web::IHttpResponseHandler
+csp::common::String ERequestVerbToString(ERequestVerb verb)
 {
-public:
-    ResponseReceiver()
-        : ResponseReceived(false)
-        , ThreadId(std::this_thread::get_id())
+    switch (verb)
     {
+    case ERequestVerb::Get:
+        return "GET";
+    case ERequestVerb::Put:
+        return "PUT";
+    case ERequestVerb::Post:
+        return "POST";
+    case ERequestVerb::Delete:
+        return "DELETE";
+    case ERequestVerb::Head:
+        return "HEAD";
+    default:
+        return "Unknown";
     }
+}
 
-    void OnHttpResponse(csp::web::HttpResponse& InResponse) override
-    {
-        // We expect the callback to have come from a seperate Thread
-        EXPECT_FALSE(std::this_thread::get_id() == ThreadId);
+CSP_INTERNAL_TEST(CSPEngine, WebClientTests, MockWebClientSendRequestTest)
+{
+    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
-        Response = InResponse;
-        ResponseReceived = true;
-    }
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
 
-    bool WaitForResponse()
-    {
-        return WaitFor([this] { return IsResponseReceived(); }, std::chrono::seconds(10));
-    }
+    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    MockHttpResponseHandler MockHandler;
 
-    bool IsResponseReceived() const { return ResponseReceived; }
-
-    HttpResponse& GetResponse() { return Response; }
-
-private:
     HttpResponse Response;
 
-    std::atomic<bool> ResponseReceived;
-    std::thread::id ThreadId;
-};
+    std::promise<bool> OnHttpResponsePromise;
+    std::future<bool> OnHttpResponseFuture = OnHttpResponsePromise.get_future();
 
-#ifdef CSP_WASM
-class TestWebClient : public EmscriptenWebClient
-#else
-class TestWebClient : public POCOWebClient
-#endif
-{
-public:
-    TestWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::IAuthContext& AuthContext, csp::common::LogSystem* LogSystem)
-        : POCOWebClient(InPort, Tp, AuthContext, LogSystem, false)
-    {
-    }
+    EXPECT_CALL(*MockClient, SendRequest)
+        .WillOnce(
+            [](ERequestVerb /*Verb*/, const Uri& /*InUri*/, HttpPayload& /*Payload*/, IHttpResponseHandler* ResponseCallback,
+                const csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
+            {
+                HttpResponse MockResponse;
+                MockResponse.SetResponseCode(EResponseCodes::ResponseOK);
 
-    TestWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem)
-        : POCOWebClient(InPort, Tp, LogSystem, false)
-    {
-    }
-};
+                // Mock payload data
+                csp::common::String JsonString = "{\"payloadData\":[{\"id\":123,\"email\":\"mock.user@magnopus.com\"}]}";
+                HttpPayload MockPayload;
+                MockPayload.SetContent(JsonString);
+                ((HttpResponse&)MockResponse).GetMutablePayload() = MockPayload;
 
-void WebClientSendRequest(csp::web::WebClient* WebClient, const char* Url, ERequestVerb Verb, HttpPayload& Payload, IHttpResponseHandler* Receiver)
-{
-#ifndef CSP_WASM
-    WebClient->SendRequest(Verb, Uri(Url), Payload, Receiver, csp::common::CancellationToken::Dummy());
-#else
+                ResponseCallback->OnHttpResponse(MockResponse);
+            });
 
-    std::thread TestThread([&]() { WebClient->SendRequest(Verb, Uri(Url), Payload, Receiver, csp::common::CancellationToken::Dummy()); });
+    EXPECT_CALL(MockHandler, OnHttpResponse)
+        .WillOnce(
+            [&](csp::web::HttpResponse& InResponse)
+            {
+                Response = InResponse;
 
-    TestThread.join();
-#endif
-}
+                OnHttpResponsePromise.set_value(true);
+            });
 
-template <typename TReceiver>
-void RunWebClientTest(const char* Url, ERequestVerb Verb, uint32_t Port, HttpPayload& Payload, EResponseCodes ExpectedResponse)
-{
-    TReceiver Receiver;
-    auto& UserSystem = *csp::systems::SystemsManager::Get().GetUserSystem();
-    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-    TestWebClient WebClient(Port, ETransferProtocol::HTTP, UserSystem.GetAuthContext(), LogSystem);
+    csp::web::HttpPayload Payload;
+    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("MockApiKey"));
 
-    WebClientSendRequest(&WebClient, Url, Verb, Payload, &Receiver);
+    MockClient->SendRequest(
+        csp::web::ERequestVerb::Get, Uri("https://mock.service/api/users"), Payload, &MockHandler, csp::common::CancellationToken::Dummy(), true);
 
-    //// Sleep thread until response is received
-    if (Receiver.WaitForResponse())
-    {
-        EXPECT_TRUE(Receiver.GetResponse().GetResponseCode() == ExpectedResponse) << "Response was " << (int)Receiver.GetResponse().GetResponseCode();
-    }
-    else
-    {
-        FAIL() << "Response timeout" << std::endl;
-    }
-}
+    OnHttpResponseFuture.wait();
+    EXPECT_TRUE(OnHttpResponseFuture.get() == true);
 
-template <typename TReceiver>
-void RunWebClientTestWithSetter(const char* Url, ERequestVerb Verb, uint32_t Port, HttpPayload& Payload, EResponseCodes ExpectedResponse)
-{
-    TReceiver Receiver;
-    auto& UserSystem = *csp::systems::SystemsManager::Get().GetUserSystem();
-    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-    TestWebClient WebClient(Port, ETransferProtocol::HTTP, LogSystem);
-    WebClient.SetAuthContext(UserSystem.GetAuthContext());
+    std::string ResponseContent = Response.GetPayload().GetContent().c_str();
+    EXPECT_TRUE(ResponseContent.find("payloadData") != std::string::npos) << "PayloadData was not found.";
 
-    WebClientSendRequest(&WebClient, Url, Verb, Payload, &Receiver);
-
-    //// Sleep thread until response is received
-    if (Receiver.WaitForResponse())
-    {
-        EXPECT_TRUE(Receiver.GetResponse().GetResponseCode() == ExpectedResponse) << "Response was " << (int)Receiver.GetResponse().GetResponseCode();
-    }
-    else
-    {
-        FAIL() << "Response timeout" << std::endl;
-    }
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientGetTestExt)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTest<ResponseReceiver>("https://reqres.in/api/users", ERequestVerb::Get, 80, Payload, EResponseCodes::ResponseOK);
+    delete MockClient;
 
     csp::CSPFoundation::Shutdown();
 }
 
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientGetSetterTestExt)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTestWithSetter<ResponseReceiver>("https://reqres.in/api/users/2", ERequestVerb::Get, 80, Payload, EResponseCodes::ResponseOK);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientPutTestExt)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-
-    rapidjson::Document JsonDoc(rapidjson::kObjectType);
-    JsonDoc.AddMember("name", "bob", JsonDoc.GetAllocator());
-    JsonDoc.AddMember("job", "builder", JsonDoc.GetAllocator());
-
-    Payload.SetContent(JsonDoc);
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTest<ResponseReceiver>("https://reqres.in/api/users/2", ERequestVerb::Put, 80, Payload, EResponseCodes::ResponseOK);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientPostTestExt)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-
-    rapidjson::Document JsonDoc(rapidjson::kObjectType);
-    JsonDoc.AddMember("email", "eve.holt@reqres.in", JsonDoc.GetAllocator());
-    JsonDoc.AddMember("password", "secret", JsonDoc.GetAllocator());
-
-    Payload.SetContent(JsonDoc);
-
-    Payload.AddHeader(CSP_TEXT("Content-Type"), CSP_TEXT("application/json"));
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTest<ResponseReceiver>("https://reqres.in/api/login", ERequestVerb::Post, 80, Payload, EResponseCodes::ResponseOK);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientDeleteTestExt)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTest<ResponseReceiver>("https://reqres.in/api/users/1", ERequestVerb::Delete, 80, Payload, EResponseCodes::ResponseNoContent);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientTestExtRequestResponseVeryVerboseLogging)
+CSP_INTERNAL_TEST(CSPEngine, WebClientTests, MockWebClientRequestResponseVeryVerboseLoggingTest)
 {
     InitialiseFoundation();
 
     {
-        // We must set the log level to VeryVerbose to receive logs for the HTTP Requests and Responses
+        RAIIMockLogger MockLogger {};
+
         csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
         LogSystem->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
 
-        RAIIMockLogger MockLogger {};
+        WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
 
         // Request/Response logs we expect to receive for our HTTP calls.
         // We are only checking against a substring of the request/response logs.
         // Get logs
-        csp::common::String CSPLogMsgGetRequestSubstring = "HTTP Request\nGET https://reqres.in/api/users/2";
-        csp::common::String CSPLogMsgGetResponseSubstring = "HTTP Response\nGET https://reqres.in/api/users/2";
+        csp::common::String CSPLogMsgGetRequestSubstring = "HTTP Request\nGET https://mock.service/api/users";
+        csp::common::String CSPLogMsgGetResponseSubstring = "HTTP Response\nGET https://mock.service/api/users";
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgGetRequestSubstring)));
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgGetResponseSubstring)));
         // Put logs
-        csp::common::String CSPLogMsgPutRequestSubstring = "HTTP Request\nPUT https://reqres.in/api/users/2";
-        csp::common::String CSPLogMsgPutResponseSubstring = "HTTP Response\nPUT https://reqres.in/api/users/2";
+        csp::common::String CSPLogMsgPutRequestSubstring = "HTTP Request\nPUT https://mock.service/api/users";
+        csp::common::String CSPLogMsgPutResponseSubstring = "HTTP Response\nPUT https://mock.service/api/users";
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgPutRequestSubstring)));
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgPutResponseSubstring)));
         // Post logs
-        csp::common::String CSPLogMsgPostRequestSubstring = "HTTP Request\nPOST https://reqres.in/api/login";
-        csp::common::String CSPLogMsgPostResponseSubstring = "HTTP Response\nPOST https://reqres.in/api/login";
+        csp::common::String CSPLogMsgPostRequestSubstring = "HTTP Request\nPOST https://mock.service/api/login";
+        csp::common::String CSPLogMsgPostResponseSubstring = "HTTP Response\nPOST https://mock.service/api/login";
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgPostRequestSubstring)));
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgPostResponseSubstring)));
         // Delete logs
-        csp::common::String CSPLogMsgDeleteRequestSubstring = "HTTP Request\nDELETE https://reqres.in/api/users/1";
-        csp::common::String CSPLogMsgDeleteResponseSubstring = "HTTP Response\nDELETE https://reqres.in/api/users/1";
+        csp::common::String CSPLogMsgDeleteRequestSubstring = "HTTP Request\nDELETE https://mock.service/api/users";
+        csp::common::String CSPLogMsgDeleteResponseSubstring = "HTTP Response\nDELETE https://mock.service/api/users";
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgDeleteRequestSubstring)));
         EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::VeryVerbose, testing::HasSubstr(CSPLogMsgDeleteResponseSubstring)));
 
+        EXPECT_CALL(*MockClient, SendRequest)
+            .WillRepeatedly(testing::DoAll(
+                // Capture: Verb (0), Uri (1), Payload (2), ResponseCallback (3), CancellationToken (4), AsyncResponse (5)
+                testing::WithArgs<0, 1, 2, 3, 4, 5>(
+                    [&MockClient, &LogSystem](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* ResponseCallback,
+                        csp::common::CancellationToken& CancellationToken, bool AsyncResponse)
+                    {
+                        // Mimic the logging behaviour of the WebClient SendRequest method
+                        auto Request = std::make_unique<csp::web::HttpRequest>(
+                            MockClient, Verb, InUri, Payload, ResponseCallback, CancellationToken, AsyncResponse);
+
+                        LogSystem->LogMsg(csp::common::LogLevel::VeryVerbose, fmt::format("{}", *(Request.get())).c_str());
+                    }),
+                // Capture: Verb (0), Uri (1), ResponseCallback (3)
+                testing::WithArgs<0, 1, 3>(
+                    [&](ERequestVerb Verb, const Uri& InUri, IHttpResponseHandler* Handler)
+                    {
+                        EResponseCodes MockedResponseCode
+                            = Verb == ERequestVerb::Delete ? EResponseCodes::ResponseNoContent : EResponseCodes::ResponseOK;
+
+                        HttpResponse MockResponse;
+                        MockResponse.SetResponseCode(MockedResponseCode);
+
+                        // Log the response
+                        LogSystem->LogMsg(csp::common::LogLevel::VeryVerbose,
+                            fmt::format("HTTP Response\n{0} {1}\nStatus: {2} - {3}", ERequestVerbToString(Verb), InUri.GetAsString(),
+                                static_cast<int>(MockResponse.GetResponseCode()), "Success")
+                                .c_str());
+
+                        Handler->OnHttpResponse(MockResponse);
+                    }),
+                testing::Return()));
+
         // GET request
+        MockHttpResponseHandler MockHandlerGet;
         HttpPayload PayloadGet;
 
-        PayloadGet.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
+        PayloadGet.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("MockApiKey"));
 
-        RunWebClientTest<ResponseReceiver>("https://reqres.in/api/users/2", ERequestVerb::Get, 80, PayloadGet, EResponseCodes::ResponseOK);
+        MockClient->SendRequest(csp::web::ERequestVerb::Get, Uri("https://mock.service/api/users"), PayloadGet, &MockHandlerGet,
+            csp::common::CancellationToken::Dummy(), true);
 
         // PUT request
+        MockHttpResponseHandler MockHandlerPut;
         HttpPayload PayloadPut;
 
         rapidjson::Document JsonDocPut(rapidjson::kObjectType);
@@ -272,352 +198,37 @@ CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientTestExtRequestRes
         JsonDocPut.AddMember("job", "builder", JsonDocPut.GetAllocator());
 
         PayloadPut.SetContent(JsonDocPut);
-        PayloadPut.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
+        PayloadPut.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("MockApiKey"));
 
-        RunWebClientTest<ResponseReceiver>("https://reqres.in/api/users/2", ERequestVerb::Put, 80, PayloadPut, EResponseCodes::ResponseOK);
+        MockClient->SendRequest(csp::web::ERequestVerb::Put, Uri("https://mock.service/api/users"), PayloadPut, &MockHandlerPut,
+            csp::common::CancellationToken::Dummy(), true);
 
         // POST request
+        MockHttpResponseHandler MockHandlerPost;
         HttpPayload PayloadPost;
 
         rapidjson::Document JsonDocPost(rapidjson::kObjectType);
-        JsonDocPost.AddMember("email", "eve.holt@reqres.in", JsonDocPost.GetAllocator());
+        JsonDocPost.AddMember("email", "mock.user@magnopus.com", JsonDocPost.GetAllocator());
         JsonDocPost.AddMember("password", "secret", JsonDocPost.GetAllocator());
 
         PayloadPost.SetContent(JsonDocPost);
 
         PayloadPost.AddHeader(CSP_TEXT("Content-Type"), CSP_TEXT("application/json"));
-        PayloadPost.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
+        PayloadPost.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("MockApiKey"));
 
-        RunWebClientTest<ResponseReceiver>("https://reqres.in/api/login", ERequestVerb::Post, 80, PayloadPost, EResponseCodes::ResponseOK);
-
-        // Delete request
-        HttpPayload PayloadDelete;
-        PayloadDelete.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-        RunWebClientTest<ResponseReceiver>(
-            "https://reqres.in/api/users/1", ERequestVerb::Delete, 80, PayloadDelete, EResponseCodes::ResponseNoContent);
-    }
-
-    csp::CSPFoundation::Shutdown();
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientTestExtRequestResponseNoLogging)
-{
-    InitialiseFoundation();
-
-    {
-        RAIIMockLogger MockLogger {};
-
-        // With the log level NOT set to VeryVerbose we expect to receive no logs for the HTTP Requests and Responses
-        EXPECT_CALL(MockLogger.MockLogCallback, Call(testing::_, testing::_)).Times(0);
-
-        // GET request
-        HttpPayload PayloadGet;
-
-        PayloadGet.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-        RunWebClientTest<ResponseReceiver>("https://reqres.in/api/users/2", ERequestVerb::Get, 80, PayloadGet, EResponseCodes::ResponseOK);
-
-        // PUT request
-        HttpPayload PayloadPut;
-
-        rapidjson::Document JsonDocPut(rapidjson::kObjectType);
-        JsonDocPut.AddMember("name", "bob", JsonDocPut.GetAllocator());
-        JsonDocPut.AddMember("job", "builder", JsonDocPut.GetAllocator());
-
-        PayloadPut.SetContent(JsonDocPut);
-        PayloadPut.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-        RunWebClientTest<ResponseReceiver>("https://reqres.in/api/users/2", ERequestVerb::Put, 80, PayloadPut, EResponseCodes::ResponseOK);
-
-        // POST request
-        HttpPayload PayloadPost;
-
-        rapidjson::Document JsonDocPost(rapidjson::kObjectType);
-        JsonDocPost.AddMember("email", "eve.holt@reqres.in", JsonDocPost.GetAllocator());
-        JsonDocPost.AddMember("password", "secret", JsonDocPost.GetAllocator());
-
-        PayloadPost.SetContent(JsonDocPost);
-
-        PayloadPost.AddHeader(CSP_TEXT("Content-Type"), CSP_TEXT("application/json"));
-        PayloadPost.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-        RunWebClientTest<ResponseReceiver>("https://reqres.in/api/login", ERequestVerb::Post, 80, PayloadPost, EResponseCodes::ResponseOK);
+        MockClient->SendRequest(csp::web::ERequestVerb::Post, Uri("https://mock.service/api/login"), PayloadPost, &MockHandlerPost,
+            csp::common::CancellationToken::Dummy(), true);
 
         // Delete request
+        MockHttpResponseHandler MockHandlerDelete;
         HttpPayload PayloadDelete;
-        PayloadDelete.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
+        PayloadDelete.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("MockApiKey"));
 
-        RunWebClientTest<ResponseReceiver>(
-            "https://reqres.in/api/users/1", ERequestVerb::Delete, 80, PayloadDelete, EResponseCodes::ResponseNoContent);
+        MockClient->SendRequest(csp::web::ERequestVerb::Delete, Uri("https://mock.service/api/users"), PayloadDelete, &MockHandlerDelete,
+            csp::common::CancellationToken::Dummy(), true);
+
+        delete MockClient;
     }
-
-    csp::CSPFoundation::Shutdown();
-}
-
-class PollingLoginResponseReceiver : public ResponseWaiter, public IHttpResponseHandler
-{
-public:
-    PollingLoginResponseReceiver(std::thread::id InThreadId)
-        : ResponseReceived(false)
-        , ThreadId(InThreadId)
-    {
-    }
-
-    void OnHttpResponse(HttpResponse& InResponse) override
-    {
-        // Check that callbacks are called from the same thread as we poll from
-        EXPECT_TRUE(ThreadId == std::this_thread::get_id());
-
-        Response = InResponse;
-        ResponseReceived = true;
-
-        if (Response.GetResponseCode() == EResponseCodes::ResponseOK)
-        {
-            rapidjson::Document ResponseJson;
-            ResponseJson.Parse(Response.GetPayload().GetContent().c_str());
-
-            if (ResponseJson.IsObject())
-            {
-                EXPECT_TRUE(ResponseJson["accessToken"].IsString());
-
-                if (ResponseJson["accessToken"].IsString())
-                {
-                    AccessToken = ResponseJson["accessToken"].GetString();
-                }
-            }
-            else
-            {
-                FAIL() << "Invalid response JSON" << std::endl;
-            }
-        }
-        else
-        {
-            FAIL() << "Invalid response code " << (int)Response.GetResponseCode() << std::endl;
-        }
-    }
-
-    bool WaitForResponse(csp::web::WebClient* WebClient)
-    {
-        return WaitFor(
-            [this, WebClient]
-            {
-#ifndef CSP_WASM
-                WebClient->ProcessResponses();
-#endif
-                return IsResponseReceived();
-            },
-            std::chrono::seconds(10));
-    }
-
-    bool IsResponseReceived() const { return ResponseReceived; }
-
-    HttpResponse& GetResponse() { return Response; }
-    const std::string& GetAccessToken() { return AccessToken; }
-
-private:
-    HttpResponse Response;
-    std::string AccessToken;
-    std::atomic<bool> ResponseReceived;
-
-    std::thread::id ThreadId;
-};
-
-// This test will be fixed and reenabled as part of OF-1536
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientPollingTest)
-{
-    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
-
-    PollingLoginResponseReceiver Receiver(std::this_thread::get_id());
-
-    {
-        auto& UserSystem = *csp::systems::SystemsManager::Get().GetUserSystem();
-        csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-        WebClient* Client;
-#ifdef CSP_WASM
-        Client = new csp::web::EmscriptenWebClient(80, csp::web::ETransferProtocol::HTTPS, UserSystem.GetAuthContext(), LogSystem);
-#else
-        Client = new TestWebClient(80, csp::web::ETransferProtocol::HTTPS, UserSystem.GetAuthContext(), LogSystem);
-#endif
-        EXPECT_TRUE(Client != nullptr);
-
-        HttpPayload Payload;
-
-        Payload.AddHeader(CSP_TEXT("Content-Type"), CSP_TEXT("application/json-patch+json"));
-
-        rapidjson::Document JsonDoc(rapidjson::kObjectType);
-        JsonDoc.AddMember("deviceId", "CSPEngine", JsonDoc.GetAllocator());
-
-        Payload.SetContent(JsonDoc);
-
-        // Tell request not to callback until we poll with WebClient::ProcessResponses
-        // This ensures that callbacks are issued from this thread (which we check
-        // in the receiver above using the std::thread::id)
-        bool AsyncResponse = false;
-
-        Client->SendRequest(
-            ERequestVerb::Post, Uri("api/v1/users/login"), Payload, &Receiver, csp::common::CancellationToken::Dummy(), AsyncResponse);
-
-        if (Receiver.WaitForResponse(Client))
-        {
-            bool ResponseIsValid = Receiver.GetResponse().GetResponseCode() == EResponseCodes::ResponseOK;
-            EXPECT_TRUE(ResponseIsValid);
-
-            if (ResponseIsValid)
-            {
-                EXPECT_TRUE(Receiver.GetAccessToken().length() > 0);
-            }
-        }
-        else
-        {
-            FAIL() << "Response timeout" << std::endl;
-        }
-    }
-
-    csp::CSPFoundation::Shutdown();
-}
-
-class RetryResponseReceiver : public ResponseWaiter, public IHttpResponseHandler
-{
-public:
-    RetryResponseReceiver()
-        : ResponseReceived(false)
-        , ThreadId(std::this_thread::get_id())
-    {
-    }
-
-    void OnHttpResponse(HttpResponse& InResponse) override
-    {
-        // We expect the callback to have come from a seperate Thread
-        EXPECT_FALSE(std::this_thread::get_id() == ThreadId);
-
-        bool RetryIssued = false;
-        constexpr uint32_t MaxNumRequestRetries = 3;
-
-        if (InResponse.GetResponseCode() == EResponseCodes::ResponseNotFound)
-        {
-#ifdef CSP_WASM
-            std::thread TestThread([&]() { RetryIssued = InResponse.GetRequest()->Retry(MaxNumRequestRetries); });
-
-            TestThread.join();
-#else
-            RetryIssued = InResponse.GetRequest()->Retry(MaxNumRequestRetries);
-#endif
-        }
-
-        if (!RetryIssued)
-        {
-            EXPECT_TRUE(InResponse.GetRequest()->GetRetryCount() >= MaxNumRequestRetries);
-
-            Response = InResponse;
-            ResponseReceived = true;
-        }
-        else
-        {
-            std::cerr << "Retrying Request" << std::endl;
-        }
-    }
-
-    bool WaitForResponse()
-    {
-        return WaitFor([this] { return IsResponseReceived(); }, std::chrono::seconds(10));
-    }
-
-    bool IsResponseReceived() const { return ResponseReceived; }
-
-    HttpResponse& GetResponse() { return Response; }
-
-private:
-    HttpResponse Response;
-
-    std::atomic<bool> ResponseReceived;
-    std::thread::id ThreadId;
-};
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientRetryTest)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTest<RetryResponseReceiver>("https://reqres.in/api/users/23", ERequestVerb::Get, 80, Payload, EResponseCodes::ResponseNotFound);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail404Test)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTest<ResponseReceiver>("https://reqres.in/apiiii/users/23", ERequestVerb::Get, 80, Payload, EResponseCodes::ResponseNotFound);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail400Test)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-    Payload.AddContent("{ \"email\": \"test@olympus\" }");
-    Payload.AddHeader(CSP_TEXT("x-api-key"), CSP_TEXT("reqres-free-v1"));
-
-    RunWebClientTest<RetryResponseReceiver>("https://reqres.in/api/register", ERequestVerb::Post, 80, Payload, EResponseCodes::ResponseBadRequest);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-// Current fails on wasm platform tests due to CORS policy.
-#ifndef CSP_WASM
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, WebClientUserAgentTest)
-{
-    InitialiseFoundation();
-
-    HttpPayload Payload;
-    ResponseReceiver Receiver;
-
-    auto& UserSystem = *csp::systems::SystemsManager::Get().GetUserSystem();
-    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-    auto* WebClient = new TestWebClient(80, ETransferProtocol::HTTP, UserSystem.GetAuthContext(), LogSystem);
-    EXPECT_TRUE(WebClient != nullptr);
-
-    WebClientSendRequest(WebClient, "https://postman-echo.com/get", ERequestVerb::Get, Payload, &Receiver);
-
-    //// Sleep thread until response is received
-    if (Receiver.WaitForResponse())
-    {
-        std::string ResponseContent = Receiver.GetResponse().GetPayload().GetContent().c_str();
-
-        EXPECT_TRUE(ResponseContent.find(TESTS_CLIENT_SKU) != std::string::npos) << TESTS_CLIENT_SKU << " was not found.";
-    }
-    else
-    {
-        FAIL() << "Response timeout" << std::endl;
-    }
-
-    csp::CSPFoundation::Shutdown();
-}
-#endif
-
-#include "CSP/Systems/SystemsManager.h"
-#include "PublicAPITests/UserSystemTestHelpers.h"
-
-CSP_INTERNAL_TEST(DISABLED_CSPEngine, WebClientTests, HttpFail403Test)
-{
-    InitialiseFoundation();
-
-    auto* UserSystem = csp::systems::SystemsManager::Get().GetUserSystem();
-    csp::common::String UserId;
-    LogInAsNewTestUser(UserSystem, UserId);
-
-    HttpPayload Payload;
-    RunWebClientTest<RetryResponseReceiver>(
-        (std::string(EndpointBaseURI()) + "/mag-user/appsettings").c_str(), ERequestVerb::Get, 80, Payload, EResponseCodes::ResponseForbidden);
 
     csp::CSPFoundation::Shutdown();
 }

--- a/Tests/src/Mocks/WebClientMock.h
+++ b/Tests/src/Mocks/WebClientMock.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../../Library/src/Common/Web/HttpPayload.h"
+#include "../../Library/src/Common/Web/HttpRequest.h"
+#include "../../Library/src/Common/Web/HttpResponse.h"
+#include "../../Library/src/Common/Web/WebClient.h"
+#include "CSP/Common/Systems/Log/LogSystem.h"
+#include <gmock/gmock.h>
+
+class MockHttpResponseHandler : public csp::web::IHttpResponseHandler
+{
+public:
+    MockHttpResponseHandler() { }
+
+    MOCK_METHOD(void, OnHttpProgress, (csp::web::HttpRequest & Request), (override));
+    MOCK_METHOD(void, OnHttpResponse, (csp::web::HttpResponse & Response), (override));
+    MOCK_METHOD(bool, ShouldDelete, (), (const, override));
+};
+
+class WebClientMock : public csp::web::WebClient
+{
+public:
+    WebClientMock(const uint32_t InPort, const csp::web::ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh)
+        : WebClient(InPort, Tp, LogSystem, AutoRefresh)
+    {
+    }
+
+    MOCK_METHOD(void, SendRequest,
+        (csp::web::ERequestVerb Verb, const csp::web::Uri& InUri, csp::web::HttpPayload& Payload, csp::web::IHttpResponseHandler* ResponseCallback,
+            csp::common::CancellationToken& CancellationToken, bool AsyncResponse),
+        (override));
+
+    MOCK_METHOD(void, SetAuthContext, (csp::common::IAuthContext & AuthContext), (override));
+
+    MOCK_METHOD(std::string, MD5Hash, (const void* Data, const size_t Size), (override));
+
+    MOCK_METHOD(void, SetFileUploadContentFromFile,
+        (csp::web::HttpPayload * Payload, const char* FilePath, const char* Version, const csp::common::String& MediaType), (override));
+
+    MOCK_METHOD(void, SetFileUploadContentFromString,
+        (csp::web::HttpPayload * Payload, const csp::common::String& StringSource, const csp::common::String& FileName, const char* Version,
+            const csp::common::String& MediaTypeType),
+        (override));
+
+    MOCK_METHOD(void, SetFileUploadContentFromBuffer,
+        (csp::web::HttpPayload * Payload, const char* Buffer, size_t BufferLength, const csp::common::String& FileName, const char* Version,
+            const csp::common::String& MediaType),
+        (override));
+
+protected:
+    MOCK_METHOD(void, Send, (csp::web::HttpRequest & Request), (override));
+};


### PR DESCRIPTION
Our original WebClient Unit Tests were using a third party backend service to validate our requests. However we have found this service to be unstable. 3-6 months ago tests stopped working as the service changed to require an auth token, and last week the service fell over entirely.

As we now have Google Mock setup, we decided to mock the Web Client.

While the WebClient has five public methods, the tests were only really exercising one of them, `SendRequest`. Originally there were many tests, but they went beyond the scope of testing core WebClient functionality, for example also testing polling behaviour of the derived WebClient types - SignalRWebClient and EmscriptenWebClient.

These additional tests have therefore been stripped out, leaving us with two tests that I believe give us the same coverage.

The diff will be very hard to view so probably best to select to 'View file'.