### PR TITLE
[OB-5310] feat: Add audio controls to video player space component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.35.0]
+
+### 🍰 🙌 New Features
+
+- [OB-5310] feat: Added Volume and AudioType properties to `VideoPlayerSpaceComponent`. By @MAG-ME.
+
 ## [6.33.0]
 
 ### 🙈 🙉 🙊 Test Changes

--- a/Library/include/CSP/Multiplayer/Components/AudioSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AudioSpaceComponent.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "CSP/Multiplayer/ComponentBase.h"
-#include "CSP/Multiplayer/Components/Interfaces/IAudioSourceComponent.h"
+#include "CSP/Multiplayer/Components/Interfaces/IAudioControlComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IEnableableComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IPositionComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IThirdPartyComponentRef.h"
@@ -59,7 +59,7 @@ enum class AudioPropertyKeys : uint16_t
 ///
 /// This component creates immersive soundscapes by playing audio that reacts to the user's position in the space.
 /// Whether it's background music, sound effects, or voiceovers, the AudioSpaceComponent makes sound more engaging by positioning it in 3D space.
-class CSP_API AudioSpaceComponent : public ComponentBase, public IEnableableComponent, public IPositionComponent, public IThirdPartyComponentRef, public IAudioSourceComponent
+class CSP_API AudioSpaceComponent : public ComponentBase, public IAudioControlComponent, public IEnableableComponent, public IPositionComponent, public IThirdPartyComponentRef
 {
 public:
     /// @brief Constructs the audio space component, and associates it with the specified Parent space entity.
@@ -116,19 +116,19 @@ public:
     /// @param Value The timestamp recorded from the moment when the audio clip started playing, in Unix timestamp format.
     void SetTimeSincePlay(float Value);
 
-    /// \addtogroup IAudioSourceComponent
+    /// \addtogroup IAudioControlComponent
     /// @{
-    /// @copydoc IAudioSourceComponent::GetAudioType()
+    /// @copydoc IAudioControlComponent::GetAudioType()
     AudioType GetAudioType() const override;
-    /// @copydoc IAudioSourceComponent::SetAudioType()
+    /// @copydoc IAudioControlComponent::SetAudioType()
     void SetAudioType(AudioType Value) override;
-    /// @copydoc IAudioSourceComponent::GetAttenuationRadius()
+    /// @copydoc IAudioControlComponent::GetAttenuationRadius()
     float GetAttenuationRadius() const override;
-    /// @copydoc IAudioSourceComponent::SetAttenuationRadius()
+    /// @copydoc IAudioControlComponent::SetAttenuationRadius()
     void SetAttenuationRadius(float Value) override;
-    /// @copydoc IAudioSourceComponent::GetVolume()
+    /// @copydoc IAudioControlComponent::GetVolume()
     float GetVolume() const override;
-    /// @copydoc IAudioSourceComponent::SetVolume()
+    /// @copydoc IAudioControlComponent::SetVolume()
     void SetVolume(float Value) override;
     /// @}
  

--- a/Library/include/CSP/Multiplayer/Components/AudioSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AudioSpaceComponent.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "CSP/Multiplayer/ComponentBase.h"
+#include "CSP/Multiplayer/Components/Interfaces/IAudioSourceComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IEnableableComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IPositionComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IThirdPartyComponentRef.h"
@@ -33,16 +34,6 @@ enum class AudioPlaybackState
     Reset = 0,
     Pause,
     Play,
-    Num
-};
-
-/// @brief Specifies the type of audio source for an audio component.
-enum class AudioType
-{
-    /// A global audio type keeps the volume of the audio independent from the player position.
-    Global = 0,
-    /// A spatial audio takes the player position into account to attenuate or amplify the volume.
-    Spatial,
     Num
 };
 
@@ -68,7 +59,7 @@ enum class AudioPropertyKeys : uint16_t
 ///
 /// This component creates immersive soundscapes by playing audio that reacts to the user's position in the space.
 /// Whether it's background music, sound effects, or voiceovers, the AudioSpaceComponent makes sound more engaging by positioning it in 3D space.
