### PR TITLE
[NT-0] build: Emscripten profiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,8 +216,6 @@ target_compile_options(csp-lib
 	    -Wno-missing-field-initializers
 	    # Don't error on ignored qualifiers, such as returning const objects. These should be simple to remove at some point.
 	    -Wno-ignored-qualifiers
-        # Real big deal, REAL BUG in our custom list types, memcopying virtual objects :(
-        -Wno-nontrivial-memcall
     >
 
     $<$<CXX_COMPILER_ID:GNU>:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ target_compile_options(csp-lib
 	    -Wno-missing-field-initializers
 	    # Don't error on ignored qualifiers, such as returning const objects. These should be simple to remove at some point.
 	    -Wno-ignored-qualifiers
+        # Real big deal, REAL BUG in our custom list types, memcopying virtual objects :(
+        -Wno-nontrivial-memcall
     >
 
     $<$<CXX_COMPILER_ID:GNU>:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,51 +3,74 @@
   "include": ["./ConanPresets.json"],
   "configurePresets": [
     {
-      "name": "default-static",
-      "displayName": "multi config static",
+      "name": "multi-static",
+      "displayName": "multi-config static (with tests)",
       "inherits": "conan-default",
       "cacheVariables": {
-        "CSP_BUILD_SHARED": "OFF"
+        "CSP_BUILD_SHARED": "OFF",
+        "BUILD_TESTING": "ON"
       }
     },
     {
-      "name": "default-shared",
-      "displayName": "multi config shared",
+      "name": "multi-shared",
+      "displayName": "multi-config shared",
       "inherits": "conan-default",
       "cacheVariables": {
         "CSP_BUILD_SHARED": "ON",
         "BUILD_TESTING": "OFF"
       }
     },
-    {
-      "name": "release-static",
-      "displayName": "release single config static",
-      "inherits": "conan-release",
-      "cacheVariables": {
-        "CSP_BUILD_SHARED": "OFF"
-      }
-    },
-    {
-      "name": "release-shared",
-      "displayName": "release single config shared",
-      "inherits": "conan-release",
-      "cacheVariables": {
-        "CSP_BUILD_SHARED": "ON",
-        "BUILD_TESTING": "OFF"
-      }
-    },
+
     {
       "name": "debug-static",
-      "displayName": "debug single config static",
+      "displayName": "single-config debug static",
       "inherits": "conan-debug",
       "cacheVariables": {
-        "CSP_BUILD_SHARED": "OFF"
+        "CSP_BUILD_SHARED": "OFF",
+        "BUILD_TESTING": "OFF"
+      }
+    },
+    {
+      "name": "debug-static-tests",
+      "displayName": "single-config debug static (with tests)",
+      "inherits": "conan-debug",
+      "cacheVariables": {
+        "CSP_BUILD_SHARED": "OFF",
+        "BUILD_TESTING": "ON"
       }
     },
     {
       "name": "debug-shared",
-      "displayName": "debug single config shared",
+      "displayName": "single-config debug shared",
       "inherits": "conan-debug",
+      "cacheVariables": {
+        "CSP_BUILD_SHARED": "ON",
+        "BUILD_TESTING": "OFF"
+      }
+    },
+
+    {
+      "name": "release-static",
+      "displayName": "single-config release static",
+      "inherits": "conan-release",
+      "cacheVariables": {
+        "CSP_BUILD_SHARED": "OFF",
+        "BUILD_TESTING": "OFF"
+      }
+    },
+    {
+      "name": "release-static-tests",
+      "displayName": "single-config release static (with tests)",
+      "inherits": "conan-release",
+      "cacheVariables": {
+        "CSP_BUILD_SHARED": "OFF",
+        "BUILD_TESTING": "ON"
+      }
+    },
+    {
+      "name": "release-shared",
+      "displayName": "single-config release shared",
+      "inherits": "conan-release",
       "cacheVariables": {
         "CSP_BUILD_SHARED": "ON",
         "BUILD_TESTING": "OFF"
@@ -56,33 +79,23 @@
   ],
   "buildPresets": [
     {
-      "name": "multi-release-static",
-      "configurePreset": "default-static",
-      "configuration": "Release"
-    },
-    {
       "name": "multi-debug-static",
-      "configurePreset": "default-static",
+      "configurePreset": "multi-static",
       "configuration": "Debug"
     },
     {
-      "name": "multi-release-shared",
-      "configurePreset": "default-shared",
+      "name": "multi-release-static",
+      "configurePreset": "multi-static",
       "configuration": "Release"
     },
     {
       "name": "multi-debug-shared",
-      "configurePreset": "default-shared",
+      "configurePreset": "multi-shared",
       "configuration": "Debug"
     },
     {
-      "name": "release-static",
-      "configurePreset": "release-static",
-      "configuration": "Release"
-    },
-    {
-      "name": "release-shared",
-      "configurePreset": "release-shared",
+      "name": "multi-release-shared",
+      "configurePreset": "multi-shared",
       "configuration": "Release"
     },
     {
@@ -91,9 +104,29 @@
       "configuration": "Debug"
     },
     {
+      "name": "debug-static-tests",
+      "configurePreset": "debug-static-tests",
+      "configuration": "Debug"
+    },
+    {
       "name": "debug-shared",
       "configurePreset": "debug-shared",
       "configuration": "Debug"
+    },
+    {
+      "name": "release-static",
+      "configurePreset": "release-static",
+      "configuration": "Release"
+    },
+    {
+      "name": "release-static-tests",
+      "configurePreset": "release-static-tests",
+      "configuration": "Release"
+    },
+    {
+      "name": "release-shared",
+      "configurePreset": "release-shared",
+      "configuration": "Release"
     }
   ]
 }

--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -276,7 +276,15 @@ public:
         }
 
         auto After = CurrentSize - Index;
+// This is a real problem, don't ignore this, it needs fixed. (Or this entire type needs deleted)
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"
+#endif
         std::memmove(ObjectArray + (Index + 1), ObjectArray + Index, sizeof(T) * After);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
         ++CurrentSize;
 
         T* ObjectPtr = &ObjectArray[Index];

--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -279,6 +279,7 @@ public:
 // This is a real problem, don't ignore this, it needs fixed. (Or this entire type needs deleted)
 #if defined(__clang__)
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wnontrivial-memcall"
 #endif
         std::memmove(ObjectArray + (Index + 1), ObjectArray + Index, sizeof(T) * After);

--- a/Library/src/Common/Variant.cpp
+++ b/Library/src/Common/Variant.cpp
@@ -253,7 +253,15 @@ Vector4 Variant::GetVector4() const
 
 size_t Variant::GetSizeOfInternalValue() { return sizeof(InternalValue); }
 
+// This is a real problem, don't ignore this, it needs fixed. (Or this entire type needs deleted)
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"
+#endif
 Variant::InternalValue::InternalValue() { memset(this, 0x0, sizeof(InternalValue)); }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 Variant::InternalValue::~InternalValue() { }
 

--- a/Library/src/Common/Variant.cpp
+++ b/Library/src/Common/Variant.cpp
@@ -256,6 +256,7 @@ size_t Variant::GetSizeOfInternalValue() { return sizeof(InternalValue); }
 // This is a real problem, don't ignore this, it needs fixed. (Or this entire type needs deleted)
 #if defined(__clang__)
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wnontrivial-memcall"
 #endif
 Variant::InternalValue::InternalValue() { memset(this, 0x0, sizeof(InternalValue)); }

--- a/profiles/host/emscripten
+++ b/profiles/host/emscripten
@@ -22,11 +22,3 @@ tools.build:cxxflags=["-pthread","-fwasm-exceptions"]
 tools.build:cflags=["-pthread","-fwasm-exceptions"]
 tools.build:exelinkflags=["-pthread"]
 tools.build:compiler_executables={'c':'{{ emsdk }}/upstream/emscripten/emcc{{ ext }}', 'cpp':'{{ emsdk }}/upstream/emscripten/em++{{ ext }}'}
-
-[buildenv]
-CC=emcc
-CXX=em++
-AR=emar
-NM=emnm
-RANLIB=emranlib
-STRIP=emstrip

--- a/profiles/host/emscripten
+++ b/profiles/host/emscripten
@@ -1,18 +1,32 @@
+# Use templating to get the EMSDK location and use it for compiler_executables.
+# We need to run a .bat on windows, but there should be no extension needed on unix (shebangs)
+# The EMSDK environment variable is set when you activate an emscripten install, or source the emsdk_env scripts.
+{% set emsdk = os.getenv("EMSDK") %}
+{% set ext = ".bat" if platform.system() == "Windows" else "" %}
+
 [settings]
 arch=wasm
 build_type=Release
 compiler=emcc
 compiler.cppstd=17
 compiler.libcxx=libc++
-compiler.version=3.1.50
+compiler.version=5.0.2
 os=Emscripten
 
 [tool_requires]
 ninja/1.11.1
-emsdk/3.1.50
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 tools.build:cxxflags=["-pthread","-fwasm-exceptions"]
 tools.build:cflags=["-pthread","-fwasm-exceptions"]
 tools.build:exelinkflags=["-pthread"]
+tools.build:compiler_executables={'c':'{{ emsdk }}/upstream/emscripten/emcc{{ ext }}', 'cpp':'{{ emsdk }}/upstream/emscripten/em++{{ ext }}'}
+
+[buildenv]
+CC=emcc
+CXX=em++
+AR=emar
+NM=emnm
+RANLIB=emranlib
+STRIP=emstrip


### PR DESCRIPTION
Enablement for the building of the WASM bindings project. 

This is about being able to build a static .a file, devoid of tests, with an emscripten host. You still use a windows (or whatever platform you're on) build profile. This is genuine cross-compilation, I hadn't really been thinking of it that way before.

You'll note this isn't really about producing WASM, this is about producing a library cross compiled to the WASM runtime, using the emscripten compilers. WASM + JS will be produced in the bindings repo by consuming these symbols. Seems a bit overcomplex, but separates the build configuration of that project (as well as the declarations of the bindings), which is something Magnopus needs to break the inter-team responsibility shrugging that's been going on.

The mental model to have (and the way you have to configure cmake supports this), is that `.a` is library, whilst `.wasm/.js` is equivalent to an executable. It is when you link into the executable that you decide things like initial/maximum memory, whether this is also a node build, are we going to include the web filesystem api, etc. Not things that CSP as a library needs to have an opinion on.

I have taken the opportunity to reframe the presets around a consistent axis.

Not in a CI harness yet, tested locally as usual. Getting antsy about this ... I want my CI harnesses, they make me feel better.

> [!NOTE]
>
> To be honest, i'm not sure the single-config build presets are pulling their weight. It's the difference between typing `cmake --build --preset debug-static` or `cmake --build build\Debug`. I might argue that if we are to do presets like this, we should also add install presets so then you can mindlessly type `--preset` into every step using the same name, which _is_ the most caveman thing to do, but it also adds a _bunch_ of duplication to the presets file for not much actual gain. Minor issue, can talk about it in weekly sync.