### PR TITLE
[OW-2438] feat: Properties to support cinematic camera depth of field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file. For compile
   over to this pattern, with only a handful still being registered manually due to some remaining
   edge cases.
 
+- [OW-2438] feat: Properties to support cinematic camera depth of field. By @MAG-ThomasGreenhalgh.
+  Adds focus distance and depth of field enabled properties to the cinematic camera space component.
+
 ## [6.36.0]
 
 ### 🐛 🔨 Bug Fixes
@@ -95,9 +98,9 @@ All notable changes to this project will be documented in this file. For compile
   the error handling behaviour which we can just do without. Login with email
   now, you probably already are.
   Removes username as an option from public api:
-    - UserSystem::Login
-    - UserSystem::CreateUser
-    - UserSystem::UpgradeGuestAccount
+  - UserSystem::Login
+  - UserSystem::CreateUser
+  - UserSystem::UpgradeGuestAccount
 
 ### 🐛 🔨 Bug Fixes
 
@@ -141,7 +144,7 @@ All notable changes to this project will be documented in this file. For compile
 - [OF-1836] fix: Log errors when parsing malformed JSON by magnopus-swifty
   This is a partial fix to log errors when parsing malformed JSON strings and avoid hitting unwanted assertions.
   A more complete fix will implement error handling logic so calling code can correctly report failures.
-  
+
 ### 🍰 🙌 New Features
 
 - [OF-1818] feat: Update AsyncCompletedEventCallback format by MAG-AdamThorn
@@ -150,7 +153,7 @@ All notable changes to this project will be documented in this file. For compile
 ### 🐛 🔨 Bug Fixes
 
 - [OB-5070] fix: `GetMaterials` no longer bails out after first failure
-  Previously this method was designed such that if any material failed to download, it would effectively cancel all the other in-flight downloads. This has now changed to allow all other downloads to run to completion. This doesn't currently change the result type such that the failed materials are reported back to the caller in any way, but they are logged. Partial success is reported as success. 
+  Previously this method was designed such that if any material failed to download, it would effectively cancel all the other in-flight downloads. This has now changed to allow all other downloads to run to completion. This doesn't currently change the result type such that the failed materials are reported back to the caller in any way, but they are logged. Partial success is reported as success.
 
 ## [6.27.0]
 
@@ -177,40 +180,40 @@ All notable changes to this project will be documented in this file. For compile
   This has been done because of a single sticky Map<T, Array<U>> type, which obviously needs equality for Array<U>, which means
   all U's need equality. All equality operations are standard memberwise == comparison, of the like a c++20 =default would generate.
   The following types have been given new operators:
-    - MessageInfo
-    - ComponentUpdateInfo
-    - Asset
-    - AssetCollection
-    - CurrencyInfo
-    - ProductMediaInfo
-    - VariantOptionInfo
-    - ProductVariantInfo
-    - ProductInfo
-    - CartLine
-    - ShopifyStoreInfo
-    - TicketedEvent
-    - HotspotGroup
-    - Scope
-    - FeatureLimitInfo
-    - UserTierInfo
-    - FeatureQuotaInfo
-    - Sequence
-    - VersionMetadata
-    - ServiceStatus
-    - ServicesDeploymentStatus
-    - Site
-    - BasicSpace
-    - Space
-    - UserRoleInfo
-    - InviteUserRoleInfo
-    - OlyAnchorPosition
-    - OlyRotation
-    - Anchor
-    - AnchorResolution
-    - PointOfInterest
-    - BasicProfile
-    - Profile
-    - Array<T>
+  - MessageInfo
+  - ComponentUpdateInfo
+  - Asset
+  - AssetCollection
+  - CurrencyInfo
+  - ProductMediaInfo
+  - VariantOptionInfo
+  - ProductVariantInfo
+  - ProductInfo
+  - CartLine
+  - ShopifyStoreInfo
+  - TicketedEvent
+  - HotspotGroup
+  - Scope
+  - FeatureLimitInfo
+  - UserTierInfo
+  - FeatureQuotaInfo
+  - Sequence
+  - VersionMetadata
+  - ServiceStatus
+  - ServicesDeploymentStatus
+  - Site
+  - BasicSpace
+  - Space
+  - UserRoleInfo
+  - InviteUserRoleInfo
+  - OlyAnchorPosition
+  - OlyRotation
+  - Anchor
+  - AnchorResolution
+  - PointOfInterest
+  - BasicProfile
+  - Profile
+  - Array<T>
 
 ## [6.24.0]
 