-class CSP_API AudioSpaceComponent : public ComponentBase, public IEnableableComponent, public IPositionComponent, public IThirdPartyComponentRef
+class CSP_API AudioSpaceComponent : public ComponentBase, public IEnableableComponent, public IPositionComponent, public IThirdPartyComponentRef, public IAudioSourceComponent
 {
 public:
     /// @brief Constructs the audio space component, and associates it with the specified Parent space entity.
@@ -91,14 +82,6 @@ public:
     /// @param Value The new playback state of the audio of this audio component.
     void SetPlaybackState(AudioPlaybackState Value);
 
-    /// @brief Gets the type of the audio of this audio component.
-    /// @return The type of the audio of this audio component.
-    AudioType GetAudioType() const;
-
-    /// @brief Sets the type of the audio of this audio component.
-    /// @param Value Type of the audio of this audio component.
-    void SetAudioType(AudioType Value);
-
     /// @brief Gets the asset ID for this audio asset.
     /// @return The ID of this audio asset.
     const csp::common::String& GetAudioAssetId() const;
@@ -117,22 +100,6 @@ public:
     /// @param Value The ID of the asset collection associated with this component.
     void SetAssetCollectionId(const csp::common::String& Value);
 
-    /// @brief Gets the attenuation for the audio when a spatial audio type.
-    ///        The radius is the minimum distance between the origin of this audio component and
-    ///        the position of the player, from within which the player can start hearing
-    ///        the spatial audio in range.
-    ///        The radius is expressed in meters.
-    /// @return The minimum radius in meters from the origin of the audio component to hear the spatial audio.
-    float GetAttenuationRadius() const;
-
-    /// @brief Sets the attenuation for the audio when a spatial audio type.
-    ///        The radius is the minimum distance between the origin of this audio component and
-    ///        the position of the player, from within which the player can start hearing
-    ///        the spatial audio in range.
-    ///        The radius is expressed in meters.
-    /// @param Value The minimum radius in meters from the origin of the audio component to hear the spatial audio.
-    void SetAttenuationRadius(float Value);
-
     /// @brief Checks if the audio playback is looping.
     /// @return True if the audio loops (i.e. starts from the beginning when ended), false otherwise.
     bool GetIsLoopPlayback() const;
@@ -149,22 +116,28 @@ public:
     /// @param Value The timestamp recorded from the moment when the audio clip started playing, in Unix timestamp format.
     void SetTimeSincePlay(float Value);
 
-    /// @brief Gets the volume of the audio in a ratio between 0 and 1.
-    ///        Volume 1 represents the full volume of the audio clip of this component.
-    /// @return The volume of the audio, in a ratio between 0 and 1.
-    float GetVolume() const;
-
-    /// @brief Sets the volume of the audio in a ratio between 0 and 1.
-    ///        Volume 1 represents the full volume of the audio clip of this component.
-    /// @param Value The volume of the audio, in a ratio between 0 and 1.
-    void SetVolume(float Value);
-
+    /// \addtogroup IAudioSourceComponent
+    /// @{
+    /// @copydoc IAudioSourceComponent::GetAudioType()
+    AudioType GetAudioType() const override;
+    /// @copydoc IAudioSourceComponent::SetAudioType()
+    void SetAudioType(AudioType Value) override;
+    /// @copydoc IAudioSourceComponent::GetAttenuationRadius()
+    float GetAttenuationRadius() const override;
+    /// @copydoc IAudioSourceComponent::SetAttenuationRadius()
+    void SetAttenuationRadius(float Value) override;
+    /// @copydoc IAudioSourceComponent::GetVolume()
+    float GetVolume() const override;
+    /// @copydoc IAudioSourceComponent::SetVolume()
+    void SetVolume(float Value) override;
+    /// @}
+ 
     /// \addtogroup IEnableableComponent
     /// @{
     /// @copydoc IEnableableComponent::GetIsEnabled()
-    virtual bool GetIsEnabled() const override;
+    bool GetIsEnabled() const override;
     /// @copydoc IEnableableComponent::SetIsEnabled()
-    virtual void SetIsEnabled(bool InValue) override;
+    void SetIsEnabled(bool InValue) override;
     /// @}
 
     /// \addtogroup IThirdPartyComponentRef

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IAudioControlComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IAudioControlComponent.h
@@ -32,7 +32,7 @@ enum class AudioType
 };
 
 /// @brief Controls the audio properties of a component.
