### PR TITLE
[OB-4980] fix!: Address issues with third-party authorization flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,41 @@ All notable changes to this project will be documented in this file. For compile
 
 ### 🍰 🙌 New Features
 
-- [OB-5310] feat: Added Volume and AudioType properties to `VideoPlayerSpaceComponent`. By @MAG-ME.
+- [OF-1830] feat: Inital integration of new build system by MAG-mv
+  This adds the start of our new build system that uses conan and cmake.
+  At this point, only support for local Windows and Mac builds has been added, and had only been tested on 1 machine.
+  This should currently not replace our current build system, feel free to use for testing.
 
-- [OB-1846] feat: Setup new csp build system to support wasm builds by @MAG-mv.
+- [OF-5310] feat: Added Volume and AudioType properties to `VideoPlayerSpaceComponent`. By @MAG-ME.
+
+- [OF-1846] feat: Setup new csp build system to support wasm builds by @MAG-mv.
   This isn't currently a public-facing change. However, it includes internal changes to the internal usage of tinyspline. This should not have any effect on behaviour.
 
-## [6.33.0]
+### 🐛 🔨 Bug Fixes
+
+- [OB-4980] fix!: Address issues with third party authorization flow. By @MAG-AdamThorn
+  The third party authorization flow is divided into three parts, with two of those handled via calls to CSP. This change addresses an issue whereby a call to the first CSP method would leave you in an invalid login state if you did not complete the authorization flow. In addition, the backend services are constructing the authorization URL that users require directly, rather than CSP constructing it from data returned. This will allow the services to account for changes required to the URL depending on client type and provider. This change introduces the following breaking changes:
+  1. Spelling of method `UserSystem::GetThirdPartyProviderAuthoriseURL()` Americanised to `UserSystem::GetThirdPartyProviderAuthorizeURL()`.
+  2. Method `UserSystem::GetThirdPartyProviderAuthorizeURL()` now takes an additional optional ClientType argument.
+  3. The values of enum `EThirdPartyPlatform` are now capitalized rather than upper case and the value `Web` has been added.
+
+## [6.34.0]
+
+### 🍰 🙌 New Features
+
+- [OF-1844] feat: Add `Authorization` header to asset requests. By @MAG-AdamThorn
+  This change adds content security to our S3 Assets, by ensuring asset requests are authorized. An `Authorization` header has been added to our file Web Requests with the authenticated users bearer token.
 
 ### 🙈 🙉 🙊 Test Changes
 
 - [NT-0] test: Address issue with flackey ValidExpiryLengthInTokenOptionsTest by MAG-AdamThorn
   The test ValidExpiryLengthInTokenOptionsTest was failing when run against live services on our CI due to network latency. Adressed the flackiness and also removed calls to `NotifyRefreshTokenHasChanged()` from the UserSystem as this is already being done within the `LoginStateResult::OnResponse()`, resulting in the `UserSystem NewLoginTokenReceivedCallback` callback being fired twice.
 
-
-## [6.32.0]
+## [6.33.0]
 
 ### 🍰 🙌 New Features
 
 - [OF-1625] feat: Add enabled property to `CollisionSpaceComponent`. By @mag-lt.
-
-- [OF-1844] feat: Add `Authorization` header to asset requests. By @MAG-AdamThorn
-  This change adds content security to our S3 Assets, by ensuring asset requests are authorized. An `Authorization` header has been added to our file Web Requests with the authenticated users bearer token.
 
 ###💫 💥 Code Refactors
 
@@ -37,20 +51,18 @@ All notable changes to this project will be documented in this file. For compile
 - [OF-1848] refac!: Change underlying type of `ComponentType` and all `PropertyKey` enums to ensure compatibility with SignalR wire representation. By @mag-lt
   This is technically a breaking change, but it shouldn't force any client code changes. Explicitly defining the underlying type encodes
   the existing constaints into the type system.
-  
+
 ### 🐛 🔨 Bug Fixes
 
 - [NT-0] fix: Fix tasks dropping in signalR scheduler by @MAG-ElliotMorris
   Address issue where signalR scheduler can drop tasks in rare instances where scheduler threads are almost completely busy.
+- [OF-1822] fix: Remove several redundant SignalR threads by @MAG-ElliotMorris
+  The SignalR threading library by default, constructs several instances of the scheduler,
+  (and thus several sets of threads) during initialization. These are never cleared on WASM,
+  as emscripten pools all its workers, leading to high memory usage. Also reduce thread count
+  generally under a similar motivation, as we don't need 5 threads.
 
 ## [6.31.0]
-
-### 🍰 🙌 New Features
-
-- [OF-1830] feat: Inital integration of new build system by MAG-mv
-  This adds the start of our new build system that uses conan and cmake.
-  At this point, only support for local Windows and Mac builds has been added, and had only been tested on 1 machine.
-  This should currently not replace our current build system, feel free to use for testing.
 
 ###🔥 ❗Breaking Changes
 
@@ -71,12 +83,6 @@ All notable changes to this project will be documented in this file. For compile
   (instead of default initialised values), exposed that CSP was naively assuming
   that various optional fields are always set, resulting in `bad_optional_access`
   exceptions being thrown.
-  
-- [OF-1822] fix: Remove several redundant SignalR threads by @MAG-ElliotMorris
-  The SignalR threading library by default, constructs several instances of the scheduler,
-  (and thus several sets of threads) during initialization. These are never cleared on WASM,
-  as emscripten pools all its workers, leading to high memory usage. Also reduce thread count
-  generally under a similar motivation, as we don't need 5 threads.
 
 ## [6.30.0]
 

--- a/Library/include/CSP/Common/SharedEnums.h
+++ b/Library/include/CSP/Common/SharedEnums.h
@@ -29,7 +29,6 @@ namespace csp::common
 /// @brief Enum which represents possible login states of a CSP client.
 enum class ELoginState : uint8_t
 {
-    LoginThirdPartyProviderDetailsRequested,
     LoginRequested,
     LoggedIn,
     LogoutRequested,

--- a/Library/include/CSP/Common/SharedEnums.h
+++ b/Library/include/CSP/Common/SharedEnums.h
@@ -230,41 +230,6 @@ enum class EThirdPartyPlatform
     Web
 };
 
-inline std::string ThirdPartyPlatformToString(csp::systems::EThirdPartyPlatform Platform)
-{
-    std::string PlatformString;
-    switch (Platform)
-    {
-    case csp::systems::EThirdPartyPlatform::None:
-    {
-        PlatformString = "None";
-        break;
-    }
-    case csp::systems::EThirdPartyPlatform::Unreal:
-    {
-        PlatformString = "Unreal";
-        break;
-    }
-    case csp::systems::EThirdPartyPlatform::Unity:
-    {
-        PlatformString = "Unity";
-        break;
-    }
-    case csp::systems::EThirdPartyPlatform::Web:
-    {
-        PlatformString = "Web";
-        break;
-    }
-    default:
-    {
-        PlatformString = std::string("Unknown platform. Value") + std::to_string(static_cast<unsigned int>(Platform));
-        break;
-    }
-    }
-
-    return PlatformString;
-}
-
 /// @brief Code to indicate the result of a request.
 /// Request results should be checked for a success by clients before using any other accessors.
 enum class EResultCode : uint8_t

