### PR TITLE
[NT-0] test: Correctly exit spaces in crashing test code

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,8 +19,13 @@ All notable changes to this project will be documented in this file.
 
 🍰 🙌 New Features
 
-  [OF-1758] feat: replace assertion in token expiration with meaningful log to notify users by MAG-ChristopherAtkinson
+- [OF-1758] feat: replace assertion in token expiration with meaningful log to notify users by MAG-ChristopherAtkinson
   RefreshIfExpired invokes a fatal log message in place of the existing assert as asserting on a refresh token failure is too aggressive.
+  
+🙈 🙉 🙊 Test Changes
+
+- [NT-0] test: Await exiting spaces in certain realtime engine tests by MAG-ElliotMorris.
+  Correct usage of the realtime engine requires that the exit space call returns fully before deleting the memory, these tests did not do that.
 
 ## [6.14.0] - 2025-12-02_17-43-07
 

--- a/Tests/src/PublicAPITests/RealtimeEngineEntityTests.cpp
+++ b/Tests/src/PublicAPITests/RealtimeEngineEntityTests.cpp
@@ -1074,7 +1074,7 @@ TEST_P(EntityGlobalPosition, EntityGlobalPositionTest)
     // When performing quaternion operations, W can be negative, so no point checking
     EXPECT_EQ(ObjectTransformExpected.Scale == GlobalScale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     RealtimeEngine.reset();
 
     // Delete space
@@ -1170,7 +1170,7 @@ TEST_P(EntityGlobalRotation, EntityGlobalRotationTest)
     EXPECT_EQ(ObjectTransformExpected.Rotation.Z == GlobalRotation.Z, true);
     EXPECT_EQ(ObjectTransformExpected.Scale == GlobalScale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     RealtimeEngine.reset();
 
     // Delete space
@@ -1269,7 +1269,7 @@ TEST_P(EntityGlobalScale, EntityGlobalScaleTest)
     EXPECT_EQ(ObjectTransformExpected.Rotation.Z == GlobalRotation.Z, true);
     EXPECT_EQ(ObjectTransformExpected.Scale == GlobalScale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     RealtimeEngine.reset();
 
     // Delete space
@@ -1360,7 +1360,7 @@ TEST_P(EntityGlobalTransform, EntityGlobalTransformTest)
     EXPECT_EQ(ObjectTransformExpected.Rotation.Z == ObjectTransformActual.Rotation.Z, true);
     EXPECT_EQ(ObjectTransformExpected.Scale == ObjectTransformActual.Scale, true);
 
-    SpaceSystem->ExitSpace([](const csp::systems::NullResult& /*Result*/) {});
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
     RealtimeEngine.reset();
 
     // Delete space


### PR DESCRIPTION
These tests violated a RealtimeEngine precondition, where you had to wait until a successful exit space before deleting the realtime engine. This could cause a race condition if a message comes back over the multplayerConnection after the deletion but before the nulling of the pointer.
