### PR TITLE
[NT-0] fix: Replace List implementation with std::vector

### DIFF
--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -20,9 +20,8 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstring>
 #include <initializer_list>
-#include <utility>
+#include <vector>
 
 namespace csp::common
 {
@@ -30,21 +29,6 @@ namespace csp::common
 CSP_START_IGNORE
 template <typename T> class Array;
 CSP_END_IGNORE
-
-const auto LIST_DEFAULT_SIZE = 4;
-
-inline size_t next_pow2(size_t val)
-{
-    --val;
-    val |= val >> 1;
-    val |= val >> 2;
-    val |= val >> 4;
-    val |= val >> 8;
-    val |= val >> 16;
-    ++val;
-
-    return val;
-}
 
 /// @brief Simple DLL-safe resizable collection of objects.
 ///
@@ -57,106 +41,39 @@ template <typename T> class CSP_API List
 {
 public:
     /// @brief Constructs a list with 0 elements.
-    List()
-        : CurrentSize(0)
-        , MaximumSize(0)
-        , ObjectArray(nullptr)
-    {
-        AllocList(LIST_DEFAULT_SIZE);
-    }
+    List() { }
 
     /// @brief Constructs a list with the given number of elements.
     /// @param Size size_t : Number of elements in the array
-    List(size_t MinimumSize)
-        : CurrentSize(0)
-        , MaximumSize(0)
-        , ObjectArray(nullptr)
-    {
-        auto Size = next_pow2(MinimumSize);
-        AllocList(Size);
-    }
+    List(size_t MinimumSize) { Storage.reserve(MinimumSize); }
 
     /// @brief Copy constructor.
     /// @param Other const List<T>&
     List(const List<T>& Other)
-        : CurrentSize(0)
-        , MaximumSize(0)
-        , ObjectArray(nullptr)
+        : Storage(Other.Storage)
     {
-        if (Other.CurrentSize == 0)
-        {
-            AllocList(LIST_DEFAULT_SIZE);
-
-            return;
-        }
-
-        AllocList(Other.MaximumSize);
-        CurrentSize = Other.CurrentSize;
-
-        for (size_t i = 0; i < CurrentSize; ++i)
-        {
-            T* ObjectPtr = &ObjectArray[i];
-            new (ObjectPtr) T;
-            ObjectArray[i] = Other.ObjectArray[i];
-        }
     }
 
     CSP_NO_EXPORT List(List<T>&& Other)
-        : CurrentSize(0)
-        , MaximumSize(0)
-        , ObjectArray(nullptr)
+        : Storage(std::move(Other.Storage))
     {
-        if (Other.CurrentSize == 0)
-        {
-            AllocList(LIST_DEFAULT_SIZE);
-
-            return;
-        }
-
-        CurrentSize = Other.CurrentSize;
-        MaximumSize = Other.MaximumSize;
-        ObjectArray = Other.ObjectArray;
-
-        Other.ObjectArray = nullptr;
+        Other.Storage.clear();
     }
 
     /// @brief Constructs a list from an initializer_list.
     /// @param List std::initializer_list : Elements to construct the list from
     CSP_NO_EXPORT List(std::initializer_list<T> List)
-        : CurrentSize(0)
-        , MaximumSize(0)
-        , ObjectArray(nullptr)
+        : Storage(std::move(List))
     {
-        if (List.size() == 0)
-        {
-            AllocList(LIST_DEFAULT_SIZE);
-
-            return;
-        }
-
-        auto Size = next_pow2(List.size());
-        AllocList(Size);
-        CurrentSize = List.size();
-
-        for (size_t i = 0; i < CurrentSize; ++i)
-        {
-            T* ObjectPtr = &ObjectArray[i];
-            new (ObjectPtr) T;
-            ObjectArray[i] = *(List.begin() + i);
-        }
     }
-
-    /// @brief Destructor.
-    /// Frees list memory.
-    ~List() { FreeList(); }
 
     /// @brief Returns a pointer to the start of the list.
     /// @return T*
-    CSP_NO_EXPORT T* Data() { return CurrentSize > 0 ? &ObjectArray[0] : nullptr; }
+    CSP_NO_EXPORT T* Data() { return Storage.size() > 0 ? Storage.data() : nullptr; }
 
     /// @brief Returns a const pointer to the start of the list.
     /// @return const T*
-    CSP_NO_EXPORT const T* Data() const { return CurrentSize > 0 ? &ObjectArray[0] : nullptr; }
+    CSP_NO_EXPORT const T* Data() const { return Storage.size() > 0 ? Storage.data() : nullptr; }
 
     // Iterators
     CSP_NO_EXPORT T* begin() { return Data(); }
@@ -172,29 +89,7 @@ public:
     /// @return List<T>&
     List<T>& operator=(const List<T>& Other)
     {
-        if (this == &Other)
-        {
-            return *this;
-        }
-
-        CurrentSize = Other.CurrentSize;
-        MaximumSize = 0;
-        ObjectArray = nullptr;
-
-        if (CurrentSize == 0)
-        {
-            AllocList(LIST_DEFAULT_SIZE);
-
-            return *this;
-        }
-
-        AllocList(Other.MaximumSize);
-
-        for (size_t i = 0; i < CurrentSize; i++)
-        {
-            ObjectArray[i] = Other.ObjectArray[i];
-        }
-
+        Storage = Other.Storage;
         return *this;
     }
 
@@ -203,9 +98,9 @@ public:
     /// @return T& : List element
     T& operator[](size_t Index)
     {
-        assert(Index < CurrentSize);
+        assert(Index < Storage.size());
 
-        return ObjectArray[Index];
+        return Storage[Index];
     }
 
     /// @brief Returns a const element at the given index of the list.
@@ -213,176 +108,67 @@ public:
     /// @return const T& : List element
     const T& operator[](size_t Index) const
     {
-        assert(Index < CurrentSize);
+        assert(Index < Storage.size());
 
-        return ObjectArray[Index];
+        return Storage[Index];
     }
 
     /// @brief Appends an element to the end of the list.
     /// @param Item const T&
-    void Append(const T& Item)
-    {
-        if (CurrentSize == MaximumSize)
-        {
-            auto Size = next_pow2(MaximumSize + 1);
-            ReallocList(Size);
-        }
-
-        // Instantiate element first to allow copy assignment
-        T* ObjectPtr = &ObjectArray[CurrentSize];
-        new (ObjectPtr) T;
-        ObjectArray[CurrentSize++] = Item;
-    }
+    void Append(const T& Item) { Storage.push_back(Item); }
 
     /// @brief Appends an element to the end of the list.
     /// @param Item T&&
-    CSP_NO_EXPORT void Append(T&& Item)
-    {
-        if (CurrentSize == MaximumSize)
-        {
-            auto Size = next_pow2(MaximumSize + 1);
-            ReallocList(Size);
-        }
-
-        // Instantiate element first to allow move assignment
-        T* ObjectPtr = &ObjectArray[CurrentSize];
-        new (ObjectPtr) T;
-        ObjectArray[CurrentSize++] = std::move(Item);
-    }
+    CSP_NO_EXPORT void Append(T&& Item) { Storage.push_back(std::forward<T>(Item)); }
 
     /// @brief Appends an element at the given index of the list.
     /// @param Index size_t
     /// @param Item const T&
-    void Insert(size_t Index, const T& Item)
-    {
-        if (CurrentSize == MaximumSize)
-        {
-            auto Size = next_pow2(MaximumSize + 1);
-            ReallocList(Size);
-        }
-
-        auto After = CurrentSize - Index;
-        std::memmove(ObjectArray + (Index + 1), ObjectArray + Index, sizeof(T) * After);
-        ++CurrentSize;
-
-        T* ObjectPtr = &ObjectArray[Index];
-        new (ObjectPtr) T;
-        ObjectArray[Index] = Item;
-    }
+    void Insert(size_t Index, const T& Item) { Storage.insert(Storage.begin() + Index, Item); }
 
     /// @brief Removes an element to a specific index of the list.
     /// @param Index size_t
-    void Remove(size_t Index)
-    {
-        assert(Index < CurrentSize);
-
-        if constexpr (std::is_pointer<T>::value)
-        {
-            // I dont think the list owns any pointers that are in it. That seems weird, because it _will_ destruct value types
-            // To maintain exactly the same behaviour, do the destruct behaviour for pointers. Use regular RAII cleanup for value types below during
-            // the shift.
-
-            // delete ObjectArray[Index]; <-- What we should be doing ... (although actually, we should just have this type backed by std::list)
-            T* ObjectPtr = &ObjectArray[Index];
-            ObjectPtr->~T();
-        }
-
-        // Shift everything left
-        for (size_t i = Index; i < CurrentSize - 1; ++i)
-        {
-            ObjectArray[i] = ObjectArray[i + 1];
-        }
-        --CurrentSize;
-    }
+    void Remove(size_t Index) { Storage.erase(Storage.begin() + Index); }
 
     /// @brief Removes the given element from the list.
     /// @param Item const T& : Element to remove from the list
     void RemoveItem(const T& Item)
     {
-        for (size_t i = 0; i < CurrentSize; ++i)
-        {
-            if (ObjectArray[i] == Item)
-            {
-                Remove(i);
-                return;
-            }
-        }
+        // Shift all the elements to remove to the back of the list
+        auto NewEnd = std::remove(Storage.begin(), Storage.end(), Item);
+
+        // Erase them
+        Storage.erase(NewEnd, Storage.end());
     }
 
     /// @brief Returns the number of elements in the array.
     /// @return const size_t
-    const size_t Size() const { return CurrentSize; }
+    const size_t Size() const { return Storage.size(); }
 
     /// @brief Removes all elements in the list.
-    void Clear()
-    {
-        FreeList();
-        AllocList(LIST_DEFAULT_SIZE);
-    }
+    void Clear() { Storage.clear(); }
 
     /// @brief Checks if the list contains the given element.
     /// @param Item const T& : Element to check if the list contains
     /// @return bool
-    bool Contains(const T& Item) const
-    {
-        for (size_t i = 0; i < CurrentSize; ++i)
-        {
-            if (ObjectArray[i] == Item)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    bool Contains(const T& Item) const { return std::find(Storage.cbegin(), Storage.cend(), Item) != Storage.cend(); }
 
     /// @brief Returns a copy of this List as an Array
     /// @return Array<T>
     CSP_NO_EXPORT Array<T> ToArray() const
     {
-        Array<T> Result(CurrentSize);
+        Array<T> Result(Storage.size());
 
-        for (size_t i = 0; i < CurrentSize; ++i)
+        for (size_t i = 0; i < Storage.size(); ++i)
         {
-            Result[i] = ObjectArray[i];
+            Result[i] = Storage[i];
         }
 
         return std::move(Result);
     }
 
 private:
-    /// @brief Allocates memory for the list.
-    /// @param Size size_t : Number of elements in the list
-    void AllocList(const size_t Size)
-    {
-        ObjectArray = new T[Size];
-        MaximumSize = Size;
-    }
-
-    void ReallocList(const size_t Size)
-    {
-        T* NewArray = new T[Size];
-        if (ObjectArray)
-        {
-            std::copy(ObjectArray, ObjectArray + std::min(MaximumSize, Size), NewArray);
-            delete[] ObjectArray;
-        }
-        ObjectArray = NewArray;
-        MaximumSize = Size;
-    }
-
-    /// @brief Frees memory for the list.
-    void FreeList()
-    {
-        delete[] ObjectArray;
-        ObjectArray = nullptr;
-        CurrentSize = 0;
-        MaximumSize = 0;
-    }
-
-    size_t CurrentSize;
-    size_t MaximumSize;
-    T* ObjectArray;
+    std::vector<T> Storage;
 };
 
 } // namespace csp::common

--- a/Library/include/CSP/Common/Settings.h
+++ b/Library/include/CSP/Common/Settings.h
@@ -45,8 +45,8 @@ public:
     /// The keys and values are both strings and represent additional configurable options.
     csp::common::Map<csp::common::String, csp::common::String> Settings;
 
-    bool operator==(const csp::common::ApplicationSettings& Other);
-    bool operator!=(const csp::common::ApplicationSettings& Other);
+    bool operator==(const csp::common::ApplicationSettings& Other) const;
+    bool operator!=(const csp::common::ApplicationSettings& Other) const;
 };
 
 /// @brief Represents configuration settings related to a user in a specific context
@@ -65,8 +65,8 @@ public:
     /// @brief A key-value store of arbitrary user settings.
     csp::common::Map<csp::common::String, csp::common::String> Settings;
 
-    bool operator==(const csp::common::SettingsCollection& Other);
-    bool operator!=(const csp::common::SettingsCollection& Other);
+    bool operator==(const csp::common::SettingsCollection& Other) const;
+    bool operator!=(const csp::common::SettingsCollection& Other) const;
 };
 } // namespace csp::systems
 

