### PR TITLE
[OF-1804] build: Update Action to use access token

### DIFF
--- a/.github/workflows/update-changelog-on-tc-publish.yml
+++ b/.github/workflows/update-changelog-on-tc-publish.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          # This token will be used by subsequent git commands for authentication
+          token: ${{ secrets.MAG_BOT_HOOK_TOKEN }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Updating the 'update-changelog-on-tc-publish' Action to use the mag-bot access token so that the Action is able to skip the PR checks when committing the CHANGELOG.md update.