-CSP_INTERFACE class CSP_API IAudioSourceComponent
+CSP_INTERFACE class CSP_API IAudioControlComponent
 {
 public:
     /// @brief Gets the type of the audio of this audio component.
@@ -70,7 +70,7 @@ public:
     virtual void SetVolume(float Value) = 0;
 
 protected:
-    virtual ~IAudioSourceComponent() = default;
+    virtual ~IAudioControlComponent() = default;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/Components/Interfaces/IAudioSourceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/Interfaces/IAudioSourceComponent.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "CSP/CSPCommon.h"
+
+namespace csp::multiplayer
+{
+
+/// @brief Specifies the type of audio source for an audio source component.
+enum class AudioType
+{
+    /// A global audio type keeps the volume of the audio independent from the player position.
+    Global = 0,
+    /// A spatial audio takes the player position into account to attenuate or amplify the volume.
+    Spatial,
+    Num
+};
+
+/// @brief Controls the audio properties of a component.
+CSP_INTERFACE class CSP_API IAudioSourceComponent
+{
+public:
+    /// @brief Gets the type of the audio of this audio component.
+    /// @return The type of the audio of this audio component.
+    virtual AudioType GetAudioType() const = 0;
+
+    /// @brief Sets the type of the audio of this audio component.
+    /// @param Value Type of the audio of this audio component.
+    virtual void SetAudioType(AudioType Value) = 0;
+
+    /// @brief Gets the attenuation for the audio when a spatial audio type.
+    ///        The radius is the minimum distance between the origin of this audio component and
+    ///        the position of the player, from within which the player can start hearing
+    ///        the spatial audio in range.
+    ///        The radius is expressed in meters.
+    /// @return The minimum radius in meters from the origin of the audio component to hear the spatial audio.
+    virtual float GetAttenuationRadius() const = 0;
+
+    /// @brief Sets the attenuation for the audio when a spatial audio type.
+    ///        The radius is the minimum distance between the origin of this audio component and
+    ///        the position of the player, from within which the player can start hearing
+    ///        the spatial audio in range.
+    ///        The radius is expressed in meters.
+    /// @param Value The minimum radius in meters from the origin of the audio component to hear the spatial audio.
+    virtual void SetAttenuationRadius(float Value) = 0;
+
+    /// @brief Gets the volume of the audio in a ratio between 0 and 1.
+    ///        Volume 1 represents the full volume of the audio clip of this component.
+    /// @return The volume of the audio, in a ratio between 0 and 1.
+    virtual float GetVolume() const = 0;
+
+    /// @brief Sets the volume of the audio in a ratio between 0 and 1.
+    ///        Volume 1 represents the full volume of the audio clip of this component.
+    /// @param Value The volume of the audio, in a ratio between 0 and 1.
+    virtual void SetVolume(float Value) = 0;
+
+protected:
+    virtual ~IAudioSourceComponent() = default;
+};
+
+} // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
@@ -23,6 +23,7 @@
 #include "CSP/Common/Array.h"
 #include "CSP/Common/String.h"
 #include "CSP/Multiplayer/ComponentBase.h"
+#include "CSP/Multiplayer/Components/Interfaces/IAudioSourceComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IEnableableComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/ITransformComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
@@ -85,6 +86,8 @@ enum class VideoPlayerPropertyKeys : uint16_t
     IsVirtualVisible,
     StereoVideoType,
     IsStereoFlipped,
+    Volume,
+    AudioType,
     Num
 };
 
@@ -93,7 +96,7 @@ enum class VideoPlayerPropertyKeys : uint16_t
 ///
 /// You can use it to stream videos from a URL or play videos stored as assets in CSP, allowing users to watch videos directly within the virtual
 /// environment.
