### PR TITLE
[OF-1668] chore!: Remove SpaceEntity::ThirdPartyPlatform

### DIFF
--- a/Library/include/CSP/Multiplayer/PatchTypes.h
+++ b/Library/include/CSP/Multiplayer/PatchTypes.h
@@ -30,9 +30,8 @@ enum SpaceEntityUpdateFlags
     UPDATE_FLAGS_COMPONENTS = 16,
     UPDATE_FLAGS_SELECTION_ID = 32,
     UPDATE_FLAGS_THIRD_PARTY_REF = 64,
-    UPDATE_FLAGS_THIRD_PARTY_PLATFORM = 128,
-    UPDATE_FLAGS_PARENT = 256,
-    UPDATE_FLAGS_LOCK_TYPE = 512,
+    UPDATE_FLAGS_PARENT = 128,
+    UPDATE_FLAGS_LOCK_TYPE = 256,
 };
 
 /// @brief This Enum should be used to determine what kind of operation the component update represents.

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -204,15 +204,6 @@ public:
     /// @return Whether a new value was set, may fail if not modifiable, or if a dirty property is already set to this value.
     bool SetThirdPartyRef(const csp::common::String& InThirdPartyRef);
 
-    /// @brief Get the third party platform type of this entity.
-    /// @return A string representing third party platform type set for this entity.
-    csp::systems::EThirdPartyPlatform GetThirdPartyPlatformType() const;
-
-    /// @brief Set third party platform type for this entity.
-    /// @param InThirdPartyPlatformType csp::systems::EThirdPartyPlatform : The third party platform type to set.
-    /// @return Whether a new value was set, may fail if not modifiable, or if a dirty property is already set to this value.
-    bool SetThirdPartyPlatformType(const csp::systems::EThirdPartyPlatform InThirdPartyPlatformType);
-
     /// @brief Get the type of the Entity.
     /// @return The SpaceEntityType enum value.
     SpaceEntityType GetEntityType() const;
@@ -472,7 +463,6 @@ private:
 
     csp::common::String Name;
     SpaceTransform Transform;
-    csp::systems::EThirdPartyPlatform ThirdPartyPlatform;
     csp::common::String ThirdPartyRef;
     uint64_t SelectedId;
 

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -99,7 +99,6 @@ SpaceEntity::SpaceEntity()
     , OwnerId(0)
     , ParentId(nullptr)
     , Transform { { 0, 0, 0 }, { 0, 0, 0, 1 }, { 1, 1, 1 } }
-    , ThirdPartyPlatform(csp::systems::EThirdPartyPlatform::NONE)
     , ThirdPartyRef("")
     , SelectedId(0)
     , Parent(nullptr)