--- a/Library/include/CSP/Common/SharedEnums.h
+++ b/Library/include/CSP/Common/SharedEnums.h
@@ -221,14 +221,49 @@ enum class StereoVideoType
 namespace csp::systems
 {
 
-/// @brief Indicates special handling for any thirdparty platform
-/// @note We may remove this soon, as it's deceptive implying these are the only platforms we support.
+/// @brief Indicates the thirdparty platform
 enum class EThirdPartyPlatform
 {
-    NONE,
-    UNREAL,
-    UNITY
+    None,
+    Unreal,
+    Unity,
+    Web
 };
+
+inline std::string ThirdPartyPlatformToString(csp::systems::EThirdPartyPlatform Platform)
+{
+    std::string PlatformString;
+    switch (Platform)
+    {
+    case csp::systems::EThirdPartyPlatform::None:
+    {
+        PlatformString = "None";
+        break;
+    }
+    case csp::systems::EThirdPartyPlatform::Unreal:
+    {
+        PlatformString = "Unreal";
+        break;
+    }
+    case csp::systems::EThirdPartyPlatform::Unity:
+    {
+        PlatformString = "Unity";
+        break;
+    }
+    case csp::systems::EThirdPartyPlatform::Web:
+    {
+        PlatformString = "Web";
+        break;
+    }
+    default:
+    {
+        PlatformString = std::string("Unknown platform. Value") + std::to_string(static_cast<unsigned int>(Platform));
+        break;
+    }
+    }
+
+    return PlatformString;
+}
 
 /// @brief Code to indicate the result of a request.
 /// Request results should be checked for a success by clients before using any other accessors.

--- a/Library/include/CSP/Common/fmt_Formatters.h
+++ b/Library/include/CSP/Common/fmt_Formatters.h
@@ -73,6 +73,9 @@ template <> struct fmt::formatter<csp::web::HttpRequest> : formatter<std::string
         case csp::web::ERequestVerb::Head:
             Verb = "HEAD";
             break;
+        case csp::web::ERequestVerb::Patch:
+            Verb = "PATCH";
+            break;
         default:
             Verb = "UNKNOWN";
             break;

--- a/Library/include/CSP/Systems/Users/ThirdPartyAuthentication.h
+++ b/Library/include/CSP/Systems/Users/ThirdPartyAuthentication.h
@@ -38,10 +38,20 @@ enum EThirdPartyAuthenticationProviders
 class CSP_API ThirdPartyProviderDetails
 {
 public:
+    // @brief The name of the provider, e.g. "Google"
     csp::common::String ProviderName;
+
+    // @brief The application client id with the provider
     csp::common::String ProviderClientId;
+
+    // @brief The scopes required to authenticate with this provider
     csp::common::Array<csp::common::String> ProviderAuthScopes;
-    csp::common::String AuthoriseURL;
+
+    // @brief URL of the provider's authentication endpoint
+    csp::common::String ProviderAuthURL;
+
+    // @brief URL of the provider's token endpoint used to initiate the authorization flow
+    csp::common::String ProviderRedirectURL;
 };
 
 /// @brief Result structure for a third party auth provider details request

--- a/Library/include/CSP/Systems/Users/ThirdPartyAuthentication.h
+++ b/Library/include/CSP/Systems/Users/ThirdPartyAuthentication.h
@@ -50,6 +50,9 @@ public:
     // @brief URL of the provider's authentication endpoint
     csp::common::String ProviderAuthURL;
 
+    // @brief A unique state Id to correlate the authorization request and response from the social provider.
+    csp::common::String ThirdPartyAuthStateId;
+
     // @brief URL of the provider's token endpoint used to initiate the authorization flow
     csp::common::String ProviderRedirectURL;
 };

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -163,8 +163,8 @@ public:
     /// @param ClientType csp::common::Optional<EThirdPartyPlatform> : An optional parameter that allows the client to specify their platform for the
     /// third party authentication flow. This is used for some providers to determine the format of the Authorize URL.
     /// @param Callback StringResultCallback : callback that contains the Authorize URL that the Client should be navigating to for step 2.
-    CSP_ASYNC_RESULT void GetThirdPartyProviderAuthorizeURL(
-        EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL, StringResultCallback Callback);
+    CSP_ASYNC_RESULT void GetThirdPartyProviderAuthorizeURL(EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL,
+        const csp::common::Optional<EThirdPartyPlatform>& ClientType, StringResultCallback Callback);
 
     /// @brief Part two of the 3rd party authentication flow
     /// Note: The steps are as follows:

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -145,37 +145,45 @@ public:
     CSP_ASYNC_RESULT void LoginAsGuestWithDeferredProfileCreation(
         const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback);
 
-    /// @ingroup Third Party Authentication
-    /// @brief As a Connected Spaces Platform user the 3rd party authentication flow consists of two steps, first calling
-    /// GetThirdPartyProviderAuthoriseURL followed by LoginToThirdPartyAuthenticationProvider You can see a Sequence Diagram with all the parties
-    /// involved including what a Client should be calling and when here https://miro.com/app/board/uXjVPflpu98=/.
-
     /// @brief API to retrieve the Connected Spaces Platform supported 3rd party authentication providers
     /// @return Array of Connected Spaces Platform supported 3rd party authentication providers
     [[nodiscard]] csp::common::Array<EThirdPartyAuthenticationProviders> GetSupportedThirdPartyAuthenticationProviders() const;
 
-    /// @brief First step of the 3rd party authentication flow
-    /// If you call this API but for some reason you'd like to call this again, this is supported, the params you pass second time will replace the
-    /// ones you've passed initially
-    /// @param AuthProvider EThirdPartyAuthenticationProviders : one of the supported Authentication Providers
-    /// @param RedirectURL csp::common::String : the RedirectURL you want to be used for this authentication flow
-    /// @param Callback StringResultCallback : callback that contains the Authorise URL that the Client should be navigating next before moving to the
-    /// second Connected Spaces Platform Authentication step
-    CSP_ASYNC_RESULT void GetThirdPartyProviderAuthoriseURL(
+    /// @brief Part one of the 3rd party authentication flow
+    /// Note: The steps are as follows:
+    /// 1. This step. Call this method to retrieve the Authorization URL which is required for step 2.
+    /// 2. The caller should navigate to the Authorize URL retrieved in step 1, where they will authenticate with the 3rd party provider and retrieve
+    /// an auth token and state Id.
+    /// 3. Call @ref UserSystem::LoginToThirdPartyAuthenticationProvider() with the auth token and state Id retrieved in step 2.
+    ///
+    /// Calling this method will not impact your current login state.
+    /// @param AuthProvider EThirdPartyAuthenticationProviders : The Authentication Provider you want to be authenticated with (e.g. Google, Apple,
+    /// Discord).
+    /// @param RedirectURL csp::common::String : the RedirectURL you want to be used for this authentication flow.
+    /// @param ClientType csp::common::Optional<EThirdPartyPlatform> : An optional parameter that allows the client to specify their platform for the
+    /// third party authentication flow. This is used for some providers to determine the format of the Authorize URL.
+    /// @param Callback StringResultCallback : callback that contains the Authorize URL that the Client should be navigating to for step 2.
+    CSP_ASYNC_RESULT void GetThirdPartyProviderAuthorizeURL(
         EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL, StringResultCallback Callback);
 
-    /// @brief Second step of the 3rd party authentication flow
-    /// Note: The Authentication Provider and the Redirect URL you've passed in the first step will be used now
-    /// @param ThirdPartyToken csp::common::String : The authentication token returned by the Provider
-    /// @param ThirdPartyStateId csp::common::String : The state Id returned by the Provider
+    /// @brief Part two of the 3rd party authentication flow
+    /// Note: The steps are as follows:
+    /// 1. Call @ref UserSystem::GetThirdPartyProviderAuthorizeURL() to retrieve the Authorize URL required for step 2.
+    /// 2. The caller should navigate to the Authorize URL retrieved in step 1, where they will authenticate with the 3rd party provider and retrieve
+    /// an auth token and state Id.
+    /// 3. This step. Call this method with the auth token and state Id retrieved in step 2.
+    ///
+    /// @param ThirdPartyToken csp::common::String : The authentication token returned by the Provider in step 2.
+    /// @param ThirdPartyStateId csp::common::String : The state Id returned by the Provider in step 2.
     /// @param CreateMultiplayerConnection bool : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
     /// connection to backend services, and thus be unable to receive messages or events. This session will also be unable to enter online spaces via
     /// a csp::multiplayer::OnlineRealtimeEngine. If true, this session will receive events, and may enter both online and offline spaces.
-    /// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are over 18
+    /// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are
+    /// over 18.
     /// @param TokenOptions csp::common::Optional<TokenOptions> : Optional override for default token options.
-    /// The default token expiry length is configured by MCS and defaults to 30 minutes. Value must be less than the default expiry length, or it will
+    /// The default token expiry length is configured by MCS and defaults to 30 minutes. The value must be less than the default expiry length, or it will
     /// be ignored.
-    /// @param Callback LoginStateResultCallback : callback that contains the result of the Magnopus Cloud Services Authentication operation
+    /// @param Callback LoginStateResultCallback : callback that contains the result of the 3rd party authentication operation.
     CSP_ASYNC_RESULT void LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken,
         const csp::common::String& ThirdPartyStateId, bool CreateMultiplayerConnection, const csp::common::Optional<bool>& UserHasVerifiedAge,
         const csp::common::Optional<TokenOptions>& TokenOptions, LoginStateResultCallback Callback);
@@ -308,7 +316,6 @@ private:
     [[nodiscard]] bool EmailCheck(const std::string& Email) const;
 
     void NotifyRefreshTokenHasChanged();
-    void ResetAuthenticationState();
 
     csp::services::ApiBase* AuthenticationAPI;
     csp::services::ApiBase* ProfileAPI;

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -157,12 +157,12 @@ public:
     /// 3. Call @ref UserSystem::LoginToThirdPartyAuthenticationProvider() with the auth token and state Id retrieved in step 2.
     ///
     /// Calling this method will not impact your current login state.
-    /// @param AuthProvider EThirdPartyAuthenticationProviders : The Authentication Provider you want to be authenticated with (e.g. Google, Apple,
+    /// @param AuthProvider : The Authentication Provider you want to be authenticated with (e.g. Google, Apple,
     /// Discord).
-    /// @param RedirectURL csp::common::String : the RedirectURL you want to be used for this authentication flow.
-    /// @param ClientType csp::common::Optional<EThirdPartyPlatform> : An optional parameter that allows the client to specify their platform for the
+    /// @param RedirectURL : the RedirectURL you want to be used for this authentication flow.
+    /// @param ClientType : An optional parameter that allows the client to specify their platform for the
     /// third party authentication flow. This is used for some providers to determine the format of the Authorize URL.