-class CSP_API VideoPlayerSpaceComponent : public ComponentBase, public IEnableableComponent, public ITransformComponent, public IVisibleComponent
+class CSP_API VideoPlayerSpaceComponent : public ComponentBase, public IAudioSourceComponent, public IEnableableComponent, public ITransformComponent, public IVisibleComponent
 {
 public:
     /// @brief Constructs the video player component, and associates it with the specified Parent space entity.
@@ -186,16 +189,6 @@ public:
     /// @param Value True if the video will resize automatically, false otherwise.
     void SetIsAutoResize(bool Value);
 
-    /// @brief Gets the radius from this component origin within which the audio of this video can be heard by the user.
-    /// @note Only when the user position is within this radius the audio of the video should be heard.
-    /// @return The radius within which the audio of the video can be heard by the user.
-    float GetAttenuationRadius() const;
-
-    /// @brief Sets the radius from this component origin within which the audio of this video can be heard by the user.
-    /// @note Only when the user position is within this radius the audio of the video should be heard.
-    /// @param Value The radius within which the audio of the video can be heard by the user.
-    void SetAttenuationRadius(float Value);
-
     /// @brief Retrieves the playback state of the video of this component.
     /// @return The playback state of the video.
     VideoPlayerPlaybackState GetPlaybackState() const;
@@ -244,6 +237,22 @@ public:
     /// @param Value True if the stereo frames are flipped, false for default.
     void SetIsStereoFlipped(bool Value);
 
+    /// \addtogroup IAudioSourceComponent
+    /// @{
+    /// @copydoc IAudioSourceComponent::GetAudioType()
+    AudioType GetAudioType() const override;
+    /// @copydoc IAudioSourceComponent::SetAudioType()
+    void SetAudioType(AudioType Value) override;
+    /// @copydoc IAudioSourceComponent::GetAttenuationRadius()
+    float GetAttenuationRadius() const override;
+    /// @copydoc IAudioSourceComponent::SetAttenuationRadius()
+    void SetAttenuationRadius(float Value) override;
+    /// @copydoc IAudioSourceComponent::GetVolume()
+    float GetVolume() const override;
+    /// @copydoc IAudioSourceComponent::SetVolume()
+    void SetVolume(float Value) override;
+    /// @}
+ 
     /// \addtogroup IVisibleComponent
     /// @{
     /// @copydoc IVisibleComponent::GetIsVisible()

--- a/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
@@ -23,7 +23,7 @@
 #include "CSP/Common/Array.h"
 #include "CSP/Common/String.h"
 #include "CSP/Multiplayer/ComponentBase.h"
-#include "CSP/Multiplayer/Components/Interfaces/IAudioSourceComponent.h"
+#include "CSP/Multiplayer/Components/Interfaces/IAudioControlComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IEnableableComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/ITransformComponent.h"
 #include "CSP/Multiplayer/Components/Interfaces/IVisibleComponent.h"
@@ -96,7 +96,7 @@ enum class VideoPlayerPropertyKeys : uint16_t
 ///
 /// You can use it to stream videos from a URL or play videos stored as assets in CSP, allowing users to watch videos directly within the virtual
 /// environment.
-class CSP_API VideoPlayerSpaceComponent : public ComponentBase, public IAudioSourceComponent, public IEnableableComponent, public ITransformComponent, public IVisibleComponent
+class CSP_API VideoPlayerSpaceComponent : public ComponentBase, public IAudioControlComponent, public IEnableableComponent, public ITransformComponent, public IVisibleComponent
 {
 public:
     /// @brief Constructs the video player component, and associates it with the specified Parent space entity.
@@ -237,19 +237,19 @@ public:
     /// @param Value True if the stereo frames are flipped, false for default.
     void SetIsStereoFlipped(bool Value);
 
-    /// \addtogroup IAudioSourceComponent
+    /// \addtogroup IAudioControlComponent
     /// @{
-    /// @copydoc IAudioSourceComponent::GetAudioType()
+    /// @copydoc IAudioControlComponent::GetAudioType()
     AudioType GetAudioType() const override;
-    /// @copydoc IAudioSourceComponent::SetAudioType()
+    /// @copydoc IAudioControlComponent::SetAudioType()
     void SetAudioType(AudioType Value) override;
-    /// @copydoc IAudioSourceComponent::GetAttenuationRadius()
+    /// @copydoc IAudioControlComponent::GetAttenuationRadius()
     float GetAttenuationRadius() const override;
-    /// @copydoc IAudioSourceComponent::SetAttenuationRadius()
+    /// @copydoc IAudioControlComponent::SetAttenuationRadius()
     void SetAttenuationRadius(float Value) override;
-    /// @copydoc IAudioSourceComponent::GetVolume()
+    /// @copydoc IAudioControlComponent::GetVolume()
     float GetVolume() const override;
-    /// @copydoc IAudioSourceComponent::SetVolume()
+    /// @copydoc IAudioControlComponent::SetVolume()
     void SetVolume(float Value) override;
     /// @}
  

--- a/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
@@ -148,7 +148,7 @@ void AudioSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& I
     SetProperty(static_cast<uint32_t>(AudioPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
-/* IAudioSourceComponent */
+/* IAudioControlComponent */
 
 float AudioSpaceComponent::GetAttenuationRadius() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius)); }
 

--- a/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
@@ -106,16 +106,6 @@ void AudioSpaceComponent::SetPlaybackState(AudioPlaybackState Value)
     SetProperty(static_cast<uint32_t>(AudioPropertyKeys::PlaybackState), static_cast<int64_t>(Value));
 }
 