@@ -223,7 +226,7 @@ All notable changes to this project will be documented in this file. For compile
 
 - [NT-0] refac: Moved enum StereoVideoType to SharedEnums StereoVideoType by MAG-JamesEdgeworth
   This change moves the StereoVideoType enum from the VideoComponent to the SharedEnums header, making it more accessible for use across different components and systems that may need to reference stereo video types.
-  
+
 ### 🔥 ❗Breaking Changes
 
 - [OF-1821] feat!: Pass `LocomotionModel` on init via `CreateAvatar` by mag-lt
@@ -246,7 +249,7 @@ All notable changes to this project will be documented in this file. For compile
   SpaceEntity::IsModifiable now returns an enum, specifying the reason.
   Also adds IRealtimeEngine::IsEntityModifiable and derived functions in all realtime engine implementations.
   Also adds SpaceEntity::IsModifiableWithReason which acts as a wrapper around the above functions.
-  
+
 ### 💫 💥 Code Refactors
 
 - [NT-0] refac: Remove use of metadata for storing Hotspot Sequence keys by MAG-AdamThorn
@@ -260,17 +263,17 @@ All notable changes to this project will be documented in this file. For compile
   This method provides a means of changing a users tier (basic, pro, enterprise, etc)
   through the api. This method will only succeed when logged in as an admin user.
   This method is mostly for internal testing, but there is no harm allowing public use.
-  
+
   This method provides a means of changing a users tier (basic, pro, enterprise, etc) through the api. This method will only succeed when logged in as an admin user. This method is mostly for internal testing, but there is no harm allowing public use.
 
 ### 🔨 🔨 Chore
 
 - [OPE-3056] chore: Add exported symbols, equality operators, and hash implementation
-  for types required for the common modules in the C# SWIG wrapper. This will be a 
+  for types required for the common modules in the C# SWIG wrapper. This will be a
   common theme going forward.
-    - Exported Map<String,ReplicatedValue>, and a gamut of Optional<T> arithmetic type instantiations
-    - Add `iterator` and `reverse_iterator` typedefs and implementation to `List`
-    - Add `std::hash` specializations for `String`, `Array<T>`, `List<T>`, `Map<T>`, `ReplicatedValue`, `ApplicationSettings` and `SettingsCollection`.
+  - Exported Map<String,ReplicatedValue>, and a gamut of Optional<T> arithmetic type instantiations
+  - Add `iterator` and `reverse_iterator` typedefs and implementation to `List`
+  - Add `std::hash` specializations for `String`, `Array<T>`, `List<T>`, `Map<T>`, `ReplicatedValue`, `ApplicationSettings` and `SettingsCollection`.
 
 ### 🐛 🔨 Bug Fixes
 
@@ -287,11 +290,11 @@ All notable changes to this project will be documented in this file. For compile
 - [OB-4154] fix!: Improve how Hotspot sequence event data is handled by MAG-AdamThorn
   The existing implementation of `HotspotSequenceChangedNetworkEventData` was unnecessarily complex and confusing to developers. This event type has now been removed and new `SpaceId` and `SequenceType` properties have been added to the `SequenceChangedNetworkEventData`.
   This is a breaking change:
-  * `SequenceChangedNetworkEventData` no longer has a `HotspotData` member.
-  * `SequenceChangedNetworkEventData` has two new members, `SpaceId` (String) and `SequenceType` (ESequenceType enum).
-  * When renaming a Hotspot Sequence, access to the old and new names has been updated as follows:
-      * SequenceChangedNetworkEventData.HotspotData.Name > SequenceChangedNetworkEventData.Key
-	  * SequenceChangedNetworkEventData.HotspotData.NewName > SequenceChangedNetworkEventData.NewKey
+  - `SequenceChangedNetworkEventData` no longer has a `HotspotData` member.
+  - `SequenceChangedNetworkEventData` has two new members, `SpaceId` (String) and `SequenceType` (ESequenceType enum).
+  - When renaming a Hotspot Sequence, access to the old and new names has been updated as follows:
+    - SequenceChangedNetworkEventData.HotspotData.Name > SequenceChangedNetworkEventData.Key
+    - SequenceChangedNetworkEventData.HotspotData.NewName > SequenceChangedNetworkEventData.NewKey
 
 ## [6.19.0]
 
