### PR TITLE
[OF-1804] ci: Update the Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,10 @@
 Please write a short description of what this change does and what problem it solves.
 For more information, see our [CONTRIBUTING](https://github.com/magnopus-opensource/connected-spaces-platform/blob/main/.github/CONTRIBUTING.md) page.
+
+Every PR must include either an update to the [.github/CHANGELOG.md](https://github.com/magnopus-opensource/connected-spaces-platform/blob/main/.github/CHANGELOG.md) file, or have the `skip changelog` label applied to it - this requirement is enforced by a GitHub Action.
+
+The `skip changelog` label should only be used for purely internal changes that have no external impact on users of the library, such as:
+
+- Internal tooling/CI updates: Changes that exclusively affect the build, testing, or deployment.
+- Minor code refactors with no behavior change: Code refactors or cleanup that do not alter the library's public API, performance or external behavior.
+- Documentation or comment fixes: Corrections to internal code comments, inline documentation, or non-user-facing documentation.


### PR DESCRIPTION
Update the `Pull Request Template` to include direction as to when the `skip changelog` PR label should be used.