### PR TITLE
[OF-1850] feat: support fPIC for Linux shared builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,16 @@ set_target_properties(csp-lib PROPERTIES
   DEBUG_POSTFIX _D
 )
 
+# CSP and its internal static libraries may be linked into a shared library,
+# so build library targets with PIC on non-Windows platforms.
+if(NOT WIN32)
+  set_target_properties(
+    csp-lib
+      PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+  )
+endif()
+
 target_compile_options(csp-lib
   PRIVATE
     # Needed to compile EntityScriptBindings.cpp

--- a/ThirdParty/quickjs/CMakeLists.txt
+++ b/ThirdParty/quickjs/CMakeLists.txt
@@ -39,6 +39,16 @@ target_include_directories(csp-quickjs
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+# CSP and its internal static libraries may be linked into a shared library,
+# so build library targets with PIC on non-Windows platforms.
+if(NOT WIN32)
+  set_target_properties(
+    csp-quickjs
+      PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+  )
+endif()
+
 target_compile_definitions(csp-quickjs
   PRIVATE
     _HAS_EXCEPTIONS=0

--- a/ThirdParty/signalrclient/CMakeLists.txt
+++ b/ThirdParty/signalrclient/CMakeLists.txt
@@ -60,6 +60,16 @@ target_link_libraries(csp-signalr
     msgpack-cxx
 )
 
+# CSP and its internal static libraries may be linked into a shared library,
+# so build library targets with PIC on non-Windows platforms.
+if(NOT WIN32)
+  set_target_properties(
+    csp-signalr
+      PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+  )
+endif()
+
 target_compile_definitions(csp-signalr
   PUBLIC
     NO_SIGNALRCLIENT_EXPORTS

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,14 +7,12 @@ class CSP(ConanFile):
 
     exports_sources = "CMakeLists.txt", "Library/*", "Tests/*", "cmake/*"
 
-    options = {
-        "fPIC": [True, False],
-    }
-
     default_options = {
-        # Set fPIC to true by default which is pretty standard.
-        # This isn't always needed but we don't want to shift the responsibility of setting it to callers.
-        "fPIC": True,
+        # We currently don't support shared dependencies.
+        "*:shared": False,
+
+        # Our dependencies are always linked statically, so force PIC.
+        "*:fPIC": True,
     }
 
     def layout(self):
@@ -81,10 +79,6 @@ class CSP(ConanFile):
         deps.generate()
 
         tc = CMakeToolchain(self)
-
-        # Ensure our fPIC option is passed to cmake
-        if self.settings.os != "Windows":
-            tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = bool(self.options.fPIC)
 
         # Generate conan presets file
         tc.user_presets_path = 'ConanPresets.json'

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,16 @@ class CSP(ConanFile):
 
     exports_sources = "CMakeLists.txt", "Library/*", "Tests/*", "cmake/*"
 
+    options = {
+        "fPIC": [True, False],
+    }
+
+    default_options = {
+        # Set fPIC to true by default which is pretty standard.
+        # This isn't always needed but we don't want to shift the responsibility of setting it to callers.
+        "fPIC": True,
+    }
+
     def layout(self):
         # Explicitly set the provided generator
         # This fixes a bug with the xcode generator where conan doesn't configure correctly and points to the incorrect directory.
@@ -28,6 +38,11 @@ class CSP(ConanFile):
         # We use the Emscripten WebSockets API for Emscripten
         if self.settings.os != "Emscripten":
             self.requires("poco/1.14.2")
+
+    def config_options(self):
+        # If we're targeting windows, remove fPIC option as this isn't used on Windows.
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
 
     def configure(self):
         # Disable unnecessary Poco modules as this is a big library with dependecies.
@@ -66,6 +81,10 @@ class CSP(ConanFile):
         deps.generate()
 
         tc = CMakeToolchain(self)
+
+        # Ensure our fPIC option is passed to cmake
+        if self.settings.os != "Windows":
+            tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = bool(self.options.fPIC)
 
         # Generate conan presets file
         tc.user_presets_path = 'ConanPresets.json'


### PR DESCRIPTION
fPIC needs to be explicitly set for Linux when building as shared. I followed the Conan docs to create an option for this. I also passed this to cmake to ensure the cmake toolchain uses this variable.