### PR TITLE
[OF-1850] Allow CSP to run on linux #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to this project will be documented in this file. For compile
 - [OF-1831] feat: Add Linux support to new build system. by @MAG-mv.
   At this point, the CSP project builds on Linux for both gcc and clang. We have yet to test if this runs.
 
+- [OF-1850] feat: CSP tests now run on Linux platforms by @MAG-mv.
+  This includes code changes used by the new buld system to run tests on Linux.
+  This still isn't officially public, but noting here due to changes to List::Append.
+
 ### 🐛 🔨 Bug Fixes
 
 - [OB-4980] fix!: Address issues with third party authorization flow. By @MAG-AdamThorn

--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -53,7 +53,7 @@ inline size_t next_pow2(size_t val)
 /// This class is implemented using an array and, as such, removing items is not cheap as it requires
 /// us to move all items after it down one space.
 ///
-/// @tparam T : Object type to store in the list
+/// @tparam T : Object type to store in the list. T is required to be move-assignable.
 template <typename T> class CSP_API List
 {
 public:
@@ -275,22 +275,16 @@ public:
             ReallocList(Size);
         }
 
-        auto After = CurrentSize - Index;
-// This is a real problem, don't ignore this, it needs fixed. (Or this entire type needs deleted)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-warning-option"
-#pragma clang diagnostic ignored "-Wnontrivial-memcall"
-#endif
-        std::memmove(ObjectArray + (Index + 1), ObjectArray + Index, sizeof(T) * After);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-        ++CurrentSize;
+        // Shift elements from the new insertion point 1 index to the right.
+        std::move_backward(
+            ObjectArray + Index,
+            ObjectArray + CurrentSize,
+            ObjectArray + CurrentSize + 1
+        );
 
-        T* ObjectPtr = &ObjectArray[Index];
-        new (ObjectPtr) T;
+        // Insert the new item
         ObjectArray[Index] = Item;
+        ++CurrentSize;
     }
 
     /// @brief Removes an element to a specific index of the list.

--- a/Library/include/CSP/Common/List.h
+++ b/Library/include/CSP/Common/List.h
@@ -56,6 +56,11 @@ inline size_t next_pow2(size_t val)
 /// @tparam T : Object type to store in the list. T is required to be move-assignable.
 template <typename T> class CSP_API List
 {
+    CSP_START_IGNORE
+    // Ensure the type is move assignable due to List::Insert using std::move_backward
+    static_assert(std::is_move_assignable_v<T>);
+    CSP_END_IGNORE
+    
 public:
     using iterator = T*;
     using const_iterator = const T*;

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -1174,7 +1174,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileTest)
     // Create asset
     csp::systems::Asset Asset;
     CreateAsset(AssetSystem, AssetCollection, UniqueAssetName, nullptr, nullptr, Asset);
-    auto FilePath = std::filesystem::absolute("assets/test.json");
+    auto FilePath = std::filesystem::absolute("assets/Test.json");
     csp::systems::FileAssetDataSource Source;
     Source.FilePath = FilePath.u8string().c_str();
     const csp::common::String& FileNoMimeType = "";
@@ -1345,7 +1345,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileNoSpaceTest)
     // Create asset
     csp::systems::Asset Asset;
     CreateAsset(AssetSystem, AssetCollection, UniqueAssetName, nullptr, nullptr, Asset);
-    auto FilePath = std::filesystem::absolute("assets/test.json");
+    auto FilePath = std::filesystem::absolute("assets/Test.json");
     csp::systems::FileAssetDataSource Source;
     Source.FilePath = FilePath.u8string().c_str();
     const csp::common::String& FileNoMimeType = "";
@@ -1594,9 +1594,9 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsBufferTest)
     // Create asset
     csp::systems::Asset Asset;
     CreateAsset(AssetSystem, AssetCollection, UniqueAssetName, nullptr, nullptr, Asset);
-    Asset.FileName = "test.json";
+    Asset.FileName = "Test.json";
 
-    auto UploadFilePath = std::filesystem::absolute("assets/test.json");
+    auto UploadFilePath = std::filesystem::absolute("assets/Test.json");
     FILE* UploadFile = fopen(UploadFilePath.string().c_str(), "rb");
     uintmax_t UploadFileSize = std::filesystem::file_size(UploadFilePath);
     auto* UploadFileData = new unsigned char[UploadFileSize];
@@ -1685,7 +1685,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsFileTest)
     csp::systems::Asset Asset;
     CreateAsset(AssetSystem, AssetCollection, UniqueAssetName, nullptr, nullptr, Asset);
     // Upload data
-    auto FilePath = std::filesystem::absolute("assets/test.json");
+    auto FilePath = std::filesystem::absolute("assets/Test.json");
     csp::systems::FileAssetDataSource Source;
     Source.FilePath = FilePath.u8string().c_str();
 
@@ -1703,7 +1703,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsFileTest)
     EXPECT_EQ(Asset.Id, UpdatedAsset.Id);
 
     // Replace data
-    FilePath = std::filesystem::absolute("assets/test2.json");
+    FilePath = std::filesystem::absolute("assets/Test2.json");
     Source.FilePath = FilePath.u8string().c_str();
 
     printf("Uploading new asset data...\n");
@@ -1774,7 +1774,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsBufferTest)
     auto& InitialAssetId = Asset.Id;
 
     // Upload data
