### PR TITLE
16KB page size test

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -186,8 +186,12 @@ if not Project then
 				"-Wno-error=format-security" --In logging, __android_log_print(ANDROID_LOG_VERBOSE, "CSP", InMessage.c_str()) is unnaceptable for some reason.
             }
 
-            linkoptions { "-lm" } -- For gcc's math lib
-
+            linkoptions { 
+            "-lm", -- For gcc's math lib
+            "-Wl,-z,max-page-size=16384",
+            "-Wl,-z,common-page-size=16384"
+            } 
+        
             externalincludedirs {
                 "%{wks.location}/ThirdParty/OpenSSL/1.1.1k/include/platform/android"
             }


### PR DESCRIPTION
There's a theory this is required for the new android version required on quest, just trying to produce a build that we might be able to test, in case that turns out to be the case. (It might not / probably won't)
