### PR TITLE
[OB-5368] fix: Resolve login crash caused by race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file. For compile
   scripting system automatically where possible. This moves a large portion of CSP's own components
   over to this pattern, with only a handful still being registered manually due to some remaining
   edge cases.
+  
+### 🐛 🔨 Bug Fixes
+
+- [OB-5368] fix: Resolve login crash caused by race conditions by @MAG-AdamThorn
+  One of the client teams was hitting an exception when trying to logout of a complex Space before it had finished loading before immediately logging back in. This resulted in a number of issues initially related to race conditions caused by multiple threads trying to access the LoginState object being passed to the Login, Logout and Refresh ResponseHandlers. This issue has been resolved as well as a use-after-free race condition that could occur if the MultiplayerRealtimeEngine was destroyed while either OnElectedScopeLeader or OnVacatedScopeLeader callbacks were in-flight. 
 
 ## [6.36.0]
 

--- a/Library/include/CSP/Common/LoginState.h
+++ b/Library/include/CSP/Common/LoginState.h
@@ -27,6 +27,8 @@ namespace csp::common
 class DateTime;
 
 /// @brief Data structure representing the user login state, including detection of access token expiry
+/// @inv All writes to the LoginState happen under a mutex lock. Both LoginState and the mutex are owned by the UserSystem, and any access
+/// to the LoginState object happens while the lock on the mutex is in place.
 class CSP_API LoginState
 {
 public:

--- a/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
+++ b/Library/include/CSP/Multiplayer/MultiPlayerConnection.h
@@ -27,6 +27,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <tuple>
 #include <vector>
 
@@ -285,6 +286,11 @@ private:
         so the OnlineRealtimeEngine can receieve events agnostically from the MultiplayerConnection (Similar to what we did with the event bus).
     */
     OnlineRealtimeEngine* MultiplayerRealtimeEngine = nullptr;
+    // Set when the MultiplayerRealtimeEngine is set. Mutex guards against use-after-free race condition that can occur if the
+    // MultiplayerRealtimeEngine is destroyed while either OnElectedScopeLeader or OnVacatedScopeLeader callbacks are in-flight.
+    // Locking the weak_ptr atomically confirms the engine is still alive, and holding the mutex ensures it cannot be destroyed 
+    // while we're inside the OnElectedScopeLeader or OnVacatedScopeLeader callbacks.
+    std::weak_ptr<std::mutex> LeaderElectionGuardWeak;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -387,6 +387,10 @@ public:
     // We should remove this in OF-1785
     CSP_NO_EXPORT void SetServerSideElectionEnabled(bool Value);
 
+    // Mutex will be used in the MultiplayerConnection to guard against a use-after-free race condition that can occur in the ON_ELECTED_SCOPE_LEADER
+    // or ON_VACATED_AS_SCOPE_LEADER SignalR callbacks if the MultiplayerRealtimeEngine is freed by another thread while the callback is in-flight.
+    CSP_NO_EXPORT std::shared_ptr<std::mutex> GetLeaderElectionGuard() const { return LeaderElectionGuard; }
+
     /*
      * Called when MultiplayerConnection recieved signalR events.
      */
@@ -505,6 +509,10 @@ private:
     // Guards against a race condition whereby the OnlineRealtimeEngine dtor is called after the SignalR thread executing the
     // CreateRetrieveAllEntitiesCallback callback has checked the cancellation token, but BEFORE it has finished executing the callback.
     std::shared_ptr<std::mutex> EntityFetchBodyGuard;
+    // Mutex guards against use-after-free race condition that can occur in the ON_ELECTED_SCOPE_LEADER / ON_VACATED_AS_SCOPE_LEADER SignalR callbacks
+    // in the MultiplayerConnection. The SignalR thread may read MultiplayerRealtimeEngine as non-null only for the engine to be freed by another
+    // thread. The destructor waits to acquire this mutex (blocking until any in-flight callbacks finish) before proceeding with teardown.
+    std::shared_ptr<std::mutex> LeaderElectionGuard;
 
     std::deque<csp::multiplayer::SpaceEntity*>* PendingAdds;
     std::deque<csp::multiplayer::SpaceEntity*>* PendingRemoves;

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -499,6 +499,13 @@ private:
     std::recursive_mutex* TickEntitiesLock;
     std::mutex LeadershipElectionLock;
 
+    // Represents the lifetime of the OnlineRealtimeEngine. Used to ensure the CreateRetrieveAllEntitiesCallback callback is not executed
+    // after engine is destroyed.
+    std::shared_ptr<std::atomic<bool>> EntityFetchCancellationToken;
+    // Guards against a race condition whereby the OnlineRealtimeEngine dtor is called after the SignalR thread executing the
+    // CreateRetrieveAllEntitiesCallback callback has checked the cancellation token, but BEFORE it has finished executing the callback.
+    std::shared_ptr<std::mutex> EntityFetchBodyGuard;
+
     std::deque<csp::multiplayer::SpaceEntity*>* PendingAdds;
     std::deque<csp::multiplayer::SpaceEntity*>* PendingRemoves;
     std::set<csp::multiplayer::SpaceEntity*>* PendingOutgoingUpdateUniqueSet;

--- a/Library/include/CSP/Systems/Users/Authentication.h
+++ b/Library/include/CSP/Systems/Users/Authentication.h
@@ -21,6 +21,11 @@
 #include "CSP/Common/String.h"
 #include "CSP/Systems/SystemsResult.h"
 
+CSP_START_IGNORE
+#include <memory>
+#include <mutex>
+CSP_END_IGNORE
+
 namespace csp::common
 {
 
@@ -42,6 +47,9 @@ namespace csp::systems
 
 class UserSystem;
 class LoginStateResult;
+CSP_START_IGNORE
+struct LoginStateLockable;
+CSP_END_IGNORE
 
 /// @brief Data for access and refresh tokens, and their expiry times.
 class CSP_API LoginTokenInfo
@@ -67,15 +75,18 @@ public:
     [[nodiscard]] const csp::common::LoginState& GetLoginState() const;
     CSP_NO_EXPORT LoginStateResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
         : csp::systems::ResultBase(ResCode, HttpResCode)
-        , State(nullptr) {};
+        , State(nullptr) {}
 
 private:
     LoginStateResult();
-    LoginStateResult(csp::common::LoginState* InStatePtr);
+    CSP_START_IGNORE
+    LoginStateResult(LoginStateLockable* LoginStateLock);
+    CSP_END_IGNORE
 
     CSP_NO_EXPORT void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 
-    csp::common::LoginState* State;
+    std::shared_ptr<csp::common::LoginState> State;
+    std::shared_ptr<std::mutex> StateMutex;
 };
 
 /// @ingroup User System

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -29,6 +29,10 @@
 #include "CSP/Systems/Users/Profile.h"
 #include "CSP/Systems/Users/ThirdPartyAuthentication.h"
 
+CSP_START_IGNORE
+#include <memory>
+CSP_END_IGNORE
+
 namespace csp::web
 {
 
@@ -49,7 +53,7 @@ CSP_START_IGNORE
 class AuthContext : public csp::common::IAuthContext
 {
 public:
-    AuthContext(csp::services::ApiBase* AuthenticationAPI, csp::common::LoginState& LoginState);
+    AuthContext(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp::common::LoginState> LoginState, std::shared_ptr<std::mutex> Mutex);
 
     const csp::common::LoginState& GetLoginState() const override;
 
@@ -59,7 +63,8 @@ public:
 
 private:
     csp::services::ApiBase* AuthenticationAPI;
-    csp::common::LoginState* LoginState;
+    std::shared_ptr<csp::common::LoginState> LoginState;
+    std::shared_ptr<std::mutex> LoginStateMutex;
 };
 CSP_END_IGNORE
 
@@ -323,7 +328,12 @@ private:
     csp::services::ApiBase* PingAPI;
     csp::services::ApiBase* StripeAPI;
 
-    csp::common::LoginState CurrentLoginState;
+    // Both LoginStateResult and LogoutResult OnResponse methods write directly to CurrentLoginState, while AuthContext::RefreshToken() reads from it.
+    // A mutex is required to ensure synchronisation between these operations and avoid race conditions.
+    // All writes to the LoginState happen under LoginStateMutex lock.
+    // shared_ptr ownership ensures the LoginState and mutex outlive any in-flight response handlers that hold copies.
+    std::shared_ptr<csp::common::LoginState> CurrentLoginState;
+    std::shared_ptr<std::mutex> LoginStateMutex;
 
     LoginTokenInfoResultCallback RefreshTokenChangedCallback;
 

--- a/Library/src/Multiplayer/MultiplayerConnection.cpp
+++ b/Library/src/Multiplayer/MultiplayerConnection.cpp
@@ -176,6 +176,13 @@ MultiplayerConnection::~MultiplayerConnection()
 void MultiplayerConnection::SetOnlineRealtimeEngine(csp::multiplayer::OnlineRealtimeEngine* OnlineRealtimeEngine)
 {
     MultiplayerRealtimeEngine = OnlineRealtimeEngine;
+
+    // Mutex guards against use-after-free race condition that can occur if the MultiplayerRealtimeEngine is destroyed while either
+    // OnElectedScopeLeader or OnVacatedScopeLeader callbacks are in-flight.
+    if (OnlineRealtimeEngine)
+        LeaderElectionGuardWeak = OnlineRealtimeEngine->GetLeaderElectionGuard();
+    else
+        LeaderElectionGuardWeak.reset();
 }
 
 csp::multiplayer::OnlineRealtimeEngine* MultiplayerConnection::GetOnlineRealtimeEngine() const { return MultiplayerRealtimeEngine; }
@@ -632,6 +639,17 @@ void MultiplayerConnection::BindOnElectedScopeLeaderCallback()
         GetMultiplayerHubMethods().Get(MultiplayerHubMethod::ON_ELECTED_SCOPE_LEADER),
         [this](signalr::value Params)
         {
+            // Mutex guards against use-after-free race condition that can occur if the MultiplayerRealtimeEngine is destroyed while this callback is
+            // in-flight. Locking the weak_ptr atomically confirms the engine is still alive, and holding the mutex ensures it cannot be destroyed
+            // while we're inside the callback body.
+            auto Guard = LeaderElectionGuardWeak.lock();
+            if (!Guard)
+            {
+                LogSystem.LogMsg(
+                    common::LogLevel::Verbose, "Received OnElectedScopeLeader without an alive EntitySystem. This is expected if leaving a space.");
+                return;
+            }
+            std::scoped_lock BodyLock(*Guard);
             if (MultiplayerRealtimeEngine != nullptr)
             {
                 MultiplayerRealtimeEngine->OnElectedScopeLeader(Params);
@@ -651,6 +669,17 @@ void MultiplayerConnection::BindOnVacatedScopeLeaderCallback()
         GetMultiplayerHubMethods().Get(MultiplayerHubMethod::ON_VACATED_AS_SCOPE_LEADER),
         [this](signalr::value Params)
         {
+            // Mutex guards against use-after-free race condition that can occur if the MultiplayerRealtimeEngine is destroyed while this callback is
+            // in-flight. Locking the weak_ptr atomically confirms the engine is still alive, and holding the mutex ensures it cannot be destroyed
+            // while we're inside the callback body.
+            auto Guard = LeaderElectionGuardWeak.lock();
+            if (!Guard)
+            {
+                LogSystem.LogMsg(
+                    common::LogLevel::Verbose, "Received OnVacatedScopeLeader without an alive EntitySystem. This is expected if leaving a space.");
+                return;
+            }
+            std::scoped_lock BodyLock(*Guard);
             if (MultiplayerRealtimeEngine != nullptr)
             {
                 MultiplayerRealtimeEngine->OnVacatedAsScopeLeader(Params);

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -169,6 +169,8 @@ OnlineRealtimeEngine::OnlineRealtimeEngine()
     , EventHandler(nullptr)
     , ElectionManager(nullptr)
     , TickEntitiesLock(new std::recursive_mutex)
+    , EntityFetchCancellationToken(std::make_shared<std::atomic<bool>>(false))
+    , EntityFetchBodyGuard(std::make_shared<std::mutex>())
     , PendingAdds(nullptr)
     , PendingRemoves(nullptr)
     , PendingOutgoingUpdateUniqueSet(nullptr)
@@ -196,6 +198,8 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
     , EventHandler(new SpaceEntityEventHandler(this))
     , ElectionManager(nullptr)
     , TickEntitiesLock(new std::recursive_mutex)
+    , EntityFetchCancellationToken(std::make_shared<std::atomic<bool>>(false))
+    , EntityFetchBodyGuard(std::make_shared<std::mutex>())
     , PendingAdds(new(std::deque<csp::multiplayer::SpaceEntity*>))
     , PendingRemoves(new(std::deque<csp::multiplayer::SpaceEntity*>))
     , PendingOutgoingUpdateUniqueSet(new(std::set<csp::multiplayer::SpaceEntity*>))
@@ -214,6 +218,14 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
 
 OnlineRealtimeEngine::~OnlineRealtimeEngine()
 {
+    EntityFetchCancellationToken->store(true);
+    {
+        // This attempts to acquire the guard mutex. If the CreateRetrieveAllEntitiesCallback callback body is currently executing (the cancellation
+        // token was valid), it holds this mutex. If so the destructor blocks here until that callback finishes and then releases it. Once the
+        // destructor acquires the lock, it immediately releases it and continues.
+        std::scoped_lock lock(*EntityFetchBodyGuard);
+    }
+
     DisableLeaderElection();
     LocalDestroyAllEntities();
 
@@ -716,9 +728,24 @@ void OnlineRealtimeEngine::GetEntitiesPaged(int Skip, int Limit, const std::func
 std::function<void(const signalr::value&, std::exception_ptr)> OnlineRealtimeEngine::CreateRetrieveAllEntitiesCallback(
     int Skip, csp::common::EntityFetchCompleteCallback FetchCompleteCallback)
 {
-    const std::function Callback = [this, Skip, FetchCompleteCallback](const signalr::value& Result, std::exception_ptr Except)
+    const std::function Callback = [this, Skip, FetchCompleteCallback, Cancelled = EntityFetchCancellationToken, Guard = EntityFetchBodyGuard](
+                                       const signalr::value& Result, std::exception_ptr Except)
     {
+        // Check if the OnlineRealtimeEngine has been destroyed while we were waiting for the paged entities to come back. This can happen for example
+        // if the user has entered a large Space with many entities and exits the Space (destroying the OnlineRealtimeEngine) before processing is
+        // completed. The guard is used to stop a race condition whereby the OnlineRealtimeEngine dtor is called after the SignalR thread executing
+        // this callback has checked the cancellation token, but BEFORE it has finished executing the callback.
+        std::scoped_lock lock(*Guard);
+        if (Cancelled->load())
+        {
+            return;
+        }
+
         HandleException(Except, "Failed to retrieve paged entities.");
+        if (Except)
+        {
+            return;
+        }
 
         const auto& Results = Result.as_array();
         const auto& Items = Results[0].as_array();
@@ -798,6 +825,9 @@ std::function<void(const signalr::value&, std::exception_ptr)> OnlineRealtimeEng
 void OnlineRealtimeEngine::FetchAllEntitiesAndPopulateBuffers(
     const csp::common::String&, csp::common::EntityFetchStartedCallback FetchStartedCallback)
 {
+    // Reset the cancellation token in case this function is called multiple times during the lifespan of the OnlineRealtimeEngine (eg multiple Space
+    // entries)
+    EntityFetchCancellationToken->store(false);
     this->RetrieveAllEntities(EntityFetchCompleteCallback);
     FetchStartedCallback();
 }

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -171,6 +171,7 @@ OnlineRealtimeEngine::OnlineRealtimeEngine()
     , TickEntitiesLock(new std::recursive_mutex)
     , EntityFetchCancellationToken(std::make_shared<std::atomic<bool>>(false))
     , EntityFetchBodyGuard(std::make_shared<std::mutex>())
+    , LeaderElectionGuard(std::make_shared<std::mutex>())
     , PendingAdds(nullptr)
     , PendingRemoves(nullptr)
     , PendingOutgoingUpdateUniqueSet(nullptr)
@@ -200,6 +201,7 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
     , TickEntitiesLock(new std::recursive_mutex)
     , EntityFetchCancellationToken(std::make_shared<std::atomic<bool>>(false))
     , EntityFetchBodyGuard(std::make_shared<std::mutex>())
+    , LeaderElectionGuard(std::make_shared<std::mutex>())
     , PendingAdds(new(std::deque<csp::multiplayer::SpaceEntity*>))
     , PendingRemoves(new(std::deque<csp::multiplayer::SpaceEntity*>))
     , PendingOutgoingUpdateUniqueSet(new(std::set<csp::multiplayer::SpaceEntity*>))
@@ -224,6 +226,12 @@ OnlineRealtimeEngine::~OnlineRealtimeEngine()
         // token was valid), it holds this mutex. If so the destructor blocks here until that callback finishes and then releases it. Once the
         // destructor acquires the lock, it immediately releases it and continues.
         std::scoped_lock lock(*EntityFetchBodyGuard);
+    }
+
+    {
+        // Wait for any in-flight MultiplayerConnection ON_ELECTED_SCOPE_LEADER / ON_VACATED_AS_SCOPE_LEADER callbacks to finish before tearing down.
+        // Without this the callback may be in flight on a SignalR thread when the engine is destroyed producing a use-after-free race condition.
+        std::scoped_lock leaderLock(*LeaderElectionGuard);
     }
 
     DisableLeaderElection();
@@ -317,8 +325,8 @@ std::function<void(uint64_t)> OnlineRealtimeEngine::CreateNewLocalAvatar(const c
          * Note also however, that we don't double fetch the network ID, which is the main cost of constructing these things anyhow.
          * (Stricter interface segregation for our serializers would also have solved this problem, but only in the local sense)
          */
-        auto NewAvatar = RealtimeEngineUtils::BuildNewAvatar(UserId, *this, *ScriptRunner, *LogSystem, NetworkId, Name,
-            Transform, IsVisible, MultiplayerConnectionInst->GetClientId(), false, false, AvatarId, AvatarState, AvatarPlayMode, LocomotionModel);
+        auto NewAvatar = RealtimeEngineUtils::BuildNewAvatar(UserId, *this, *ScriptRunner, *LogSystem, NetworkId, Name, Transform, IsVisible,
+            MultiplayerConnectionInst->GetClientId(), false, false, AvatarId, AvatarState, AvatarPlayMode, LocomotionModel);
 
         std::scoped_lock EntitiesLocker(*EntitiesLock);
         // Release to vague ownership. True ownership is blurry here. It could be shared between both Entities and Objects, or just owned by
@@ -666,9 +674,13 @@ void OnlineRealtimeEngine::OnRequestToSendObject(const signalr::value& Params)
 
 void OnlineRealtimeEngine::OnElectedScopeLeader(const signalr::value& Params)
 {
-    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by calling
-    // DisableLeadershipElection. These checks could be removed if the election events were bound inside the ScopeLeadershipManager. However, I
-    // decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
+    // LeadershipElectionLock must be held while using LeaderElectionManager to prevent a use-after-free race condition caused by the
+    // OnlineRealtimeEngine being destroyed and resetting the LeaderElectionManager via a call to DisableLeaderElection().
+    std::scoped_lock LeaderElectionLocker(LeadershipElectionLock);
+
+    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by
+    // calling DisableLeadershipElection. These checks could be removed if the election events were bound inside the ScopeLeadershipManager. However,
+    // I decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
     if (LeaderElectionManager == nullptr)
     {
         return;
@@ -690,10 +702,13 @@ void OnlineRealtimeEngine::OnElectedScopeLeader(const signalr::value& Params)
 
 void OnlineRealtimeEngine::OnVacatedAsScopeLeader(const signalr::value& Params)
 {
-    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by calling
-    // DisableLeadershipElection.
-    // These checks could be removed if the election events were bound inside the ScopeLeadershipManager.
-    // However, I decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
+    // LeadershipElectionLock must be held while using LeaderElectionManager to prevent a use-after-free race condition caused by the
+    // OnlineRealtimeEngine being destroyed and resetting the LeaderElectionManager via a call to DisableLeaderElection().
+    std::scoped_lock LeaderElectionLocker(LeadershipElectionLock);
+
+    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by
+    // calling DisableLeadershipElection. These checks could be removed if the election events were bound inside the ScopeLeadershipManager. However,
+    // I decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
     if (LeaderElectionManager == nullptr)
     {
         return;

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -41,11 +41,13 @@ namespace csp::systems
 
 LoginStateResult::LoginStateResult()
     : State(nullptr)
+    , StateMutex(nullptr)
 {
 }
 
-LoginStateResult::LoginStateResult(csp::common::LoginState* InStatePtr)
-    : State(InStatePtr)
+LoginStateResult::LoginStateResult(LoginStateLockable* LoginStateLock)
+    : State(LoginStateLock->State)
+    , StateMutex(LoginStateLock->Mutex)
 {
 }
 
@@ -88,6 +90,8 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 
         if (State)
         {
+            std::scoped_lock lock(*StateMutex);
+
             State->State = ELoginState::LoggedIn;
             State->AccessToken = AuthResponse->GetAccessToken();
             State->RefreshToken = AuthResponse->GetRefreshToken();
@@ -147,14 +151,15 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
             events::Event* LoginEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGIN_EVENT_ID);
             LoginEvent->AddString("UserId", AuthResponse->GetUserId());
             events::EventSystem::Get().EnqueueEvent(LoginEvent);
-
-            SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
         }
+
+        SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
     }
     else
     {
         if (State)
         {
+            std::scoped_lock lock(*StateMutex);
             web::HttpAuth::SetAccessToken("", "", "", "");
 
             State->State = ELoginState::Error;
@@ -168,12 +173,14 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 
 LogoutResult::LogoutResult()
     : State(nullptr)
+    , StateMutex(nullptr)
 {
 }
 
-LogoutResult::LogoutResult(csp::common::LoginState* InStatePtr)
-    : NullResult(InStatePtr)
-    , State(InStatePtr)
+LogoutResult::LogoutResult(LoginStateLockable* LoginStateLock)
+    : NullResult(LoginStateLock)
+    , State(LoginStateLock->State)
+    , StateMutex(LoginStateLock->Mutex)
 {
 }
 
@@ -185,6 +192,8 @@ void LogoutResult::OnResponse(const services::ApiResponseBase* ApiResponse)
     {
         if (State)
         {
+            std::scoped_lock lock(*StateMutex);
+
             State->State = ELoginState::LoggedOut;
             State->AccessToken = "InvalidAccessToken";
             State->RefreshToken = "InvalidRefreshToken";
@@ -202,6 +211,8 @@ void LogoutResult::OnResponse(const services::ApiResponseBase* ApiResponse)
     {
         if (State)
         {
+            std::scoped_lock lock(*StateMutex);
+
             State->State = ELoginState::Error;
             State->AccessToken = "InvalidAccessToken";
             State->RefreshToken = "InvalidRefreshToken";

--- a/Library/src/Systems/Users/Authentication.h
+++ b/Library/src/Systems/Users/Authentication.h
@@ -19,8 +19,17 @@
 #include "CSP/Common/LoginState.h"
 #include "CSP/Systems/Users/Authentication.h"
 
+#include <memory>
+#include <mutex>
+
 namespace csp::systems
 {
+
+struct LoginStateLockable
+{
+    std::shared_ptr<csp::common::LoginState> State;
+    std::shared_ptr<std::mutex> Mutex;
+};
 
 /// @brief Result structure for a logout state request.
 class CSP_API LogoutResult : public NullResult
@@ -34,11 +43,12 @@ class CSP_API LogoutResult : public NullResult
 
 private:
     LogoutResult();
-    LogoutResult(csp::common::LoginState* InStatePtr);
+    LogoutResult(LoginStateLockable* LoginStateLock);
 
     CSP_NO_EXPORT void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 
-    csp::common::LoginState* State;
+    std::shared_ptr<csp::common::LoginState> State;
+    std::shared_ptr<std::mutex> StateMutex;
 };
 
 /// @brief Result url for a tier checkout session request

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -163,9 +163,10 @@ csp::common::String FormatScopesForURL(csp::common::Array<csp::common::String> S
     return FormattedScopes;
 }
 
-AuthContext::AuthContext(csp::services::ApiBase* AuthenticationAPI, csp::common::LoginState& LoginState)
+AuthContext::AuthContext(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp::common::LoginState> LoginState, std::shared_ptr<std::mutex> Mutex)
     : AuthenticationAPI { AuthenticationAPI }
-    , LoginState { &LoginState }
+    , LoginState { std::move(LoginState) }
+    , LoginStateMutex { std::move(Mutex) }
 {
 }
 
@@ -173,9 +174,17 @@ const csp::common::LoginState& AuthContext::GetLoginState() const { return *Logi
 
 void AuthContext::RefreshToken(std::function<void(bool)> Callback)
 {
-    if (LoginState->State == csp::common::ELoginState::LoggedIn)
     {
-        auto Request = std::make_shared<chs_user::RefreshRequest>();
+        std::scoped_lock lock(*LoginStateMutex);
+        if (LoginState->State != csp::common::ELoginState::LoggedIn)
+        {
+            return;
+        }
+    }
+
+    auto Request = std::make_shared<chs_user::RefreshRequest>();
+    {
+        std::scoped_lock lock(*LoginStateMutex);
         Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
         Request->SetUserId(LoginState->UserId);
         Request->SetRefreshToken(LoginState->RefreshToken);
@@ -184,31 +193,33 @@ void AuthContext::RefreshToken(std::function<void(bool)> Callback)
         Options->SetExpiryLength(LoginState->AccessTokenExpiryLength);
         Options->SetRefreshTokenExpiryLength(LoginState->RefreshTokenExpiryLength);
         Request->SetTokenOptions(Options);
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-        {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::InProgress)
-            {
-                return;
-            }
-            else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                const NullResult Result(csp::systems::EResultCode::Success, 200);
-                INVOKE_IF_NOT_NULL(Callback, true);
-            }
-            else
-            {
-                const NullResult Result(LoginStateRes.GetResultCode(), LoginStateRes.GetHttpResultCode());
-                INVOKE_IF_NOT_NULL(Callback, false);
-            }
-        };
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, LoginState);
-
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
     }
+
+    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::InProgress)
+        {
+            return;
+        }
+        else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            const NullResult Result(csp::systems::EResultCode::Success, 200);
+            INVOKE_IF_NOT_NULL(Callback, true);
+        }
+        else
+        {
+            const NullResult Result(LoginStateRes.GetResultCode(), LoginStateRes.GetHttpResultCode());
+            INVOKE_IF_NOT_NULL(Callback, false);
+        }
+    };
+
+    LoginStateLockable LockableLoginState { LoginState, LoginStateMutex };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginStateLockable, chs_user::AuthDto>(
+            LoginStateResCallback, &LockableLoginState);
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
 }
 
 UserSystem::UserSystem()
@@ -217,7 +228,10 @@ UserSystem::UserSystem()
     , ProfileAPI(nullptr)
     , PingAPI(nullptr)
     , StripeAPI { nullptr }
-    , Auth { AuthenticationAPI, CurrentLoginState }
+    , CurrentLoginState(std::make_shared<csp::common::LoginState>())
+    , LoginStateMutex(std::make_shared<std::mutex>())
+    , RefreshTokenChangedCallback(nullptr)
+    , Auth { AuthenticationAPI, CurrentLoginState, LoginStateMutex }
 {
 }
 
@@ -227,8 +241,10 @@ UserSystem::UserSystem(csp::web::WebClient* InWebClient, csp::multiplayer::Netwo
     , ProfileAPI { new chs_user::ProfileApi(InWebClient) }
     , PingAPI { new chs_user::PingApi(InWebClient) }
     , StripeAPI { new chs_user::StripeApi(InWebClient) }
+    , CurrentLoginState(std::make_shared<csp::common::LoginState>())
+    , LoginStateMutex(std::make_shared<std::mutex>())
     , RefreshTokenChangedCallback(nullptr)
-    , Auth { AuthenticationAPI, CurrentLoginState }
+    , Auth { AuthenticationAPI, CurrentLoginState, LoginStateMutex }
 {
 }
 
@@ -247,7 +263,7 @@ void UserSystem::SetNetworkEventBus(csp::multiplayer::NetworkEventBus& EventBus)
     RegisterSystemCallback();
 }
 
-const csp::common::LoginState& UserSystem::GetLoginState() const { return CurrentLoginState; }
+const csp::common::LoginState& UserSystem::GetLoginState() const { return *CurrentLoginState; }
 
 void UserSystem::SetNewLoginTokenReceivedCallback(LoginTokenInfoResultCallback Callback) { RefreshTokenChangedCallback = Callback; }
 
@@ -267,78 +283,85 @@ void UserSystem::Login(const csp::common::String& Email, const csp::common::Stri
         return;
     }
 
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
+    auto Options = std::make_shared<chs_user::TokenOptions>();
+
+    // To ensure that multiple threads are not trying to write to the CurrentLoginState object at the same time, we lock the mutex here.
     {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-        auto Request = std::make_shared<chs_user::LoginRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetEmail(Email);
-        Request->SetPassword(Password);
-        Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-        if (UserHasVerifiedAge.HasValue())
+        std::scoped_lock lock(*LoginStateMutex);
+        if (CurrentLoginState->State == csp::common::ELoginState::LoggedOut || CurrentLoginState->State == csp::common::ELoginState::Error)
         {
-            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+            CurrentLoginState->State = csp::common::ELoginState::LoginRequested;
         }
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
+        else
+        {
+            csp::systems::LoginStateResult BadResult;
+            BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+            Callback(BadResult);
+            return;
+        }
 
         if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
         {
             Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
+            CurrentLoginState->AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
         }
 
         if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
         {
             Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
+            CurrentLoginState->RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
         }
+    }
 
-        Request->SetTokenOptions(Options);
+    auto Request = std::make_shared<chs_user::LoginRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetEmail(Email);
+    Request->SetPassword(Password);
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
 
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    Request->SetTokenOptions(Options);
+
+    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
             {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
                 {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-
-                        Callback(LoginStateRes);
-                        return;
-                    }
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
 
                     Callback(LoginStateRes);
-                };
+                    return;
+                }
 
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                    CreateMultiplayerConnection);
-            }
-            else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
-            {
-                CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
                 Callback(LoginStateRes);
-            }
-        };
+            };
 
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
+        {
+            CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
+            Callback(LoginStateRes);
+        }
+    };
 
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
-    }
-    else
-    {
-        csp::systems::LoginStateResult BadResult;
-        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
-        Callback(BadResult);
-    }
+    LoginStateLockable LockableLoginState { CurrentLoginState, LoginStateMutex };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginStateLockable, chs_user::AuthDto>(
+            LoginStateResCallback, &LockableLoginState);
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const csp::common::String& RefreshToken, bool CreateMultiplayerConnection,
@@ -351,206 +374,227 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
         return;
     }
 
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
+    auto Options = std::make_shared<chs_user::TokenOptions>();
+
+    // To ensure that multiple threads are not trying to write to the CurrentLoginState object at the same time, we lock the mutex here.
     {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-        auto Request = std::make_shared<chs_user::RefreshRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetUserId(UserId);
-        Request->SetRefreshToken(RefreshToken);
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
+        std::scoped_lock lock(*LoginStateMutex);
+        if (CurrentLoginState->State == csp::common::ELoginState::LoggedOut || CurrentLoginState->State == csp::common::ELoginState::Error)
+        {
+            CurrentLoginState->State = csp::common::ELoginState::LoginRequested;
+        }
+        else
+        {
+            csp::systems::LoginStateResult BadResult;
+            BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+            BadResult.ResponseBody = "Already logged in!";
+            Callback(BadResult);
+            return;
+        }
 
         if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
         {
             Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
+            CurrentLoginState->AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
         }
 
         if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
         {
             Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
+            CurrentLoginState->RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
         }
+    }
 
-        Request->SetTokenOptions(Options);
+    auto Request = std::make_shared<chs_user::RefreshRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetUserId(UserId);
+    Request->SetRefreshToken(RefreshToken);
 
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    Request->SetTokenOptions(Options);
+
+    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
             {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
                 {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-
-                        Callback(LoginStateRes);
-                        return;
-                    }
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
 
                     Callback(LoginStateRes);
-                };
+                    return;
+                }
 
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                    CreateMultiplayerConnection);
-            }
-            else
-            {
                 Callback(LoginStateRes);
-            }
-        };
+            };
 
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else
+        {
+            Callback(LoginStateRes);
+        }
+    };
 
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
-    }
-    else
-    {
-        csp::systems::LoginStateResult BadResult;
-        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
-        BadResult.ResponseBody = "Already logged in!";
-        Callback(BadResult);
-    }
+    LoginStateLockable LockableLoginState { CurrentLoginState, LoginStateMutex };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginStateLockable, chs_user::AuthDto>(
+            LoginStateResCallback, &LockableLoginState);
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::LoginAsGuest(bool CreateMultiplayerConnection, const csp::common::Optional<bool>& UserHasVerifiedAge,
     const csp::common::Optional<TokenOptions>& TokenOptions, LoginStateResultCallback Callback)
 {
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
+    auto Options = std::make_shared<chs_user::TokenOptions>();
+
+    // To ensure that multiple threads are not trying to write to the CurrentLoginState object at the same time, we lock the mutex here.
     {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-        auto Request = std::make_shared<chs_user::LoginRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-        if (UserHasVerifiedAge.HasValue())
+        std::scoped_lock lock(*LoginStateMutex);
+        if (CurrentLoginState->State == csp::common::ELoginState::LoggedOut || CurrentLoginState->State == csp::common::ELoginState::Error)
         {
-            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+            CurrentLoginState->State = csp::common::ELoginState::LoginRequested;
         }
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
+        else
+        {
+            csp::systems::LoginStateResult BadResult;
+            BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+            Callback(BadResult);
+            return;
+        }
 
         if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
         {
             Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
+            CurrentLoginState->AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
         }
 
         if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
         {
             Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
+            CurrentLoginState->RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
         }
+    }
 
-        Request->SetTokenOptions(Options);
+    auto Request = std::make_shared<chs_user::LoginRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
 
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    Request->SetTokenOptions(Options);
+
+    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
             {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
                 {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-
-                        Callback(LoginStateRes);
-                        return;
-                    }
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
 
                     Callback(LoginStateRes);
-                };
+                    return;
+                }
 
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                    CreateMultiplayerConnection);
-            }
-            else
-            {
                 Callback(LoginStateRes);
-            }
-        };
+            };
 
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else
+        {
+            Callback(LoginStateRes);
+        }
+    };
 
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
-    }
-    else
-    {
-        csp::systems::LoginStateResult BadResult;
-        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
-        Callback(BadResult);
-    }
+    LoginStateLockable LockableLoginState { CurrentLoginState, LoginStateMutex };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginStateLockable, chs_user::AuthDto>(
+            LoginStateResCallback, &LockableLoginState);
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::LoginAsGuestWithDeferredProfileCreation(const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback)
 {
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
+    // To ensure that multiple threads are not trying to write to the CurrentLoginState object at the same time, we lock the mutex here.
     {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-        auto Request = std::make_shared<chs_user::LoginGuestRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-        if (UserHasVerifiedAge.HasValue())
+        std::scoped_lock lock(*LoginStateMutex);
+        if (CurrentLoginState->State == csp::common::ELoginState::LoggedOut || CurrentLoginState->State == csp::common::ELoginState::Error)
         {
-            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+            CurrentLoginState->State = csp::common::ELoginState::LoginRequested;
         }
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+        else
         {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
-                {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        // It would be extremely strange to hit this branch, but it remains here just in case.
-                        CSP_LOG_ERROR_FORMAT("Unexpected error connecting MultiplayerConnection. This is strange! : %s",
-                            csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-                        Callback(LoginStateRes);
-                        return;
-                    }
-
-                    Callback(LoginStateRes);
-                };
-
-                // Do not start a multiplayer connection, need to call through this to trigger all the callbacks though.
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem, false);
-            }
-            else
-            {
-                Callback(LoginStateRes);
-            }
-        };
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
-
-        // Despite the naming, "login-guest" is the deferred, optimized, non-standard guest login.
-        // The regular login endpoint that "loginAsGuest" uses is the "real" one.
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_guestPost({ Request }, ResponseHandler);
+            csp::systems::LoginStateResult BadResult;
+            BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+            Callback(BadResult);
+            return;
+        }
     }