-    /// @param Callback StringResultCallback : callback that contains the Authorize URL that the Client should be navigating to for step 2.
+    /// @param Callback : callback that contains the Authorize URL that the Client should be navigating to for step 2.
     CSP_ASYNC_RESULT void GetThirdPartyProviderAuthorizeURL(EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL,
         const csp::common::Optional<EThirdPartyPlatform>& ClientType, StringResultCallback Callback);
 
@@ -173,17 +173,17 @@ public:
     /// an auth token and state Id.
     /// 3. This step. Call this method with the auth token and state Id retrieved in step 2.
     ///
-    /// @param ThirdPartyToken csp::common::String : The authentication token returned by the Provider in step 2.
-    /// @param ThirdPartyStateId csp::common::String : The state Id returned by the Provider in step 2.
-    /// @param CreateMultiplayerConnection bool : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
+    /// @param ThirdPartyToken : The authentication token returned by the Provider in step 2.
+    /// @param ThirdPartyStateId : The state Id returned by the Provider in step 2.
+    /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
     /// connection to backend services, and thus be unable to receive messages or events. This session will also be unable to enter online spaces via
     /// a csp::multiplayer::OnlineRealtimeEngine. If true, this session will receive events, and may enter both online and offline spaces.
-    /// @param UserHasVerifiedAge csp::common::Optional<bool> : An optional bool to specify whether or not the user has verified that they are
+    /// @param UserHasVerifiedAge : An optional bool to specify whether or not the user has verified that they are
     /// over 18.
-    /// @param TokenOptions csp::common::Optional<TokenOptions> : Optional override for default token options.
+    /// @param TokenOptions : Optional override for default token options.
     /// The default token expiry length is configured by MCS and defaults to 30 minutes. The value must be less than the default expiry length, or it will
     /// be ignored.
-    /// @param Callback LoginStateResultCallback : callback that contains the result of the 3rd party authentication operation.
+    /// @param Callback : callback that contains the result of the 3rd party authentication operation.
     CSP_ASYNC_RESULT void LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken,
         const csp::common::String& ThirdPartyStateId, bool CreateMultiplayerConnection, const csp::common::Optional<bool>& UserHasVerifiedAge,
         const csp::common::Optional<TokenOptions>& TokenOptions, LoginStateResultCallback Callback);

--- a/Library/src/Common/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
+++ b/Library/src/Common/Web/EmscriptenWebClient/EmscriptenWebClient.cpp
@@ -224,6 +224,9 @@ void EmscriptenWebClient::Send(HttpRequest& Request)
     case ERequestVerb::Head:
         strcpy(attr.requestMethod, "HEAD");
         break;
+    case ERequestVerb::Patch:
+        strcpy(attr.requestMethod, "PATCH");
+        break;
     }
 
     attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;

--- a/Library/src/Common/Web/HttpRequest.h
+++ b/Library/src/Common/Web/HttpRequest.h
@@ -45,12 +45,14 @@ enum class ERequestVerb : uint8_t
     Post = 2,
     Delete = 3,
     Head = 4,
+    Patch = 5,
 
     GET = Get,
     PUT = Put,
     POST = Post,
     DELETE = Delete,
-    HEAD = Head
+    HEAD = Head,
+    PATCH = Patch
 };
 
 #pragma pop_macro("DELETE")

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
@@ -63,6 +63,22 @@ void LogHttpResponseIfLoglevelVeryVerbose(
     }
 }
 
+/// @brief Copies headers from a Poco HTTPResponse to requests response payload.
+void CopyResponseHeaders(const Poco::Net::HTTPResponse& PocoResponse, csp::web::HttpPayload& Payload)
+{
+    for (auto Iter = PocoResponse.begin(); Iter != PocoResponse.end(); ++Iter)
+    {
+        std::string Key = Iter->first;
+        std::string Val = Iter->second;
+
+        // Make Key and Val lower-case
+        std::transform(Key.begin(), Key.end(), Key.begin(), [](unsigned char c) { return std::tolower(c); });
+        std::transform(Val.begin(), Val.end(), Val.begin(), [](unsigned char c) { return std::tolower(c); });
+
+        Payload.AddHeader(Key.c_str(), Val.c_str());
+    }
+}
+
 } // namespace
 
 namespace csp::web
@@ -73,8 +89,69 @@ const uint32_t kPOCOAsyncBufferSize = 2 * 1024;
 
 EResponseCodes GetOlyResponseCode(Poco::Net::HTTPResponse::HTTPStatus PocoResponseCode) { return (EResponseCodes)PocoResponseCode; }
 
-POCOWebClient::POCOWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh) 
-: WebClient(InPort, Tp, LogSystem, AutoRefresh)
+/// @brief Prepares a Poco HTTPRequest by copying headers and cookies from the provided HttpRequest.
+/// If specified it will send a request body either streamed or inline.
+bool POCOWebClient::PrepareAndSendRequest(
+    HttpRequest& Request, Poco::Net::HTTPRequest PocoRequest, Poco::Net::HTTPClientSession* ClientSession, ERequestBodyMode SendBodyMode)
+{
+    for (auto Header : Request.GetPayload().GetHeaders())
+    {
+        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
+    }
+
+    AddCookie(PocoRequest);
+
+    switch (SendBodyMode)
+    {
+    case ERequestBodyMode::None:
+    {
+        // No body is being sent with the request
+        ClientSession->sendRequest(PocoRequest);
+        break;
+    }
+    case ERequestBodyMode::Streamed:
+    {
+        // The request body is being sent as a stream, which allows for progress tracking and cancellation support
+        size_t ContentLength = Request.GetPayload().GetContent().Length();
+        PocoRequest.setContentLength(ContentLength);
+        std::ostream& RequestStream = ClientSession->sendRequest(PocoRequest);
+        ProcessRequestAsync(*ClientSession, PocoRequest, RequestStream, Request);
+
+        if (Request.Cancelled())
+        {
+            return false;
+        }
+        break;
+    }
+    case ERequestBodyMode::Inline:
+    {
+        // The request body is being sent inline in a single operation
+        const std::string Body(Request.GetPayload().GetContent().c_str());
+        PocoRequest.setContentLength(Body.length());
+        ClientSession->sendRequest(PocoRequest) << Body;
+        break;
+    }
+    }
+
+    return true;
+}
+
+/// @brief Receives a response to a sent request, and copies cookies to the provided HttpRequest.
+std::istream& POCOWebClient::ReceiveResponse(Poco::Net::HTTPClientSession* ClientSession, Poco::Net::HTTPResponse& PocoResponse, HttpRequest& Request)
+{
+    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
+    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
+
+    {
+        std::scoped_lock Lock(CookiesMutex);
+        PocoResponse.getCookies(*Cookies);
+    }
+
+    return ResponseStream;
+}
+
+POCOWebClient::POCOWebClient(const Port InPort, const ETransferProtocol Tp, csp::common::LogSystem* LogSystem, bool AutoRefresh)
+    : WebClient(InPort, Tp, LogSystem, AutoRefresh)
 {
     Poco::Net::initializeSSL();
 
@@ -138,43 +215,6 @@ void POCOWebClient::Send(HttpRequest& Request)
     }
 }
 
