### PR TITLE
[OF-1804] fix: Fix issue with python script output

### DIFF
--- a/.github/workflows/update-changelog-on-tc-publish.yml
+++ b/.github/workflows/update-changelog-on-tc-publish.yml
@@ -62,6 +62,6 @@ jobs:
         # The changelog_updated output value is set by the Python script which is executed in the 'update_changelog_script' step
         if: ${{ steps.update_changelog_script.outputs.changelog_updated == 'true' }}
         run: |
-          git add "${CHANGELOG_FILE}"
+          git add ".github/CHANGELOG.md"
           git commit -m "Update CHANGELOG.md for release ${{ steps.get_release_info.outputs.RELEASE_VERSION }}" --no-verify
           git push


### PR DESCRIPTION
When running the `update-changelog-on-tc-publish` GH Action we found that the updated changelog was not being committed. 

The issues were:
1. We need to use a `GITHUB_OUTPUT` environment variable to output data from the python script to the invoking Action.
2. The Action was still referencing an old changelog file path variable for the git add command.