### PR TITLE
Of 1844 add auth token asset requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. For compile
 
 - [OF-1625] feat: Add enabled property to `CollisionSpaceComponent`. By @mag-lt.
 
-- [OF-1844] feat: Add `Authorization` header to asset requests. By @mag-lt. By @MAG-AdamThorn
+- [OF-1844] feat: Add `Authorization` header to asset requests. By @MAG-AdamThorn
   This change adds content security to our S3 Assets, by ensuring asset requests are authorized. An `Authorization` header has been added to our file Web Requests with the authenticated users bearer token.
 
 ###💫 💥 Code Refactors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file. For compile
 
 - [OF-1625] feat: Add enabled property to `CollisionSpaceComponent`. By @mag-lt.
 
+- [OF-1844] feat: Add `Authorization` header to asset requests. By @mag-lt. By @MAG-AdamThorn
+  This change adds content security to our S3 Assets, by ensuring asset requests are authorized. An `Authorization` header has been added to our file Web Requests with the authenticated users bearer token.
+
 ###💫 💥 Code Refactors
 
 - [OF-1848] refac: Add internal constructor to `ComponentBase` for constructing from a `Schema` structure. By @mag-lt

--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -361,7 +361,7 @@ public:
 private:
     AssetSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
     CSP_NO_EXPORT AssetSystem(csp::web::WebClient* WebClient, csp::multiplayer::NetworkEventBus& EventBus,
-        csp::common::IAuthContext& InAuthContext, common::LogSystem& LogSystem);
+        const csp::common::IAuthContext& InAuthContext, common::LogSystem& LogSystem);
     ~AssetSystem();
 
     CSP_ASYNC_RESULT void DeleteAssetCollectionById(const csp::common::String& AssetCollectionId, NullResultCallback Callback);

--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -360,7 +360,8 @@ public:
 
 private:
     AssetSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
-    CSP_NO_EXPORT AssetSystem(csp::web::WebClient* WebClient, csp::multiplayer::NetworkEventBus& EventBus, common::LogSystem& LogSystem);
+    CSP_NO_EXPORT AssetSystem(csp::web::WebClient* WebClient, csp::multiplayer::NetworkEventBus& EventBus,
+        csp::common::IAuthContext& InAuthContext, common::LogSystem& LogSystem);
     ~AssetSystem();
 
     CSP_ASYNC_RESULT void DeleteAssetCollectionById(const csp::common::String& AssetCollectionId, NullResultCallback Callback);

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -351,13 +351,13 @@ AssetSystem::AssetSystem()
 }
 
 AssetSystem::AssetSystem(
-    web::WebClient* WebClient, multiplayer::NetworkEventBus& EventBus, csp::common::IAuthContext& InAuthContext, common::LogSystem& LogSystem)
+    web::WebClient* WebClient, multiplayer::NetworkEventBus& EventBus, const csp::common::IAuthContext& InAuthContext, common::LogSystem& LogSystem)
     : SystemBase(WebClient, &EventBus, &LogSystem)
 {
     PrototypeAPI = new chs::PrototypeApi(WebClient);
     AssetDetailAPI = new chs::AssetDetailApi(WebClient);
 
-    FileManager = new web::RemoteFileManager(WebClient, &InAuthContext);
+    FileManager = new web::RemoteFileManager(WebClient, InAuthContext);
 
     RegisterSystemCallback();
 }

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -18,6 +18,7 @@
 
 #include "CSP/Common/CSPAsyncScheduler.h"
 #include "CSP/Common/ContinuationUtils.h"
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "CallHelpers.h"
 #include "LODHelpers.h"
 #include "Multiplayer/NetworkEventSerialisation.h"
@@ -349,13 +350,14 @@ AssetSystem::AssetSystem()
 {
 }
 
