### PR TITLE
[OF-1804] build: Add GH Action for changelog update

### DIFF
--- a/.github/scripts/update_changelog_release_tag.py
+++ b/.github/scripts/update_changelog_release_tag.py
@@ -1,0 +1,78 @@
+import sys
+import os
+
+def update_changelog(version, date, changelog_file_path):
+    """
+    Updates the CHANGELOG.md file by replacing:
+    '## [Unreleased]'
+    with:
+    '## [Unreleased]\n\n\n## [VERSION] - DATE'.
+    This ensures that a new '## [Unreleased]' tag is ready for the next release.
+    """
+    print(f"Attempting to update {changelog_file_path} for release {version} on {date}")
+
+    if not os.path.exists(changelog_file_path):
+        print(f"Error: Changelog file not found at {changelog_file_path}")
+        sys.exit(1)
+
+    try:
+        with open(changelog_file_path, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+
+        unreleased_found = False
+        version_entry_found = False
+        new_lines = []
+
+        # Used below when checking for an existing version entry
+        version_prefix = f"## [{version}] -"
+
+        for line in lines:
+            if line.strip() == "## [Unreleased]":
+                unreleased_found = True
+                # Keep the "## [Unreleased]" tag line and then add newlines and the new version entry below
+                new_lines.append(line)
+                new_lines.append(f"\n\n\n## [{version}] - {date}\n")
+            # Check if the version entry already exists though ignore the date portion
+            elif line.strip().startswith(version_prefix) and " - " in line.strip():
+                version_entry_found = True
+                new_lines.append(line)
+            else:
+                new_lines.append(line)
+
+        if not unreleased_found:
+            print("Error: '## [Unreleased]' section not found in CHANGELOG.md. No update performed.")
+            # Set the 'changelog_updated' output variable for the invoking GitHub Action
+            print("changelog_updated=false")
+            sys.exit(1)
+
+        if version_entry_found:
+            print(f"Changelog already contains entry for {version}. No update needed.")
+            # Exit successfully if no changes are needed.
+            # Set the 'changelog_updated' output variable for the invoking GitHub Action
+            print("changelog_updated=false")
+            sys.exit(0)
+
+        with open(changelog_file_path, 'w', encoding='utf-8') as f:
+            f.writelines(new_lines)
+
+        print(f"Successfully updated CHANGELOG.md for release {version}.")
+        # Set the 'changelog_updated' output variable for the invoking GitHub Action
+        print("changelog_updated=true")
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"An error occurred while updating the changelog: {e}")
+        # Set the 'changelog_updated' output variable for the invoking GitHub Action
+        print("changelog_updated=false")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: python update_changelog_release_tag.py <version> <date> <changelog_file_path>")
+        sys.exit(1)
+
+    release_version = sys.argv[1]
+    release_date = sys.argv[2]
+    changelog_path = sys.argv[3]
+
+    update_changelog(release_version, release_date, changelog_path)

--- a/.github/workflows/update-changelog-on-tc-publish.yml
+++ b/.github/workflows/update-changelog-on-tc-publish.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "automaton"
-          git config user.email "automaton@magnopus.com"
+          git config user.name "${{ secrets.GH_AUTOMATON_USERNAME }}"
+          git config user.email "${{ secrets.GH_AUTOMATON_EMAIL }}"
           git pull
 
       - name: Get Release Version and Date from Payload
@@ -43,31 +43,25 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "RELEASE_DATE=$RELEASE_DATE" >> $GITHUB_OUTPUT
 
-      - name: Update CHANGELOG.md
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Update CHANGELOG.md using Python
+        # The step Id is used in the next step to reference the python scripts output for 'changelog_updated'
+        id: update_changelog_script
         run: |
-          RELEASE_VERSION="${{ steps.get_release_info.outputs.RELEASE_VERSION }}"
-          RELEASE_DATE="${{ steps.get_release_info.outputs.RELEASE_DATE }}"
-          CHANGELOG_FILE=".github/CHANGELOG.md"
-
-          # Escape special characters for sed (like dots in version numbers)
-          ESCAPED_VERSION=$(echo "$RELEASE_VERSION" | sed 's/\./\\./g')
-
-          # Check if "## [Unreleased]" exists and "## [$RELEASE_VERSION]" does not
-          if grep -q "## \[Unreleased\]" "$CHANGELOG_FILE" && ! grep -q "## \[$ESCAPED_VERSION\]" "$CHANGELOG_FILE"; then
-            echo "Updating CHANGELOG.md for release $RELEASE_VERSION."
-
-            # This `sed` command searches for the line containing "## [Unreleased]".
-            # When it finds it, it performs a 'c\' (change) operation.
-            # It replaces the *entire line* with the following multiline string:
-            # "## [Unreleased]\n\n## [$RELEASE_VERSION] - $RELEASE_DATE"
-            sed -i "/## \[Unreleased\]/c\## \[Unreleased\]\n\n## \[$RELEASE_VERSION\] - $RELEASE_DATE" "$CHANGELOG_FILE"
-
-          else
-            echo "Changelog already contains entry for $RELEASE_VERSION or '## [Unreleased]' not found. No update needed."
-          fi
+          python .github/scripts/update_changelog_release_tag.py \
+            "${{ steps.get_release_info.outputs.RELEASE_VERSION }}" \
+            "${{ steps.get_release_info.outputs.RELEASE_DATE }}" \
+            ".github/CHANGELOG.md"
 
       - name: Commit and Push Changes
+        # Only commit and push if the changelog was updated
+        # The changelog_updated output value is set by the Python script which is executed in the 'update_changelog_script' step
+        if: ${{ steps.update_changelog_script.outputs.changelog_updated == 'true' }}
         run: |
           git add "${CHANGELOG_FILE}"
-          git commit -m "[NT-0] docs: Update CHANGELOG.md for release ${{ steps.get_release_info.outputs.RELEASE_VERSION }}" || echo "No changes to commit."
+          git commit -m "Update CHANGELOG.md for release ${{ steps.get_release_info.outputs.RELEASE_VERSION }}" --no-verify
           git push


### PR DESCRIPTION
Adding a new GitHub Action which listens for a `release-published` event from TeamCity. This event includes the following payload data:
- release version
- release date

This payload data is used to update the changelog file.