### PR TITLE
[NT-0] feat: Add non-exported iterators to Map

### DIFF
--- a/Library/include/CSP/Common/Map.h
+++ b/Library/include/CSP/Common/Map.h
@@ -34,8 +34,6 @@ template <typename TKey, typename TValue> class CSP_API Map
 {
 public:
     using MapType = std::map<TKey, TValue>;
-    using iterator = typename MapType::iterator;
-    using const_iterator = typename MapType::const_iterator;
 
     /// @brief Constructs a map with 0 elements.
     Map() { Container = new MapType(); }
@@ -124,17 +122,17 @@ public:
     bool HasKey(const TKey& Key) const { return Container->count(Key) > 0; }
 
     // Iterators
-    CSP_NO_EXPORT iterator begin() { return Container->begin(); }
-    CSP_NO_EXPORT const_iterator begin() const { return Container->begin(); }
-    CSP_NO_EXPORT const_iterator cbegin() const { return Container->cbegin(); }
+    CSP_NO_EXPORT typename MapType::iterator begin() { return Container->begin(); }
+    CSP_NO_EXPORT typename MapType::const_iterator begin() const { return Container->begin(); }
+    CSP_NO_EXPORT typename MapType::const_iterator cbegin() const { return Container->cbegin(); }
 
-    CSP_NO_EXPORT iterator end() { return Container->end(); }
-    CSP_NO_EXPORT const_iterator end() const { return Container->end(); }
-    CSP_NO_EXPORT const_iterator cend() const { return Container->cend(); }
+    CSP_NO_EXPORT typename MapType::iterator end() { return Container->end(); }
+    CSP_NO_EXPORT typename MapType::const_iterator end() const { return Container->end(); }
+    CSP_NO_EXPORT typename MapType::const_iterator cend() const { return Container->cend(); }
 
     // These finds are more efficient than using std::find over the iterators (non-linear container)
-    CSP_NO_EXPORT iterator Find(const TKey& Key) { return Container->find(Key); }
-    CSP_NO_EXPORT const_iterator Find(const TKey& Key) const { return Container->find(Key); }
+    CSP_NO_EXPORT typename MapType::iterator Find(const TKey& Key) { return Container->find(Key); }
+    CSP_NO_EXPORT typename MapType::const_iterator Find(const TKey& Key) const { return Container->find(Key); }
 
     /// @brief Returns a copy of all keys in this map.
     ///        This copy should be disposed by the caller once it is no longer needed.


### PR DESCRIPTION
Using these for the SWIG stuff. The spelling is different to our standards because they need to adapt into STL compatible names, similar to what we do in List. Expect more of this stuff for the other interop types over the next few weeks. As this is strictly forwarding the underlying container, I didn't feel the need for additional tests, but am willing to be told that I'm wrong there.

Iterators are a cool pattern man, you expose these standard things and you get practically every algorithm you need for free, without needing to adapt the underlying type.

Feels like there's a language trying to come out where containers are just a standard set of iterators and a utility header like `<algorithm>`