-    else
+
+    auto Request = std::make_shared<chs_user::LoginGuestRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
+
+    if (UserHasVerifiedAge.HasValue())
     {
-        csp::systems::LoginStateResult BadResult;
-        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
-        Callback(BadResult);
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
     }
+
+    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            {
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                {
+                    // It would be extremely strange to hit this branch, but it remains here just in case.
+                    CSP_LOG_ERROR_FORMAT("Unexpected error connecting MultiplayerConnection. This is strange! : %s",
+                        csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+                    Callback(LoginStateRes);
+                    return;
+                }
+
+                Callback(LoginStateRes);
+            };
+
+            // Do not start a multiplayer connection, need to call through this to trigger all the callbacks though.
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem, false);
+        }
+        else
+        {
+            Callback(LoginStateRes);
+        }
+    };
+
+    LoginStateLockable LockableLoginState { CurrentLoginState, LoginStateMutex };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginStateLockable, chs_user::AuthDto>(
+            LoginStateResCallback, &LockableLoginState);
+
+    // Despite the naming, "login-guest" is the deferred, optimized, non-standard guest login.
+    // The regular login endpoint that "loginAsGuest" uses is the "real" one.
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_guestPost({ Request }, ResponseHandler);
 }
 
 csp::common::Array<EThirdPartyAuthenticationProviders> UserSystem::GetSupportedThirdPartyAuthenticationProviders() const
