### PR TITLE
[OB-3492] fix: Error early in QuotaSystem

### DIFF
--- a/Library/include/CSP/Systems/Quota/Quota.h
+++ b/Library/include/CSP/Systems/Quota/Quota.h
@@ -135,6 +135,9 @@ public:
     /// @return csp::common::Array<FeatureProgress> : const array of feature progress class
     const csp::common::Array<FeatureLimitInfo>& GetFeaturesLimitInfo() const;
 
+    CSP_NO_EXPORT FeaturesLimitResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
+        : csp::systems::ResultBase(ResCode, HttpResCode) { };
+
 private:
     FeaturesLimitResult(void*) {};
 
@@ -158,6 +161,9 @@ public:
     /// @returnFeatureProgress : const ref to feature progress class
     const FeatureLimitInfo& GetFeatureLimitInfo() const;
 
+     CSP_NO_EXPORT FeatureLimitResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
+        : csp::systems::ResultBase(ResCode, HttpResCode) { };
+
 private:
     FeatureLimitResult(void*) {};
 
@@ -180,6 +186,9 @@ public:
     /// @brief Retrieves the user tier result.
     /// @returnFeatureProgress : const ref to user tier information class
     const UserTierInfo& GetUserTierInfo() const;
+
+     CSP_NO_EXPORT UserTierResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
+        : csp::systems::ResultBase(ResCode, HttpResCode) { };
 
 private:
     UserTierResult(void*) {};

--- a/Library/include/CSP/Systems/Quota/QuotaSystem.h
+++ b/Library/include/CSP/Systems/Quota/QuotaSystem.h
@@ -19,6 +19,11 @@
 #include "CSP/Systems/Quota/Quota.h"
 #include "CSP/Systems/SystemBase.h"
 
+namespace csp::common
+{
+class IAuthContext;
+}
+
 namespace csp::services
 {
 
@@ -38,6 +43,7 @@ namespace csp::systems
 /// @ingroup Quota System
 /// @brief Public facing system that allows interfacing with Magnopus Connect Services' Quota Server.
 /// Offers methods for receiving Quota Queries.
+/// All functions in the quota system require the user to be logged in.
 class CSP_API CSP_NO_DISPOSE QuotaSystem : public SystemBase
 {
     CSP_START_IGNORE
@@ -98,11 +104,13 @@ public:
 
 private:
     QuotaSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
-    CSP_NO_EXPORT QuotaSystem(csp::web::WebClient* InWebClient, csp::common::LogSystem& LogSystem);
+    CSP_NO_EXPORT QuotaSystem(csp::web::WebClient* InWebClient, csp::common::LogSystem& LogSystem, const csp::common::IAuthContext& Context);
     ~QuotaSystem();
 
     csp::services::ApiBase* QuotaTierAssignmentAPI;
     csp::services::ApiBase* QuotaManagementAPI;
     csp::services::ApiBase* QuotaActivityAPI;
+
+    const csp::common::IAuthContext* Context;
 };
 } // namespace csp::systems

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -15,8 +15,9 @@
  */
 
 #include "CSP/Systems/Quota/QuotaSystem.h"
+#include "Systems/ResultHelpers.h"
 
-#include "CSP/Systems/Users/UserSystem.h"
+#include "CSP/Common/Interfaces/IAuthContext.h"
 #include "Services/TrackingService/Api.h"
 
 namespace chs = csp::services::generated::trackingservice;
@@ -28,11 +29,13 @@ QuotaSystem::QuotaSystem()
     , QuotaTierAssignmentAPI(nullptr)
     , QuotaManagementAPI(nullptr)
     , QuotaActivityAPI(nullptr)
+    , Context { nullptr }
 {
 }
 
-QuotaSystem::QuotaSystem(csp::web::WebClient* InWebClient, csp::common::LogSystem& LogSystem)
+QuotaSystem::QuotaSystem(csp::web::WebClient* InWebClient, csp::common::LogSystem& LogSystem, const csp::common::IAuthContext& Context)
     : SystemBase(InWebClient, nullptr, &LogSystem)
+    , Context { &Context }
 {
     QuotaManagementAPI = new chs::QuotaManagementApi(InWebClient);
     QuotaTierAssignmentAPI = new chs::QuotaTierAssignmentApi(InWebClient);
@@ -48,14 +51,20 @@ QuotaSystem::~QuotaSystem()
 
 void QuotaSystem::GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback)
 {
+    if (Context->GetLoginState().State != common::ELoginState::LoggedIn)
+    {
+        LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetTotalSpacesOwnedByUser: User is not logged in. Aborting operation.");
+        Callback(MakeInvalid<FeatureLimitResult>());
+        return;
+    }
+
     std::vector<csp::common::String> FeatureNamesList = { TierFeatureEnumToString(TierFeatures::SpaceOwner) };
 
     csp::services::ResponseHandlerPtr ResponseHandler = QuotaManagementAPI->CreateHandler<FeatureLimitCallback, FeatureLimitResult, void,
         csp::services::DtoArray<chs::QuotaFeatureLimitProgressDto>>(Callback, nullptr);
 
     static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)
