### PR TITLE
[NT-0] fix: Use const string ref for return type

### DIFF
--- a/Library/include/CSP/Common/MimeTypeHelper.h
+++ b/Library/include/CSP/Common/MimeTypeHelper.h
@@ -825,8 +825,8 @@ public:
 
     /// @brief Gets mime type from a file path.
     /// @param FilePath const String&
-    /// @return String&
-    String& GetMimeType(const String& FilePath);
+    /// @return const String&
+    const String& GetMimeType(const String& FilePath);
 
 private:
     /// @brief Private singleton constructor.

--- a/Library/src/Common/MimeTypeHelper.cpp
+++ b/Library/src/Common/MimeTypeHelper.cpp
@@ -28,7 +28,7 @@ MimeTypeHelper& MimeTypeHelper::Get()
     return Instance;
 }
 
-String& MimeTypeHelper::GetMimeType(const String& FilePath)
+const String& MimeTypeHelper::GetMimeType(const String& FilePath)
 {
     auto Segments = FilePath.Split('.');
     auto Extension = Segments[Segments.Size() - 1].Trim();


### PR DESCRIPTION
When generating the code with SWIG we noticed that it is not compatible to return a mutable string reference. For that reason, since we don't want mutability we add const and use const ref instead.