@@ -299,7 +302,7 @@ All notable changes to this project will be documented in this file. For compile
 
 - [NT-0] feat: Exposed equality and inequality operators for `Vector2`, `Vector3`, `Vector4` and `Map` by MAG-ElliotMorris.
   Also added hash functions in the `std` namespace for the Vector types.
-  
+
 ### 🐛 🔨 Bug Fixes
 
 - [OB-4123] fix: Fix some text rendering as black/unreadable in generated docs.
@@ -328,7 +331,7 @@ All notable changes to this project will be documented in this file. For compile
 
 - [OF-1758] feat: replace assertion in token expiration with meaningful log to notify users by MAG-ChristopherAtkinson
   RefreshIfExpired invokes a fatal log message in place of the existing assert as asserting on a refresh token failure is too aggressive.
-  
+
 ### 🙈 🙉 🙊 Test Changes
 
 - [NT-0] test: Await exiting spaces in certain realtime engine tests by MAG-ElliotMorris.

--- a/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
@@ -44,6 +44,8 @@ enum class CinematicCameraPropertyKeys : uint16_t
     Aperture,
     IsViewerCamera,
     ThirdPartyComponentRef,
+    FocusDistance,
+    DepthOfFieldEnabled,
     Num
 };
 
@@ -153,8 +155,24 @@ public:
 
     /// @brief Set aperture
     /// Note: reserved for future use, do not implement on clients
-    /// @param Value float : aperture Flag
+    /// @param Value float : aperture
     void SetAperture(float Value);
+
+    /// @brief Get focus distance.
+    /// @param Value float : focus distance
+    float GetFocusDistance() const;
+
+    /// @brief Set focus distance
+    /// @param Value float : focus distance
+    void SetFocusDistance(float Value);
+
+    /// @brief Get depth of field enabled flag
+    /// @return Current depth of field enabled flag
+    bool GetDepthOfFieldEnabled() const;
+
+    /// @brief Set depth of field enabled flag
+    /// @param Value boolean : Depth of field enabled flag
+    void SetDepthOfFieldEnabled(bool Value);
 
     /// @brief Get IsViewerCamera.
     /// Note: reserved for future use, do not implement on clients

--- a/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
@@ -149,12 +149,10 @@ public:
     void SetShutterSpeed(float Value);
 
     /// @brief Get aperture.
-    /// Note: reserved for future use, do not implement on clients
     /// @param Value float : aperture
     float GetAperture() const;
 
     /// @brief Set aperture
-    /// Note: reserved for future use, do not implement on clients
     /// @param Value float : aperture
     void SetAperture(float Value);
 

--- a/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
@@ -86,6 +86,16 @@ const auto Schema = ComponentSchema {
             4.0f,
         },
         {
+            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FocusDistance),
+            "focusDistance",
+            5.0f,
+        },
+        {
+            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::DepthOfFieldEnabled),
+            "depthOfFieldEnabled",
+            false,
+        },
+        {
             static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::IsViewerCamera),
             "isViewerCamera",
             false,
@@ -200,6 +210,28 @@ void CinematicCameraSpaceComponent::SetShutterSpeed(float Value)
 float CinematicCameraSpaceComponent::GetAperture() const { return GetFloatProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Aperture)); }
 
 void CinematicCameraSpaceComponent::SetAperture(float Value) { SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Aperture), Value); }
+
+// Focus Distance
+float CinematicCameraSpaceComponent::GetFocusDistance() const
+{
+    return GetFloatProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::FocusDistance));
+}
+
+void CinematicCameraSpaceComponent::SetFocusDistance(float Value)
+{
+    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::FocusDistance), Value);
+}
+
+// Depth of Field Enabled
+bool CinematicCameraSpaceComponent::GetDepthOfFieldEnabled() const
+{
+    return GetBooleanProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::DepthOfFieldEnabled));
+}
+
+void CinematicCameraSpaceComponent::SetDepthOfFieldEnabled(bool Value)
+{
+    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::DepthOfFieldEnabled), Value);
+}
 
 // Is Viewer Camera
 bool CinematicCameraSpaceComponent::GetIsViewerCamera() const

--- a/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/CinematicCameraComponentTests.cpp
@@ -87,6 +87,8 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     EXPECT_FLOAT_EQ(CinematicCamera->GetIso(), 400.0f);
     EXPECT_FLOAT_EQ(CinematicCamera->GetShutterSpeed(), 0.0167f);
     EXPECT_FLOAT_EQ(CinematicCamera->GetAperture(), 4.0f);
