### PR TITLE
[OB-4757] fix: Ensure AnalyticsRecord queue is cleared after batch sent

### DIFF
--- a/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
+++ b/Library/include/CSP/Systems/Analytics/AnalyticsSystem.h
@@ -30,6 +30,7 @@ CSP_START_IGNORE
 class CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSendRateTest_Test;
 class CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSizeTest_Test;
 class CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsQueueTest_Test;
+class CSPEngine_AnalyticsSystemTests_ClearAnalyticsEventQueueTest_Test;
 #endif
 CSP_END_IGNORE
 
@@ -69,6 +70,7 @@ class CSP_API AnalyticsSystem : public SystemBase
     friend class ::CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSendRateTest_Test;
     friend class ::CSPEngine_AnalyticsSystemTests_QueueAnalyticsEventQueueSizeTest_Test;
     friend class ::CSPEngine_AnalyticsSystemTests_FlushAnalyticsEventsQueueTest_Test;
+    friend class ::CSPEngine_AnalyticsSystemTests_ClearAnalyticsEventQueueTest_Test;
 #endif
     /** @endcond */
     CSP_END_IGNORE

--- a/Library/src/Systems/Analytics/AnalyticsSystem.cpp
+++ b/Library/src/Systems/Analytics/AnalyticsSystem.cpp
@@ -221,7 +221,7 @@ void AnalyticsSystem::FlushAnalyticsEventsQueue(NullResultCallback Callback)
 
     SetTimeSinceLastQueueSend(CurrentTime);
 
-    NullResultCallback SendBatchAnalyticsCallback = [Callback, LogSystem = this->LogSystem](const NullResult& Result)
+    NullResultCallback SendBatchAnalyticsCallback = [this, Callback](const NullResult& Result)
     {
         if (Result.GetResultCode() == csp::systems::EResultCode::InProgress)
         {
@@ -230,15 +230,19 @@ void AnalyticsSystem::FlushAnalyticsEventsQueue(NullResultCallback Callback)
 
         if (Result.GetResultCode() == csp::systems::EResultCode::Success)
         {
-            LogSystem->LogMsg(common::LogLevel::Verbose, "Successfully sent the Analytics Record queue.");
+            this->LogSystem->LogMsg(common::LogLevel::Verbose, "Successfully sent the Analytics Record queue.");
         }
         else if (Result.GetResultCode() == csp::systems::EResultCode::Failed)
         {
-            LogSystem->LogMsg(common::LogLevel::Error,
+            this->LogSystem->LogMsg(common::LogLevel::Error,
                 fmt::format("Failed to send Analytics Event. ResCode: {}, HttpResCode: {}", static_cast<int>(Result.GetResultCode()),
                     Result.GetHttpResultCode())
                     .c_str());
         }
+
+        // Note: We may in the future wish to consider a retry mechanism when there is a failure to send the AnalyticsRecordQueue.
+        // For now we are just clearing the queue in either case.
+        this->AnalyticsRecordQueue.clear();
 
         if (Callback)
         {


### PR DESCRIPTION
The AnalyticsRecord queue was not being cleared after each batch of records was sent. This has been addressed and tests updated/added to verify that the behaviour is correct.