@@ -666,16 +710,51 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
         Callback(ErrorResult);
     }
 
-    if (CurrentLoginState.State != csp::common::ELoginState::LoggedOut && CurrentLoginState.State != csp::common::ELoginState::Error)
-    {
-        CSP_LOG_MSG(csp::common::LogLevel::Warning, "You are not in the correct login state to proceed with third-party authentication.");
+    auto Options = std::make_shared<chs_user::TokenOptions>();
 
-        csp::systems::LoginStateResult BadResult;
-        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
-        Callback(BadResult);
+    // To ensure that multiple threads are not trying to write to the CurrentLoginState object at the same time, we lock the mutex here.
+    {
+        std::scoped_lock lock(*LoginStateMutex);
+        if (CurrentLoginState->State == csp::common::ELoginState::LoggedOut || CurrentLoginState->State == csp::common::ELoginState::Error)
+        {
+            CurrentLoginState->State = csp::common::ELoginState::LoginRequested;
+        }
+        else
+        {
+            CSP_LOG_MSG(csp::common::LogLevel::Warning, "You are not in the correct login state to proceed with third-party authentication.");
+
+            csp::systems::LoginStateResult BadResult;
+            BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+            Callback(BadResult);
+            return;
+        }
+
+        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
+        {
+            Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
+            CurrentLoginState->AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
+        }
+
+        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
+        {
+            Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
+            CurrentLoginState->RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
+        }
     }
 
-    CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+    const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
+    Request->SetProvider(ConvertExternalAuthProvidersToString(ThirdPartyRequestedAuthProvider));
+    Request->SetToken(ThirdPartyToken);
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
+
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    Request->SetTokenOptions(Options);
 
     LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
     {
@@ -703,78 +782,64 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
         }
     };
 