-AudioType AudioSpaceComponent::GetAudioType() const
-{
-    return static_cast<AudioType>(GetIntegerProperty(static_cast<uint32_t>(AudioPropertyKeys::AudioType)));
-}
-
-void AudioSpaceComponent::SetAudioType(AudioType Value)
-{
-    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AudioType), static_cast<int64_t>(Value));
-}
-
 const csp::common::String& AudioSpaceComponent::GetAudioAssetId() const
 {
     return GetStringProperty(static_cast<uint32_t>(AudioPropertyKeys::AudioAssetId));
@@ -136,10 +126,6 @@ void AudioSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
     SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AssetCollectionId), Value);
 }
 
-float AudioSpaceComponent::GetAttenuationRadius() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius)); }
-
-void AudioSpaceComponent::SetAttenuationRadius(float Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius), Value); }
-
 bool AudioSpaceComponent::GetIsLoopPlayback() const { return GetBooleanProperty(static_cast<uint32_t>(AudioPropertyKeys::IsLoopPlayback)); }
 
 void AudioSpaceComponent::SetIsLoopPlayback(bool Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::IsLoopPlayback), Value); }
@@ -147,6 +133,36 @@ void AudioSpaceComponent::SetIsLoopPlayback(bool Value) { SetProperty(static_cas
 float AudioSpaceComponent::GetTimeSincePlay() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::TimeSincePlay)); }
 
 void AudioSpaceComponent::SetTimeSincePlay(float Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::TimeSincePlay), Value); }
+
+bool AudioSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(AudioPropertyKeys::IsEnabled)); }
+
+void AudioSpaceComponent::SetIsEnabled(bool InValue) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::IsEnabled), InValue); }
+
+const csp::common::String& AudioSpaceComponent::GetThirdPartyComponentRef() const
+{
+    return GetStringProperty(static_cast<uint32_t>(AudioPropertyKeys::ThirdPartyComponentRef));
+}
+
+void AudioSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
+{
+    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::ThirdPartyComponentRef), InValue);
+}
+
+/* IAudioSourceComponent */
+
+float AudioSpaceComponent::GetAttenuationRadius() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius)); }
+
+void AudioSpaceComponent::SetAttenuationRadius(float Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius), Value); }
+
+AudioType AudioSpaceComponent::GetAudioType() const
+{
+    return static_cast<AudioType>(GetIntegerProperty(static_cast<uint32_t>(AudioPropertyKeys::AudioType)));
+}
+
+void AudioSpaceComponent::SetAudioType(AudioType Value)
+{
+    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AudioType), static_cast<int64_t>(Value));
+}
 
 float AudioSpaceComponent::GetVolume() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::Volume)); }
 
@@ -163,20 +179,6 @@ void AudioSpaceComponent::SetVolume(float Value)
             LogSystem->LogMsg(csp::common::LogLevel::Error, fmt::format("Invalid value for volume ({:.2f}). Must be from 0.0 to 1.0", Value).c_str());
         }
     }