-void POCOWebClient::Get(HttpRequest& Request)
-{
-    CSP_PROFILE_SCOPED_FORMAT("GET %s", Request.GetUri().GetAsStdString().c_str());
-
-    Poco::URI Uri(Request.GetUri().GetAsStdString());
-
-    // HTTPSessionFactory returns an unmanaged raw pointer - unique_ptr ensures the session is safely cleaned up after use.
-    std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
-    Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_GET, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
-
-    for (auto Header : Request.GetPayload().GetHeaders())
-    {
-        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
-    }
-
-    AddCookie(PocoRequest);
-
-    ClientSession->sendRequest(PocoRequest);
-
-    Poco::Net::HTTPResponse PocoResponse;
-    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
-    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
-
-    {
-        std::scoped_lock Lock(CookiesMutex);
-
-        PocoResponse.getCookies(*Cookies);
-    }
-
-    if (PocoResponse.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
-    {
-        ProcessResponseAsync(*ClientSession, PocoResponse, ResponseStream, Request);
-    }
-
-    LogHttpResponseIfLoglevelVeryVerbose(LogSystem, "GET", Request, PocoResponse);
-}
-
 void POCOWebClient::AddCookie(Poco::Net::HTTPRequest& PocoRequest)
 {
     {
@@ -203,6 +243,29 @@ void POCOWebClient::AddCookie(Poco::Net::HTTPRequest& PocoRequest)
     PocoRequest.setCookies(CookieCollection);
 }
 
+void POCOWebClient::Get(HttpRequest& Request)
+{
+    CSP_PROFILE_SCOPED_FORMAT("GET %s", Request.GetUri().GetAsStdString().c_str());
+
+    Poco::URI Uri(Request.GetUri().GetAsStdString());
+
+    // HTTPSessionFactory returns an unmanaged raw pointer - unique_ptr ensures the session is safely cleaned up after use.
+    std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
+    Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_GET, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
+
+    PrepareAndSendRequest(Request, PocoRequest, ClientSession.get(), ERequestBodyMode::None);
+
+    Poco::Net::HTTPResponse PocoResponse;
+    std::istream& ResponseStream = ReceiveResponse(ClientSession.get(), PocoResponse, Request);
+
+    if (PocoResponse.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
+    {
+        ProcessResponseAsync(*ClientSession, PocoResponse, ResponseStream, Request);
+    }
+
+    LogHttpResponseIfLoglevelVeryVerbose(LogSystem, "GET", Request, PocoResponse);
+}
+
 void POCOWebClient::Post(HttpRequest& Request)
 {
     CSP_PROFILE_SCOPED_FORMAT("POST %s", Request.GetUri().GetAsStdString().c_str());
@@ -213,32 +276,13 @@ void POCOWebClient::Post(HttpRequest& Request)
     std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
     Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_POST, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
 
-    for (auto Header : Request.GetPayload().GetHeaders())
-    {
-        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
-    }
-
-    AddCookie(PocoRequest);
-
-    size_t ContentLength = Request.GetPayload().GetContent().Length();
-    PocoRequest.setContentLength(ContentLength);
-    std::ostream& RequestStream = ClientSession->sendRequest(PocoRequest);
-    ProcessRequestAsync(*ClientSession, PocoRequest, RequestStream, Request);
-
-    if (Request.Cancelled())
+    if (!PrepareAndSendRequest(Request, PocoRequest, ClientSession.get(), ERequestBodyMode::Streamed))
     {
         return;
     }
 
     Poco::Net::HTTPResponse PocoResponse;
-    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
-    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
-
-    {
-        std::scoped_lock Lock(CookiesMutex);
-
-        PocoResponse.getCookies(*Cookies);
-    }
+    std::istream& ResponseStream = ReceiveResponse(ClientSession.get(), PocoResponse, Request);
 
     std::string ResponseString;
     Poco::StreamCopier::copyToString(ResponseStream, ResponseString);
@@ -246,17 +290,7 @@ void POCOWebClient::Post(HttpRequest& Request)
     auto& Payload = ((HttpResponse&)Request.GetResponse()).GetMutablePayload();
 
     // Get all response headers
-    for (auto Iter = PocoResponse.begin(); Iter != PocoResponse.end(); ++Iter)
-    {
-        std::string Key = Iter->first;
-        std::string Val = Iter->second;
-
-        // Make Key and Val lower-case
-        std::transform(Key.begin(), Key.end(), Key.begin(), [](unsigned char c) { return std::tolower(c); });
-        std::transform(Val.begin(), Val.end(), Val.begin(), [](unsigned char c) { return std::tolower(c); });
-
-        Payload.AddHeader(Key.c_str(), Val.c_str());
-    }
+    CopyResponseHeaders(PocoResponse, Payload);
 
     LogHttpResponseIfLoglevelVeryVerbose(LogSystem, "POST", Request, PocoResponse);
 }
@@ -271,32 +305,13 @@ void POCOWebClient::Put(HttpRequest& Request)
     std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
     Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_PUT, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
 
-    for (auto Header : Request.GetPayload().GetHeaders())
-    {
-        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
-    }
-
-    AddCookie(PocoRequest);
-
-    size_t ContentLength = Request.GetPayload().GetContent().Length();
-    PocoRequest.setContentLength(ContentLength);
-    std::ostream& RequestStream = ClientSession->sendRequest(PocoRequest);
-    ProcessRequestAsync(*ClientSession, PocoRequest, RequestStream, Request);
-
-    if (Request.Cancelled())
+    if (!PrepareAndSendRequest(Request, PocoRequest, ClientSession.get(), ERequestBodyMode::Streamed))
     {
         return;
     }
 
     Poco::Net::HTTPResponse PocoResponse;
-    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
-    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
-
-    {
-        std::scoped_lock Lock(CookiesMutex);
-
-        PocoResponse.getCookies(*Cookies);
-    }
+    std::istream& ResponseStream = ReceiveResponse(ClientSession.get(), PocoResponse, Request);
 
     if (PocoResponse.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
     {
@@ -318,26 +333,10 @@ void POCOWebClient::Delete(HttpRequest& Request)
     std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
     Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_DELETE, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
 
-    for (auto Header : Request.GetPayload().GetHeaders())
-    {
-        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
-    }
-
-    AddCookie(PocoRequest);
-
-    const std::string Body(Request.GetPayload().GetContent().c_str());
-    PocoRequest.setContentLength(Body.length());
-    ClientSession->sendRequest(PocoRequest) << Body;
+    PrepareAndSendRequest(Request, PocoRequest, ClientSession.get(), ERequestBodyMode::Inline);
 
     Poco::Net::HTTPResponse PocoResponse;
-    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
-    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
-
-    {
-        std::scoped_lock Lock(CookiesMutex);
-
-        PocoResponse.getCookies(*Cookies);
-    }
+    std::istream& ResponseStream = ReceiveResponse(ClientSession.get(), PocoResponse, Request);
 
     if (PocoResponse.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
     {
@@ -359,24 +358,10 @@ void POCOWebClient::Head(HttpRequest& Request)
     std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
     Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_HEAD, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
 
-    for (auto Header : Request.GetPayload().GetHeaders())
-    {
-        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
-    }
-
-    AddCookie(PocoRequest);
-
-    ClientSession->sendRequest(PocoRequest);
+    PrepareAndSendRequest(Request, PocoRequest, ClientSession.get(), ERequestBodyMode::None);
 
     Poco::Net::HTTPResponse PocoResponse;
-    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
-    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
-
-    {
-        std::scoped_lock Lock(CookiesMutex);
-
-        PocoResponse.getCookies(*Cookies);
-    }
+    std::istream& ResponseStream = ReceiveResponse(ClientSession.get(), PocoResponse, Request);
 
     if (PocoResponse.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
     {
@@ -396,32 +381,13 @@ void POCOWebClient::Patch(HttpRequest& Request)
     std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
     Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_PATCH, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
 
-    for (auto Header : Request.GetPayload().GetHeaders())
-    {
-        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
-    }
-
-    AddCookie(PocoRequest);
-
-    size_t ContentLength = Request.GetPayload().GetContent().Length();
-    PocoRequest.setContentLength(ContentLength);
-    std::ostream& RequestStream = ClientSession->sendRequest(PocoRequest);
-    ProcessRequestAsync(*ClientSession, PocoRequest, RequestStream, Request);
-
-    if (Request.Cancelled())
+    if (!PrepareAndSendRequest(Request, PocoRequest, ClientSession.get(), ERequestBodyMode::Streamed))
     {
         return;
     }
 
     Poco::Net::HTTPResponse PocoResponse;
-    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
-    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
-
-    {
-        std::scoped_lock Lock(CookiesMutex);
-
-        PocoResponse.getCookies(*Cookies);
-    }
+    std::istream& ResponseStream = ReceiveResponse(ClientSession.get(), PocoResponse, Request);
 
     std::string ResponseString;
     Poco::StreamCopier::copyToString(ResponseStream, ResponseString);
@@ -429,17 +395,7 @@ void POCOWebClient::Patch(HttpRequest& Request)
     auto& Payload = ((HttpResponse&)Request.GetResponse()).GetMutablePayload();
 
     // Get all response headers
-    for (auto Iter = PocoResponse.begin(); Iter != PocoResponse.end(); ++Iter)
-    {
-        std::string Key = Iter->first;
-        std::string Val = Iter->second;
-
-        // Make Key and Val lower-case
-        std::transform(Key.begin(), Key.end(), Key.begin(), [](unsigned char c) { return std::tolower(c); });
-        std::transform(Val.begin(), Val.end(), Val.begin(), [](unsigned char c) { return std::tolower(c); });
-
-        Payload.AddHeader(Key.c_str(), Val.c_str());
-    }
+    CopyResponseHeaders(PocoResponse, Payload);
 
     LogHttpResponseIfLoglevelVeryVerbose(LogSystem, "PATCH", Request, PocoResponse);
 }

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
@@ -125,6 +125,9 @@ void POCOWebClient::Send(HttpRequest& Request)
         case ERequestVerb::Head:
             Head(Request);
             break;
+        case ERequestVerb::Patch:
+            Patch(Request);
+            break;
         default:
             break;
         }
@@ -381,6 +384,64 @@ void POCOWebClient::Head(HttpRequest& Request)
     }
 
     LogHttpResponseIfLoglevelVeryVerbose(LogSystem, "HEAD", Request, PocoResponse);
+}
+
+void POCOWebClient::Patch(HttpRequest& Request)
+{
+    CSP_PROFILE_SCOPED_FORMAT("PATCH %s", Request.GetUri().GetAsStdString().c_str());
+
+    Poco::URI Uri(Request.GetUri().GetAsStdString());
+
+    // HTTPSessionFactory returns an unmanaged raw pointer - unique_ptr ensures the session is safely cleaned up after use.
+    std::unique_ptr<Poco::Net::HTTPClientSession> ClientSession(Poco::Net::HTTPSessionFactory::defaultFactory().createClientSession(Uri));
+    Poco::Net::HTTPRequest PocoRequest(Poco::Net::HTTPRequest::HTTP_PATCH, Uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
+
+    for (auto Header : Request.GetPayload().GetHeaders())
+    {
+        PocoRequest.add(Header.first.c_str(), Header.second.c_str());
+    }
+
+    AddCookie(PocoRequest);
+
+    size_t ContentLength = Request.GetPayload().GetContent().Length();
+    PocoRequest.setContentLength(ContentLength);
+    std::ostream& RequestStream = ClientSession->sendRequest(PocoRequest);
+    ProcessRequestAsync(*ClientSession, PocoRequest, RequestStream, Request);
+
+    if (Request.Cancelled())
+    {
+        return;
+    }
+
+    Poco::Net::HTTPResponse PocoResponse;
+    std::istream& ResponseStream = ClientSession->receiveResponse(PocoResponse);
+    Request.SetResponseCode(GetOlyResponseCode(PocoResponse.getStatus()));
+
+    {
+        std::scoped_lock Lock(CookiesMutex);
+
+        PocoResponse.getCookies(*Cookies);
+    }
+
+    std::string ResponseString;
+    Poco::StreamCopier::copyToString(ResponseStream, ResponseString);
+    Request.SetResponseData(ResponseString.c_str(), ResponseString.length());
+    auto& Payload = ((HttpResponse&)Request.GetResponse()).GetMutablePayload();
+
+    // Get all response headers
+    for (auto Iter = PocoResponse.begin(); Iter != PocoResponse.end(); ++Iter)
+    {
+        std::string Key = Iter->first;
+        std::string Val = Iter->second;
+
+        // Make Key and Val lower-case
+        std::transform(Key.begin(), Key.end(), Key.begin(), [](unsigned char c) { return std::tolower(c); });
+        std::transform(Val.begin(), Val.end(), Val.begin(), [](unsigned char c) { return std::tolower(c); });
+
+        Payload.AddHeader(Key.c_str(), Val.c_str());
+    }
+
+    LogHttpResponseIfLoglevelVeryVerbose(LogSystem, "PATCH", Request, PocoResponse);
 }
 
 void POCOWebClient::ProcessResponseAsync(

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
@@ -72,6 +72,7 @@ protected:
     void Put(HttpRequest& Request);
     void Delete(HttpRequest& Request);
     void Head(HttpRequest& Request);
+    void Patch(HttpRequest& Request);
 
     void ProcessResponseAsync(
         Poco::Net::HTTPClientSession& ClientSession, Poco::Net::HTTPResponse& PocoResponse, std::istream& ResponseStream, HttpRequest& Request);

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
@@ -83,6 +83,24 @@ protected:
 
     std::vector<Poco::Net::HTTPCookie>* Cookies;
     std::mutex CookiesMutex;
+
+private:
+    /// @brief Specifies how the request body will be sent.
+    enum class ERequestBodyMode
+    {
+        // No body is sent with the request
+        None,
+        // Body is streamed in chunks with progress tracking and cancellation support
+        Streamed,
+        // Body is written inline to the request stream in a single operation
+        Inline
+    };
+
+    bool PrepareAndSendRequest(
+        HttpRequest& Request, Poco::Net::HTTPRequest PocoRequest, Poco::Net::HTTPClientSession* ClientSession, ERequestBodyMode SendBodyMode);
+
+    std::istream& ReceiveResponse(
+        Poco::Net::HTTPClientSession* ClientSession, Poco::Net::HTTPResponse& PocoResponse, HttpRequest& Request);
 };
 
 } // namespace csp::web

--- a/Library/src/Common/Web/WebClient.cpp
+++ b/Library/src/Common/Web/WebClient.cpp
@@ -414,6 +414,9 @@ void WebClient::PrintClientErrorResponseMessages(const HttpResponse& Response)
     case ERequestVerb::Head:
         Verb = "HEAD";
         break;
+    case ERequestVerb::Patch:
+        Verb = "PATCH";
+        break;
     default:
         break;
     }

--- a/Library/src/Systems/Assets/Asset.cpp
+++ b/Library/src/Systems/Assets/Asset.cpp
@@ -155,13 +155,13 @@ void AssetDetailDtoToAsset(const chs::AssetDetailDto& Dto, csp::systems::Asset& 
         else
         {
             Asset.ThirdPartyPackagedAssetIdentifier = Dto.GetAddressableId();
-            Asset.ThirdPartyPlatformType = EThirdPartyPlatform::NONE;
+            Asset.ThirdPartyPlatformType = EThirdPartyPlatform::None;
         }
     }
     else
     {
         Asset.ThirdPartyPackagedAssetIdentifier = "";
-        Asset.ThirdPartyPlatformType = EThirdPartyPlatform::NONE;
+        Asset.ThirdPartyPlatformType = EThirdPartyPlatform::None;
     }
 
     if (Dto.HasUri())
@@ -189,7 +189,7 @@ Asset::Asset()
     : Type(EAssetType::MODEL)
     , Version(0)
     , ThirdPartyPackagedAssetIdentifier("")
-    , ThirdPartyPlatformType(EThirdPartyPlatform::NONE)
+    , ThirdPartyPlatformType(EThirdPartyPlatform::None)
 {
 }
 

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -852,7 +852,7 @@ void AssetSystem::CreateAsset(const AssetCollection& AssetCollection, const Stri
         }
         else if (ThirdPartyPackagedAssetIdentifier.HasValue())
         {
-            InAddressableId = StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(EThirdPartyPlatform::NONE));
+            InAddressableId = StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(EThirdPartyPlatform::None));
         }
         else if (ThirdPartyPlatform.HasValue())
         {
@@ -902,7 +902,7 @@ async::task<AssetResult> AssetSystem::CreateAsset(const AssetCollection& AssetCo
         }
         else if (ThirdPartyPackagedAssetIdentifier.HasValue())
         {
-            InAddressableId = StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(EThirdPartyPlatform::NONE));
+            InAddressableId = StringFormat("%s|%d", ThirdPartyPackagedAssetIdentifier->c_str(), static_cast<int>(EThirdPartyPlatform::None));
         }
         else if (ThirdPartyPlatform.HasValue())
         {

--- a/Library/src/Systems/Users/ThirdPartyAuthentication.cpp
+++ b/Library/src/Systems/Users/ThirdPartyAuthentication.cpp
@@ -49,7 +49,12 @@ void SocialProviderInfoDtoToProviderDetails(const chs::SocialProviderInfo& Dto, 
 
     if (Dto.HasAuthorizeEndpoint())
     {
-        ProviderDetails.AuthoriseURL = Dto.GetAuthorizeEndpoint();
+        ProviderDetails.ProviderAuthURL = Dto.GetAuthorizeEndpoint();
+    }
+
+    if (Dto.HasRedirectUri())
+    {
+        ProviderDetails.ProviderRedirectURL = Dto.GetRedirectUri();
     }
 }
 }; // namespace

--- a/Library/src/Systems/Users/ThirdPartyAuthentication.cpp
+++ b/Library/src/Systems/Users/ThirdPartyAuthentication.cpp
@@ -52,6 +52,11 @@ void SocialProviderInfoDtoToProviderDetails(const chs::SocialProviderInfo& Dto, 
         ProviderDetails.ProviderAuthURL = Dto.GetAuthorizeEndpoint();
     }
 
+    if (Dto.HasThirdPartyAuthStateId())
+    {
+        ProviderDetails.ThirdPartyAuthStateId = Dto.GetThirdPartyAuthStateId();
+    }
+
     if (Dto.HasRedirectUri())
     {
         ProviderDetails.ProviderRedirectURL = Dto.GetRedirectUri();

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -537,25 +537,18 @@ void UserSystem::GetThirdPartyProviderAuthoriseURL(
 {
     ResetAuthenticationState();
 
-    // Get provider_base_url and client_id
     ProviderDetailsResultCallback ThirdPartyAuthenticationDetailsCallback = [=](const ProviderDetailsResult& ProviderDetailsRes)
     {
         if (ProviderDetailsRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
-            const auto AuthoriseUrl = ProviderDetailsRes.GetDetails().AuthoriseURL;
-            const auto ProviderClientId = ProviderDetailsRes.GetDetails().ProviderClientId;
+            const auto ProviderRedirectUrl = ProviderDetailsRes.GetDetails().ProviderRedirectURL;
+            
             ThirdPartyAuthStateId = csp::GenerateUUID().c_str();
             ThirdPartyRequestedAuthProvider = AuthProvider;
             ThirdPartyAuthRedirectURL = RedirectURL;
-            const auto AuthProviderFormattedScopes = FormatScopesForURL(ProviderDetailsRes.GetDetails().ProviderAuthScopes);
-
-            auto AuthoriseURL = csp::common::StringFormat(
-                "%s?client_id=%s&scope=%s&state=%s&response_type=code&redirect_uri=%s&prompt=select_account&response_mode=form_post",
-                AuthoriseUrl.c_str(), ProviderClientId.c_str(), AuthProviderFormattedScopes.c_str(), ThirdPartyAuthStateId.c_str(),
-                RedirectURL.c_str());
-
+                        
             StringResult SuccessResult(ProviderDetailsRes.GetResultCode(), ProviderDetailsRes.GetHttpResultCode());
-            SuccessResult.SetValue(AuthoriseURL);
+            SuccessResult.SetValue(ProviderRedirectUrl);
             Callback(SuccessResult);
         }
         else if (ProviderDetailsRes.GetResultCode() != csp::systems::EResultCode::InProgress)
@@ -578,7 +571,8 @@ void UserSystem::GetThirdPartyProviderAuthoriseURL(
     CurrentLoginState.State = csp::common::ELoginState::LoginThirdPartyProviderDetailsRequested;
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)
-        ->social_providersProviderGet({ ConvertExternalAuthProvidersToString(AuthProvider), csp::CSPFoundation::GetTenant(), {} }, ResponseHandler);
+        ->social_providersProviderGet(
+            { ConvertExternalAuthProvidersToString(AuthProvider), RedirectURL, csp::CSPFoundation::GetTenant(), {} }, ResponseHandler);
 }
 
 void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken, const csp::common::String& ThirdPartyStateId,
@@ -599,7 +593,7 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
     // checking that the stored ThirdPartyAuthStateId matches the one passed by the Client as a security safety net suggested by the Auth Providers
     if (ThirdPartyAuthStateId != ThirdPartyStateId)
     {
-        CSP_LOG_MSG(common::LogLevel::Error, "The state ID is not correct"); // intentionally not to explicit about the error for security reasons
+        CSP_LOG_MSG(common::LogLevel::Error, "The state ID is not correct"); // intentionally not too explicit about the error for security reasons
         CurrentLoginState.State = csp::common::ELoginState::Error;
 
         csp::systems::LoginStateResult ErrorResult;

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -93,9 +93,9 @@ bool CheckExpiryLengthFormat(const csp::common::String& ExpiryLength)
     return false;
 }
 
-inline std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::common::Optional<csp::systems::EThirdPartyPlatform>& ClientType)
+std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::common::Optional<csp::systems::EThirdPartyPlatform>& ClientType)
 {
-    if (!ClientType.HasValue() || *ClientType == csp::systems::EThirdPartyPlatform::None)
+    if (!ClientType.HasValue())
     {
         return std::nullopt;
     }
@@ -113,6 +113,10 @@ inline std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::
     case csp::systems::EThirdPartyPlatform::Web:
     {
         return "Web";
+    }
+    case csp::systems::EThirdPartyPlatform::None:
+    {
+        return std::nullopt;
     }
     }
 

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -645,73 +645,7 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
         Callback(ErrorResult);
     }
 
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
-    {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-        {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
-                {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-                    }
-
-                    Callback(LoginStateRes);
-                };
-
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                    CreateMultiplayerConnection);
-            }
-            else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
-            {
-                CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
-                Callback(LoginStateRes);
-            }
-        };
-
-        const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
-        Request->SetProvider(ConvertExternalAuthProvidersToString(ThirdPartyRequestedAuthProvider));
-        Request->SetToken(ThirdPartyToken);
-        Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-        if (UserHasVerifiedAge.HasValue())
-        {
-            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
-        }
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
-        {
-            Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
-        }
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
-        {
-            Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
-        }
-
-        Request->SetTokenOptions(Options);
-
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
-
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
-    }
-    else
+    if (CurrentLoginState.State != csp::common::ELoginState::LoggedOut && CurrentLoginState.State != csp::common::ELoginState::Error)
     {
         CSP_LOG_MSG(csp::common::LogLevel::Warning, "You are not in the correct login state to proceed with third-party authentication.");
 
@@ -719,6 +653,70 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(BadResult);
     }