@@ -121,7 +120,6 @@ SpaceEntity::SpaceEntity(csp::common::IRealtimeEngine* InEntitySystem, csp::comm
     , OwnerId(0)
     , ParentId(nullptr)
     , Transform { { 0, 0, 0 }, { 0, 0, 0, 1 }, { 1, 1, 1 } }
-    , ThirdPartyPlatform(csp::systems::EThirdPartyPlatform::NONE)
     , ThirdPartyRef("")
     , SelectedId(0)
     , Parent(nullptr)
@@ -260,14 +258,6 @@ bool SpaceEntity::SetThirdPartyRef(const csp::common::String& InThirdPartyRef)
 {
     return SetProperty(*this, ThirdPartyRef, InThirdPartyRef, SpaceEntityComponentKey::ThirdPartyRef, UPDATE_FLAGS_THIRD_PARTY_REF, LogSystem);
 }
-
-bool SpaceEntity::SetThirdPartyPlatformType(const csp::systems::EThirdPartyPlatform InThirdPartyPlatformType)
-{
-    return SetProperty(*this, ThirdPartyPlatform, static_cast<int64_t>(InThirdPartyPlatformType), SpaceEntityComponentKey::ThirdPartyPlatform,
-        UPDATE_FLAGS_THIRD_PARTY_PLATFORM, LogSystem);
-}
-
-csp::systems::EThirdPartyPlatform SpaceEntity::GetThirdPartyPlatformType() const { return ThirdPartyPlatform; }
 
 SpaceEntityType SpaceEntity::GetEntityType() const { return Type; }
 
@@ -1081,11 +1071,6 @@ csp::common::Array<EntityProperty> SpaceEntity::CreateReplicatedProperties()
             SpaceEntityComponentKey::ThirdPartyRef, UPDATE_FLAGS_THIRD_PARTY_REF,
             [&ThirdPartyRef = ThirdPartyRef]() { return csp::common::ReplicatedValue { ThirdPartyRef }; },
             [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(ThirdPartyRef, Value.GetString(), UPDATE_FLAGS_THIRD_PARTY_REF); }
-        },
-        {
-            SpaceEntityComponentKey::ThirdPartyPlatform, UPDATE_FLAGS_THIRD_PARTY_PLATFORM,
-            [&ThirdPartyPlatform = ThirdPartyPlatform]() { return csp::common::ReplicatedValue { static_cast<int64_t>(ThirdPartyPlatform) }; },
-            [this](const csp::common::ReplicatedValue& Value) { SetPropertyDirect(ThirdPartyPlatform, static_cast<systems::EThirdPartyPlatform>(Value.GetInt()), UPDATE_FLAGS_THIRD_PARTY_PLATFORM); }
         },
         {
             SpaceEntityComponentKey::LockType, UPDATE_FLAGS_LOCK_TYPE,

--- a/Library/src/Multiplayer/SpaceEntityKeys.h
+++ b/Library/src/Multiplayer/SpaceEntityKeys.h
@@ -37,6 +37,8 @@ constexpr const uint16_t COMPONENT_KEY_COMPONENTTYPE = COMPONENT_KEYS_START_VIEW
 // The reason we handle these differently is because the component key values are dynamic,
 // as they represent the index of our component, and not the type. This is due to being able to have multiple
 // components of the same type on an entity, so we can't use the component type as a unique key.
+
+// ThirdPartyPlatform = COMPONENT_KEYS_START_VIEWS + 7 Removed 14/10/2025, (Can't put this inline cause of the wrapper gen!)
 enum class SpaceEntityComponentKey : uint16_t
 {
     // Property Keys.
@@ -46,7 +48,6 @@ enum class SpaceEntityComponentKey : uint16_t
     Scale = COMPONENT_KEYS_START_VIEWS + 3,
     SelectedClientId = COMPONENT_KEYS_START_VIEWS + 4,
     ThirdPartyRef = COMPONENT_KEYS_START_VIEWS + 6,
-    ThirdPartyPlatform = COMPONENT_KEYS_START_VIEWS + 7,
     LockType = COMPONENT_KEYS_START_VIEWS + 8
 };
 

--- a/Tests/src/PublicAPITests/RealtimeEngineEntityTests.cpp
+++ b/Tests/src/PublicAPITests/RealtimeEngineEntityTests.cpp
@@ -428,7 +428,6 @@ TEST_P(ObjectCreate, ObjectCreateTest)
     EXPECT_EQ(CreatedObject->GetRotation(), ObjectTransform.Rotation);
     EXPECT_EQ(CreatedObject->GetScale(), ObjectTransform.Scale);
     EXPECT_EQ(CreatedObject->GetThirdPartyRef(), "");
-    EXPECT_EQ(CreatedObject->GetThirdPartyPlatformType(), csp::systems::EThirdPartyPlatform::NONE);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     RealtimeEngine.reset();


### PR DESCRIPTION
Remove SpaceEntity::ThirdParty platform, a redundant property.

Does not remove the third party platform concept entirely, as that's required for assets (for some reason, this truth sourced from the ticket).

Was quick, so just pulled this out of the backlog and did it in a timeslot I had.

**Breaking Changes**
Removed `SpaceEntity::SetThirdPartyPlatformType`, `SpaceEntity::GetThirdPartyPlatformType`