-}
-
-bool AudioSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(AudioPropertyKeys::IsEnabled)); }
-
-void AudioSpaceComponent::SetIsEnabled(bool InValue) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::IsEnabled), InValue); }
-
-const csp::common::String& AudioSpaceComponent::GetThirdPartyComponentRef() const
-{
-    return GetStringProperty(static_cast<uint32_t>(AudioPropertyKeys::ThirdPartyComponentRef));
-}
-
-void AudioSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
-{
-    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -26,6 +26,7 @@
 namespace
 {
 constexpr const float DefaultAttenuationRadius = 10.f; // Distance in meters
+constexpr const float DefaultVolume = 1.f;
 }
 
 namespace csp::multiplayer
@@ -125,6 +126,14 @@ const auto Schema = ComponentBase::ComponentSchema {
         {
             static_cast<ComponentBase::PropertyKey>(VideoPlayerPropertyKeys::IsVirtualVisible),
             true,
+        },
+        {
+            static_cast<ComponentBase::PropertyKey>(VideoPlayerPropertyKeys::Volume),
+            DefaultVolume,
+        },
+        {
+            static_cast<ComponentBase::PropertyKey>(VideoPlayerPropertyKeys::AudioType),
+            static_cast<int64_t>(AudioType::Spatial),
         },
     },
 };
@@ -311,7 +320,7 @@ void VideoPlayerSpaceComponent::SetIsVirtualVisible(bool Value)
     SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible), Value);
 }
 
-/* IAudioSourceComponent */
+/* IAudioControlComponent */
 
 float VideoPlayerSpaceComponent::GetAttenuationRadius() const
 {

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 #include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
-
+#include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
+
 #include "Multiplayer/Component/Schema.h"
 #include "Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h"
+
+#include <fmt/format.h>
 
 namespace
 {
@@ -264,16 +267,6 @@ float VideoPlayerSpaceComponent::GetTimeSincePlay() const { return GetFloatPrope
 
 void VideoPlayerSpaceComponent::SetTimeSincePlay(float Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::TimeSincePlay), Value); }
 
-float VideoPlayerSpaceComponent::GetAttenuationRadius() const
-{
-    return GetFloatProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AttenuationRadius));
-}
-
-void VideoPlayerSpaceComponent::SetAttenuationRadius(float Value)
-{
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AttenuationRadius), Value);
-}
-
 VideoPlayerSourceType VideoPlayerSpaceComponent::GetVideoPlayerSourceType() const
 {
     return static_cast<VideoPlayerSourceType>(GetIntegerProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::VideoPlayerSourceType)));
@@ -316,6 +309,45 @@ bool VideoPlayerSpaceComponent::GetIsVirtualVisible() const
 void VideoPlayerSpaceComponent::SetIsVirtualVisible(bool Value)
 {
     SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible), Value);
+}
+
+/* IAudioSourceComponent */
+
+float VideoPlayerSpaceComponent::GetAttenuationRadius() const
+{
+    return GetFloatProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AttenuationRadius));
+}
+
+void VideoPlayerSpaceComponent::SetAttenuationRadius(float Value)
+{
+    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AttenuationRadius), Value);
+}
+
+AudioType VideoPlayerSpaceComponent::GetAudioType() const
+{
+    return static_cast<AudioType>(GetIntegerProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AudioType)));
+}
+
+void VideoPlayerSpaceComponent::SetAudioType(AudioType Value)
+{
+    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AudioType), static_cast<int64_t>(Value));
+}
+
+float VideoPlayerSpaceComponent::GetVolume() const { return GetFloatProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Volume)); }
+
+void VideoPlayerSpaceComponent::SetVolume(float Value)
+{
+    if (Value >= 0.f && Value <= 1.f)
+    {
+        SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Volume), Value);
+    }
+    else
+    {
+        if (LogSystem != nullptr)
+        {
+            LogSystem->LogMsg(csp::common::LogLevel::Error, fmt::format("Invalid value for volume ({:.2f}). Must be from 0.0 to 1.0", Value).c_str());
+        }
+    }
 }
 
 /* IEnableableComponent */

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
@@ -58,4 +58,8 @@ DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVirtualVisi
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsEnabled);
 
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, AudioType, int32_t, AudioType);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, float, float, Volume);
+
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.cpp
@@ -58,7 +58,7 @@ DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsVirtualVisi
 
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, bool, bool, IsEnabled);
 
-DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, AudioType, int32_t, AudioType);
+DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, csp::multiplayer::AudioType, int32_t, AudioType);
 DEFINE_SCRIPT_PROPERTY_TYPE(VideoPlayerSpaceComponent, float, float, Volume);
 
 

