### PR TITLE
Shutdown after ParseWithErrorLogging_LogsFailure

### DIFF
--- a/Tests/src/InternalTests/JsonTests.cpp
+++ b/Tests/src/InternalTests/JsonTests.cpp
@@ -354,4 +354,6 @@ CSP_INTERNAL_TEST(CSPEngine, JsonTests, ParseWithErrorLogging_LogsFailure)
     EXPECT_EQ(
         log_,
         "Error: ParseWithErrorLogging_LogsFailure: JSON parse error: Missing a name for object member. (at offset 2). Context: { invalid json }");
+
+    csp::CSPFoundation::Shutdown();
 }


### PR DESCRIPTION
This went in without a shutdown, which can fail subsequent tests if you run them linearly. Understandable, these manual non-RAII shutdowns arn't a great pattern