+
+    CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+
+    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            {
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                {
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+                }
+
+                Callback(LoginStateRes);
+            };
+
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
+        {
+            CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
+            Callback(LoginStateRes);
+        }
+    };
+
+    const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
+    Request->SetProvider(ConvertExternalAuthProvidersToString(ThirdPartyRequestedAuthProvider));
+    Request->SetToken(ThirdPartyToken);
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
+
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    auto Options = std::make_shared<chs_user::TokenOptions>();
+
+    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
+    {
+        Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
+        CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
+    }
+
+    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
+    {
+        Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
+        CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
+    }
+
+    Request->SetTokenOptions(Options);
+
+    CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
+            LoginStateResCallback, &CurrentLoginState);
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::Logout(NullResultCallback Callback)

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -95,7 +95,7 @@ bool CheckExpiryLengthFormat(const csp::common::String& ExpiryLength)
 
 inline std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::common::Optional<csp::systems::EThirdPartyPlatform>& ClientType)
 {
-    if (!ClientType.HasValue())
+    if (!ClientType.HasValue() || *ClientType == csp::systems::EThirdPartyPlatform::None)
     {
         return std::nullopt;
     }

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -532,21 +532,40 @@ csp::common::Array<EThirdPartyAuthenticationProviders> UserSystem::GetSupportedT
     return Providers;
 }
 