-    auto FilePath = std::filesystem::absolute("assets/test.json");
+    auto FilePath = std::filesystem::absolute("assets/Test.json");
     csp::systems::FileAssetDataSource Source;
     Source.FilePath = FilePath.u8string().c_str();
 
@@ -1786,9 +1786,9 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsBufferTest)
     UploadAssetData(AssetSystem, AssetCollection, Asset, Source, Uri);
 
     // Replace data
-    Asset.FileName = "test2.json";
+    Asset.FileName = "Test2.json";
 
-    auto UpdateFilePath = std::filesystem::absolute("assets/test2.json");
+    auto UpdateFilePath = std::filesystem::absolute("assets/Test2.json");
     FILE* UpdateFile = fopen(UpdateFilePath.string().c_str(), "rb");
     uintmax_t UpdateFileSize = std::filesystem::file_size(UpdateFilePath);
     auto* UpdateFileData = new unsigned char[UpdateFileSize];
@@ -2098,7 +2098,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, AssetProcessedCallbackTest)
     CreateAsset(AssetSystem, AssetCollection, UniqueAssetName, nullptr, nullptr, Asset);
 
     // Upload data
-    auto FilePath = std::filesystem::absolute("assets/test.json");
+    auto FilePath = std::filesystem::absolute("assets/Test.json");
     csp::systems::FileAssetDataSource Source;
     Source.FilePath = FilePath.u8string().c_str();
 

--- a/Tests/src/PublicAPITests/MCSExternalDependencyTests.cpp
+++ b/Tests/src/PublicAPITests/MCSExternalDependencyTests.cpp
@@ -181,8 +181,8 @@ CSP_PUBLIC_TEST(CSPEngine, MCSExternalDependencyTests, ResolveMultiplayerHubMeth
     csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(LogLevel::Fatal);
 
     // Validate that the failure to find the multiplayer hub methods code path has been triggered and populated through the log system
-    const String ErrorMsg = "Failed to resolve the Multiplayer Hub Method: DeleteObjects";
-    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Fatal, ErrorMsg)).Times(1);
+    const String ErrorMsg = "Failed to resolve the Multiplayer Hub Method:";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Fatal, testing::HasSubstr(ErrorMsg))).Times(1);
 
     auto const MultiplayerHubMethodMap = csp::multiplayer::MultiplayerHubMethodMap();
     auto const Methods = Array<String> {};
@@ -196,8 +196,8 @@ CSP_PUBLIC_TEST(CSPEngine, MCSExternalDependencyTests, ResolveMultiplayerHubMeth
     csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(LogLevel::Fatal);
 
     // Validate that the failure to find the multiplayer hub methods code path has been triggered and populated through the log system
-    const String ErrorMsg = "Failed to resolve the Multiplayer Hub Method: GenerateObjectIds";
-    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Fatal, ErrorMsg)).Times(1);
+    const String ErrorMsg = "Failed to resolve the Multiplayer Hub Method:";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Fatal, testing::HasSubstr(ErrorMsg))).Times(1);
 
     auto const MultiplayerHubMethodMap = csp::multiplayer::MultiplayerHubMethodMap();
     auto const Methods = Array<String> { "DeleteObjects", "SendEventMessage", "StopListening" };

--- a/Tests/src/PublicAPITests/QuotaSystemTests.cpp
+++ b/Tests/src/PublicAPITests/QuotaSystemTests.cpp
@@ -482,7 +482,7 @@ CSP_PUBLIC_TEST(CSPEngine, QuotaSystemTests, GetTotalSpaceSizeinKilobytes)
     auto& InitialAssetId = Asset.Id;
 
     // Upload data
-    auto FilePath = std::filesystem::absolute("assets/testkb.json");
+    auto FilePath = std::filesystem::absolute("assets/Testkb.json");
     uintmax_t UpdateFileSize = std::filesystem::file_size(FilePath);
     csp::systems::FileAssetDataSource Source;
     Source.FilePath = FilePath.u8string().c_str();

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -2283,7 +2283,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceThumbnailTest)
 
     ::Space Space;
     FileAssetDataSource SpaceThumbnail;
-    const std::string LocalFileName = "test.json";
+    const std::string LocalFileName = "Test.json";
     const auto FilePath = std::filesystem::absolute("assets/" + LocalFileName);
     SpaceThumbnail.FilePath = FilePath.u8string().c_str();
     SpaceThumbnail.SetMimeType("application/json");
@@ -2343,7 +2343,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetSpaceThumbnailWithGuestUserTest)
 
     ::Space Space;
     FileAssetDataSource SpaceThumbnail;
-    const std::string LocalFileName = "test.json";
+    const std::string LocalFileName = "Test.json";
     auto FilePath = std::filesystem::absolute("assets/" + LocalFileName);
     SpaceThumbnail.FilePath = FilePath.u8string().c_str();
     SpaceThumbnail.SetMimeType("application/json");


### PR DESCRIPTION
This will be split into 2 PRs due to trouble fixing a script issue with ScopeLeadershipScriptEventTest.

We had 3 seperate issues that was preventing tests from running on Linux:
- Incorrect casing for test files
- Invalid List::Append implementation due to using std::memmove on non-triable types
- Assuming ordering of unordered_map iteration (We fixed some of these issues already when running on apple-clang 