### PR TITLE
[NT-0] test: Fix flackey ValidExpiryLengthInTokenOptionsTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.33.0]
+
+### 🙈 🙉 🙊 Test Changes
+
+- [NT-0] test: Address issue with flackey ValidExpiryLengthInTokenOptionsTest by MAG-AdamThorn
+  The test ValidExpiryLengthInTokenOptionsTest was failing when run against live services on our CI due to network latency. Adressed the flackiness and also removed calls to `NotifyRefreshTokenHasChanged()` from the UserSystem as this is already being done within the `LoginStateResult::OnResponse()`, resulting in the `UserSystem NewLoginTokenReceivedCallback` callback being fired twice.
+
+
 ## [6.32.0]
 
 ### 🍰 🙌 New Features

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -272,8 +272,6 @@ void UserSystem::Login(const csp::common::String& Email, const csp::common::Stri
         {
             if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
             {
-                NotifyRefreshTokenHasChanged();
-
                 csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
                     = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
                 {
@@ -613,8 +611,6 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
-            NotifyRefreshTokenHasChanged();
-
             csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
                 = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
             {

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -530,27 +530,33 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ValidExpiryLengthInTokenOptionsTest)
     auto* UserSystem = SystemsManager.GetUserSystem();
 
     auto TokenOptions = csp::systems::TokenOptions();
-    TokenOptions.AccessTokenExpiryLength = "00:00:05";
+    TokenOptions.AccessTokenExpiryLength = "00:00:30";
 
-    // Ensure that the token expiry time matched the provided token options
+    std::promise<csp::systems::LoginTokenInfoResult> TokenPromise;
+    std::future<csp::systems::LoginTokenInfoResult> TokenFuture = TokenPromise.get_future();
+
     UserSystem->SetNewLoginTokenReceivedCallback(
-        [](const csp::systems::LoginTokenInfoResult& Result)
+        [&TokenPromise](const csp::systems::LoginTokenInfoResult& Result)
         {
-            EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
-
-            const auto TokenInfo = Result.GetLoginTokenInfo();
-
-            const auto AccessExpiryTime = csp::common::DateTime(TokenInfo.AccessExpiryTime);
-            const auto CurrentTime = csp::common::DateTime::UtcTimeNow();
-
-            // Calculate the delta from the available time points as we do not support duration in DateTime
-            const auto Delta = AccessExpiryTime.GetTimePoint() - CurrentTime.GetTimePoint();
-            EXPECT_LE(Delta, 10s);
+            TokenPromise.set_value(Result);
         });
 
     // Log in
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId, true, true, TokenOptions);
+
+    ASSERT_EQ(TokenFuture.wait_for(30s), std::future_status::ready) << "NewLoginTokenReceivedCallback was not invoked";
+
+    const auto Result = TokenFuture.get();
+    EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+
+    const auto TokenInfo = Result.GetLoginTokenInfo();
+    const auto AccessExpiryTime = csp::common::DateTime(TokenInfo.AccessExpiryTime);
+    const auto CurrentTime = csp::common::DateTime::UtcTimeNow();
+
+    // Calculate the delta from the available time points as we do not support duration in DateTime
+    const auto Delta = AccessExpiryTime.GetTimePoint() - CurrentTime.GetTimePoint();
+    EXPECT_LE(Delta, 40s);
 
     // Log out
     LogOut(UserSystem);


### PR DESCRIPTION
The test `ValidExpiryLengthInTokenOptionsTest` was failing when run against live tests on our CI, but was passing when run locally against local or live CHS. I was able to reproduce the issue by putting a breakpoint in the `SetNewLoginTokenReceivedCallback` and waiting for 5+ seconds, which was greater than the specified token expiry length. This then caused log out to fail as the user token had already expired.

For the fix I introduced a future/promise and moved calculation of the delta to outside the callback. I also increased the token expiry length to account for latency. The token expiry is now set to 30 seconds. I do not expect latency to approach this however the duration set has no bearing on the purpose of the test, which is simply to check that the `AccessExpiryTime` is correct within a generous threshold.

In addition to the above I have removed two calls to `NotifyRefreshTokenHasChanged()` from the UserSystem as this is already being done within the `LoginStateResult::OnResponse()`, which was resulting in the `UserSystem NewLoginTokenReceivedCallback` being fired twice.