-void UserSystem::GetThirdPartyProviderAuthoriseURL(
+void UserSystem::GetThirdPartyProviderAuthorizeURL(
     EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL, StringResultCallback Callback)
 {
-    ResetAuthenticationState();
+    if (AuthProvider == EThirdPartyAuthenticationProviders::Invalid)
+    {
+        CSP_LOG_ERROR_MSG(
+            "UserSystem::GetThirdPartyProviderAuthorizeURL() - EThirdPartyAuthenticationProviders::Invalid was passed as an AuthProvider.");
+
+        StringResult ErrorResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(ErrorResult);
+
+        return;
+    }
+
+    if (RedirectURL.IsEmpty())
+    {
+        CSP_LOG_ERROR_MSG("UserSystem::GetThirdPartyProviderAuthorizeURL() - An empty RedirectURL was passed.");
+
+        StringResult ErrorResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(ErrorResult);
+
+        return;
+    }
 
     ProviderDetailsResultCallback ThirdPartyAuthenticationDetailsCallback = [=](const ProviderDetailsResult& ProviderDetailsRes)
     {
         if (ProviderDetailsRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
             const auto ProviderRedirectUrl = ProviderDetailsRes.GetDetails().ProviderRedirectURL;
-            
+
             ThirdPartyAuthStateId = csp::GenerateUUID().c_str();
             ThirdPartyRequestedAuthProvider = AuthProvider;
             ThirdPartyAuthRedirectURL = RedirectURL;
-                        
+
             StringResult SuccessResult(ProviderDetailsRes.GetResultCode(), ProviderDetailsRes.GetHttpResultCode());
             SuccessResult.SetValue(ProviderRedirectUrl);
             Callback(SuccessResult);
@@ -555,8 +574,6 @@ void UserSystem::GetThirdPartyProviderAuthoriseURL(
         {
             CSP_LOG_FORMAT(common::LogLevel::Error, "The retrieval of third party details was not successful. ResCode: %d, HttpResCode: %d",
                 static_cast<int>(ProviderDetailsRes.GetResultCode()), ProviderDetailsRes.GetHttpResultCode());
-
-            CurrentLoginState.State = csp::common::ELoginState::Error;
 
             StringResult ErrorResult(ProviderDetailsRes.GetResultCode(), ProviderDetailsRes.GetHttpResultCode());
             ErrorResult.SetValue("error");
@@ -568,8 +585,6 @@ void UserSystem::GetThirdPartyProviderAuthoriseURL(
         = AuthenticationAPI->CreateHandler<ProviderDetailsResultCallback, ProviderDetailsResult, void, chs_user::SocialProviderInfo>(
             ThirdPartyAuthenticationDetailsCallback, nullptr, csp::web::EResponseCodes::ResponseOK);
 
-    CurrentLoginState.State = csp::common::ELoginState::LoginThirdPartyProviderDetailsRequested;
-
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)
         ->social_providersProviderGet(
             { ConvertExternalAuthProvidersToString(AuthProvider), RedirectURL, csp::CSPFoundation::GetTenant(), {} }, ResponseHandler);
@@ -579,91 +594,104 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
     bool CreateMultiplayerConnection, const csp::common::Optional<bool>& UserHasVerifiedAge, const csp::common::Optional<TokenOptions>& TokenOptions,
     LoginStateResultCallback Callback)
 {
-    if (CurrentLoginState.State != csp::common::ELoginState::LoginThirdPartyProviderDetailsRequested)
+    if (ThirdPartyToken.IsEmpty() || ThirdPartyStateId.IsEmpty())
     {
-        CSP_LOG_FORMAT(common::LogLevel::Error, "The LoginState: %d is incorrect for proceeding with the third party authentication login",
-            CurrentLoginState.State);
-        CurrentLoginState.State = csp::common::ELoginState::Error;
+        CSP_LOG_ERROR_MSG(
+            "UserSystem::LoginToThirdPartyAuthenticationProvider() - both ThirdPartyToken and ThirdPartyStateId must be provided. Please call "
+            "AssetSystem::GetThirdPartyProviderAuthorizeURL() first to get an Authorization URL, which can then be used to retrieve them.");
 
         csp::systems::LoginStateResult ErrorResult;
-        ErrorResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseForbidden);
+        ErrorResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(ErrorResult);
+
+        return;
     }
 
-    // checking that the stored ThirdPartyAuthStateId matches the one passed by the Client as a security safety net suggested by the Auth Providers
+    // Check that the stored ThirdPartyAuthStateId matches the one passed by the Client.
+    // This is a security precaution suggested by the Auth Providers.
     if (ThirdPartyAuthStateId != ThirdPartyStateId)
     {
-        CSP_LOG_MSG(common::LogLevel::Error, "The state ID is not correct"); // intentionally not too explicit about the error for security reasons
-        CurrentLoginState.State = csp::common::ELoginState::Error;
+        CSP_LOG_ERROR_MSG("The provided ThirdPartyStateId is not correct"); // intentionally not too explicit about the error for security reasons
 
         csp::systems::LoginStateResult ErrorResult;
         ErrorResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(ErrorResult);
     }
 
-    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
     {
-        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+
+        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
         {
-            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
             {
-                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
                 {
-                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+                    if (ErrCode != csp::multiplayer::ErrorCode::None)
+                    {
+                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+                    }
 
                     Callback(LoginStateRes);
-                    return;
-                }
+                };
 
+                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                    CreateMultiplayerConnection);
+            }
+            else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
+            {
+                CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
                 Callback(LoginStateRes);
-            };
+            }
+        };
 
-            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                CreateMultiplayerConnection);
-        }
-        else
+        const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
+        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+        Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
+        Request->SetProvider(ConvertExternalAuthProvidersToString(ThirdPartyRequestedAuthProvider));
+        Request->SetToken(ThirdPartyToken);
+        Request->SetTenant(csp::CSPFoundation::GetTenant());
+
+        if (UserHasVerifiedAge.HasValue())
         {
-            Callback(LoginStateRes);
+            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
         }
-    };
 