-    const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
-    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-    Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
-    Request->SetProvider(ConvertExternalAuthProvidersToString(ThirdPartyRequestedAuthProvider));
-    Request->SetClient(ThirdPartyClientType);
-    Request->SetToken(ThirdPartyToken);
-    Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-    if (UserHasVerifiedAge.HasValue())
-    {
-        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
-    }
-
-    auto Options = std::make_shared<chs_user::TokenOptions>();
-
-    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
-    {
-        Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-        CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
-    }
-
-    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
-    {
-        Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-        CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
-    }
-
-    Request->SetTokenOptions(Options);
-
-    CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+    LoginStateLockable LockableLoginState { CurrentLoginState, LoginStateMutex };
 
     csp::services::ResponseHandlerPtr ResponseHandler
-        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, &CurrentLoginState);
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, LoginStateLockable, chs_user::AuthDto>(
+            LoginStateResCallback, &LockableLoginState);
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::Logout(NullResultCallback Callback)
 {
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedIn)
+    // To ensure that multiple threads are not trying to write to the CurrentLoginState object at the same time, we lock the mutex here.
     {
-        CurrentLoginState.State = csp::common::ELoginState::LogoutRequested;
-
-        // Disconnect MultiplayerConnection before logging out
-        csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ErrorCallback = [Callback, this](csp::multiplayer::ErrorCode ErrCode)
+        std::scoped_lock lock(*LoginStateMutex);
+        if (CurrentLoginState->State == csp::common::ELoginState::LoggedIn)
         {
-            if (ErrCode != csp::multiplayer::ErrorCode::None)
-            {
-                CSP_LOG_ERROR_FORMAT("Error disconnecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-            }
-
-            auto Request = std::make_shared<chs_user::LogoutRequest>();
-            Request->SetUserId(CurrentLoginState.UserId);
-            Request->SetDeviceId(CurrentLoginState.DeviceId);
-
-            csp::services::ResponseHandlerPtr ResponseHandler
-                = AuthenticationAPI->CreateHandler<NullResultCallback, LogoutResult, csp::common::LoginState, csp::services::NullDto>(
-                    Callback, &CurrentLoginState, csp::web::EResponseCodes::ResponseNoContent);
-
-            static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogoutPost({ Request }, ResponseHandler);
-        };
-
-        auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-        MultiplayerConnection->Disconnect(ErrorCallback);
+            CurrentLoginState->State = csp::common::ELoginState::LogoutRequested;
+        }
+        else
+        {
+            csp::systems::LogoutResult BadResult;
+            BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+            Callback(BadResult);
+            return;
+        }
     }
-    else
+
+    // Disconnect MultiplayerConnection before logging out
+    csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ErrorCallback = [Callback, this](csp::multiplayer::ErrorCode ErrCode)
     {
-        csp::systems::LogoutResult BadResult;
-        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
-        Callback(BadResult);
-    }
+        if (ErrCode != csp::multiplayer::ErrorCode::None)
+        {
+            CSP_LOG_ERROR_FORMAT("Error disconnecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+        }
+
+        csp::common::String UserId;
+        csp::common::String DeviceId;
+        {
+            std::scoped_lock lock(*LoginStateMutex);
+            UserId = CurrentLoginState->UserId;
+            DeviceId = CurrentLoginState->DeviceId;
+        }
+
+        auto Request = std::make_shared<chs_user::LogoutRequest>();
+        Request->SetUserId(UserId);
+        Request->SetDeviceId(DeviceId);
+
+        LoginStateLockable LockableLogoutState { CurrentLoginState, LoginStateMutex };
+
+        csp::services::ResponseHandlerPtr ResponseHandler
+            = AuthenticationAPI->CreateHandler<NullResultCallback, LogoutResult, LoginStateLockable, csp::services::NullDto>(
+                Callback, &LockableLogoutState, csp::web::EResponseCodes::ResponseNoContent);
+
+        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogoutPost({ Request }, ResponseHandler);
+    };
+
+    auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
+    MultiplayerConnection->Disconnect(ErrorCallback);
 }
 
 void UserSystem::CreateUser(const csp::common::Optional<csp::common::String>& DisplayName, const csp::common::String& Email,
@@ -818,7 +883,11 @@ void UserSystem::CreateUser(const csp::common::Optional<csp::common::String>& Di
 void UserSystem::UpgradeGuestAccount(
     const csp::common::String& DisplayName, const csp::common::String& Email, const csp::common::String& Password, ProfileResultCallback Callback)
 {
-    const csp::common::String UserId = CurrentLoginState.UserId;
+    csp::common::String UserId;
+    {
+        std::scoped_lock lock(*LoginStateMutex);
+        UserId = CurrentLoginState->UserId;
+    }
 
     auto Request = std::make_shared<chs_user::UpgradeGuestRequest>();
 
@@ -835,7 +904,11 @@ void UserSystem::UpgradeGuestAccount(
 
 void UserSystem::ConfirmUserEmail(NullResultCallback Callback)
 {
-    const csp::common::String UserId = CurrentLoginState.UserId;
+    csp::common::String UserId;
+    {
+        std::scoped_lock lock(*LoginStateMutex);
+        UserId = CurrentLoginState->UserId;
+    }
 
     csp::services::ResponseHandlerPtr ResponseHandler = ProfileAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -15,7 +15,9 @@
  */
 #include "Awaitable.h"
 #include "CSP/CSPFoundation.h"
+#include "CSP/Common/Interfaces/IRealtimeEngine.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
+#include "CSP/Multiplayer/SpaceTransform.h"
 #include "CSP/Systems/Settings/SettingsSystem.h"
 #include "CSP/Systems/Spaces/Space.h"
 #include "CSP/Systems/SystemsManager.h"
@@ -157,7 +159,7 @@ struct AuthorizeURLTokens
 AuthorizeURLTokens ExtractTokensFromAuthorizeURL(const csp::common::String& AuthorizeURL)
 {
     AuthorizeURLTokens URLTokens;
-    
+
     const char* STATE_ID_URL_PARAM = "state=";
     const char* CLIENT_ID_URL_PARAM = "client_id=";
     const char* SCOPE_URL_PARAM = "scope=";
@@ -551,10 +553,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ValidExpiryLengthInTokenOptionsTest)
     std::future<csp::systems::LoginTokenInfoResult> TokenFuture = TokenPromise.get_future();
 
     UserSystem->SetNewLoginTokenReceivedCallback(
-        [&TokenPromise](const csp::systems::LoginTokenInfoResult& Result)
-        {
-            TokenPromise.set_value(Result);
-        });
+        [&TokenPromise](const csp::systems::LoginTokenInfoResult& Result) { TokenPromise.set_value(Result); });
 
     // Log in
     csp::common::String UserId;
@@ -1322,4 +1321,76 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DefaultApplicationSettingsTest)
     ASSERT_EQ(ApplicationSetting.Settings.Size(), 1);
     ASSERT_TRUE(ApplicationSetting.Settings.HasKey("URL"));
     ASSERT_EQ(ApplicationSetting.Settings["URL"], "https://www.google.com/search?q=why+google");
+}
+
+// Regression test to ensure that the EntityFetchCancellationToken sentinel in the
+// OnlineRealtimeEngine prevents the RetrieveAllEntities callback from accessing a destroyed RealtimeEngine.
+//
+// This issue was occuring under the following conditions:
+//   1. A user enters a space containing many entities.
+//   2. The OnlineRealtimeEngine is destroyed before the RetrieveAllEntitiesCallback has completed.
+//   3. Entities being created in the loop try to access the LogSystem member of the OnlineRealtimeEngine causing a crash.
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EnterSpaceTeardownDuringEntityFetchTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    // Setup: Populate the Space with several SpaceEntities and then exit cleanly.
+    {
+        std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(csp::common::RealtimeEngineType::Online) };
+
+        std::atomic<bool> FetchComplete { false };
+        RealtimeEngine->SetEntityFetchCompleteCallback([&FetchComplete](uint32_t) { FetchComplete = true; });
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+        EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+        EXPECT_TRUE(ResponseWaiter::WaitFor([&FetchComplete] { return FetchComplete.load(); }, 30s));
+
+        const csp::multiplayer::SpaceTransform EntityTransform
+            = { csp::common::Vector3::Zero(), csp::common::Vector4::Identity(), csp::common::Vector3::One() };
+
+        for (int i = 0; i < 3; ++i)
+        {
+            char EntityName[64];
+            SPRINTF(EntityName, "CSP-UNITTEST-ENTITY-%d", i);
+            auto [Entity] = AWAIT(RealtimeEngine.get(), CreateEntity, EntityName, EntityTransform, csp::common::Optional<uint64_t> {});
+            EXPECT_NE(Entity, nullptr);
+        }
+
+        auto [ExitResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+        EXPECT_EQ(ExitResult.GetResultCode(), csp::systems::EResultCode::Success);
+        RealtimeEngine.reset();
+    }
+
+    // Enter the Space once more and destroy the RealtimeEngine without waiting for the RetrieveAllEntities callback to complete.
+    // Ensure the FetchPromise is not ready and then exit the space.
+    {
+        std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(csp::common::RealtimeEngineType::Online) };
+
+        std::promise<bool> FetchPromise;
+        std::future<bool> FetchFuture = FetchPromise.get_future();
+
+        RealtimeEngine->SetEntityFetchCompleteCallback([&FetchPromise](uint32_t) { FetchPromise.set_value(true); });
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+        EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+        RealtimeEngine.reset();
+
+        EXPECT_EQ(FetchFuture._Is_ready(), false);
+
+        auto [ExitResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+        EXPECT_EQ(ExitResult.GetResultCode(), csp::systems::EResultCode::Success);
+    }
+
+    DeleteSpace(SpaceSystem, Space.Id);
+    LogOut(UserSystem);
 }

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -1394,3 +1394,85 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EnterSpaceTeardownDuringEntityFetchT
     DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
+
+// Regression test for the LoginStateMutex guard in UserSystem.
+//
+// The crash was occurring under the following conditions:
+//   1. A user calls Logout().
+//   2. Before the logout response is received, Login() is called again.
+//   3. Both OnResponse handlers execute concurrently on different threads and write to
+//      CurrentLoginState without synchronization, causing a data race.
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginStateMutexGuardTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+
+    csp::common::String UserId;
+    csp::systems::Profile TestUser = CreateTestUser();
+    LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
+
+    // Call Logout without blocking, then immediately call Login for the same user.
+    // Without the LoginStateMutex, the concurrent OnResponse callbacks would produce a data
+    // race on CurrentLoginState — potentially crashing or corrupting the login state.
+    std::promise<bool> LogoutPromise;
+    std::future<bool> LogoutFuture = LogoutPromise.get_future();
+    std::promise<bool> LoginPromise;
+    std::future<bool> LoginFuture = LoginPromise.get_future();
+
+    csp::systems::EResultCode LogoutResultCode { csp::systems::EResultCode::InProgress };
+    csp::systems::EResultCode LoginResultCode { csp::systems::EResultCode::InProgress };
+
+    UserSystem->Logout(
+        [&](const csp::systems::NullResult& Result)
+        {
+            if (Result.GetResultCode() != csp::systems::EResultCode::InProgress)
+            {
+                LogoutResultCode = Result.GetResultCode();
+                LogoutPromise.set_value(true);
+            }
+        });
+
+    UserSystem->Login(TestUser.Email, GeneratedTestAccountPassword, true, true, csp::systems::TokenOptions(),
+        [&](const csp::systems::LoginStateResult& Result)
+        {
+            if (Result.GetResultCode() != csp::systems::EResultCode::InProgress)
+            {
+                LoginResultCode = Result.GetResultCode();
+                LoginPromise.set_value(true);
+            }
+        });
+
+    std::future_status LogoutStatus = LogoutFuture.wait_for(30s);
+    std::future_status LoginStatus = LoginFuture.wait_for(30s);
+
+    if (LogoutStatus == std::future_status::ready)
+    {
+        EXPECT_TRUE(LogoutFuture.get());
+    }
+    else
+    {
+        FAIL() << "Logout did not complete successfully.";
+    }
+
+    if (LoginStatus == std::future_status::ready)
+    {
+        EXPECT_TRUE(LoginFuture.get());
+    }
+    else
+    {
+        FAIL() << "Login did not complete successfully.";
+    }
+
+    // Ensure the call to Logout was successful — we were validly logged in when it was dispatched.
+    EXPECT_EQ(LogoutResultCode, csp::systems::EResultCode::Success);
+
+    // The LoginState must be in a valid state, not partially overwritten by concurrent writes from the two response handlers.
+    const csp::common::ELoginState FinalState = UserSystem->GetLoginState().State;
+    EXPECT_TRUE(FinalState == csp::common::ELoginState::LoggedIn || FinalState == csp::common::ELoginState::LoggedOut
+        || FinalState == csp::common::ELoginState::Error);
+
+    if (LoginResultCode == csp::systems::EResultCode::Success)
+    {
+        LogOut(UserSystem);
+    }
+}


### PR DESCRIPTION
The Unreal client team hitting an exception when attempting to do the following:

- A user enters a complex space with many Entities. Before these have finished loading the user calls their local LogOut method, which internally calls the CSP SpaceSystem::ExitSpace() followed by UserSystem::Logout() methods. Without waiting for their local Logout method to return they click Login again.

This resulted in a number of issues initially related to race conditions caused by multiple threads trying to access the LoginState object being passed to the Login, Logout and Refresh ResponseHandlers.

To address this I did the following: 

1. Introduced a sentinel `EntityFetchCancellationToken` and mutex lock `EntityFetchBodyGuard` to the `OnlineRealtimeEngine`.

2. Updated usage of `LoginState` within the `UserSystem`, so that whenever a `ResponseHandler` is being created for Login, Logout or RefreshToken refresh, we lock the object to avoid race conditions - we do this by wrapping it in a new `LoginStateLockable` object.

This resolved the issue in Unreal. However, after adding new tests in CSP to validate this behaviour I encountered a new use-after-free race condition that can occur if the `MultiplayerRealtimeEngine` is destroyed while either `OnElectedScopeLeader` or `OnVacatedScopeLeader` callbacks are in-flight. This issue was addressed with the addition of a new LeaderElection mutex and supporting logic.