--- a/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
+++ b/Library/src/Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h
@@ -59,6 +59,9 @@ public:
     DECLARE_SCRIPT_PROPERTY(bool, IsVirtualVisible);
 
     DECLARE_SCRIPT_PROPERTY(bool, IsEnabled);
+
+    DECLARE_SCRIPT_PROPERTY(int32_t, AudioType);
+    DECLARE_SCRIPT_PROPERTY(float, Volume);
 };
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -359,7 +359,9 @@ void BindComponents(qjs::Context::Module* Module)
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVisible, "isVisible")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsARVisible, "isARVisible")
         .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsVirtualVisible, "isVirtualVisible")
-        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsEnabled, "isEnabled");
+        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, IsEnabled, "isEnabled")
+        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, AudioType, "audioType")
+        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, Volume, "volume");
 
     Module->class_<AvatarSpaceComponentScriptInterface>("AvatarSpaceComponent")
         .constructor<>()

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -242,7 +242,6 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
         video.isEnabled = false;
         video.audioType = 0;
         video.volume = 0.5;
-        video.
 
     )xx";
 

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -93,6 +93,8 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     EXPECT_EQ(VideoComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(VideoComponent->GetIsEnabled(), true);
     EXPECT_EQ(VideoComponent->GetIsStereoFlipped(), false);
+    EXPECT_EQ(VideoComponent->GetAudioType(), AudioType::Spatial);
+    EXPECT_EQ(VideoComponent->GetVolume(), 1.f);
 
     CreatedObject->QueueUpdate();
     RealtimeEngine->ProcessPendingEntityOperations();
@@ -119,6 +121,8 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     VideoComponent->SetIsVirtualVisible(false);
     VideoComponent->SetIsEnabled(false);
     VideoComponent->SetIsStereoFlipped(true);
+    VideoComponent->SetAudioType(AudioType::Global);
+    VideoComponent->SetVolume(0.5f);
 
     // Ensure values are set correctly
     EXPECT_EQ(VideoComponent->GetPosition(), csp::common::Vector3::One());
@@ -139,6 +143,8 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerComponentTest)
     EXPECT_EQ(VideoComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(VideoComponent->GetIsEnabled(), false);
     EXPECT_EQ(VideoComponent->GetIsStereoFlipped(), true);
+    EXPECT_EQ(VideoComponent->GetAudioType(), AudioType::Global);
+    EXPECT_EQ(VideoComponent->GetVolume(), 0.5f);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 
@@ -207,6 +213,8 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     EXPECT_EQ(VideoPlayerComponent->GetIsVirtualVisible(), true);
     EXPECT_EQ(VideoPlayerComponent->GetIsEnabled(), true);
     EXPECT_EQ(VideoPlayerComponent->GetIsStereoFlipped(), false);
+    EXPECT_EQ(VideoPlayerComponent->GetAudioType(), AudioType::Spatial);
+    EXPECT_EQ(VideoPlayerComponent->GetVolume(), 1.f);
 
     // Setup script
     const std::string VideoPlayerScriptText = R"xx(
@@ -232,6 +240,9 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
         video.isARVisible = false;
         video.isVirtualVisible = false;
         video.isEnabled = false;
+        video.audioType = 0;
+        video.volume = 0.5;
+        video.
 
     )xx";
 
@@ -262,6 +273,8 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     EXPECT_EQ(VideoPlayerComponent->GetIsARVisible(), false);
     EXPECT_EQ(VideoPlayerComponent->GetIsVirtualVisible(), false);
     EXPECT_EQ(VideoPlayerComponent->GetIsEnabled(), false);
+    EXPECT_EQ(VideoPlayerComponent->GetAudioType(), AudioType::Global);
+    EXPECT_EQ(VideoPlayerComponent->GetVolume(), 0.5f);
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 


### PR DESCRIPTION
Added new properties to the video space component

- Created a new interface `IAudioControlComponent` with common audio properties for audio and video player components
- Used the interface in the audio component
- Added Volume and AudioType, replicating the values from the audio component
- Updated the script binding to include the new properties
- Updated the Video Player tests to exercise the new properties in C++ and via a script