--- a/Library/src/Common/Settings.cpp
+++ b/Library/src/Common/Settings.cpp
@@ -20,20 +20,20 @@
 
 namespace csp::common
 {
-bool ApplicationSettings::operator==(const ApplicationSettings& Other)
+bool ApplicationSettings::operator==(const ApplicationSettings& Other) const
 {
     return (ApplicationName == Other.ApplicationName) && (Context == Other.Context) && (AllowAnonymous == Other.AllowAnonymous)
         && (Settings == Other.Settings);
 }
 
-bool ApplicationSettings::operator!=(const ApplicationSettings& Other) { return !(*this == Other); }
+bool ApplicationSettings::operator!=(const ApplicationSettings& Other) const { return !(*this == Other); }
 
-bool SettingsCollection::operator==(const SettingsCollection& Other)
+bool SettingsCollection::operator==(const SettingsCollection& Other) const
 {
     return (UserId == Other.UserId) && (Context == Other.Context) && (Settings == Other.Settings);
 }
 
-bool SettingsCollection::operator!=(const SettingsCollection& Other) { return !(*this == Other); }
+bool SettingsCollection::operator!=(const SettingsCollection& Other) const { return !(*this == Other); }
 } // namespace csp::systems
 
 void ToJson(csp::json::JsonSerializer& Serializer, const csp::common::ApplicationSettings& Obj)


### PR DESCRIPTION
This type is riddled with issues, the placement new manual management doesn't account for the difference between trivially copyable and non-trivially copyable types very well, and this is playing havok on wrapper gen stuff where ownership gets complicated.

To be honest, I couldn't figure out exactly what in this was causing an issue with the C# garbage collector. I think it's the std::copy copying types that in themselves contain non-trivially relocatable types (like maps). This was manifesting as an error similar to that map<string, string> release error we saw a while back.

Call this experimental, as I'm not sure it actually addresses the issue (I have a 100% repro using the C# bindings), but we'll see. It's fully non breaking at least.