### PR TITLE
[OF-1805] feat: Add new GoogleGenAI Quota tier feature

### DIFF
--- a/Library/include/CSP/Systems/Quota/Quota.h
+++ b/Library/include/CSP/Systems/Quota/Quota.h
@@ -56,6 +56,7 @@ enum class TierFeatures
     OpenAI,
     Shopify,
     TicketedSpace,
+    GoogleGenAI,
     Invalid
 };
 

--- a/Library/src/Systems/Quota/Quota.cpp
+++ b/Library/src/Systems/Quota/Quota.cpp
@@ -256,6 +256,8 @@ const csp::common::String TierFeatureEnumToString(const TierFeatures& Value)
         return "TotalUploadSizeInKilobytes";
     case TierFeatures::SpaceOwner:
         return "SpaceOwner";
+    case TierFeatures::GoogleGenAI:
+        return "GoogleGenAI";
     case TierFeatures::Invalid:
         return "Invalid";
     default:
@@ -341,6 +343,11 @@ TierFeatures StringToTierFeatureEnum(const csp::common::String& Value)
     if (Value == "SpaceOwner")
     {
         return TierFeatures::SpaceOwner;
+    }
+
+    if (Value == "GoogleGenAI")
+    {
+        return TierFeatures::GoogleGenAI;
     }
 
     CSP_LOG_ERROR_FORMAT("QuotaSystem TierFeature not recognized: %s. Defaulting to Invalid", Value.c_str());


### PR DESCRIPTION
Services-level support is being added for Gemini-based services. To ensure usage is managed appropriately, we are also tracking and limiting usage via the quota system. This requires a new Quota Feature Tier type: `GoogleGenAI` which has been added.

**Please note:**
MCS have not yet added the type, which means that one of our tests `GetTierFeaturesQuota`, has had to be temporarily updated to account for this. Currently the `GetTierFeaturesQuota` returns 9 tiers, but will return 10 once MCS have added the type. Once MCS have done this I will remove the temporary workaround.

Another change I have made to the test is to no-longer validate every property of the returned `FeatureQuotaInfo` object as its data is subject to change at any point. This is a permanent change and will not be reverted once the new type is added by MCS.