-        ->usersUserIdQuota_progressGet(
-            { csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, FeatureNamesList }, ResponseHandler);
+        ->usersUserIdQuota_progressGet({ Context->GetLoginState().UserId, FeatureNamesList }, ResponseHandler);
 }
 
 void QuotaSystem::GetConcurrentUsersInSpace(const csp::common::String& SpaceId, FeatureLimitCallback Callback)
@@ -80,6 +89,13 @@ void QuotaSystem::GetTotalSpaceSizeInKilobytes(const csp::common::String& SpaceI
 
 void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFeatures>& FeatureNames, FeaturesLimitCallback Callback)
 {
+    if (Context->GetLoginState().State != common::ELoginState::LoggedIn)
+    {
+        LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetTierFeatureProgressForUser: User is not logged in. Aborting operation.");
+        Callback(MakeInvalid<FeaturesLimitResult>());
+        return;
+    }
+
     csp::services::ResponseHandlerPtr ResponseHandler = QuotaManagementAPI->CreateHandler<FeaturesLimitCallback, FeaturesLimitResult, void,
         csp::services::DtoArray<chs::QuotaFeatureLimitProgressDto>>(Callback, nullptr);
 
@@ -92,8 +108,7 @@ void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFea
     }
 
     static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)
-        ->usersUserIdQuota_progressGet(
-            { csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId, FeatureNamesList }, ResponseHandler);
+        ->usersUserIdQuota_progressGet({ Context->GetLoginState().UserId, FeatureNamesList }, ResponseHandler);
 }
 
 void QuotaSystem::GetTierFeatureProgressForSpace(
@@ -115,11 +130,18 @@ void QuotaSystem::GetTierFeatureProgressForSpace(
 
 void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
 {
+    if (Context->GetLoginState().State != common::ELoginState::LoggedIn)
+    {
+        LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetCurrentUserTier: User is not logged in. Aborting operation.");
+        Callback(MakeInvalid<UserTierResult>());
+        return;
+    }
+
     csp::services::ResponseHandlerPtr ResponseHandler
         = QuotaTierAssignmentAPI->CreateHandler<UserTierCallback, UserTierResult, void, chs::QuotaTierAssignmentDto>(Callback, nullptr);
 
     static_cast<chs::QuotaTierAssignmentApi*>(QuotaTierAssignmentAPI)
-        ->usersUserIdTier_assignmentGet({ csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState().UserId }, ResponseHandler);
+        ->usersUserIdTier_assignmentGet({ Context->GetLoginState().UserId }, ResponseHandler);
 }
 
 void QuotaSystem::SetUserTier(TierNames TierName, const csp::common::String& UserId, UserTierCallback Callback)

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -212,7 +212,7 @@ void SystemsManager::CreateSystems(csp::multiplayer::ISignalRConnection* SignalR
     MaintenanceSystem = new csp::systems::MaintenanceSystem(WebClient, *LogSystem);
     EventTicketingSystem = new csp::systems::EventTicketingSystem(WebClient, *LogSystem);
     ECommerceSystem = new csp::systems::ECommerceSystem(WebClient, *LogSystem);
-    QuotaSystem = new csp::systems::QuotaSystem(WebClient, *LogSystem);
+    QuotaSystem = new csp::systems::QuotaSystem(WebClient, *LogSystem, UserSystem->GetAuthContext());
     SequenceSystem = new csp::systems::SequenceSystem(WebClient, MultiplayerConnection->GetEventBus(), *LogSystem);
     HotspotSequenceSystem = new csp::systems::HotspotSequenceSystem(SequenceSystem, SpaceSystem, MultiplayerConnection->GetEventBus(), *LogSystem);
     ConversationSystem

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -523,3 +523,30 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTotalSpaceSizeinKilobytes)
     // Delete space
     DeleteSpace(SpaceSystem, Space.Id);
 }
+
+CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, FailWhenNotLoggedInTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto QuotaSystem = SystemsManager.GetQuotaSystem();
+
+    {
+        auto [Result] = AWAIT_PRE(QuotaSystem, GetTotalSpacesOwnedByUser, RequestPredicate);
+
+        EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+        EXPECT_EQ(Result.GetHttpResultCode(), 0);
+    }
+
+    {
+        auto [Result] = AWAIT_PRE(QuotaSystem, GetTierFeatureProgressForUser, RequestPredicate, {});
+
+        EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+        EXPECT_EQ(Result.GetHttpResultCode(), 0);
+    }
+
+    {
+        auto [Result] = AWAIT_PRE(QuotaSystem, GetCurrentUserTier, RequestPredicate);
+
+        EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+        EXPECT_EQ(Result.GetHttpResultCode(), 0);
+    }
+}


### PR DESCRIPTION
This now returns early in the QuotaSystem functions that require the UserId if the user is not logged in. We also injected IAuthContext into the QuotaSystem instead of directly accessing the UserSystem on the SystemsManager singleton