+    EXPECT_FLOAT_EQ(CinematicCamera->GetFocusDistance(), 5.0f);
+    EXPECT_FALSE(CinematicCamera->GetDepthOfFieldEnabled());
     EXPECT_FALSE(CinematicCamera->GetIsViewerCamera());
 
     // Set the new values
@@ -100,6 +102,8 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     CinematicCamera->SetIso(1000.0f);
     CinematicCamera->SetShutterSpeed(0.003f);
     CinematicCamera->SetAperture(10.0f);
+    CinematicCamera->SetFocusDistance(1.0f);
+    CinematicCamera->SetDepthOfFieldEnabled(true);
     CinematicCamera->SetIsViewerCamera(true);
 
     EXPECT_FLOAT_EQ(CinematicCamera->GetFocalLength(), 2.0f);
@@ -112,6 +116,8 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraComponentTest)
     EXPECT_FLOAT_EQ(CinematicCamera->GetIso(), 1000.0f);
     EXPECT_FLOAT_EQ(CinematicCamera->GetShutterSpeed(), 0.003f);
     EXPECT_FLOAT_EQ(CinematicCamera->GetAperture(), 10.0f);
+    EXPECT_FLOAT_EQ(CinematicCamera->GetFocusDistance(), 1.0f);
+    EXPECT_TRUE(CinematicCamera->GetDepthOfFieldEnabled());
     EXPECT_TRUE(CinematicCamera->GetIsViewerCamera());
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
@@ -227,20 +233,22 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
 
     // Setup script
     const std::string CinematicCameraScriptText = R"xx(
-		const cinematicCamera = ThisEntity.getCinematicCameraComponents()[0];
-		cinematicCamera.position = [3, 2, 1];
-		cinematicCamera.rotation = [1, 2, 3, 1];
-		cinematicCamera.aspectRatio = 1.3;
-		cinematicCamera.sensorSize = [1,2];
-		cinematicCamera.nearClip = 1;
-		cinematicCamera.farClip = 100;
-		cinematicCamera.iso = 1000;
-		cinematicCamera.shutterSpeed = 0.003;
-		cinematicCamera.aperture = 10;
-		cinematicCamera.focalLength = 2;
-		cinematicCamera.isViewerCamera = true;
-		cinematicCamera.isEnabled = false;
-	)xx";
+        const cinematicCamera = ThisEntity.getCinematicCameraComponents()[0];
+        cinematicCamera.position = [3, 2, 1];
+        cinematicCamera.rotation = [1, 2, 3, 1];
+        cinematicCamera.aspectRatio = 1.3;
+        cinematicCamera.sensorSize = [1,2];
+        cinematicCamera.nearClip = 1;
+        cinematicCamera.farClip = 100;
+        cinematicCamera.iso = 1000;
+        cinematicCamera.shutterSpeed = 0.003;
+        cinematicCamera.aperture = 10;
+        cinematicCamera.focalLength = 2;
+        cinematicCamera.isViewerCamera = true;
+        cinematicCamera.isEnabled = false;
+        cinematicCamera.focusDistance = 10.0;
+        cinematicCamera.depthOfFieldEnabled = true;
+    )xx";
 
     CreatedObject->GetScript().SetScriptSource(CinematicCameraScriptText.c_str());
     CreatedObject->GetScript().Invoke();
@@ -259,6 +267,8 @@ CSP_PUBLIC_TEST(CSPEngine, CinematicCameraTests, CinematicCameraScriptInterfaceT
     EXPECT_FLOAT_EQ(CinematicCamera->GetFocalLength(), 2.0f);
     EXPECT_TRUE(CinematicCamera->GetIsViewerCamera());
     EXPECT_FALSE(CinematicCamera->GetIsEnabled());
+    EXPECT_FLOAT_EQ(CinematicCamera->GetFocusDistance(), 10.0f);
+    EXPECT_TRUE(CinematicCamera->GetDepthOfFieldEnabled());
 
     auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
 


### PR DESCRIPTION
[OW-2438] feat: Properties to support cinematic camera depth of field

- Updated cinematic camera component to add depth of field enabled and focus distance properties
- Added properties to cinematic camera component tests
- Removed '_reserved for future use_' comment for aperture property on cinematic camera component as it will be used by clients for depth of field


[OW-2438]: https://magnopus.atlassian.net/browse/OW-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