### PR TITLE
[NT-0] docs: Update the changelog for our next release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - [OF-1807] feat: support text asset type to support ai chatbot by MAG-ChristopherAtkinson in https://github.com/magnopus-opensource/connected-spaces-platform/pull/853
   Introduce a new TEXT EAssetType to support storage of prompt and guardrail assets for the AI chatbot component.
+- [OF-1784] feat: Multiplayer System by MAG-mv in https://github.com/magnopus-opensource/connected-spaces-platform/pull/842
+  Part 1 of the server-side leader election work. Addition of a new Multiplayer System which exposes the necessary functionality for leader election from the mcs MultiplayerServices api.
 
 ### 🐛 🔨 Bug Fixes
 


### PR DESCRIPTION
We are in the process of setting up nightly releases of CSP as part of a Continuous Deployment initiative. As part of that a GitHub Action has been added to update the changelog `## [Unreleased]` tag with the release version and date when releases are made.

A next step will be to add a further GitHub action that enforces the changelog update as part of a PR (with label for skipping where required). However before adding that, I would like to validate the flow as it stands.

This PR contains a manual update of the CHANGELOG.md file for the commits made since our last release. Once merged I will publish a new version of CSP using the new build config which will later be scheduled to perform a nightly release.