### PR TITLE
[NT-0] fix: Fix tasks dropping in signalR scheduler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to this project will be documented in this file. For compile
 - [OF-1848] refac!: Change underlying type of `ComponentType` and all `PropertyKey` enums to ensure compatibility with SignalR wire representation. By @mag-lt
   This is technically a breaking change, but it shouldn't force any client code changes. Explicitly defining the underlying type encodes
   the existing constaints into the type system.
+  
+### 🐛 🔨 Bug Fixes
+
+- [NT-0] fix: Fix tasks dropping in signalR scheduler by @MAG-ElliotMorris
+  Address issue where signalR scheduler can drop tasks in rare instances where scheduler threads are almost completely busy.
 
 ## [6.31.0]
 

--- a/ThirdParty/signalrclient/src/signalr_default_scheduler.cpp
+++ b/ThirdParty/signalrclient/src/signalr_default_scheduler.cpp
@@ -148,9 +148,9 @@ namespace signalr
                     // find the first callback that is ready to run, find a thread to run it and remove it from the list
                     auto curr_time = std::chrono::steady_clock::now();
                     auto it = callbacks.begin();
-                    auto found = false;
                     while (it != callbacks.end())
                     {
+                        auto found = false;
                         if (it->second <= curr_time)
                         {
                             for (auto& thread : threads)


### PR DESCRIPTION
This is a rather rare bug. When the default scheduler is almost full, and it attempts to schedule multiple tasks, there is a path where it can run a task, and then fail to run a subsequent task, but _think_ it has, thus dropping the task from the queue of tasks to run.

Whilst rare, this can have really pernicious effects with timer based tasks, particularly the connection keep alive signal. It also becomes more likely to occur in larger spaces with more network traffic, lending an air of instability.

This is a fix already made [upstream](https://github.com/aspnet/SignalR-Client-Cpp/blob/f5ab36773544d5a9f1f8a012cbecfd849341bb64/src/signalrclient/signalr_default_scheduler.cpp#L157). I will make a ticket to perform a signalR library merge, because I'm certain there are other fixes we are also missing.

I made a whole video on this if you have access to Magnopus internals, see here : https://magnopus.slack.com/archives/C02UB7Z8ZFS/p1775140578901449