-    const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
-    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-    Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
-    Request->SetProvider(ConvertExternalAuthProvidersToString(ThirdPartyRequestedAuthProvider));
-    Request->SetToken(ThirdPartyToken);
-    Request->SetTenant(csp::CSPFoundation::GetTenant());
+        auto Options = std::make_shared<chs_user::TokenOptions>();
 
-    if (UserHasVerifiedAge.HasValue())
-    {
-        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
+        {
+            Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
+            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
+        }
+
+        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
+        {
+            Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
+            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
+        }
+
+        Request->SetTokenOptions(Options);
+
+        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+
+        csp::services::ResponseHandlerPtr ResponseHandler
+            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
+                LoginStateResCallback, &CurrentLoginState);
+
+        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
     }
-
-    auto Options = std::make_shared<chs_user::TokenOptions>();
-
-    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
+    else
     {
-        Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-        CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
+        CSP_LOG_MSG(csp::common::LogLevel::Warning, "You are not in the correct login state to proceed with third-party authentication.");
+
+        csp::systems::LoginStateResult BadResult;
+        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(BadResult);
     }
-
-    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
-    {
-        Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-        CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
-    }
-
-    Request->SetTokenOptions(Options);
-
-    CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-    csp::services::ResponseHandlerPtr ResponseHandler
-        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, &CurrentLoginState);
-
-    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::Logout(NullResultCallback Callback)
@@ -921,13 +949,6 @@ void UserSystem::NotifyRefreshTokenHasChanged()
 
         RefreshTokenChangedCallback(InternalResult);
     }
-}
-
-void UserSystem::ResetAuthenticationState()
-{
-    CurrentLoginState.State = csp::common::ELoginState::LoggedOut;
-    ThirdPartyAuthStateId = "";
-    ThirdPartyRequestedAuthProvider = EThirdPartyAuthenticationProviders::Invalid;
 }
 
 void UserSystem::SetUserPermissionsChangedCallback(UserPermissionsChangedCallbackHandler Callback)

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -532,8 +532,8 @@ csp::common::Array<EThirdPartyAuthenticationProviders> UserSystem::GetSupportedT
     return Providers;
 }
 
-void UserSystem::GetThirdPartyProviderAuthorizeURL(
-    EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL, StringResultCallback Callback)
+void UserSystem::GetThirdPartyProviderAuthorizeURL(EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL,
+    const csp::common::Optional<EThirdPartyPlatform>& ClientType, StringResultCallback Callback)
 {
     if (AuthProvider == EThirdPartyAuthenticationProviders::Invalid)
     {
@@ -581,13 +581,20 @@ void UserSystem::GetThirdPartyProviderAuthorizeURL(
         }
     };
 
+    std::optional<csp::common::String> ClientTypeString;
+
+    if (ClientType.HasValue() && *ClientType != csp::systems::EThirdPartyPlatform::None)
+    {
+        ClientTypeString = csp::systems::ThirdPartyPlatformToString(*ClientType).c_str();
+    }
+
     const csp::services::ResponseHandlerPtr ResponseHandler
         = AuthenticationAPI->CreateHandler<ProviderDetailsResultCallback, ProviderDetailsResult, void, chs_user::SocialProviderInfo>(
             ThirdPartyAuthenticationDetailsCallback, nullptr, csp::web::EResponseCodes::ResponseOK);
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)
         ->social_providersProviderGet(
-            { ConvertExternalAuthProvidersToString(AuthProvider), RedirectURL, csp::CSPFoundation::GetTenant(), {} }, ResponseHandler);
+            { ConvertExternalAuthProvidersToString(AuthProvider), RedirectURL, csp::CSPFoundation::GetTenant(), ClientTypeString }, ResponseHandler);
 }
 
 void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken, const csp::common::String& ThirdPartyStateId,

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -561,8 +561,8 @@ void UserSystem::GetThirdPartyProviderAuthorizeURL(EThirdPartyAuthenticationProv
         if (ProviderDetailsRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
             const auto ProviderRedirectUrl = ProviderDetailsRes.GetDetails().ProviderRedirectURL;
+            ThirdPartyAuthStateId = ProviderDetailsRes.GetDetails().ThirdPartyAuthStateId;
 
-            ThirdPartyAuthStateId = csp::GenerateUUID().c_str();
             ThirdPartyRequestedAuthProvider = AuthProvider;
             ThirdPartyAuthRedirectURL = RedirectURL;
 

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -93,6 +93,32 @@ bool CheckExpiryLengthFormat(const csp::common::String& ExpiryLength)
     return false;
 }
 
+inline std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::common::Optional<csp::systems::EThirdPartyPlatform>& ClientType)
+{
+    if (!ClientType.HasValue())
+    {
+        return std::nullopt;
+    }
+
+    switch (*ClientType)
+    {
+    case csp::systems::EThirdPartyPlatform::Unreal:
+    {
+        return "Unreal";
+    }
+    case csp::systems::EThirdPartyPlatform::Unity:
+    {
+        return "Unity";
+    }
+    case csp::systems::EThirdPartyPlatform::Web:
+    {
+        return "Web";
+    }
+    }
+
+    return std::nullopt;
+}
+
 }
 
 namespace csp::systems
@@ -581,20 +607,14 @@ void UserSystem::GetThirdPartyProviderAuthorizeURL(EThirdPartyAuthenticationProv
         }
     };
 
-    std::optional<csp::common::String> ClientTypeString;
-
-    if (ClientType.HasValue() && *ClientType != csp::systems::EThirdPartyPlatform::None)
-    {
-        ClientTypeString = csp::systems::ThirdPartyPlatformToString(*ClientType).c_str();
-    }
+    std::optional<csp::common::String> Client = ThirdPartyPlatformToString(ClientType);
 
     const csp::services::ResponseHandlerPtr ResponseHandler
         = AuthenticationAPI->CreateHandler<ProviderDetailsResultCallback, ProviderDetailsResult, void, chs_user::SocialProviderInfo>(
             ThirdPartyAuthenticationDetailsCallback, nullptr, csp::web::EResponseCodes::ResponseOK);
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)
-        ->social_providersProviderGet(
-            { ConvertExternalAuthProvidersToString(AuthProvider), RedirectURL, csp::CSPFoundation::GetTenant(), ClientTypeString }, ResponseHandler);
+        ->social_providersProviderGet({ ConvertExternalAuthProvidersToString(AuthProvider), RedirectURL, csp::CSPFoundation::GetTenant(), Client }, ResponseHandler);
 }
 
 void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken, const csp::common::String& ThirdPartyStateId,

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -1998,11 +1998,11 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, ThirdPartyPackagedAssetIdentifierTe
     EXPECT_EQ(Assets.Size(), 1);
     EXPECT_EQ(Assets[0].Name, UniqueAssetName);
     EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, "");
-    EXPECT_EQ(Assets[0].ThirdPartyPlatformType, csp::systems::EThirdPartyPlatform::NONE);
+    EXPECT_EQ(Assets[0].ThirdPartyPlatformType, csp::systems::EThirdPartyPlatform::None);
     // Delete asset
     DeleteAsset(AssetSystem, assetCollection, Asset);
 
