### PR TITLE
[NT-0] build: Cmake conveniences for downstream integrators.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,11 @@ target_compile_definitions(csp-lib
 
 # Warnings as errors flag
 # Sets WX/Werror
-set_target_properties(csp-lib PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+set_target_properties(csp-lib PROPERTIES
+  COMPILE_WARNING_AS_ERROR ON
+  OUTPUT_NAME ConnectedSpacesPlatform
+  DEBUG_POSTFIX _D
+)
 
 target_compile_options(csp-lib
   PRIVATE
@@ -193,6 +197,7 @@ target_compile_options(csp-lib
 
     # Set warning level and exceptions for msvc
     $<$<CXX_COMPILER_ID:MSVC>:
+      /EHsc     # C++ exception handling (not added by default with Ninja generator)
       /W4       # Sets warning level 4 (high)
       /utf-8    # fmt asked us for this, seems like we need to explicitly opt into unicode on windows
       /wd4251   # Allow stl members to be exported
@@ -257,6 +262,7 @@ configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CSPConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/CSPConfig.cmake
   INSTALL_DESTINATION ${CSP_CONFIG_INSTALL_DIR}
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR
 )
 
 write_basic_package_version_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ include(FetchContent)
 FetchContent_Declare(
   csp-services
   GIT_REPOSITORY https://github.com/magnopus-opensource/csp-services.git
-  GIT_TAG        v2.0-d20260311.r94e4b446b.Release
+  GIT_TAG        v2.0-d20260421.r0e1d359b9.Release
   GIT_SHALLOW    TRUE
   GIT_PROGRESS   TRUE
 )

--- a/cmake/CSPConfig.cmake.in
+++ b/cmake/CSPConfig.cmake.in
@@ -1,16 +1,36 @@
 @PACKAGE_INIT@
 
+set_and_check(CSP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+# Captured at the time CSP was configured. configure_package_config_file()
+# substitutes @CSP_BUILD_SHARED@ with the literal ON/OFF value, so the
+# installed CSPConfig.cmake records how this CSP was built and consumers
+# don't have to know.
+set(CSP_BUILT_SHARED @CSP_BUILD_SHARED@)
+
 include(CMakeFindDependencyMacro)
 
+# Public-API dependencies: appear in installed headers
+# (CSPAsyncScheduler.h, fmt_Formatters.h, ReplicatedValueException.h).
+# Required regardless of whether CSP was built shared or static.
+# We should endevour to remove these as neccesary dependencies.
 find_dependency(fmt)
 find_dependency(RapidJSON)
 find_dependency(Async++)
-find_dependency(tinyspline)
-find_dependency(glm)
-find_dependency(msgpack-cxx)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-  find_dependency(Poco)
+# Private link-only dependencies. Currently, for a STATIC CSP, 
+# all dependencies are required to be resolved.
+# For a SHARED CSP, these deps are baked into the DLL and do NOT appear on
+# the exported target's link interface, so consumers never reference them.
+# We should endevour to bake these into static libs so we can remove these from here.
+if(NOT CSP_BUILT_SHARED)
+  find_dependency(tinyspline)
+  find_dependency(glm)
+  find_dependency(msgpack-cxx)
+
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    find_dependency(Poco)
+  endif()
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/CSPTargets.cmake")

--- a/cmake/multiplayer_files.cmake
+++ b/cmake/multiplayer_files.cmake
@@ -45,6 +45,7 @@ set(CSP_MULTIPLAYER_PUBLIC_INCLUDES
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/Components/TextSpaceComponent.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/Components/VideoPlayerSpaceComponent.h
 
+    ${CSP_MULTIPLAYER_INCLUDE_DIR}/Components/Interfaces/IAudioControlComponent.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/Components/Interfaces/IEnableableComponent.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/Components/Interfaces/IExternalResourceComponent.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/Components/Interfaces/IPositionComponent.h

--- a/profiles/host/emscripten
+++ b/profiles/host/emscripten
@@ -10,7 +10,6 @@ os=Emscripten
 [tool_requires]
 ninja/1.11.1
 emsdk/3.1.50
-*: cmake/3.31.6
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja

--- a/profiles/host/osx_arm
+++ b/profiles/host/osx_arm
@@ -6,5 +6,3 @@ compiler.libcxx=libc++
 compiler.version=17
 os=Macos
 
-[tool_requires]
-*: cmake/3.31.6

--- a/profiles/host/windows_msvc
+++ b/profiles/host/windows_msvc
@@ -12,5 +12,3 @@ os=Windows
 # We have to set poco to build as static here
 poco/*:shared=False
 
-[tool_requires]
-*: cmake/3.31.6

--- a/profiles/host/windows_ninja
+++ b/profiles/host/windows_ninja
@@ -1,0 +1,17 @@
+[settings]
+arch=x86_64
+compiler=msvc
+compiler.cppstd=17
+compiler.runtime=dynamic
+compiler.version=194
+os=Windows
+
+[options]
+# We have to set poco to build as static here
+poco/*:shared=False
+
+[tool_requires]
+ninja/1.11.1
+
+[conf]
+tools.cmake.cmaketoolchain:generator=Ninja


### PR DESCRIPTION
Pulled these changes out of the unity backwards integration branch, as they're somewhat different from the bulk of that change. They were all sourced from desires and necessities found integrating the new build system into the unity swig bindings.

Mostly convenience updates based on using the cmake build system and discovering some quirks. Makes downstream integration less burdensome.