### PR TITLE
[NT-0] fix: Add missing Client param for usersLogin_socialPost call

### DIFF
--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -327,6 +327,7 @@ private:
     LoginTokenInfoResultCallback RefreshTokenChangedCallback;
 
     csp::common::String ThirdPartyAuthStateId;
+    csp::common::String ThirdPartyClientId;
     csp::common::String ThirdPartyAuthRedirectURL;
     EThirdPartyAuthenticationProviders ThirdPartyRequestedAuthProvider = EThirdPartyAuthenticationProviders::Invalid;
 

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -592,6 +592,7 @@ void UserSystem::GetThirdPartyProviderAuthorizeURL(EThirdPartyAuthenticationProv
         {
             const auto ProviderRedirectUrl = ProviderDetailsRes.GetDetails().ProviderRedirectURL;
             ThirdPartyAuthStateId = ProviderDetailsRes.GetDetails().ThirdPartyAuthStateId;
+            ThirdPartyClientId = ProviderDetailsRes.GetDetails().ProviderClientId;
 
             ThirdPartyRequestedAuthProvider = AuthProvider;
             ThirdPartyAuthRedirectURL = RedirectURL;
@@ -690,6 +691,7 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
     Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
     Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
     Request->SetProvider(ConvertExternalAuthProvidersToString(ThirdPartyRequestedAuthProvider));
+    Request->SetClient(ThirdPartyClientId);
     Request->SetToken(ThirdPartyToken);
     Request->SetTenant(csp::CSPFoundation::GetTenant());
 

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -146,7 +146,15 @@ csp::systems::Profile GetFullProfileByUserId(csp::systems::UserSystem* UserSyste
     return GetProfileResult.GetProfile();
 }
 
-void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, const csp::common::String& RedirectURL)
+struct AuthorizeURLTokens
+{
+    std::string StateId;
+    std::string ClientId;
+    std::string Scope;
+    std::string RetrievedRedirectURL;
+};
+
+void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, const csp::common::String& RedirectURL, AuthorizeURLTokens& OutTokens)
 {
     EXPECT_FALSE(AuthoriseURL.IsEmpty());
     EXPECT_NE(AuthoriseURL, "error");
@@ -157,10 +165,10 @@ void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, con
     const char* REDIRECT_URL_PARAM = "redirect_uri=";
     const char* INVALID_URL_PARAM_VALUE = "N/A";
 
-    std::string StateId = INVALID_URL_PARAM_VALUE;
-    std::string ClientId = INVALID_URL_PARAM_VALUE;
-    std::string Scope = INVALID_URL_PARAM_VALUE;
-    std::string RetrievedRedirectURL = INVALID_URL_PARAM_VALUE;
+    OutTokens.StateId = INVALID_URL_PARAM_VALUE;
+    OutTokens.ClientId = INVALID_URL_PARAM_VALUE;
+    OutTokens.Scope = INVALID_URL_PARAM_VALUE;
+    OutTokens.RetrievedRedirectURL = INVALID_URL_PARAM_VALUE;
 
     const auto& Tokens = AuthoriseURL.Split('&');
     for (size_t idx = 0; idx < Tokens.Size(); ++idx)
@@ -168,22 +176,22 @@ void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, con
         std::string URLElement(Tokens[idx].c_str());
         if (URLElement.find(STATE_ID_URL_PARAM, 0) == 0)
         {
-            StateId = URLElement.substr(strlen(STATE_ID_URL_PARAM));
+            OutTokens.StateId = URLElement.substr(strlen(STATE_ID_URL_PARAM));
             continue;
         }
         else if (URLElement.find(CLIENT_ID_URL_PARAM, 0) == 0)
         {
-            ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
+            OutTokens.ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
             continue;
         }
         else if (URLElement.find(SCOPE_URL_PARAM, 0) == 0)
         {
-            Scope = URLElement.substr(strlen(SCOPE_URL_PARAM));
+            OutTokens.Scope = URLElement.substr(strlen(SCOPE_URL_PARAM));
             continue;
         }
         else if (URLElement.find(REDIRECT_URL_PARAM, 0) == 0)
         {
-            RetrievedRedirectURL = URLElement.substr(strlen(REDIRECT_URL_PARAM));
+            OutTokens.RetrievedRedirectURL = URLElement.substr(strlen(REDIRECT_URL_PARAM));
             continue;
         }
     }