-    CreateAsset(AssetSystem, assetCollection, UniqueAssetName, ThirdPartyPackagedAssetIdentifier, csp::systems::EThirdPartyPlatform::UNITY, Asset);
+    CreateAsset(AssetSystem, assetCollection, UniqueAssetName, ThirdPartyPackagedAssetIdentifier, csp::systems::EThirdPartyPlatform::Unity, Asset);
 
     // Get assets
     GetAssetsInCollection(AssetSystem, assetCollection, Assets);
@@ -2010,7 +2010,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, ThirdPartyPackagedAssetIdentifierTe
     EXPECT_EQ(Assets.Size(), 1);
     EXPECT_EQ(Assets[0].Name, UniqueAssetName);
     EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifier);
-    EXPECT_EQ(Assets[0].ThirdPartyPlatformType, csp::systems::EThirdPartyPlatform::UNITY);
+    EXPECT_EQ(Assets[0].ThirdPartyPlatformType, csp::systems::EThirdPartyPlatform::Unity);
 
     Assets[0].ThirdPartyPackagedAssetIdentifier = ThirdPartyPackagedAssetIdentifierLocal;
     EXPECT_EQ(Assets[0].ThirdPartyPackagedAssetIdentifier, ThirdPartyPackagedAssetIdentifierLocal);

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -146,28 +146,6 @@ csp::systems::Profile GetFullProfileByUserId(csp::systems::UserSystem* UserSyste
     return GetProfileResult.GetProfile();
 }
 
-// Decode a percent-encoded URL
-std::string DecodeURL(const std::string& EncodedURL)
-{
-    std::string DecodedURL;
-    DecodedURL.reserve(EncodedURL.size());
-    for (size_t i = 0; i < EncodedURL.size(); ++i)
-    {
-        if (EncodedURL[i] == '%' && i + 2 < EncodedURL.size())
-        {
-            std::string HexCode = std::string(EncodedURL.substr(i + 1, 2));
-            int Hex = std::stoi(HexCode, nullptr, 16);
-            DecodedURL += static_cast<char>(Hex);
-            i += 2;
-        }
-        else
-        {
-            DecodedURL += EncodedURL[i];
-        }
-    }
-    return DecodedURL;
-}
-
 void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, const csp::common::String& RedirectURL)
 {
     EXPECT_FALSE(AuthoriseURL.IsEmpty());
@@ -229,10 +207,7 @@ void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, con
     EXPECT_GT(ClientId.length(), 0);
     EXPECT_GE(Scope.length(), 0);
 
-    // AuthoriseURL is encoded and must be decoded before comparing
-    std::string DecodedRedirectURL(DecodeURL(RetrievedRedirectURL));
-
-    EXPECT_EQ(DecodedRedirectURL, RedirectURL.c_str());
+    EXPECT_EQ(RetrievedRedirectURL, RedirectURL.c_str());
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -146,6 +146,28 @@ csp::systems::Profile GetFullProfileByUserId(csp::systems::UserSystem* UserSyste
     return GetProfileResult.GetProfile();
 }
 
+// Decode a percent-encoded URL
+std::string DecodeURL(const std::string& EncodedURL)
+{
+    std::string DecodedURL;
+    DecodedURL.reserve(EncodedURL.size());
+    for (size_t i = 0; i < EncodedURL.size(); ++i)
+    {
+        if (EncodedURL[i] == '%' && i + 2 < EncodedURL.size())
+        {
+            std::string HexCode = std::string(EncodedURL.substr(i + 1, 2));
+            int Hex = std::stoi(HexCode, nullptr, 16);
+            DecodedURL += static_cast<char>(Hex);
+            i += 2;
+        }
+        else
+        {
+            DecodedURL += EncodedURL[i];
+        }
+    }
+    return DecodedURL;
+}
+
 void ValidateThirdPartyAuthoriseURL(const csp::common::String& AuthoriseURL, const csp::common::String& RedirectURL)
 {
     EXPECT_FALSE(AuthoriseURL.IsEmpty());
@@ -206,7 +228,11 @@ void ValidateThirdPartyAuthoriseURL(const csp::common::String& AuthoriseURL, con
     EXPECT_GT(StateId.length(), 0);
     EXPECT_GT(ClientId.length(), 0);
     EXPECT_GE(Scope.length(), 0);
-    EXPECT_EQ(RetrievedRedirectURL, RedirectURL.c_str());
+
+    // AuthoriseURL is encoded and must be decoded before comparing
+    std::string DecodedRedirectURL(DecodeURL(RetrievedRedirectURL));
+
+    EXPECT_EQ(DecodedRedirectURL, RedirectURL.c_str());
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -953,6 +953,24 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTest)
     ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
 }
 
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTestWithClient)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+
+    const auto RedirectURL = "https://dev.magnoverse.space/oauth";
+
+    csp::systems::EThirdPartyPlatform Client = csp::systems::EThirdPartyPlatform::Unity;
+
+    // Retrieve Authorize URL for Google
+    auto [ResGoogle] = AWAIT_PRE(UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate,
+        csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL, Client);
+    EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
+
+    const auto& AuthorizeURL = ResGoogle.GetValue();
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
+}
+
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForDiscordTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -971,7 +971,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTest)
 
     // Retrieve Authorize URL for Google
     auto [ResGoogle] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL);
+        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL, nullptr);
     EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = ResGoogle.GetValue();
@@ -987,7 +987,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForDiscordTest)
 
     // Retrieve Authorize URL for Discord
     auto [Result] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Discord, RedirectURL);
+        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Discord, RedirectURL, nullptr);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = Result.GetValue();
@@ -1003,7 +1003,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForAppleTest)
 
     // Retrieve Authorize URL for Apple
     auto [Result] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Apple, RedirectURL);
+        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Apple, RedirectURL, nullptr);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = Result.GetValue();

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -168,7 +168,7 @@ std::string DecodeURL(const std::string& EncodedURL)
     return DecodedURL;
 }
 
-void ValidateThirdPartyAuthoriseURL(const csp::common::String& AuthoriseURL, const csp::common::String& RedirectURL)
+void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, const csp::common::String& RedirectURL)
 {
     EXPECT_FALSE(AuthoriseURL.IsEmpty());
     EXPECT_NE(AuthoriseURL, "error");
@@ -962,52 +962,52 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetThirdPartySupportedProvidersTest)
     EXPECT_TRUE(FoundGoogle && FoundDiscord && FoundApple);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForGoogleTest)
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
 
     const auto RedirectURL = "https://dev.magnoverse.space/oauth";
 
-    // Retrieve Authorise URL for Google
+    // Retrieve Authorize URL for Google
     auto [ResGoogle] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthoriseURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL);
+        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL);
     EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
 
-    const auto& AuthoriseURL = ResGoogle.GetValue();
-    ValidateThirdPartyAuthoriseURL(AuthoriseURL, RedirectURL);
+    const auto& AuthorizeURL = ResGoogle.GetValue();
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForDiscordTest)
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForDiscordTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
 
     const auto RedirectURL = "https://dev.magnoverse.space/oauth";
 
-    // Retrieve Authorise URL for Discord
+    // Retrieve Authorize URL for Discord
     auto [Result] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthoriseURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Discord, RedirectURL);
+        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Discord, RedirectURL);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
-    const auto& AuthoriseURL = Result.GetValue();
-    ValidateThirdPartyAuthoriseURL(AuthoriseURL, RedirectURL);
+    const auto& AuthorizeURL = Result.GetValue();
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthoriseURLForAppleTest)
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForAppleTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
     auto* UserSystem = SystemsManager.GetUserSystem();
 
     const auto RedirectURL = "https://dev.magnoverse.space/oauth";
 
-    // Retrieve Authorise URL for Apple
+    // Retrieve Authorize URL for Apple
     auto [Result] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthoriseURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Apple, RedirectURL);
+        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Apple, RedirectURL);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
-    const auto& AuthoriseURL = Result.GetValue();
-    ValidateThirdPartyAuthoriseURL(AuthoriseURL, RedirectURL);
+    const auto& AuthorizeURL = Result.GetValue();
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
 }
 
 // As the following three tests require manual actions explained inside, they are currently disabled


### PR DESCRIPTION
The third-party authorization flow is divided into three parts, with two of those handled via calls to CSP. This change addresses an issue whereby a call to the first CSP method would log you out or leave you in an invalid login state if you did not complete the authorization flow.

In addition, the backend services are now constructing the authorization URL that users require directly, rather than CSP constructing it from data returned. This will allow the services to account for changes required to the URL depending on client type and provider.

This change has been validated with the Unity team via a feature publish.

**This change introduces the following breaking changes:**
  1. Spelling of method `UserSystem::GetThirdPartyProviderAuthoriseURL()` has been Americanised to `UserSystem::GetThirdPartyProviderAuthorizeURL()`.
  2. Method `UserSystem::GetThirdPartyProviderAuthorizeURL()` now takes an additional optional ClientType argument of type `EThirdPartyPlatform`.
  3. The values of enum `EThirdPartyPlatform` are now capitalized rather than upper case and the value `Web` has been added.