### PR TITLE
[OF-1793] ci: Integrated .NET bindings layer build+test workflow.

### DIFF
--- a/.github/workflows/unity-interop-tests.yml
+++ b/.github/workflows/unity-interop-tests.yml
@@ -1,0 +1,19 @@
+name: .NET Interop Binding Integration
+
+# Run a fully integrated build of the unity bindings, based on the CSP build from the current branch.
+# If breaking changes are made, push directly to the "csp-development" branch in the connected-spaces-platform-unity repo, which represents the breaking changeset of the next release.
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  # The github head_ref||ref_name thing is dealing with a difference between a PR head and a regular branch head, since they're not just branch names when coming from PR's
+  run-unity-interop-layer-integration:
+    uses: magnopus-opensource/connected-spaces-platform-unity/.github/workflows/build-desktop.yml@csp-development
+    with:
+      unity_ext_matrix: '[false]'
+      platform_matrix: '["windows-latest"]'
+      csp_branch: ${{ github.head_ref || github.ref_name }}
+      binding_repo_branch: csp-development
+

--- a/.github/workflows/unity-interop-tests.yml
+++ b/.github/workflows/unity-interop-tests.yml
@@ -13,7 +13,7 @@ jobs:
     uses: magnopus-opensource/connected-spaces-platform-unity/.github/workflows/build-desktop.yml@csp-development
     with:
       unity_ext_matrix: '[false]'
-      platform_matrix: '["windows-latest"]'
+      platform_matrix: '["windows-2022"]'
       csp_branch: ${{ github.head_ref || github.ref_name }}
       binding_repo_branch: csp-development
 


### PR DESCRIPTION
Add an action that builds and runs test automation in the downstream swig bindings repo, building this branch's version of CSP, and running the integration tests against it.

Uses a `csp-development` branch in the bindings repo as our integration targets. Updates go directly into that branch. You can [see ](https://github.com/magnopus-opensource/connected-spaces-platform-unity/tree/csp-development) I've made several releases worth of changes all at once to get this up to date, but with this gate, it will now be required to stay up to date on a break-by-break bases.

We'll be syncing that branch each release in the unity interop repo, at least that's the plan.