@@ -194,20 +202,20 @@ void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, con
     std::string URLElement(NewTokens[1].c_str());
     if (URLElement.find(CLIENT_ID_URL_PARAM, 0) == 0)
     {
-        ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
+        OutTokens.ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
     }
 
     // validate that the following contain something that potentially makes sense
-    EXPECT_NE(StateId, INVALID_URL_PARAM_VALUE);
-    EXPECT_NE(ClientId, INVALID_URL_PARAM_VALUE);
-    EXPECT_NE(Scope, INVALID_URL_PARAM_VALUE);
-    EXPECT_NE(RetrievedRedirectURL, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(OutTokens.StateId, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(OutTokens.ClientId, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(OutTokens.Scope, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(OutTokens.RetrievedRedirectURL, INVALID_URL_PARAM_VALUE);
 
-    EXPECT_GT(StateId.length(), 0);
-    EXPECT_GT(ClientId.length(), 0);
-    EXPECT_GE(Scope.length(), 0);
+    EXPECT_GT(OutTokens.StateId.length(), 0);
+    EXPECT_GT(OutTokens.ClientId.length(), 0);
+    EXPECT_GE(OutTokens.Scope.length(), 0);
 
-    EXPECT_EQ(RetrievedRedirectURL, RedirectURL.c_str());
+    EXPECT_EQ(OutTokens.RetrievedRedirectURL, RedirectURL.c_str());
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)
@@ -945,12 +953,14 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTest)
     const auto RedirectURL = "https://dev.magnoverse.space/oauth";
 
     // Retrieve Authorize URL for Google
-    auto [ResGoogle] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL, nullptr);
+    auto [ResGoogle] = AWAIT_PRE(UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate,
+        csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL, nullptr);
     EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = ResGoogle.GetValue();
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
+    AuthorizeURLTokens Tokens;
+
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTestWithClient)
@@ -968,7 +978,39 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTestWithClie
     EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = ResGoogle.GetValue();
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
+    AuthorizeURLTokens Tokens;
+
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginThirdPartyFailValidateStateTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+
+    const auto Token = "DummyToken";
+    const auto RedirectURL = "https://dev.magnoverse.space/oauth";
+
+    // Retrieve Authorize URL for Google
+    auto [ResGoogle] = AWAIT_PRE(UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate,
+        csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL, nullptr);
+    EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
+
+    const auto& AuthorizeURL = ResGoogle.GetValue();
+    AuthorizeURLTokens URLTokens;
+
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, URLTokens);
+
+    EXPECT_EQ(UserSystem->GetLoginState().State, csp::common::ELoginState::LoggedOut);
+
+    // Attempt to login which we expect to fail
+    auto [ResLogin]
+        = AWAIT_PRE(UserSystem, LoginToThirdPartyAuthenticationProvider, RequestPredicate, Token, URLTokens.StateId.c_str(), false, true, {});
+    EXPECT_EQ(ResLogin.GetResultCode(), csp::systems::EResultCode::Failed);
+
+    // If ELoginState == Error that means it passed the check comparing the state Id passed in to the one cached from the call to
+    // GetThirdPartyProviderAuthorizeURL() and attempted to log in, which will fail.
+    EXPECT_EQ(UserSystem->GetLoginState().State, csp::common::ELoginState::Error);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForDiscordTest)
@@ -979,12 +1021,14 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForDiscordTest)
     const auto RedirectURL = "https://dev.magnoverse.space/oauth";
 
     // Retrieve Authorize URL for Discord
-    auto [Result] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Discord, RedirectURL, nullptr);
+    auto [Result] = AWAIT_PRE(UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate,
+        csp::systems::EThirdPartyAuthenticationProviders::Discord, RedirectURL, nullptr);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = Result.GetValue();
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
+    AuthorizeURLTokens Tokens;
+
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForAppleTest)
@@ -995,12 +1039,14 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForAppleTest)
     const auto RedirectURL = "https://dev.magnoverse.space/oauth";
 
     // Retrieve Authorize URL for Apple
-    auto [Result] = AWAIT_PRE(
-        UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate, csp::systems::EThirdPartyAuthenticationProviders::Apple, RedirectURL, nullptr);
+    auto [Result] = AWAIT_PRE(UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate,
+        csp::systems::EThirdPartyAuthenticationProviders::Apple, RedirectURL, nullptr);
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = Result.GetValue();
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL);
+    AuthorizeURLTokens Tokens;
+
+    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
 }
 
 // As the following three tests require manual actions explained inside, they are currently disabled

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -154,68 +154,74 @@ struct AuthorizeURLTokens
     std::string RetrievedRedirectURL;
 };
 
