### PR TITLE
[OF-1804] ci: Add ssh deploy key

### DIFF
--- a/.github/workflows/update-changelog-on-tc-publish.yml
+++ b/.github/workflows/update-changelog-on-tc-publish.yml
@@ -8,12 +8,17 @@ on:
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
+
+    # add permissions to allow pushing changes to the repository
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          # This token will be used by subsequent git commands for authentication
-          token: ${{ secrets.MAG_BOT_HOOK_TOKEN }}
+          # This key provides the SSH authentication and authorization to bypass branch protection and execute the final git push.
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
It was proving problematic to get the GitHub Action to successfully bypass the branch protection rules so that it could commit the changelog update to main without requiring a PR and approvals.

This issues have now been resolved by validating the required GitHub settings through local testing using my credentials. I then updated the GitHub settings to include the GitHub user and confirmed that the Action then performed correctly.

This local testing required that I perform a reset to remove my test commit from main. I also removed my last commit which was updating the GitHub Action to use a deploy key rather than the GitHub PAT. After running the Action again it was not successful. I am therefore reinstating the Deploy Key as it is required.