-AssetSystem::AssetSystem(web::WebClient* WebClient, multiplayer::NetworkEventBus& EventBus, common::LogSystem& LogSystem)
+AssetSystem::AssetSystem(
+    web::WebClient* WebClient, multiplayer::NetworkEventBus& EventBus, csp::common::IAuthContext& InAuthContext, common::LogSystem& LogSystem)
     : SystemBase(WebClient, &EventBus, &LogSystem)
 {
     PrototypeAPI = new chs::PrototypeApi(WebClient);
     AssetDetailAPI = new chs::AssetDetailApi(WebClient);
 
-    FileManager = new web::RemoteFileManager(WebClient);
+    FileManager = new web::RemoteFileManager(WebClient, &InAuthContext);
 
     RegisterSystemCallback();
 }

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -203,7 +203,7 @@ void SystemsManager::CreateSystems(csp::multiplayer::ISignalRConnection* SignalR
     // SystemBase inheritors
 
     SpaceSystem = new csp::systems::SpaceSystem(WebClient, MultiplayerConnection->GetEventBus(), UserSystem, *LogSystem);
-    AssetSystem = new csp::systems::AssetSystem(WebClient, MultiplayerConnection->GetEventBus(), *LogSystem);
+    AssetSystem = new csp::systems::AssetSystem(WebClient, MultiplayerConnection->GetEventBus(), UserSystem->GetAuthContext(), *LogSystem);
     AnchorSystem = new csp::systems::AnchorSystem(WebClient, *LogSystem);
     PointOfInterestSystem = new csp::systems::PointOfInterestInternalSystem(WebClient, *LogSystem);
     ApplicationSettingsSystem = new csp::systems::ApplicationSettingsSystem(WebClient, *LogSystem);

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -24,13 +24,13 @@
 
 namespace
 {
-csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(csp::common::IAuthContext* InAuthContext)
+csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(const csp::common::IAuthContext& InAuthContext)
 {
     csp::common::Optional<csp::common::String> BearerToken;
 
-    if (InAuthContext && InAuthContext->GetLoginState().State == csp::common::ELoginState::LoggedIn)
+    if (InAuthContext.GetLoginState().State == csp::common::ELoginState::LoggedIn)
     {
-        csp::common::String AccessToken = InAuthContext->GetLoginState().AccessToken;
+        csp::common::String AccessToken = InAuthContext.GetLoginState().AccessToken;
         BearerToken = csp::common::String(fmt::format("Bearer {}", AccessToken.c_str()).c_str());
     }
 
@@ -41,7 +41,7 @@ csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(csp::com
 namespace csp::web
 {
 
-RemoteFileManager::RemoteFileManager(csp::web::WebClient* InWebClient, csp::common::IAuthContext* InAuthContext)
+RemoteFileManager::RemoteFileManager(csp::web::WebClient* InWebClient, const csp::common::IAuthContext& InAuthContext)
     : WebClient(InWebClient)
     , AuthContext(InAuthContext)
 {

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -19,8 +19,6 @@
 #include "Common/Web/HttpAuth.h"
 #include "Common/Web/HttpPayload.h"
 #include "Common/Web/WebClient.h"
-#include <CSP/Systems/SystemsManager.h>
-#include <CSP/Systems/Users/UserSystem.h>
 
 #include <fmt/format.h>
 
@@ -33,7 +31,7 @@ csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(csp::com
     if (InAuthContext && InAuthContext->GetLoginState().State == csp::common::ELoginState::LoggedIn)
     {
         csp::common::String AccessToken = InAuthContext->GetLoginState().AccessToken;
-        BearerToken = fmt::format("Bearer {}", AccessToken.c_str()).c_str();
+        BearerToken = csp::common::String(fmt::format("Bearer {}", AccessToken.c_str()).c_str());
     }
 
     return BearerToken;

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -15,6 +15,7 @@
  */
 #include "Web/RemoteFileManager.h"
 
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "Common/Web/HttpAuth.h"
 #include "Common/Web/HttpPayload.h"
 #include "Common/Web/WebClient.h"
@@ -25,16 +26,13 @@
 
 namespace
 {
-csp::common::Optional<csp::common::String> ConstructAuthorizationHeader()
+csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(csp::common::IAuthContext* InAuthContext)
 {
     csp::common::Optional<csp::common::String> BearerToken;
 
-    auto& SystemsManager = csp::systems::SystemsManager::Get();
-    auto& UserSystem = *SystemsManager.GetUserSystem();
-
-    if (UserSystem.GetLoginState().State == csp::common::ELoginState::LoggedIn)
+    if (InAuthContext && InAuthContext->GetLoginState().State == csp::common::ELoginState::LoggedIn)
     {
-        csp::common::String AccessToken = UserSystem.GetLoginState().AccessToken;
+        csp::common::String AccessToken = InAuthContext->GetLoginState().AccessToken;
         BearerToken = fmt::format("Bearer {}", AccessToken.c_str()).c_str();
     }
 
@@ -45,8 +43,9 @@ csp::common::Optional<csp::common::String> ConstructAuthorizationHeader()
 namespace csp::web
 {
 
-RemoteFileManager::RemoteFileManager(csp::web::WebClient* InWebClient)
+RemoteFileManager::RemoteFileManager(csp::web::WebClient* InWebClient, csp::common::IAuthContext* InAuthContext)
     : WebClient(InWebClient)
+    , AuthContext(InAuthContext)
 {
 }
 
@@ -60,7 +59,7 @@ void RemoteFileManager::GetFile(
     csp::web::HttpPayload Payload;
     Payload.AddHeader(CSP_TEXT("Content-Type"), CSP_TEXT("text/json"));
 
-    auto BearerToken = ConstructAuthorizationHeader();
+    auto BearerToken = ConstructAuthorizationHeader(AuthContext);
 
     if (BearerToken.HasValue())
     {
@@ -75,7 +74,7 @@ void RemoteFileManager::GetResponseHeaders(const csp::common::String& Url, csp::
     csp::web::Uri GetUri(Url);
     csp::web::HttpPayload Payload;
 
-    auto BearerToken = ConstructAuthorizationHeader();
+    auto BearerToken = ConstructAuthorizationHeader(AuthContext);
 
     if (BearerToken.HasValue())
     {

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -18,6 +18,29 @@
 #include "Common/Web/HttpAuth.h"
 #include "Common/Web/HttpPayload.h"
 #include "Common/Web/WebClient.h"
+#include <CSP/Systems/SystemsManager.h>
+#include <CSP/Systems/Users/UserSystem.h>
+
+#include <fmt/format.h>
+
+namespace
+{
+csp::common::Optional<csp::common::String> ConstructAuthorizationHeader()
+{
+    csp::common::Optional<csp::common::String> BearerToken;
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto& UserSystem = *SystemsManager.GetUserSystem();
+
+    if (UserSystem.GetLoginState().State == csp::common::ELoginState::LoggedIn)
+    {
+        csp::common::String AccessToken = UserSystem.GetLoginState().AccessToken;
+        BearerToken = fmt::format("Bearer {}", AccessToken.c_str()).c_str();
+    }
+
+    return BearerToken;
+}
+} // namespace
 
 namespace csp::web
 {
@@ -37,6 +60,13 @@ void RemoteFileManager::GetFile(
     csp::web::HttpPayload Payload;
     Payload.AddHeader(CSP_TEXT("Content-Type"), CSP_TEXT("text/json"));
 
+    auto BearerToken = ConstructAuthorizationHeader();
+
+    if (BearerToken.HasValue())
+    {
+        Payload.AddHeader(CSP_TEXT("Authorization"), *BearerToken);
+    }
+
     WebClient->SendRequest(csp::web::ERequestVerb::GET, GetUri, Payload, ResponseHandler, CancellationToken);
 }
 
@@ -44,6 +74,13 @@ void RemoteFileManager::GetResponseHeaders(const csp::common::String& Url, csp::
 {
     csp::web::Uri GetUri(Url);
     csp::web::HttpPayload Payload;
+
+    auto BearerToken = ConstructAuthorizationHeader();
+
+    if (BearerToken.HasValue())
+    {
+        Payload.AddHeader(CSP_TEXT("Authorization"), *BearerToken);
+    }
 
     WebClient->SendRequest(csp::web::ERequestVerb::HEAD, GetUri, Payload, ResponseHandler, csp::common::CancellationToken::Dummy());
 }

--- a/Library/src/Web/RemoteFileManager.h
+++ b/Library/src/Web/RemoteFileManager.h
@@ -29,8 +29,8 @@ public:
     RemoteFileManager(csp::web::WebClient* InWebClient);
     ~RemoteFileManager();
 
-    void GetFile(
-        const csp::common::String& FileUrl, csp::services::ResponseHandlerPtr ResponseHandler, csp::common::CancellationToken& CancellationToken);
+    void GetFile(const csp::common::String& FileUrl, csp::services::ResponseHandlerPtr ResponseHandler,
+        csp::common::CancellationToken& CancellationToken);
     void GetResponseHeaders(const csp::common::String& Url, csp::services::ResponseHandlerPtr ResponseHandler);
 
 private:

--- a/Library/src/Web/RemoteFileManager.h
+++ b/Library/src/Web/RemoteFileManager.h
@@ -31,7 +31,7 @@ namespace csp::web
 class RemoteFileManager
 {
 public:
-    RemoteFileManager(csp::web::WebClient* InWebClient, csp::common::IAuthContext* InAuthContext);
+    RemoteFileManager(csp::web::WebClient* InWebClient, const csp::common::IAuthContext& InAuthContext);
     ~RemoteFileManager();
 
     void GetFile(const csp::common::String& FileUrl, csp::services::ResponseHandlerPtr ResponseHandler,
@@ -40,7 +40,7 @@ public:
 
 private:
     csp::web::WebClient* WebClient;
-    csp::common::IAuthContext* AuthContext;
+    const csp::common::IAuthContext& AuthContext;
 };
 
 } // namespace csp::web

--- a/Library/src/Web/RemoteFileManager.h
+++ b/Library/src/Web/RemoteFileManager.h
@@ -20,13 +20,18 @@
 #include "Common/Web/WebClient.h"
 #include "Services/PrototypeService/AssetFileDto.h"
 
+namespace csp::common
+{
+class IAuthContext;
+} // namespace csp::common
+
 namespace csp::web
 {
 
 class RemoteFileManager
 {
 public:
-    RemoteFileManager(csp::web::WebClient* InWebClient);
+    RemoteFileManager(csp::web::WebClient* InWebClient, csp::common::IAuthContext* InAuthContext);
     ~RemoteFileManager();
 
     void GetFile(const csp::common::String& FileUrl, csp::services::ResponseHandlerPtr ResponseHandler,
@@ -35,6 +40,7 @@ public:
 
 private:
     csp::web::WebClient* WebClient;
+    csp::common::IAuthContext* AuthContext;
 };
 
 } // namespace csp::web

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -88,7 +88,7 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
 
     EXPECT_CALL(MockContext, GetLoginState).WillRepeatedly(::testing::ReturnRef(LoginState));
 
-    RemoteFileManager FileManager(&MockClient, &MockContext);
+    RemoteFileManager FileManager(&MockClient, MockContext);
 
     FileManager.GetFile(FileUrl, &MockHandler, csp::common::CancellationToken::Dummy());
 
@@ -149,7 +149,7 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
 
     EXPECT_CALL(MockContext, GetLoginState).WillRepeatedly(::testing::ReturnRef(LoginState));
 
-    RemoteFileManager FileManager(&MockClient, &MockContext);
+    RemoteFileManager FileManager(&MockClient, MockContext);
 
     FileManager.GetResponseHeaders(FileUrl, &MockHandler);
 

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -21,16 +21,24 @@
 #include "TestHelpers.h"
 #include "Web/RemoteFileManager.h"
 
+#include "gtest/gtest-param-test.h"
 #include "gtest/gtest.h"
 #include <gmock/gmock.h>
 
 using namespace csp::web;
 
-/*
- * Tests that GetFile sends a GET request with the correct URI and Content-Type header.
- * Confirm that it does not include an Authorization header when the user is not logged in.
- */
-CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileSendsCorrectRequestWhenNotLoggedIn)
+namespace CSPEngine
+{
+
+class GetFile : public PublicTestBaseInternalWithParam<std::tuple<csp::common::ELoginState, csp::common::String>>
+{
+};
+
+class GetResponseHeaders : public PublicTestBaseInternalWithParam<std::tuple<csp::common::ELoginState, csp::common::String>>
+{
+};
+
+TEST_P(GetFile, GetFileSendsCorrectRequest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
@@ -40,9 +48,14 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileSendsCorrectRequestW
 
     const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
 
+    // Construct a LoginState object with the correct state.
+    csp::common::LoginState LoginState;
+    LoginState.State = std::get<0>(GetParam());
+    LoginState.AccessToken = std::get<1>(GetParam());
+
     EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
-            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
+            [&FileUrl, &LoginState](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
                 csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
             {
                 EXPECT_EQ(Verb, ERequestVerb::GET);
@@ -55,109 +68,23 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileSendsCorrectRequestW
                 ASSERT_NE(ContentTypeIt, Headers.end());
                 EXPECT_EQ(ContentTypeIt->second, "text/json");
 
-                // Confirm that the Authorization header is not present when we are not logged in
-                EXPECT_FALSE(Headers.count("Authorization")) << "Expected no Authorization header to be present in the request";
+                if (LoginState.State == csp::common::ELoginState::LoggedIn)
+                {
+                    // Verify that the Authorization header is present
+                    auto AuthIt = Headers.find("Authorization");
+                    ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
+
+                    std::string BearerToken = AuthIt->second;
+
+                    // Verify the token is not empty after "Bearer "
+                    EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
+
+                    const std::string Prefix("Bearer ");
+
+                    EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
+                        << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
+                }
             });
-
-    // The LoginState ctor default initialises the state to csp::common::ELoginState::LoggedOut, which is what we want for this test.
-    csp::common::LoginState LoginState;
-
-    EXPECT_CALL(MockContext, GetLoginState).WillOnce(::testing::ReturnRef(LoginState));
-
-    RemoteFileManager FileManager(&MockClient, &MockContext);
-
-    FileManager.GetFile(FileUrl, &MockHandler, csp::common::CancellationToken::Dummy());
-
-    csp::CSPFoundation::Shutdown();
-}
-
-/*
- * Tests that GetResponseHeaders sends a GET request with the correct URI.
- * Confirm that it does not include an Authorization header when the user is not logged in.
- */
-CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersSendsCorrectRequestWhenNotLoggedIn)
-{
-    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
-
-    auto MockClient = WebClientMock(80, ETransferProtocol::HTTP, nullptr, true);
-    auto MockContext = MockAuthContext();
-    MockApiResponseHandler MockHandler;
-
-    const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
-
-    EXPECT_CALL(MockClient, SendRequest)
-        .WillOnce(
-            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
-                csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
-            {
-                EXPECT_EQ(Verb, ERequestVerb::HEAD);
-
-                EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
-
-                // The X-AssetPlatform header is added to all HTTP requests. Verify that no additional headers have been set
-                const auto& Headers = Payload.GetHeaders();
-                EXPECT_EQ(Headers.size(), 1) << "Expected exactly one header to be present in the request";
-            });
-
-    // The LoginState ctor default initialises the state to csp::common::ELoginState::LoggedOut, which is what we want for this test.
-    csp::common::LoginState LoginState;
-
-    EXPECT_CALL(MockContext, GetLoginState).WillOnce(::testing::ReturnRef(LoginState));
-
-    RemoteFileManager FileManager(&MockClient, &MockContext);
-
-    FileManager.GetResponseHeaders(FileUrl, &MockHandler);
-
-    csp::CSPFoundation::Shutdown();
-}
-
-/*
- * Test that GetFile includes the Authorization header with a Bearer token when the user is logged in.
- */
-CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileIncludesAuthorizationHeaderWhenLoggedIn)
-{
-    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
-
-    auto MockClient = WebClientMock(80, ETransferProtocol::HTTP, nullptr, true);
-    auto MockContext = MockAuthContext();
-    MockApiResponseHandler MockHandler;
-
-    const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
-
-    EXPECT_CALL(MockClient, SendRequest)
-        .WillOnce(
-            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
-                csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
-            {
-                EXPECT_EQ(Verb, ERequestVerb::GET);
-
-                EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
-
-                // Verify Content-Type header is set
-                const auto& Headers = Payload.GetHeaders();
-                auto ContentTypeIt = Headers.find("Content-Type");
-                ASSERT_NE(ContentTypeIt, Headers.end());
-                EXPECT_EQ(ContentTypeIt->second, "text/json");
-
-                // Verify that the Authorization header is present
-                auto AuthIt = Headers.find("Authorization");
-                ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
-
-                std::string BearerToken = AuthIt->second;
-
-                // Verify the token is not empty after "Bearer "
-                EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
-
-                const std::string Prefix("Bearer ");
-
-                EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
-                    << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
-            });
-
-    // Construct a LoginState object with the correct state.
-    csp::common::LoginState LoginState;
-    LoginState.State = csp::common::ELoginState::LoggedIn;
-    LoginState.AccessToken = "MockAccessToken";
 
     EXPECT_CALL(MockContext, GetLoginState).WillRepeatedly(::testing::ReturnRef(LoginState));
 
@@ -168,10 +95,7 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileIncludesAuthorizatio
     csp::CSPFoundation::Shutdown();
 }
 
-/*
- * Test that GetResponseHeaders includes the Authorization header with a Bearer token when the user is logged in.
- */
-CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersIncludesAuthorizationHeaderWhenLoggedIn)
+TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
@@ -181,38 +105,47 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersIncludesA
 
     const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
 
+    // Construct a LoginState object with the correct state.
+    csp::common::LoginState LoginState;
+    LoginState.State = std::get<0>(GetParam());
+    LoginState.AccessToken = std::get<1>(GetParam());
+
     EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
-            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
+            [&FileUrl, &LoginState](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
                 csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
             {
                 EXPECT_EQ(Verb, ERequestVerb::HEAD);
 
                 EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
 
-                // The X-AssetPlatform header is added to all HTTP requests. In addition the Authorization header should have been set
-                const auto& Headers = Payload.GetHeaders();
-                EXPECT_EQ(Headers.size(), 2) << "Expected exactly two headers to be present in the request";
+                if (LoginState.State == csp::common::ELoginState::LoggedIn)
+                {
+                    // The X-AssetPlatform header is added to all HTTP requests. In addition the Authorization header should have been set
+                    const auto& Headers = Payload.GetHeaders();
+                    EXPECT_EQ(Headers.size(), 2) << "Expected exactly two headers to be present in the request";
 
-                // Verify that the Authorization header is present
-                auto AuthIt = Headers.find("Authorization");
-                ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
+                    // Verify that the Authorization header is present
+                    auto AuthIt = Headers.find("Authorization");
+                    ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
 
-                std::string BearerToken = AuthIt->second;
+                    std::string BearerToken = AuthIt->second;
 
-                // Verify the token is not empty after "Bearer "
-                EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
+                    // Verify the token is not empty after "Bearer "
+                    EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
 
-                const std::string Prefix("Bearer ");
+                    const std::string Prefix("Bearer ");
 
-                EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
-                    << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
+                    EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
+                        << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
+                }
+                else
+                {
+                    // The X-AssetPlatform header is added to all HTTP requests. There should be no additional Authorization header set
+                    const auto& Headers = Payload.GetHeaders();
+                    EXPECT_EQ(Headers.size(), 1) << "Expected exactly one header to be present in the request";
+                }
             });
-
-    // Construct a LoginState object with the correct state.
-    csp::common::LoginState LoginState;
-    LoginState.State = csp::common::ELoginState::LoggedIn;
-    LoginState.AccessToken = "MockAccessToken";
 
     EXPECT_CALL(MockContext, GetLoginState).WillRepeatedly(::testing::ReturnRef(LoginState));
 
@@ -221,4 +154,14 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersIncludesA
     FileManager.GetResponseHeaders(FileUrl, &MockHandler);
 
     csp::CSPFoundation::Shutdown();
+}
+
+INSTANTIATE_TEST_SUITE_P(RemoteFileManagerTests, GetFile,
+    testing::Values(
+        std::make_tuple(csp::common::ELoginState::LoggedOut, ""), std::make_tuple(csp::common::ELoginState::LoggedIn, "MockAccessToken")));
+
+INSTANTIATE_TEST_SUITE_P(RemoteFileManagerTests, GetResponseHeaders,
+    testing::Values(
+        std::make_tuple(csp::common::ELoginState::LoggedOut, ""), std::make_tuple(csp::common::ELoginState::LoggedIn, "MockAccessToken")));
+        
 }

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -15,14 +15,11 @@
  */
 
 #include "CSP/CSPFoundation.h"
-#include "CSP/Systems/SystemsManager.h"
-#include "CSP/Systems/Users/UserSystem.h"
+#include "Mocks/AuthContextMock.h"
 #include "Mocks/WebClientMock.h"
 #include "PlatformTestUtils.h"
 #include "TestHelpers.h"
 #include "Web/RemoteFileManager.h"
-
-#include <fmt/format.h>
 
 #include "gtest/gtest.h"
 #include <gmock/gmock.h>
@@ -37,14 +34,13 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileSendsCorrectRequestW
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
-    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-
-    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    auto MockClient = WebClientMock(80, ETransferProtocol::HTTP, nullptr, true);
+    auto MockContext = MockAuthContext();
     MockApiResponseHandler MockHandler;
 
     const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
 
-    EXPECT_CALL(*MockClient, SendRequest)
+    EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
             [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
                 csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
@@ -63,11 +59,14 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileSendsCorrectRequestW
                 EXPECT_FALSE(Headers.count("Authorization")) << "Expected no Authorization header to be present in the request";
             });
 
-    RemoteFileManager FileManager(MockClient);
+    // The LoginState ctor default initialises the state to csp::common::ELoginState::LoggedOut, which is what we want for this test.
+    csp::common::LoginState LoginState;
+
+    EXPECT_CALL(MockContext, GetLoginState).WillOnce(::testing::ReturnRef(LoginState));
+
+    RemoteFileManager FileManager(&MockClient, &MockContext);
 
     FileManager.GetFile(FileUrl, &MockHandler, csp::common::CancellationToken::Dummy());
-
-    delete MockClient;
 
     csp::CSPFoundation::Shutdown();
 }
@@ -80,16 +79,15 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersSendsCorr
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
-    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
-
-    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    auto MockClient = WebClientMock(80, ETransferProtocol::HTTP, nullptr, true);
+    auto MockContext = MockAuthContext();
     MockApiResponseHandler MockHandler;
 
     const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
 
-    EXPECT_CALL(*MockClient, SendRequest)
+    EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
-            [&FileUrl, LogSystem](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
+            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
                 csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
             {
                 EXPECT_EQ(Verb, ERequestVerb::HEAD);
@@ -101,11 +99,14 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersSendsCorr
                 EXPECT_EQ(Headers.size(), 1) << "Expected exactly one header to be present in the request";
             });
 
-    RemoteFileManager FileManager(MockClient);
+    // The LoginState ctor default initialises the state to csp::common::ELoginState::LoggedOut, which is what we want for this test.
+    csp::common::LoginState LoginState;
+
+    EXPECT_CALL(MockContext, GetLoginState).WillOnce(::testing::ReturnRef(LoginState));
+
+    RemoteFileManager FileManager(&MockClient, &MockContext);
 
     FileManager.GetResponseHeaders(FileUrl, &MockHandler);
-
-    delete MockClient;
 
     csp::CSPFoundation::Shutdown();
 }
@@ -117,22 +118,13 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileIncludesAuthorizatio
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
-    auto& SystemsManager = csp::systems::SystemsManager::Get();
-    auto* UserSystem = SystemsManager.GetUserSystem();
-
-    // Log in to ensure we have a valid LoginState with an AccessToken. This should result in the Authorization header being included in the HTTP
-    // request.
-    csp::common::String UserId;
-    LogInAsGuest(UserSystem, UserId);
-
-    csp::common::LogSystem* LogSystem = SystemsManager.GetLogSystem();
-
-    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    auto MockClient = WebClientMock(80, ETransferProtocol::HTTP, nullptr, true);
+    auto MockContext = MockAuthContext();
     MockApiResponseHandler MockHandler;
 
     const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
 
-    EXPECT_CALL(*MockClient, SendRequest)
+    EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
             [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
                 csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
@@ -162,12 +154,16 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileIncludesAuthorizatio
                     << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
             });
 
-    RemoteFileManager FileManager(MockClient);
+    // Construct a LoginState object with the correct state.
+    csp::common::LoginState LoginState;
+    LoginState.State = csp::common::ELoginState::LoggedIn;
+    LoginState.AccessToken = "MockAccessToken";
+
+    EXPECT_CALL(MockContext, GetLoginState).WillRepeatedly(::testing::ReturnRef(LoginState));
+
+    RemoteFileManager FileManager(&MockClient, &MockContext);
+
     FileManager.GetFile(FileUrl, &MockHandler, csp::common::CancellationToken::Dummy());
-
-    LogOut(UserSystem);
-
-    delete MockClient;
 
     csp::CSPFoundation::Shutdown();
 }
@@ -179,22 +175,13 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersIncludesA
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
 
-    auto& SystemsManager = csp::systems::SystemsManager::Get();
-    auto* UserSystem = SystemsManager.GetUserSystem();
-
-    // Log in to ensure we have a valid LoginState with an AccessToken. This should result in the Authorization header being included in the HTTP
-    // request.
-    csp::common::String UserId;
-    LogInAsGuest(UserSystem, UserId);
-
-    csp::common::LogSystem* LogSystem = SystemsManager.GetLogSystem();
-
-    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    auto MockClient = WebClientMock(80, ETransferProtocol::HTTP, nullptr, true);
+    auto MockContext = MockAuthContext();
     MockApiResponseHandler MockHandler;
 
     const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
 
-    EXPECT_CALL(*MockClient, SendRequest)
+    EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
             [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
                 csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
@@ -222,12 +209,16 @@ CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersIncludesA
                     << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
             });
 
-    RemoteFileManager FileManager(MockClient);
+    // Construct a LoginState object with the correct state.
+    csp::common::LoginState LoginState;
+    LoginState.State = csp::common::ELoginState::LoggedIn;
+    LoginState.AccessToken = "MockAccessToken";
+
+    EXPECT_CALL(MockContext, GetLoginState).WillRepeatedly(::testing::ReturnRef(LoginState));
+
+    RemoteFileManager FileManager(&MockClient, &MockContext);
+
     FileManager.GetResponseHeaders(FileUrl, &MockHandler);
-
-    LogOut(UserSystem);
-
-    delete MockClient;
 
     csp::CSPFoundation::Shutdown();
 }

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/CSPFoundation.h"
+#include "CSP/Systems/SystemsManager.h"
+#include "CSP/Systems/Users/UserSystem.h"
+#include "Mocks/WebClientMock.h"
+#include "PlatformTestUtils.h"
+#include "TestHelpers.h"
+#include "Web/RemoteFileManager.h"
+
+#include <fmt/format.h>
+
+#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+
+using namespace csp::web;
+
+/*
+ * Tests that GetFile sends a GET request with the correct URI and Content-Type header.
+ * Confirm that it does not include an Authorization header when the user is not logged in.
+ */
+CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileSendsCorrectRequestWhenNotLoggedIn)
+{
+    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
+
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
+
+    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    MockApiResponseHandler MockHandler;
+
+    const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
+
+    EXPECT_CALL(*MockClient, SendRequest)
+        .WillOnce(
+            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
+                csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
+            {
+                EXPECT_EQ(Verb, ERequestVerb::GET);
+
+                EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
+
+                // Verify Content-Type header is set
+                const auto& Headers = Payload.GetHeaders();
+                auto ContentTypeIt = Headers.find("Content-Type");
+                ASSERT_NE(ContentTypeIt, Headers.end());
+                EXPECT_EQ(ContentTypeIt->second, "text/json");
+
+                // Confirm that the Authorization header is not present when we are not logged in
+                EXPECT_FALSE(Headers.count("Authorization")) << "Expected no Authorization header to be present in the request";
+            });
+
+    RemoteFileManager FileManager(MockClient);
+
+    FileManager.GetFile(FileUrl, &MockHandler, csp::common::CancellationToken::Dummy());
+
+    delete MockClient;
+
+    csp::CSPFoundation::Shutdown();
+}
+
+/*
+ * Tests that GetResponseHeaders sends a GET request with the correct URI.
+ * Confirm that it does not include an Authorization header when the user is not logged in.
+ */
+CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersSendsCorrectRequestWhenNotLoggedIn)
+{
+    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
+
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
+
+    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    MockApiResponseHandler MockHandler;
+
+    const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
+
+    EXPECT_CALL(*MockClient, SendRequest)
+        .WillOnce(
+            [&FileUrl, LogSystem](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
+                csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
+            {
+                EXPECT_EQ(Verb, ERequestVerb::HEAD);
+
+                EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
+
+                // The X-AssetPlatform header is added to all HTTP requests. Verify that no additional headers have been set
+                const auto& Headers = Payload.GetHeaders();
+                EXPECT_EQ(Headers.size(), 1) << "Expected exactly one header to be present in the request";
+            });
+
+    RemoteFileManager FileManager(MockClient);
+
+    FileManager.GetResponseHeaders(FileUrl, &MockHandler);
+
+    delete MockClient;
+
+    csp::CSPFoundation::Shutdown();
+}
+
+/*
+ * Test that GetFile includes the Authorization header with a Bearer token when the user is logged in.
+ */
+CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetFileIncludesAuthorizationHeaderWhenLoggedIn)
+{
+    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+
+    // Log in to ensure we have a valid LoginState with an AccessToken. This should result in the Authorization header being included in the HTTP
+    // request.
+    csp::common::String UserId;
+    LogInAsGuest(UserSystem, UserId);
+
+    csp::common::LogSystem* LogSystem = SystemsManager.GetLogSystem();
+
+    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    MockApiResponseHandler MockHandler;
+
+    const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
+
+    EXPECT_CALL(*MockClient, SendRequest)
+        .WillOnce(
+            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
+                csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
+            {
+                EXPECT_EQ(Verb, ERequestVerb::GET);
+
+                EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
+
+                // Verify Content-Type header is set
+                const auto& Headers = Payload.GetHeaders();
+                auto ContentTypeIt = Headers.find("Content-Type");
+                ASSERT_NE(ContentTypeIt, Headers.end());
+                EXPECT_EQ(ContentTypeIt->second, "text/json");
+
+                // Verify that the Authorization header is present
+                auto AuthIt = Headers.find("Authorization");
+                ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
+
+                std::string BearerToken = AuthIt->second;
+
+                // Verify the token is not empty after "Bearer "
+                EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
+
+                const std::string Prefix("Bearer ");
+
+                EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
+                    << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
+            });
+
+    RemoteFileManager FileManager(MockClient);
+    FileManager.GetFile(FileUrl, &MockHandler, csp::common::CancellationToken::Dummy());
+
+    LogOut(UserSystem);
+
+    delete MockClient;
+
+    csp::CSPFoundation::Shutdown();
+}
+
+/*
+ * Test that GetResponseHeaders includes the Authorization header with a Bearer token when the user is logged in.
+ */
+CSP_INTERNAL_TEST(CSPEngine, RemoteFileManagerTests, GetResponseHeadersIncludesAuthorizationHeaderWhenLoggedIn)
+{
+    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+
+    // Log in to ensure we have a valid LoginState with an AccessToken. This should result in the Authorization header being included in the HTTP
+    // request.
+    csp::common::String UserId;
+    LogInAsGuest(UserSystem, UserId);
+
+    csp::common::LogSystem* LogSystem = SystemsManager.GetLogSystem();
+
+    WebClientMock* MockClient = new WebClientMock(80, ETransferProtocol::HTTP, LogSystem, true);
+    MockApiResponseHandler MockHandler;
+
+    const csp::common::String FileUrl = "https://mock.service/assets/test-file.glb";
+
+    EXPECT_CALL(*MockClient, SendRequest)
+        .WillOnce(
+            [&FileUrl](ERequestVerb Verb, const Uri& InUri, HttpPayload& Payload, IHttpResponseHandler* /*ResponseCallback*/,
+                csp::common::CancellationToken& /*CancellationToken*/, bool /*AsyncResponse*/)
+            {
+                EXPECT_EQ(Verb, ERequestVerb::HEAD);
+
+                EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
+
+                // The X-AssetPlatform header is added to all HTTP requests. In addition the Authorization header should have been set
+                const auto& Headers = Payload.GetHeaders();
+                EXPECT_EQ(Headers.size(), 2) << "Expected exactly two headers to be present in the request";
+
+                // Verify that the Authorization header is present
+                auto AuthIt = Headers.find("Authorization");
+                ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
+
+                std::string BearerToken = AuthIt->second;
+
+                // Verify the token is not empty after "Bearer "
+                EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
+
+                const std::string Prefix("Bearer ");
+
+                EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
+                    << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
+            });
+
+    RemoteFileManager FileManager(MockClient);
+    FileManager.GetResponseHeaders(FileUrl, &MockHandler);
+
+    LogOut(UserSystem);
+
+    delete MockClient;
+
+    csp::CSPFoundation::Shutdown();
+}

--- a/Tests/src/Mocks/AuthContextMock.h
+++ b/Tests/src/Mocks/AuthContextMock.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "CSP/Common/Interfaces/IAuthContext.h"
+#include <gmock/gmock.h>
+
+class MockAuthContext : public csp::common::IAuthContext
+{
+public:
+    MockAuthContext() { }
+
+    MOCK_METHOD(const csp::common::LoginState&, GetLoginState, (), (const, override));
+    MOCK_METHOD(void, RefreshToken, (std::function<void(bool)> Callback), (override));
+};

--- a/Tests/src/Mocks/WebClientMock.h
+++ b/Tests/src/Mocks/WebClientMock.h
@@ -19,6 +19,7 @@
 #include "../../Library/src/Common/Web/HttpRequest.h"
 #include "../../Library/src/Common/Web/HttpResponse.h"
 #include "../../Library/src/Common/Web/WebClient.h"
+#include "../../Library/src/Services/ApiBase/ApiBase.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include <gmock/gmock.h>
 
@@ -27,9 +28,18 @@ class MockHttpResponseHandler : public csp::web::IHttpResponseHandler
 public:
     MockHttpResponseHandler() { }
 
-    MOCK_METHOD(void, OnHttpProgress, (csp::web::HttpRequest & Request), (override));
-    MOCK_METHOD(void, OnHttpResponse, (csp::web::HttpResponse & Response), (override));
+    MOCK_METHOD(void, OnHttpProgress, (csp::web::HttpRequest& Request), (override));
+    MOCK_METHOD(void, OnHttpResponse, (csp::web::HttpResponse& Response), (override));
     MOCK_METHOD(bool, ShouldDelete, (), (const, override));
+};
+
+class MockApiResponseHandler : public csp::services::ApiResponseHandlerBase
+{
+public:
+    MockApiResponseHandler() { }
+
+    MOCK_METHOD(void, OnHttpProgress, (csp::web::HttpRequest& Request), (override));
+    MOCK_METHOD(void, OnHttpResponse, (csp::web::HttpResponse& Response), (override));
 };
 
 class WebClientMock : public csp::web::WebClient

--- a/Tests/src/PublicTestBase.h
+++ b/Tests/src/PublicTestBase.h
@@ -72,6 +72,15 @@ protected:
     void TearDown() override;
 };
 
+// For parameterized (data driven) internal tests
+// This is the parameterized equivalent of CSP_INTERNAL_TEST which uses ::testing::Test directly
+template <typename T> class PublicTestBaseInternalWithParam : public ::testing::TestWithParam<T>
+{
+protected:
+    void SetUp() override { ::testing::TestWithParam<T>::SetUp(); }
+    void TearDown() override { ::testing::TestWithParam<T>::TearDown(); }
+};
+
 // If you want to use a new parameterized test structure, you need to explicitly instantiate here (and in the .cpp)
 extern template class PublicTestBaseWithParam<std::tuple<csp::systems::SpaceAttributes, csp::systems::EResultCode, std::string>>;
 extern template class PublicTestBaseWithParam<std::tuple<csp::common::RealtimeEngineType, bool, csp::systems::EResultCode, std::string>>;


### PR DESCRIPTION
This change adds content security to our S3 Assets, by ensuring asset requests are authorized.

An `Authorization` header has been added to our file Web Requests with the authenticated users bearer token.

Tests have been added using a Mocked WebClient to ensure requests include the Authorization header when the user is authenticated. 