-void ValidateThirdPartyAuthorizeURL(const csp::common::String& AuthoriseURL, const csp::common::String& RedirectURL, AuthorizeURLTokens& OutTokens)
+AuthorizeURLTokens ExtractTokensFromAuthorizeURL(const csp::common::String& AuthorizeURL)
 {
-    EXPECT_FALSE(AuthoriseURL.IsEmpty());
-    EXPECT_NE(AuthoriseURL, "error");
-
+    AuthorizeURLTokens URLTokens;
+    
     const char* STATE_ID_URL_PARAM = "state=";
     const char* CLIENT_ID_URL_PARAM = "client_id=";
     const char* SCOPE_URL_PARAM = "scope=";
     const char* REDIRECT_URL_PARAM = "redirect_uri=";
     const char* INVALID_URL_PARAM_VALUE = "N/A";
 
-    OutTokens.StateId = INVALID_URL_PARAM_VALUE;
-    OutTokens.ClientId = INVALID_URL_PARAM_VALUE;
-    OutTokens.Scope = INVALID_URL_PARAM_VALUE;
-    OutTokens.RetrievedRedirectURL = INVALID_URL_PARAM_VALUE;
+    URLTokens.StateId = INVALID_URL_PARAM_VALUE;
+    URLTokens.ClientId = INVALID_URL_PARAM_VALUE;
+    URLTokens.Scope = INVALID_URL_PARAM_VALUE;
+    URLTokens.RetrievedRedirectURL = INVALID_URL_PARAM_VALUE;
 
-    const auto& Tokens = AuthoriseURL.Split('&');
-    for (size_t idx = 0; idx < Tokens.Size(); ++idx)
+    const auto& QueryParams = AuthorizeURL.Split('&');
+    for (size_t idx = 0; idx < QueryParams.Size(); ++idx)
     {
-        std::string URLElement(Tokens[idx].c_str());
+        std::string URLElement(QueryParams[idx].c_str());
         if (URLElement.find(STATE_ID_URL_PARAM, 0) == 0)
         {
-            OutTokens.StateId = URLElement.substr(strlen(STATE_ID_URL_PARAM));
+            URLTokens.StateId = URLElement.substr(strlen(STATE_ID_URL_PARAM));
             continue;
         }
         else if (URLElement.find(CLIENT_ID_URL_PARAM, 0) == 0)
         {
-            OutTokens.ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
+            URLTokens.ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
             continue;
         }
         else if (URLElement.find(SCOPE_URL_PARAM, 0) == 0)
         {
-            OutTokens.Scope = URLElement.substr(strlen(SCOPE_URL_PARAM));
+            URLTokens.Scope = URLElement.substr(strlen(SCOPE_URL_PARAM));
             continue;
         }
         else if (URLElement.find(REDIRECT_URL_PARAM, 0) == 0)
         {
-            OutTokens.RetrievedRedirectURL = URLElement.substr(strlen(REDIRECT_URL_PARAM));
+            URLTokens.RetrievedRedirectURL = URLElement.substr(strlen(REDIRECT_URL_PARAM));
             continue;
         }
     }
 
-    const auto NewTokens = Tokens[0].Split('?');
+    const auto NewTokens = QueryParams[0].Split('?');
     EXPECT_EQ(NewTokens.Size(), 2);
 
     std::string URLElement(NewTokens[1].c_str());
     if (URLElement.find(CLIENT_ID_URL_PARAM, 0) == 0)
     {
-        OutTokens.ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
+        URLTokens.ClientId = URLElement.substr(strlen(CLIENT_ID_URL_PARAM));
     }
 
+    return URLTokens;
+}
+
+void ValidateThirdPartyAuthorizeURL(const AuthorizeURLTokens& URLTokens, const csp::common::String& RedirectURL)
+{
+    const char* INVALID_URL_PARAM_VALUE = "N/A";
+
     // validate that the following contain something that potentially makes sense
-    EXPECT_NE(OutTokens.StateId, INVALID_URL_PARAM_VALUE);
-    EXPECT_NE(OutTokens.ClientId, INVALID_URL_PARAM_VALUE);
-    EXPECT_NE(OutTokens.Scope, INVALID_URL_PARAM_VALUE);
-    EXPECT_NE(OutTokens.RetrievedRedirectURL, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(URLTokens.StateId, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(URLTokens.ClientId, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(URLTokens.Scope, INVALID_URL_PARAM_VALUE);
+    EXPECT_NE(URLTokens.RetrievedRedirectURL, INVALID_URL_PARAM_VALUE);
 
-    EXPECT_GT(OutTokens.StateId.length(), 0);
-    EXPECT_GT(OutTokens.ClientId.length(), 0);
-    EXPECT_GE(OutTokens.Scope.length(), 0);
+    EXPECT_GT(URLTokens.StateId.length(), 0);
+    EXPECT_GT(URLTokens.ClientId.length(), 0);
+    EXPECT_GE(URLTokens.Scope.length(), 0);
 
-    EXPECT_EQ(OutTokens.RetrievedRedirectURL, RedirectURL.c_str());
+    EXPECT_EQ(URLTokens.RetrievedRedirectURL, RedirectURL.c_str());
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ForgotPasswordTest)
@@ -958,9 +964,9 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTest)
     EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = ResGoogle.GetValue();
-    AuthorizeURLTokens Tokens;
 
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
+    AuthorizeURLTokens Tokens = ExtractTokensFromAuthorizeURL(AuthorizeURL);
+    ValidateThirdPartyAuthorizeURL(Tokens, RedirectURL);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTestWithClient)
@@ -978,39 +984,9 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTestWithClie
     EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = ResGoogle.GetValue();
-    AuthorizeURLTokens Tokens;
 
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
-}
-
-CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginThirdPartyFailValidateStateTest)
-{
-    auto& SystemsManager = csp::systems::SystemsManager::Get();
-    auto* UserSystem = SystemsManager.GetUserSystem();
-
-    const auto Token = "DummyToken";
-    const auto RedirectURL = "https://dev.magnoverse.space/oauth";
-
-    // Retrieve Authorize URL for Google
-    auto [ResGoogle] = AWAIT_PRE(UserSystem, GetThirdPartyProviderAuthorizeURL, RequestPredicate,
-        csp::systems::EThirdPartyAuthenticationProviders::Google, RedirectURL, nullptr);
-    EXPECT_EQ(ResGoogle.GetResultCode(), csp::systems::EResultCode::Success);
-
-    const auto& AuthorizeURL = ResGoogle.GetValue();
-    AuthorizeURLTokens URLTokens;
-
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, URLTokens);
-
-    EXPECT_EQ(UserSystem->GetLoginState().State, csp::common::ELoginState::LoggedOut);
-
-    // Attempt to login which we expect to fail
-    auto [ResLogin]
-        = AWAIT_PRE(UserSystem, LoginToThirdPartyAuthenticationProvider, RequestPredicate, Token, URLTokens.StateId.c_str(), false, true, {});
-    EXPECT_EQ(ResLogin.GetResultCode(), csp::systems::EResultCode::Failed);
-
-    // If ELoginState == Error that means it passed the check comparing the state Id passed in to the one cached from the call to
-    // GetThirdPartyProviderAuthorizeURL() and attempted to log in, which will fail.
-    EXPECT_EQ(UserSystem->GetLoginState().State, csp::common::ELoginState::Error);
+    AuthorizeURLTokens Tokens = ExtractTokensFromAuthorizeURL(AuthorizeURL);
+    ValidateThirdPartyAuthorizeURL(Tokens, RedirectURL);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForDiscordTest)
@@ -1026,9 +1002,9 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForDiscordTest)
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = Result.GetValue();
-    AuthorizeURLTokens Tokens;
 
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
+    AuthorizeURLTokens Tokens = ExtractTokensFromAuthorizeURL(AuthorizeURL);
+    ValidateThirdPartyAuthorizeURL(Tokens, RedirectURL);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForAppleTest)
@@ -1044,9 +1020,9 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForAppleTest)
     EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
 
     const auto& AuthorizeURL = Result.GetValue();
-    AuthorizeURLTokens Tokens;
 
-    ValidateThirdPartyAuthorizeURL(AuthorizeURL, RedirectURL, Tokens);
+    AuthorizeURLTokens Tokens = ExtractTokensFromAuthorizeURL(AuthorizeURL);
+    ValidateThirdPartyAuthorizeURL(Tokens, RedirectURL);
 }
 
 // As the following three tests require manual actions explained inside, they are currently disabled


### PR DESCRIPTION
We were missing the `Client` param for the `chs_user::LoginSocialRequest` object sent to `(AuthenticationAPI)->usersLogin_socialPost()`.

This has been added as well as a test that confirms that the `ELoginState` is valid after a failed login attempt.