### PR TITLE
[OF-1866] feat: Add public API for interacting with Components defined w/ Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file. For compile
 
 ### 🍰 🙌 New Features
 
+- [OF-1866] feat: Add public API for interacting with Components defined in terms of a Schema description. By @mag-lt.
+  This adds the following public methods:
+  - `IRealtimeEngine::GetComponentSchemaRegistry()`: Returns a "registry" instance, a read-only type describing the Components known by the engine. This can be used to interrogate the shape of a Component at runtime. Currently this is populated by CSP with a corresponding Schema for each of the hardcoded Component types in the library. It is still not possible to register a new schema externally, but this will come in a future release.
+  - `SpaceEntity::AddComponentByTypeId(uint64_t TypeId)`: Allows adding a component that corresponds to a Schema with the given TypeId.
+  - `ComponentBase::GetTypeId()`: This returns the unique integer ID representing the component type. For traditional hardcoded components, this corresponds to casting the `ComponentType` to its underlying integer value. This supersedes `GetComponentType` in that it allows for representing an open vs closed set of components. Details of allocating these IDs in a unique fashion is still to be defined.
+  - `ComponentBase::GetSchemaProperty(uint16_t Key)`: Get the value of a property corresponding to the one declared with the given Key in the Schema. The Key must be in the Schema, or null is returned. This supersedes the hardcoded wrapper methods typically written, trading off static typing for the flexibility of defining components externally.
+  - `ComponentBase::SetSchemaProperty(uint16_t Key, const csp::common::ReplicatedValue& Value)`: Set the value of a property corresponding to the one declared with the given Key in the Schema. The Key must be in the Schema, and the value must match the type declared there or it is ignored. This supersedes the hardcoded wrapper methods typically written, trading off static typing for the flexibility of defining components externally.
+
 - [OW-2438] feat: Properties to support cinematic camera depth of field. By @MAG-ThomasGreenhalgh.
   Adds focus distance and depth of field enabled properties to the cinematic camera space component.
 

--- a/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
+++ b/Library/include/CSP/Common/Interfaces/IRealtimeEngine.h
@@ -23,7 +23,7 @@
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Common/String.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "CSP/Multiplayer/IComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
@@ -399,7 +399,7 @@ public:
 
     /// @brief Get the registry of component schemas, for enquiring about known components and their shape.
     /// @return A non-owning pointer to the registry. Despite being pointer vs a reference, this is contractually non-null.
-    CSP_NO_EXPORT virtual const csp::multiplayer::ComponentSchemaRegistry* GetComponentSchemaRegistry() const = 0;
+    virtual const csp::multiplayer::IComponentSchemaRegistry* GetComponentSchemaRegistry() const = 0;
 
 protected:
     // We want copies and moves and such to be possible for derived types, but they need to be sure to explicitly implement the behaviour.

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -183,6 +183,14 @@ public:
     // Used for handling behavior when a client first deletes the component.
     CSP_NO_EXPORT virtual void OnLocalDelete();
 
+    /// @brief Get a property value by schema key.
+    /// @return A pointer to the value, or nullptr if the key is not in this component's schema.
+    const csp::common::ReplicatedValue* GetSchemaProperty(uint16_t Key) const;
+
+    /// @brief Set a property value by schema key.
+    /// Silently ignored if the key is absent from this component's schema or the value type does not match the schema definition.
+    void SetSchemaProperty(uint16_t Key, const csp::common::ReplicatedValue& Value);
+
 protected:
     ComponentBase();
     ComponentBase(uint64_t TypeId, csp::common::LogSystem* LogSystem, SpaceEntity* Parent);
@@ -228,6 +236,8 @@ protected:
     csp::common::LogSystem* LogSystem = nullptr;
 
     csp::common::Map<csp::common::String, EntityActionHandler> ActionMap;
+
+    std::unique_ptr<ComponentSchema> CachedSchema;
 
 private:
     void InitialiseProperties();

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -129,6 +129,17 @@ public:
     /// @return The type of the component as an enum.
     ComponentType GetComponentType() const;
 
+    /// @brief Get the TypeId of the component.
+    /// @return A unique integer ID representing the component type.
+    ///
+    /// @note This method is conceptually similar to GetComponentType(), but handles an 
+    ///       open set of IDs. For built-in, statically defined components, this ID is 
+    ///       guaranteed to be the exact integer cast of its ComponentType enum value. 
+    ///       For dynamically registered components, it returns the ID specified by its schema.
+    ///
+    /// @see GetComponentType()
+    uint64_t GetTypeId() const;
+
     /// @brief Get a map of the replicated values defined for this component.
     ///
     /// The index of the map represents a unique index for the property,
@@ -174,6 +185,7 @@ public:
 
 protected:
     ComponentBase();
+    ComponentBase(uint64_t TypeId, csp::common::LogSystem* LogSystem, SpaceEntity* Parent);
 
     const csp::common::ReplicatedValue& GetProperty(uint32_t Key) const;
     bool GetBooleanProperty(uint32_t Key) const;
@@ -206,7 +218,7 @@ protected:
 
     SpaceEntity* Parent;
     uint16_t Id;
-    ComponentType Type;
+    uint64_t Type;
     csp::common::Map<uint32_t, csp::common::ReplicatedValue> Properties;
     csp::common::Map<uint32_t, csp::common::ReplicatedValue> DirtyProperties;
 

--- a/Library/include/CSP/Multiplayer/ComponentSchema.h
+++ b/Library/include/CSP/Multiplayer/ComponentSchema.h
@@ -19,7 +19,6 @@
 
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/Array.h"
-#include "CSP/Common/Map.h"
 #include "CSP/Common/String.h"
 
 #include <cstdint>
@@ -48,7 +47,5 @@ public:
     /// @brief The properties of this component
     csp::common::Array<ComponentProperty> Properties;
 };
-
-using ComponentSchemaRegistry = csp::common::Map<csp::multiplayer::ComponentSchema::TypeIdType, csp::multiplayer::ComponentSchema>;
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/IComponentSchemaRegistry.h
+++ b/Library/include/CSP/Multiplayer/IComponentSchemaRegistry.h
@@ -16,23 +16,25 @@
 
 #pragma once
 
-#include "CSP/Multiplayer/IComponentSchemaRegistry.h"
-
-#include <unordered_map>
+#include "CSP/CSPCommon.h"
+#include "CSP/Common/Array.h"
+#include "CSP/Multiplayer/ComponentSchema.h"
 
 namespace csp::multiplayer
 {
 
-class ComponentSchemaRegistryImpl final : public IComponentSchemaRegistry
+/// @brief Read-only interface for querying registered component schemas.
+class CSP_API IComponentSchemaRegistry
 {
 public:
-    ComponentSchemaRegistryImpl(const csp::common::Array<ComponentSchema>& AdditionalComponents);
+    virtual ~IComponentSchemaRegistry() = default;
 
-    csp::common::Array<ComponentSchema> GetAll() const override;
-    const ComponentSchema* Find(uint64_t TypeId) const override;
+    /// @brief Returns all registered schemas.
+    virtual csp::common::Array<ComponentSchema> GetAll() const = 0;
 
-private:
-    std::unordered_map<ComponentSchema::TypeIdType, ComponentSchema> SchemaMap;
+    /// @brief Finds the schema for the given TypeId.
+    /// @return A pointer to the schema if found, otherwise nullptr.
+    virtual const ComponentSchema* Find(uint64_t TypeId) const = 0;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/IComponentSchemaRegistry.h
+++ b/Library/include/CSP/Multiplayer/IComponentSchemaRegistry.h
@@ -35,6 +35,13 @@ public:
     /// @brief Finds the schema for the given TypeId.
     /// @return A pointer to the schema if found, otherwise nullptr.
     virtual const ComponentSchema* Find(uint64_t TypeId) const = 0;
+
+protected:
+    CSP_NO_EXPORT IComponentSchemaRegistry() = default;
+    IComponentSchemaRegistry(const IComponentSchemaRegistry&) = delete;
+    IComponentSchemaRegistry(IComponentSchemaRegistry&&) = delete;
+    IComponentSchemaRegistry& operator=(const IComponentSchemaRegistry&) = delete;
+    IComponentSchemaRegistry& operator=(IComponentSchemaRegistry&&) = delete;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
@@ -235,7 +235,7 @@ public:
 
     /// @brief Get the registry of component schemas, for enquiring about known components and their shape.
     /// @return A non-owning pointer to the registry. Despite being pointer vs a reference, this is contractually non-null.
-    CSP_NO_EXPORT const csp::multiplayer::ComponentSchemaRegistry* GetComponentSchemaRegistry() const override;
+    const csp::multiplayer::IComponentSchemaRegistry* GetComponentSchemaRegistry() const override;
 
     /***** IREALTIMEENGINE INTERFACE IMPLEMENTAITON END *************************************************/
 
@@ -269,6 +269,6 @@ private:
     std::unique_ptr<class OfflineSpaceEntityEventHandler> EventHandler;
     std::unique_ptr<EntityScriptBinding> ScriptBinding;
 
-    csp::multiplayer::ComponentSchemaRegistry ComponentRegistry;
+    std::unique_ptr<csp::multiplayer::IComponentSchemaRegistry> ComponentRegistry;
 };
 }

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -276,7 +276,7 @@ public:
 
     /// @brief Get the registry of component schemas, for enquiring about known components and their shape.
     /// @return A non-owning pointer to the registry. Despite being pointer vs a reference, this is contractually non-null.
-    CSP_NO_EXPORT const csp::multiplayer::ComponentSchemaRegistry* GetComponentSchemaRegistry() const override;
+    const csp::multiplayer::IComponentSchemaRegistry* GetComponentSchemaRegistry() const override;
 
     /***** IREALTIMEENGINE INTERFACE IMPLEMENTAITON END *************************************************/
 
@@ -517,7 +517,7 @@ private:
     // May not be null
     csp::multiplayer::NetworkEventBus* NetworkEventBus;
 
-    csp::multiplayer::ComponentSchemaRegistry ComponentRegistry;
+    std::unique_ptr<csp::multiplayer::IComponentSchemaRegistry> ComponentRegistry;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/SpaceEntity.h
+++ b/Library/include/CSP/Multiplayer/SpaceEntity.h
@@ -277,6 +277,15 @@ public:
     /// @return The newly created component.
     ComponentBase* AddComponent(ComponentType Type);
 
+    /// @brief Add a component by TypeId.
+    /// For a TypeId that maps to a built-in, statically defined component, this creates the same concrete type as AddComponent(ComponentType) for
+    /// backwards compatibility (i.e. it is still safe to cast it to the specific concrete type). However, the intention of this method is to use the
+    /// returned component via the base interface only.
+    /// For a TypeId that maps to a schema-defined component, this creates a ComponentBase backed by the registered schema.
+    /// @param TypeId The TypeId to look up.
+    /// @return The newly created component, or nullptr if TypeId is not registered.
+    ComponentBase* AddComponentByTypeId(uint64_t TypeId);
+
     /// @brief Mark that a component has just been updated, ie, that a property on it has been modified.
     /// @param Component ComponentBase : The component that has just updated
     /// @warning This is a pattern divergence, as updates to component data happen immediately, rather than being deferred via the regular patch flow.
@@ -450,7 +459,7 @@ public:
 
 private:
     uint16_t GenerateComponentId();
-    ComponentBase* InstantiateComponent(uint16_t Id, ComponentType Type);
+    ComponentBase* InstantiateComponent(uint16_t Id, uint64_t TypeId);
 
     void AddChildEntity(SpaceEntity* ChildEntity);
 

--- a/Library/src/Common/ReplicatedValue.cpp
+++ b/Library/src/Common/ReplicatedValue.cpp
@@ -114,7 +114,11 @@ ReplicatedValue& ReplicatedValue::operator=(ReplicatedValue&& Other)
     return *this;
 }
 
-bool ReplicatedValue::operator==(const ReplicatedValue& OtherValue) const { return (Value) == OtherValue.Value; }
+bool ReplicatedValue::operator==(const ReplicatedValue& OtherValue) const
+{
+    return OtherValue.ReplicatedType == ReplicatedType && (Value) == OtherValue.Value;
+}
+
 bool ReplicatedValue::operator!=(const ReplicatedValue& OtherValue) const { return (*this == OtherValue) == false; }
 
 void ReplicatedValue::SetBool(bool InValue)

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -36,25 +36,30 @@ static const csp::common::ReplicatedValue InvalidValue = csp::common::Replicated
 ComponentBase::ComponentBase()
     : Parent(nullptr)
     , Id(0)
-    , Type(ComponentType::Invalid)
+    , Type(static_cast<uint64_t>(ComponentType::Invalid))
     , ScriptInterface(nullptr)
     , LogSystem(nullptr)
 {
     InitialiseProperties();
 }
 
-ComponentBase::ComponentBase(ComponentType Type, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
+ComponentBase::ComponentBase(uint64_t TypeId, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
     : Parent(Parent)
     , Id(0)
-    , Type(Type)
+    , Type(TypeId)
     , ScriptInterface(nullptr)
     , LogSystem(LogSystem)
 {
     InitialiseProperties();
 }
 
+ComponentBase::ComponentBase(ComponentType Type, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
+    : ComponentBase(static_cast<uint64_t>(Type), LogSystem, Parent)
+{
+}
+
 ComponentBase::ComponentBase(const ComponentSchema& Schema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ComponentBase(static_cast<ComponentType>(Schema.TypeId), LogSystem, Parent)
+    : ComponentBase(Schema.TypeId, LogSystem, Parent)
 {
     for (const auto& Property : Schema.Properties)
     {
@@ -73,7 +78,9 @@ uint16_t ComponentBase::GetId() const { return Id; }
 
 void ComponentBase::SetId(uint16_t NewId) { this->Id = NewId; }
 
-ComponentType ComponentBase::GetComponentType() const { return Type; }
+ComponentType ComponentBase::GetComponentType() const { return static_cast<ComponentType>(Type); }
+
+uint64_t ComponentBase::GetTypeId() const { return Type; }
 
 const csp::common::Map<uint32_t, csp::common::ReplicatedValue>* ComponentBase::GetProperties() const { return &Properties; }
 

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -26,6 +26,7 @@
 #include "Multiplayer/Script/ComponentScriptHelpers.h"
 #include "Multiplayer/Script/ComponentScriptInterface.h"
 
+#include <algorithm>
 #include <fmt/format.h>
 
 namespace csp::multiplayer
@@ -61,6 +62,8 @@ ComponentBase::ComponentBase(ComponentType Type, csp::common::LogSystem* LogSyst
 ComponentBase::ComponentBase(const ComponentSchema& Schema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
     : ComponentBase(Schema.TypeId, LogSystem, Parent)
 {
+    this->CachedSchema = std::make_unique<ComponentSchema>(Schema);
+
     for (const auto& Property : Schema.Properties)
     {
         Properties[Property.Key] = Property.DefaultValue;
@@ -81,6 +84,46 @@ void ComponentBase::SetId(uint16_t NewId) { this->Id = NewId; }
 ComponentType ComponentBase::GetComponentType() const { return static_cast<ComponentType>(Type); }
 
 uint64_t ComponentBase::GetTypeId() const { return Type; }
+
+namespace
+{
+    const ComponentProperty* FindSchemaProperty(const ComponentSchema& Schema, uint16_t Key)
+    {
+        const auto It
+            = std::find_if(Schema.Properties.begin(), Schema.Properties.end(), [Key](const ComponentProperty& Prop) { return Prop.Key == Key; });
+        return It != Schema.Properties.end() ? &*It : nullptr;
+    }
+} // namespace
+
+const csp::common::ReplicatedValue* ComponentBase::GetSchemaProperty(uint16_t Key) const
+{
+    if (!CachedSchema)
+    {
+        return nullptr;
+    }
+
+    if (!FindSchemaProperty(*CachedSchema, Key))
+    {
+        return nullptr;
+    }
+
+    const auto& Value = GetProperty(Key);
+    return Value != InvalidValue ? &Value : nullptr;
+}
+
+void ComponentBase::SetSchemaProperty(uint16_t Key, const csp::common::ReplicatedValue& Value)
+{
+    if (!CachedSchema)
+    {
+        return;
+    }
+
+    if (const auto* Property = FindSchemaProperty(*CachedSchema, Key);
+        Property && Value.GetReplicatedValueType() == Property->DefaultValue.GetReplicatedValueType())
+    {
+        SetProperty(Key, Value);
+    }
+}
 
 const csp::common::Map<uint32_t, csp::common::ReplicatedValue>* ComponentBase::GetProperties() const { return &Properties; }
 

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -22,6 +22,7 @@
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
 #include "ComponentBaseKeys.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/RealtimeEngineUtils.h"
 #include "Multiplayer/Script/ComponentScriptHelpers.h"
 #include "Multiplayer/Script/ComponentScriptInterface.h"
@@ -81,7 +82,7 @@ uint16_t ComponentBase::GetId() const { return Id; }
 
 void ComponentBase::SetId(uint16_t NewId) { this->Id = NewId; }
 
-ComponentType ComponentBase::GetComponentType() const { return static_cast<ComponentType>(Type); }
+ComponentType ComponentBase::GetComponentType() const { return ToComponentType(Type).value_or(ComponentType::Invalid); }
 
 uint64_t ComponentBase::GetTypeId() const { return Type; }
 

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -16,6 +16,8 @@
 
 #include "ComponentSchemaRegistry.h"
 
+#include "CSP/Multiplayer/ComponentBase.h"
+
 #include "CSP/Multiplayer/Components/AIChatbotComponent.h"
 #include "CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h"
 #include "CSP/Multiplayer/Components/AudioSpaceComponent.h"
@@ -45,46 +47,59 @@
 namespace csp::multiplayer
 {
 
-ComponentSchemaRegistry MergeWithLegacyComponents(const csp::common::Array<ComponentSchema>& AdditionalComponents)
+ComponentSchemaRegistryImpl::ComponentSchemaRegistryImpl(const csp::common::Array<ComponentSchema>& AdditionalComponents)
 {
-    const auto ToPair = [](const ComponentSchema& Schema) {
-        return std::make_pair(Schema.TypeId, Schema);
-    };
-
-    auto Registry = ComponentSchemaRegistry {
-        ToPair(StaticModelSpaceComponent::GetSchema()),
-        ToPair(AnimatedModelSpaceComponent::GetSchema()),
-        ToPair(VideoPlayerSpaceComponent::GetSchema()),
-        ToPair(ImageSpaceComponent::GetSchema()),
-        ToPair(ExternalLinkSpaceComponent::GetSchema()),
-        ToPair(AvatarSpaceComponent::GetSchema()),
-        ToPair(LightSpaceComponent::GetSchema()),
-        ToPair(ScriptSpaceComponent::GetSchema()),
-        ToPair(ButtonSpaceComponent::GetSchema()),
-        ToPair(CustomSpaceComponent::GetSchema()),
-        ToPair(PortalSpaceComponent::GetSchema()),
-        ToPair(ConversationSpaceComponent::GetSchema()),
-        ToPair(AudioSpaceComponent::GetSchema()),
-        ToPair(SplineSpaceComponent::GetSchema()),
-        ToPair(CollisionSpaceComponent::GetSchema()),
-        ToPair(ReflectionSpaceComponent::GetSchema()),
-        ToPair(FogSpaceComponent::GetSchema()),
-        ToPair(ECommerceSpaceComponent::GetSchema()),
-        ToPair(CinematicCameraSpaceComponent::GetSchema()),
-        ToPair(FiducialMarkerSpaceComponent::GetSchema()),
-        ToPair(GaussianSplatSpaceComponent::GetSchema()),
-        ToPair(TextSpaceComponent::GetSchema()),
-        ToPair(HotspotSpaceComponent::GetSchema()),
-        ToPair(ScreenSharingSpaceComponent::GetSchema()),
-        ToPair(AIChatbotSpaceComponent::GetSchema()), 
-    };
-
     for (const auto& Schema : AdditionalComponents)
     {
-        Registry[Schema.TypeId] = Schema;
+        SchemaMap[Schema.TypeId] = Schema;
     }
 
-    return Registry;
+    const auto AddSchema = [this](const ComponentSchema& Schema) { SchemaMap[Schema.TypeId] = Schema; };
+
+    AddSchema(StaticModelSpaceComponent::GetSchema());
+    AddSchema(AnimatedModelSpaceComponent::GetSchema());
+    AddSchema(VideoPlayerSpaceComponent::GetSchema());
+    AddSchema(ImageSpaceComponent::GetSchema());
+    AddSchema(ExternalLinkSpaceComponent::GetSchema());
+    AddSchema(AvatarSpaceComponent::GetSchema());
+    AddSchema(LightSpaceComponent::GetSchema());
+    AddSchema(ScriptSpaceComponent::GetSchema());
+    AddSchema(ButtonSpaceComponent::GetSchema());
+    AddSchema(CustomSpaceComponent::GetSchema());
+    AddSchema(PortalSpaceComponent::GetSchema());
+    AddSchema(ConversationSpaceComponent::GetSchema());
+    AddSchema(AudioSpaceComponent::GetSchema());
+    AddSchema(SplineSpaceComponent::GetSchema());
+    AddSchema(CollisionSpaceComponent::GetSchema());
+    AddSchema(ReflectionSpaceComponent::GetSchema());
+    AddSchema(FogSpaceComponent::GetSchema());
+    AddSchema(ECommerceSpaceComponent::GetSchema());
+    AddSchema(CinematicCameraSpaceComponent::GetSchema());
+    AddSchema(FiducialMarkerSpaceComponent::GetSchema());
+    AddSchema(GaussianSplatSpaceComponent::GetSchema());
+    AddSchema(TextSpaceComponent::GetSchema());
+    AddSchema(HotspotSpaceComponent::GetSchema());
+    AddSchema(ScreenSharingSpaceComponent::GetSchema());
+    AddSchema(AIChatbotSpaceComponent::GetSchema());
+}
+
+csp::common::Array<ComponentSchema> ComponentSchemaRegistryImpl::GetAll() const
+{
+    csp::common::Array<ComponentSchema> Result(SchemaMap.size());
+    size_t Index = 0;
+
+    for (const auto& [TypeId, Schema] : SchemaMap)
+    {
+        Result[Index++] = Schema;
+    }
+
+    return Result;
+}
+
+const ComponentSchema* ComponentSchemaRegistryImpl::Find(uint64_t TypeId) const
+{
+    const auto It = SchemaMap.find(TypeId);
+    return It != SchemaMap.end() ? &It->second : nullptr;
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -44,6 +44,9 @@
 #include "CSP/Multiplayer/Components/TextSpaceComponent.h"
 #include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
 
+#include <limits>
+#include <type_traits>
+
 namespace csp::multiplayer
 {
 
@@ -102,8 +105,16 @@ const ComponentSchema* ComponentSchemaRegistryImpl::Find(uint64_t TypeId) const
     return It != SchemaMap.end() ? &It->second : nullptr;
 }
 
-bool IsLegacyComponentTypeId(uint64_t TypeId)
+std::optional<ComponentType> ToComponentType(uint64_t TypeId)
 {
+    using Underlying = std::underlying_type_t<ComponentType>;
+    static_assert(std::is_unsigned_v<Underlying>);
+
+    if (TypeId > static_cast<uint64_t>(std::numeric_limits<Underlying>::max()))
+    {
+        return std::nullopt;
+    }
+
     switch (static_cast<ComponentType>(TypeId))
     {
     case ComponentType::Invalid:
@@ -137,10 +148,12 @@ bool IsLegacyComponentTypeId(uint64_t TypeId)
     case ComponentType::ScreenSharing:
     case ComponentType::AIChatbot:
     case ComponentType::Delete:
-        return true;
+        return static_cast<ComponentType>(TypeId);
     }
 
-    return false;
+    return std::nullopt;
 }
+
+bool IsLegacyComponentTypeId(uint64_t TypeId) { return ToComponentType(TypeId).has_value(); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -18,6 +18,7 @@
 
 #include "CSP/Multiplayer/ComponentBase.h"
 
+#include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Multiplayer/Components/AIChatbotComponent.h"
 #include "CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h"
 #include "CSP/Multiplayer/Components/AudioSpaceComponent.h"
@@ -44,20 +45,33 @@
 #include "CSP/Multiplayer/Components/TextSpaceComponent.h"
 #include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
 
+#include <fmt/format.h>
+
 #include <limits>
 #include <type_traits>
 
 namespace csp::multiplayer
 {
 
-ComponentSchemaRegistryImpl::ComponentSchemaRegistryImpl(const csp::common::Array<ComponentSchema>& AdditionalComponents)
+ComponentSchemaRegistryImpl::ComponentSchemaRegistryImpl(
+    csp::common::LogSystem& LogSystem, const csp::common::Array<ComponentSchema>& AdditionalComponents)
 {
+    const auto AddSchema = [this, &LogSystem](const ComponentSchema& Schema)
+    {
+        const auto Result = SchemaMap.insert_or_assign(Schema.TypeId, Schema);
+        const auto DidReplace = !Result.second;
+
+        if (DidReplace)
+        {
+            LogSystem.LogMsg(
+                csp::common::LogLevel::Warning, fmt::format("Replaced a previously registered schema for TypeId: {}", Schema.TypeId).c_str());
+        }
+    };
+
     for (const auto& Schema : AdditionalComponents)
     {
-        SchemaMap[Schema.TypeId] = Schema;
+        AddSchema(Schema);
     }
-
-    const auto AddSchema = [this](const ComponentSchema& Schema) { SchemaMap[Schema.TypeId] = Schema; };
 
     AddSchema(StaticModelSpaceComponent::GetSchema());
     AddSchema(AnimatedModelSpaceComponent::GetSchema());

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -102,4 +102,45 @@ const ComponentSchema* ComponentSchemaRegistryImpl::Find(uint64_t TypeId) const
     return It != SchemaMap.end() ? &It->second : nullptr;
 }
 
+bool IsLegacyComponentTypeId(uint64_t TypeId)
+{
+    switch (static_cast<ComponentType>(TypeId))
+    {
+    case ComponentType::Invalid:
+    case ComponentType::Core:
+    case ComponentType::UIController_DEPRECATED:
+    case ComponentType::StaticModel:
+    case ComponentType::AnimatedModel:
+    case ComponentType::MediaSurface_DEPRECATED:
+    case ComponentType::VideoPlayer:
+    case ComponentType::ImageSequencer_DEPRECATED:
+    case ComponentType::ExternalLink:
+    case ComponentType::AvatarData:
+    case ComponentType::Light:
+    case ComponentType::Button:
+    case ComponentType::Image:
+    case ComponentType::ScriptData:
+    case ComponentType::Custom:
+    case ComponentType::Conversation:
+    case ComponentType::Portal:
+    case ComponentType::Audio:
+    case ComponentType::Spline:
+    case ComponentType::Collision:
+    case ComponentType::Reflection:
+    case ComponentType::Fog:
+    case ComponentType::ECommerce:
+    case ComponentType::FiducialMarker:
+    case ComponentType::GaussianSplat:
+    case ComponentType::Text:
+    case ComponentType::Hotspot:
+    case ComponentType::CinematicCamera:
+    case ComponentType::ScreenSharing:
+    case ComponentType::AIChatbot:
+    case ComponentType::Delete:
+        return true;
+    }
+
+    return false;
+}
+
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.h
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.h
@@ -22,6 +22,11 @@
 #include <optional>
 #include <unordered_map>
 
+namespace csp::common
+{
+class LogSystem;
+}
+
 namespace csp::multiplayer
 {
 
@@ -32,7 +37,7 @@ bool IsLegacyComponentTypeId(uint64_t TypeId);
 class ComponentSchemaRegistryImpl final : public IComponentSchemaRegistry
 {
 public:
-    ComponentSchemaRegistryImpl(const csp::common::Array<ComponentSchema>& AdditionalComponents);
+    ComponentSchemaRegistryImpl(csp::common::LogSystem&, const csp::common::Array<ComponentSchema>& AdditionalComponents);
 
     csp::common::Array<ComponentSchema> GetAll() const override;
     const ComponentSchema* Find(uint64_t TypeId) const override;

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.h
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.h
@@ -16,12 +16,16 @@
 
 #pragma once
 
+#include "CSP/Multiplayer/ComponentBase.h"
 #include "CSP/Multiplayer/IComponentSchemaRegistry.h"
 
+#include <optional>
 #include <unordered_map>
 
 namespace csp::multiplayer
 {
+
+std::optional<ComponentType> ToComponentType(uint64_t TypeId);
 
 bool IsLegacyComponentTypeId(uint64_t TypeId);
 

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.h
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.h
@@ -23,6 +23,8 @@
 namespace csp::multiplayer
 {
 
+bool IsLegacyComponentTypeId(uint64_t TypeId);
+
 class ComponentSchemaRegistryImpl final : public IComponentSchemaRegistry
 {
 public:

--- a/Library/src/Multiplayer/MCSComponentPacker.cpp
+++ b/Library/src/Multiplayer/MCSComponentPacker.cpp
@@ -95,7 +95,7 @@ mcs::ItemComponentData ToItemComponentData(ComponentBase* Value)
 
     // Manually write the component type, as this isn't stored in the component properties.
     // This is currently the ONLY value that uses a uint64 types as a key for some reason. The rest use int64.
-    ComponentPacker.WriteValue(COMPONENT_KEY_COMPONENTTYPE, static_cast<uint64_t>(Value->GetComponentType()));
+    ComponentPacker.WriteValue(COMPONENT_KEY_COMPONENTTYPE, Value->GetTypeId());
 
     // Our current component keys are stores as uint32s when they should really be stored as uint16, as this is what we support.
     std::unique_ptr<common::Array<uint32_t>> Keys(const_cast<common::Array<uint32_t>*>(Value->GetProperties()->Keys()));

--- a/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
@@ -115,7 +115,7 @@ OfflineRealtimeEngine::OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, 
     const csp::common::Array<ComponentSchema>& AdditionalComponents)
     : LogSystem { &LogSystem }
     , ScriptRunner { &RemoteScriptRunner }
-    , ComponentRegistry { std::make_unique<ComponentSchemaRegistryImpl>(AdditionalComponents) }
+    , ComponentRegistry { std::make_unique<ComponentSchemaRegistryImpl>(*this->LogSystem, AdditionalComponents) }
 {
     ScriptBinding = std::unique_ptr<EntityScriptBinding>(EntityScriptBinding::BindEntitySystem(this, *this->LogSystem, *this->ScriptRunner));
 

--- a/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
@@ -115,7 +115,7 @@ OfflineRealtimeEngine::OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, 
     const csp::common::Array<ComponentSchema>& AdditionalComponents)
     : LogSystem { &LogSystem }
     , ScriptRunner { &RemoteScriptRunner }
-    , ComponentRegistry { MergeWithLegacyComponents(AdditionalComponents) }
+    , ComponentRegistry { std::make_unique<ComponentSchemaRegistryImpl>(AdditionalComponents) }
 {
     ScriptBinding = std::unique_ptr<EntityScriptBinding>(EntityScriptBinding::BindEntitySystem(this, *this->LogSystem, *this->ScriptRunner));
 
@@ -328,7 +328,7 @@ ModifiableStatus OfflineRealtimeEngine::IsEntityModifiable(const csp::multiplaye
     }
 }
 
-const csp::multiplayer::ComponentSchemaRegistry* OfflineRealtimeEngine::GetComponentSchemaRegistry() const { return &ComponentRegistry; }
+const csp::multiplayer::IComponentSchemaRegistry* OfflineRealtimeEngine::GetComponentSchemaRegistry() const { return ComponentRegistry.get(); }
 
 std::recursive_mutex& OfflineRealtimeEngine::GetEntitiesLock() { return EntitiesLock; }
 

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -205,7 +205,7 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
     , EntityPatchRate(90)
     , ScriptRunner(&ScriptRunner)
     , NetworkEventBus(&NetworkEventBus)
-    , ComponentRegistry { MergeWithLegacyComponents(AdditionalComponents) }
+    , ComponentRegistry { std::make_unique<ComponentSchemaRegistryImpl>(AdditionalComponents) }
 {
     ScriptBinding = std::unique_ptr<EntityScriptBinding>(EntityScriptBinding::BindEntitySystem(this, *this->LogSystem, *this->ScriptRunner));
 
@@ -836,7 +836,7 @@ ModifiableStatus OnlineRealtimeEngine::IsEntityModifiable(const csp::multiplayer
     return ModifiableStatus::Modifiable;
 }
 
-const csp::multiplayer::ComponentSchemaRegistry* OnlineRealtimeEngine::GetComponentSchemaRegistry() const { return &ComponentRegistry; }
+const csp::multiplayer::IComponentSchemaRegistry* OnlineRealtimeEngine::GetComponentSchemaRegistry() const { return ComponentRegistry.get(); }
 
 void OnlineRealtimeEngine::RetrieveAllEntities(csp::common::EntityFetchCompleteCallback FetchCompleteCallback)
 {

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -205,7 +205,7 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
     , EntityPatchRate(90)
     , ScriptRunner(&ScriptRunner)
     , NetworkEventBus(&NetworkEventBus)
-    , ComponentRegistry { std::make_unique<ComponentSchemaRegistryImpl>(AdditionalComponents) }
+    , ComponentRegistry { std::make_unique<ComponentSchemaRegistryImpl>(*this->LogSystem, AdditionalComponents) }
 {
     ScriptBinding = std::unique_ptr<EntityScriptBinding>(EntityScriptBinding::BindEntitySystem(this, *this->LogSystem, *this->ScriptRunner));
 

--- a/Library/src/Multiplayer/Script/ComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentScriptInterface.cpp
@@ -55,7 +55,7 @@ int64_t ComponentScriptInterface::GetComponentType() const
 {
     if (Component)
     {
-        return (int64_t)Component->GetComponentType();
+        return static_cast<int64_t>(Component->GetTypeId());
     }
 
     return (int64_t)ComponentType::Invalid;

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -489,7 +489,7 @@ void EntityScriptBinding::Bind(int64_t ContextId, csp::common::IJSScriptRunner& 
 
     const auto RegisterDynamicComponentGetters = [this, Context, ContextId](auto&& ClassRegistrar) -> decltype(auto)
     {
-        for (const auto& [TypeId, Schema] : EntitySystem->GetComponentSchemaRegistry()->GetUnderlying())
+        for (const auto& Schema : EntitySystem->GetComponentSchemaRegistry()->GetAll())
         {
             if (IsScriptable(Schema))
             {

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -21,6 +21,7 @@
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Common/Vector.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/CinematicCameraSpaceComponentScriptInterface.h"
 #include "Multiplayer/Script/ComponentBinding/CustomSpaceComponentScriptInterface.h"
@@ -358,7 +359,7 @@ class EntityScriptBinding::SchemaCacheImpl
 public:
     std::vector<qjs::Value> GetComponents(qjs::Context& Context, EntityScriptInterface& Entity, const ComponentSchema& Schema)
     {
-        switch (static_cast<ComponentType>(Schema.TypeId))
+        switch (ToComponentType(Schema.TypeId).value_or(ComponentType::Invalid))
         {
         case ComponentType::VideoPlayer:
             return GetComponents<VideoPlayerSpaceComponentScriptInterface>(Context, Entity, Schema);
@@ -383,11 +384,9 @@ private:
     {
         const auto Proto = GetOrCreate(Schema.TypeId, [&] { return MakeComponentPrototype<ScriptInterface>(Context, Schema); });
 
-        const auto ComponentType = static_cast<csp::multiplayer::ComponentType>(Schema.TypeId);
-
         auto Wrapped = std::vector<qjs::Value>();
 
-        for (auto* Component : Entity.GetComponentsOfType<ScriptInterface>(ComponentType))
+        for (auto* Component : Entity.GetComponentsOfType<ScriptInterface>(Schema.TypeId))
         {
             auto Instance = qjs::js_traits<ScriptInterface*>::wrap(Proto.ctx, Component);
             JS_SetPrototype(Proto.ctx, Instance, Proto.v); // Overwrite the prototype

--- a/Library/src/Multiplayer/Script/EntityScriptInterface.h
+++ b/Library/src/Multiplayer/Script/EntityScriptInterface.h
@@ -73,19 +73,18 @@ public:
 
     template <typename ScriptInterface> std::vector<ScriptInterface*> GetComponentsOfType(ComponentType Type);
     template <typename ScriptInterface, ComponentType Type> std::vector<ScriptInterface*> GetComponentsOfType();
+    template <typename ScriptInterface> std::vector<ScriptInterface*> GetComponentsOfType(uint64_t TypeId);
 
 private:
     SpaceEntity* Entity;
 };
 
-template <typename ScriptInterface> std::vector<ScriptInterface*> EntityScriptInterface::GetComponentsOfType(ComponentType Type)
+template <typename ScriptInterface> std::vector<ScriptInterface*> EntityScriptInterface::GetComponentsOfType(uint64_t TypeId)
 {
     std::vector<ScriptInterface*> Components;
 
     if (Entity)
     {
-        const ComponentType ThisType = Type;
-
         const auto& ComponentMap = *Entity->GetComponents();
         const auto ComponentKeys = ComponentMap.Keys();
 
@@ -93,7 +92,7 @@ template <typename ScriptInterface> std::vector<ScriptInterface*> EntityScriptIn
         {
             ComponentBase* Component = ComponentMap[ComponentKeys->operator[](i)];
 
-            if ((Component != nullptr) && (Component->GetComponentType() == ThisType) && (Component->GetScriptInterface() != nullptr))
+            if ((Component != nullptr) && (Component->GetTypeId() == TypeId) && (Component->GetScriptInterface() != nullptr))
             {
                 Components.push_back((ScriptInterface*)Component->GetScriptInterface());
             }
@@ -103,6 +102,11 @@ template <typename ScriptInterface> std::vector<ScriptInterface*> EntityScriptIn
     }
 
     return Components;
+}
+
+template <typename ScriptInterface> std::vector<ScriptInterface*> EntityScriptInterface::GetComponentsOfType(ComponentType Type)
+{
+    return GetComponentsOfType<ScriptInterface>(static_cast<uint64_t>(Type));
 }
 
 template <typename ScriptInterface, ComponentType Type> std::vector<ScriptInterface*> EntityScriptInterface::GetComponentsOfType()

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -359,7 +359,7 @@ ComponentBase* SpaceEntity::AddComponentByTypeId(uint64_t TypeId)
     std::scoped_lock ScopedComponentsLock { ComponentsLock };
 
     // Only allow one script component
-    if (static_cast<ComponentType>(TypeId) == ComponentType::ScriptData)
+    if (ToComponentType(TypeId) == ComponentType::ScriptData)
     {
         ComponentBase* ScriptComponent = FindFirstComponentOfType(ComponentType::ScriptData);
 
@@ -932,9 +932,8 @@ void SpaceEntity::AddComponentFromItemComponentData(uint16_t ComponentId, const 
 {
     auto ComponentDataMap = std::get<std::map<uint16_t, mcs::ItemComponentData>>(ComponentData.GetValue());
     const auto TypeId = std::get<uint64_t>(ComponentDataMap[COMPONENT_KEY_COMPONENTTYPE].GetValue());
-    const auto MessageComponentType = static_cast<ComponentType>(TypeId);
 
-    if (MessageComponentType != ComponentType::Invalid)
+    if (TypeId != static_cast<uint64_t>(ComponentType::Invalid))
     {
         auto* Component = InstantiateComponent(ComponentId, TypeId);
 

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -47,6 +47,7 @@
 #include "CSP/Multiplayer/OfflineRealtimeEngine.h"
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Multiplayer/Script/EntityScript.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/MCS/MCSTypes.h"
 #include "Multiplayer/MCSComponentPacker.h"
 #include "Multiplayer/PatchUtils.h"
@@ -336,7 +337,9 @@ ComponentBase* SpaceEntity::GetComponent(uint16_t Key)
     }
 }
 
-ComponentBase* SpaceEntity::AddComponent(ComponentType AddType)
+ComponentBase* SpaceEntity::AddComponent(ComponentType AddType) { return AddComponentByTypeId(static_cast<uint64_t>(AddType)); }
+
+ComponentBase* SpaceEntity::AddComponentByTypeId(uint64_t TypeId)
 {
     // Ensure we can modify the entity. The criteria for this can be found on the specific RealtimeEngine::IsEntityModifiable overloads.
     ModifiableStatus Modifiable = IsModifiable();
@@ -356,7 +359,7 @@ ComponentBase* SpaceEntity::AddComponent(ComponentType AddType)
     std::scoped_lock ScopedComponentsLock { ComponentsLock };
 
     // Only allow one script component
-    if (AddType == ComponentType::ScriptData)
+    if (static_cast<ComponentType>(TypeId) == ComponentType::ScriptData)
     {
         ComponentBase* ScriptComponent = FindFirstComponentOfType(ComponentType::ScriptData);
 
@@ -373,7 +376,7 @@ ComponentBase* SpaceEntity::AddComponent(ComponentType AddType)
     }
 
     auto ComponentId = GenerateComponentId();
-    auto* Component = InstantiateComponent(ComponentId, AddType);
+    auto* Component = InstantiateComponent(ComponentId, TypeId);
 
     // If Component is null, component has not been instantiated, so is skipped. (Can this ever be null... seems a bit of a footgun not to just
     // assert)
@@ -501,9 +504,30 @@ uint16_t SpaceEntity::GenerateComponentId()
     }
 }
 
-ComponentBase* SpaceEntity::InstantiateComponent(uint16_t InstantiateId, ComponentType InstantiateType)
+ComponentBase* SpaceEntity::InstantiateComponent(uint16_t InstantiateId, uint64_t TypeId)
 {
+    if (!IsLegacyComponentTypeId(TypeId))
+    {
+        const auto* Registry = EntitySystem != nullptr ? EntitySystem->GetComponentSchemaRegistry() : nullptr;
+
+        const auto* Schema = Registry != nullptr ? Registry->Find(TypeId) : nullptr;
+
+        if (Schema == nullptr)
+        {
+            if (LogSystem != nullptr)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, fmt::format("Unknown Component TypeId: {}", TypeId).c_str());
+            }
+            return nullptr;
+        }
+
+        auto* Component = new ComponentBase(*Schema, LogSystem, this);
+        Component->Id = InstantiateId;
+        return Component;
+    }
+
     ComponentBase* Component;
+    const auto InstantiateType = static_cast<ComponentType>(TypeId);
 
     switch (InstantiateType)
     {
@@ -907,11 +931,12 @@ std::unique_ptr<SpaceEntityStatePatcher>& SpaceEntity::GetStatePatcher() { retur
 void SpaceEntity::AddComponentFromItemComponentData(uint16_t ComponentId, const mcs::ItemComponentData& ComponentData)
 {
     auto ComponentDataMap = std::get<std::map<uint16_t, mcs::ItemComponentData>>(ComponentData.GetValue());
-    ComponentType MessageComponentType = static_cast<ComponentType>(std::get<uint64_t>(ComponentDataMap[COMPONENT_KEY_COMPONENTTYPE].GetValue()));
+    const auto TypeId = std::get<uint64_t>(ComponentDataMap[COMPONENT_KEY_COMPONENTTYPE].GetValue());
+    const auto MessageComponentType = static_cast<ComponentType>(TypeId);
 
     if (MessageComponentType != ComponentType::Invalid)
     {
-        auto* Component = InstantiateComponent(ComponentId, MessageComponentType);
+        auto* Component = InstantiateComponent(ComponentId, TypeId);
 
         // if Component == nullptr component has not been instantiated, so is skipped.
         if (Component != nullptr)
@@ -938,7 +963,7 @@ void SpaceEntity::AddComponentFromItemComponentData(uint16_t ComponentId, const 
 ComponentUpdateInfo SpaceEntity::AddComponentFromItemComponentDataPatch(uint16_t ComponentId, const mcs::ItemComponentData& ComponentData)
 {
     auto ComponentDataMap = std::get<std::map<uint16_t, mcs::ItemComponentData>>(ComponentData.GetValue());
-    ComponentType PatchComponentType = static_cast<ComponentType>(std::get<uint64_t>(ComponentDataMap[COMPONENT_KEY_COMPONENTTYPE].GetValue()));
+    const auto PatchComponentType = std::get<uint64_t>(ComponentDataMap[COMPONENT_KEY_COMPONENTTYPE].GetValue());
 
     auto UpdateType = ComponentUpdateType::Update;
 
@@ -946,7 +971,7 @@ ComponentUpdateInfo SpaceEntity::AddComponentFromItemComponentDataPatch(uint16_t
     {
         UpdateType = ComponentUpdateType::Add;
     }
-    else if (Components[ComponentId]->GetComponentType() != PatchComponentType)
+    else if (Components[ComponentId]->GetTypeId() != PatchComponentType)
     {
         UpdateType = ComponentUpdateType::Delete;
     }

--- a/Library/src/Multiplayer/SpaceEntity.cpp
+++ b/Library/src/Multiplayer/SpaceEntity.cpp
@@ -378,8 +378,9 @@ ComponentBase* SpaceEntity::AddComponentByTypeId(uint64_t TypeId)
     auto ComponentId = GenerateComponentId();
     auto* Component = InstantiateComponent(ComponentId, TypeId);
 
-    // If Component is null, component has not been instantiated, so is skipped. (Can this ever be null... seems a bit of a footgun not to just
-    // assert)
+    // If Component is null, component has not been instantiated, so is skipped.
+    // This has historically been the case if a new Component type/class is added in a new version of the library,
+    // and an older client receives it. With dynamic schema-based components, this is more likely to happen.
     if (Component != nullptr)
     {
         // Either add the component to the patch, or just directly insert it.

--- a/Tests/cmake/test_files.cmake
+++ b/Tests/cmake/test_files.cmake
@@ -12,6 +12,7 @@ set(CSP_TESTS_SOURCES
     ${CSP_TESTS_SOURCE_DIR}/TestHelpers.h
 
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/ComponentSchemaScriptBindingTests.cpp
+    ${CSP_TESTS_SOURCE_DIR}/InternalTests/ComponentSchemaTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/EncodeTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/EntityPropertyTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/EventTests.cpp

--- a/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
@@ -70,16 +70,7 @@ public:
             auto* Entity
                 = std::get<0>(AWAIT(&Fixture.Engine, CreateEntity, Name, csp::multiplayer::SpaceTransform {}, csp::common::Optional<uint64_t> {}));
 
-            const auto FindSchema = [&](auto TypeId) -> const Schema*
-            {
-                const auto& Registry = Fixture.Engine.GetComponentSchemaRegistry()->GetUnderlying();
-                if (const auto It = Registry.find(TypeId); It != Registry.end())
-                {
-                    return &It->second;
-                }
-
-                return nullptr;
-            };
+            const auto FindSchema = [&](auto TypeId) -> const Schema* { return Fixture.Engine.GetComponentSchemaRegistry()->Find(TypeId); };
 
             auto SchemaComponents = std::vector<Component*>();
 
@@ -718,7 +709,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleEntityIn
                 TestFixture::Entity::ComponentCreationArgs::InstanceCount { 1 },
             },
         });
-    
+
     const auto& EntityTwoComponent = *EntityTwo.SchemaComponents.front();
 
     ASSERT_EQ(EntityTwoComponent.GetProperty(0), "");

--- a/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
@@ -80,7 +80,6 @@ public:
 
             auto SchemaComponents = std::vector<Component>();
 
-            auto SchemaComponentKey = uint16_t { 0 };
             for (const auto& [TypeId, InstanceCount] : ComponentsToAdd)
             {
                 if (const auto* Schema = FindSchema(TypeId))

--- a/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
@@ -584,7 +584,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, BaseClassFunctio
     Component.SetComponentName("Test Component");
 
     ASSERT_EQ(Component.GetId(), static_cast<Property::KeyType>(0));
-    ASSERT_EQ(static_cast<Schema::TypeIdType>(Component.GetComponentType()), static_cast<Schema::TypeIdType>(123));
+    ASSERT_EQ(Component.GetTypeId(), Schema::TypeIdType { 123 });
 
     constexpr auto ScriptText = R"(
         import { assert } from "CSPTest";

--- a/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
@@ -48,11 +48,17 @@ public:
 
     struct Entity final
     {
-        struct Component : public csp::multiplayer::ComponentBase
+        struct Component final
         {
-            using ComponentBase::ComponentBase;
-            using ComponentBase::GetProperty;
-            using ComponentBase::SetProperty;
+            void SetProperty(uint16_t Key, csp::common::ReplicatedValue Value) { Ref.SetSchemaProperty(Key, std::move(Value)); }
+
+            std::optional<csp::common::ReplicatedValue> GetProperty(uint16_t Key) const
+            {
+                const auto* MaybeValue = Ref.GetSchemaProperty(Key);
+                return MaybeValue ? *MaybeValue : std::optional<csp::common::ReplicatedValue>();
+            }
+
+            csp::multiplayer::ComponentBase& Ref;
         };
 
         struct ComponentCreationArgs final
@@ -72,7 +78,7 @@ public:
 
             const auto FindSchema = [&](auto TypeId) -> const Schema* { return Fixture.Engine.GetComponentSchemaRegistry()->Find(TypeId); };
 
-            auto SchemaComponents = std::vector<Component*>();
+            auto SchemaComponents = std::vector<Component>();
 
             auto SchemaComponentKey = uint16_t { 0 };
             for (const auto& [TypeId, InstanceCount] : ComponentsToAdd)
@@ -81,14 +87,11 @@ public:
                 {
                     for (uint16_t Count = 0; Count < InstanceCount; ++Count)
                     {
-                        // This (mis)uses what is available via the public API to add a component to an entity with a given schema
-                        // as there isn't currently a way of doing this via the public API.
-                        auto ComponentToAdd = std::make_unique<Component>(*Schema, &Fixture.LogSystem, Entity);
-
-                        SchemaComponents.push_back(ComponentToAdd.get());
-
                         // ownership: SpaceEntity is presumably supposed to take ownership, but it currently leaks all components
-                        Entity->AddComponentDirect(SchemaComponentKey++, ComponentToAdd.release());
+                        if (auto* SchemaComponent = Entity->AddComponentByTypeId(TypeId))
+                        {
+                            SchemaComponents.push_back({ *SchemaComponent });
+                        }
                     }
                 }
             }
@@ -106,7 +109,7 @@ public:
 
         csp::multiplayer::SpaceEntity& Ref;
         csp::multiplayer::ScriptSpaceComponent& ScriptComponent;
-        std::vector<Component*> SchemaComponents;
+        std::vector<Component> SchemaComponents;
     };
 
     Entity MakeEntity(const csp::common::String& Name, std::vector<Entity::ComponentCreationArgs> ComponentsToAdd)
@@ -303,7 +306,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, SupportedTypesGe
 
     ASSERT_EQ(Entity.SchemaComponents.size(), 1);
 
-    const auto& Component = *Entity.SchemaComponents.front();
+    const auto& Component = Entity.SchemaComponents.front();
     EXPECT_EQ(Component.GetProperty(0), false);
     EXPECT_EQ(Component.GetProperty(1), 0.5f);
     EXPECT_EQ(Component.GetProperty(2), static_cast<int64_t>(1234));
@@ -447,14 +450,24 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, CoercesOrThrowsW
 
     ASSERT_EQ(Entity.SchemaComponents.size(), 1);
 
-    const auto& Component = *Entity.SchemaComponents.front();
-    EXPECT_EQ(Component.GetProperty(0).GetReplicatedValueType(), csp::common::ReplicatedValueType::Boolean);
-    EXPECT_EQ(Component.GetProperty(1).GetReplicatedValueType(), csp::common::ReplicatedValueType::Float);
-    EXPECT_EQ(Component.GetProperty(2).GetReplicatedValueType(), csp::common::ReplicatedValueType::Integer);
-    EXPECT_EQ(Component.GetProperty(3).GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
-    EXPECT_EQ(Component.GetProperty(4).GetReplicatedValueType(), csp::common::ReplicatedValueType::Vector2);
-    EXPECT_EQ(Component.GetProperty(5).GetReplicatedValueType(), csp::common::ReplicatedValueType::Vector3);
-    EXPECT_EQ(Component.GetProperty(6).GetReplicatedValueType(), csp::common::ReplicatedValueType::Vector4);
+    const auto GetReplicatedValueType = [](const auto& MaybeValue) -> std::optional<csp::common::ReplicatedValueType>
+    {
+        if (MaybeValue)
+        {
+            return MaybeValue->GetReplicatedValueType();
+        }
+
+        return {};
+    };
+
+    const auto& Component = Entity.SchemaComponents.front();
+    EXPECT_EQ(GetReplicatedValueType(Component.GetProperty(0)), csp::common::ReplicatedValueType::Boolean);
+    EXPECT_EQ(GetReplicatedValueType(Component.GetProperty(1)), csp::common::ReplicatedValueType::Float);
+    EXPECT_EQ(GetReplicatedValueType(Component.GetProperty(2)), csp::common::ReplicatedValueType::Integer);
+    EXPECT_EQ(GetReplicatedValueType(Component.GetProperty(3)), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(GetReplicatedValueType(Component.GetProperty(4)), csp::common::ReplicatedValueType::Vector2);
+    EXPECT_EQ(GetReplicatedValueType(Component.GetProperty(5)), csp::common::ReplicatedValueType::Vector3);
+    EXPECT_EQ(GetReplicatedValueType(Component.GetProperty(6)), csp::common::ReplicatedValueType::Vector4);
 
     // Note: we might consider changing the setters to always prevent setting the value when the type
     // differs, but currently we get the default quickjspp behaviour, which is consistent with our
@@ -580,11 +593,11 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, BaseClassFunctio
 
     ASSERT_EQ(Entity.SchemaComponents.size(), 1);
 
-    auto& Component = *Entity.SchemaComponents.front();
-    Component.SetComponentName("Test Component");
+    auto& Component = Entity.SchemaComponents.front();
+    Component.Ref.SetComponentName("Test Component");
 
-    ASSERT_EQ(Component.GetId(), static_cast<Property::KeyType>(0));
-    ASSERT_EQ(Component.GetTypeId(), Schema::TypeIdType { 123 });
+    ASSERT_EQ(Component.Ref.GetId(), static_cast<Property::KeyType>(0));
+    ASSERT_EQ(Component.Ref.GetTypeId(), Schema::TypeIdType { 123 });
 
     constexpr auto ScriptText = R"(
         import { assert } from "CSPTest";
@@ -606,7 +619,8 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, BaseClassFunctio
 
     auto MaybeScriptMessage = std::optional<std::string>();
 
-    Component.RegisterActionHandler("ScriptMessage", [&](auto*, auto&, const auto& Message) { MaybeScriptMessage = std::string(Message.c_str()); });
+    Component.Ref.RegisterActionHandler(
+        "ScriptMessage", [&](auto*, auto&, const auto& Message) { MaybeScriptMessage = std::string(Message.c_str()); });
 
     EXPECT_TRUE(Fixture.InvokeScript(Entity, ScriptText));
 
@@ -641,8 +655,8 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleComponen
 
     ASSERT_EQ(Entity.SchemaComponents.size(), 2);
 
-    auto& One = *Entity.SchemaComponents[0];
-    auto& Two = *Entity.SchemaComponents[1];
+    auto& One = Entity.SchemaComponents[0];
+    auto& Two = Entity.SchemaComponents[1];
 
     One.SetProperty(0, "One");
     Two.SetProperty(0, "Two");
@@ -699,7 +713,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleEntityIn
         example.stringProperty = "1";
     )"));
 
-    const auto& EntityOneComponent = *EntityOne.SchemaComponents.front();
+    const auto& EntityOneComponent = EntityOne.SchemaComponents.front();
     EXPECT_EQ(EntityOneComponent.GetProperty(0), "1");
 
     auto EntityTwo = Fixture.MakeEntity("Test Entity",
@@ -710,7 +724,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleEntityIn
             },
         });
 
-    const auto& EntityTwoComponent = *EntityTwo.SchemaComponents.front();
+    const auto& EntityTwoComponent = EntityTwo.SchemaComponents.front();
 
     ASSERT_EQ(EntityTwoComponent.GetProperty(0), "");
 

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -17,10 +17,14 @@
 #include "TestHelpers.h"
 
 #include "CSP/Common/Systems/Log/LogSystem.h"
+#include "CSP/Multiplayer/Components/AudioSpaceComponent.h"
 #include "CSP/Multiplayer/OfflineRealtimeEngine.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
 #include "CSP/Systems/Script/ScriptSystem.h"
+#include "Multiplayer/MCS/MCSTypes.h"
+#include "Multiplayer/SpaceEntityKeys.h"
 
+#include <limits>
 #include <memory>
 
 namespace
@@ -61,4 +65,242 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetTypeIdMatchesComponentType
     ASSERT_NE(Component, nullptr);
 
     EXPECT_EQ(Component->GetTypeId(), static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio));
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetTypeIdReturnsRegisteredTypeIdForSchemaDrivenComponent)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_EQ(Component->GetTypeId(), uint64_t { 123 });
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetTypeIdPreservesFullUint64)
+{
+    constexpr uint64_t LargeTypeId = std::numeric_limits<uint64_t>::max();
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { LargeTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(LargeTypeId);
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_EQ(Component->GetTypeId(), LargeTypeId);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentByTypeIdCreatesComponent)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+
+    EXPECT_NE(Component, nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentWithUnregisteredTypeIdReturnsNullptr)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(uint64_t { 999 });
+
+    EXPECT_EQ(Component, nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentByTypeIdReturnsNullptrWhenEntityIsLocked)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    Entity->Lock();
+
+    const auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+
+    EXPECT_EQ(Component, nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentByTypeIdWithHardcodedTypeIdCreatesConcreteType)
+{
+    auto Fixture = TestFixture({});
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio));
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_NE(dynamic_cast<const csp::multiplayer::AudioSpaceComponent*>(Component), nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponentDataWithLargeTypeIdCreatesSchemaComponent)
+{
+    constexpr uint64_t LargeTypeId = std::numeric_limits<uint64_t>::max();
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { LargeTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { LargeTypeId } },
+    };
+
+    Entity->AddComponentFromItemComponentData(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+
+    EXPECT_NE(Component, nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponentDataCreatesSchemaComponent)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { uint64_t { 123 } } },
+        { 0, csp::multiplayer::mcs::ItemComponentData { std::string { "OverriddenValue" } } },
+    };
+
+    Entity->AddComponentFromItemComponentData(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+
+    EXPECT_NE(Component, nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponentDataWithHardcodedTypeIdCreatesConcreteType)
+{
+    auto Fixture = TestFixture({});
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { uint64_t { 17 } } },
+    };
+
+    Entity->AddComponentFromItemComponentData(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_NE(dynamic_cast<const csp::multiplayer::AudioSpaceComponent*>(Component), nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponentDataPatchAddsSchemaComponent)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { uint64_t { 123 } } },
+    };
+
+    Entity->AddComponentFromItemComponentDataPatch(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+
+    EXPECT_NE(Component, nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponentDataPatchWithHardcodedTypeIdCreatesConcreteType)
+{
+    auto Fixture = TestFixture({});
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { uint64_t { 17 } } },
+    };
+
+    Entity->AddComponentFromItemComponentDataPatch(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_NE(dynamic_cast<const csp::multiplayer::AudioSpaceComponent*>(Component), nullptr);
 }

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -111,6 +111,32 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetTypeIdPreservesFullUint64)
     EXPECT_EQ(Component->GetTypeId(), LargeTypeId);
 }
 
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetComponentTypeReturnsInvalidForTypeIdAboveLegacyRange)
+{
+    using Underlying = std::underlying_type_t<csp::multiplayer::ComponentType>;
+    constexpr auto WrapOffset = uint64_t { std::numeric_limits<Underlying>::max() } + 1;
+    constexpr auto WrappedTypeId = WrapOffset + static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio);
+    static_assert(static_cast<csp::multiplayer::ComponentType>(WrappedTypeId) == csp::multiplayer::ComponentType::Audio);
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { WrappedTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(WrappedTypeId);
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_EQ(Component->GetComponentType(), csp::multiplayer::ComponentType::Invalid);
+}
+
 CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentByTypeIdCreatesComponent)
 {
     auto Fixture = TestFixture({
@@ -365,6 +391,121 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponent
     ASSERT_NE(Value, nullptr);
 
     EXPECT_EQ(Value->GetString(), csp::common::String { "OverriddenValue" });
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentWithTypeIdAboveLegacyRangeNotTreatedAsLegacy)
+{
+    using Underlying = std::underlying_type_t<csp::multiplayer::ComponentType>;
+    constexpr auto WrapOffset = uint64_t { std::numeric_limits<Underlying>::max() } + 1;
+    constexpr auto WrappedTypeId = WrapOffset + static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio);
+    static_assert(static_cast<csp::multiplayer::ComponentType>(WrappedTypeId) == csp::multiplayer::ComponentType::Audio);
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { WrappedTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(WrappedTypeId);
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_EQ(dynamic_cast<const csp::multiplayer::AudioSpaceComponent*>(Component), nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentAboveLegacyRangeNotMisinterpretedAsScript)
+{
+    using Underlying = std::underlying_type_t<csp::multiplayer::ComponentType>;
+    constexpr auto WrapOffset = uint64_t { std::numeric_limits<Underlying>::max() } + 1;
+    constexpr auto WrappedTypeId = WrapOffset + static_cast<uint64_t>(csp::multiplayer::ComponentType::ScriptData);
+    static_assert(static_cast<csp::multiplayer::ComponentType>(WrappedTypeId) == csp::multiplayer::ComponentType::ScriptData);
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { WrappedTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* ScriptComponent = Entity->AddComponent(csp::multiplayer::ComponentType::ScriptData);
+    ASSERT_NE(ScriptComponent, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(WrappedTypeId);
+    ASSERT_NE(Component, nullptr);
+    EXPECT_NE(Component, ScriptComponent);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemDataAboveLegacyRangeNotTreatedAsLegacy)
+{
+    using Underlying = std::underlying_type_t<csp::multiplayer::ComponentType>;
+    constexpr auto WrapOffset = uint64_t { std::numeric_limits<Underlying>::max() } + 1;
+    constexpr auto WrappedTypeId = WrapOffset + static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio);
+    static_assert(static_cast<csp::multiplayer::ComponentType>(WrappedTypeId) == csp::multiplayer::ComponentType::Audio);
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { WrappedTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { WrappedTypeId } },
+    };
+
+    Entity->AddComponentFromItemComponentData(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_EQ(dynamic_cast<const csp::multiplayer::AudioSpaceComponent*>(Component), nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemDataAboveLegacyRangeNotRejectedAsInvalid)
+{
+    using Underlying = std::underlying_type_t<csp::multiplayer::ComponentType>;
+    constexpr auto WrapOffset = uint64_t { std::numeric_limits<Underlying>::max() } + 1;
+    constexpr auto WrappedTypeId = WrapOffset + static_cast<uint64_t>(csp::multiplayer::ComponentType::Invalid);
+    static_assert(static_cast<csp::multiplayer::ComponentType>(WrappedTypeId) == csp::multiplayer::ComponentType::Invalid);
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { WrappedTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { WrappedTypeId } },
+    };
+
+    Entity->AddComponentFromItemComponentData(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    EXPECT_NE(Entity->GetComponent(0), nullptr);
 }
 
 CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetSchemaPropertyReturnsDefaultValue)

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -304,3 +304,253 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponent
 
     EXPECT_NE(dynamic_cast<const csp::multiplayer::AudioSpaceComponent*>(Component), nullptr);
 }
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponentDataSetsPropertyValues)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "DefaultValue" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { uint64_t { 123 } } },
+        { 0, csp::multiplayer::mcs::ItemComponentData { std::string { "OverriddenValue" } } },
+    };
+
+    Entity->AddComponentFromItemComponentData(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+    ASSERT_NE(Component, nullptr);
+
+    const auto* Value = Component->GetSchemaProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(Value->GetString(), csp::common::String { "OverriddenValue" });
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponentDataPatchSetsPropertyValues)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "DefaultValue" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto ComponentData = std::map<uint16_t, csp::multiplayer::mcs::ItemComponentData> {
+        { csp::multiplayer::COMPONENT_KEY_COMPONENTTYPE, csp::multiplayer::mcs::ItemComponentData { uint64_t { 123 } } },
+        { 0, csp::multiplayer::mcs::ItemComponentData { std::string { "OverriddenValue" } } },
+    };
+
+    Entity->AddComponentFromItemComponentDataPatch(0, csp::multiplayer::mcs::ItemComponentData { ComponentData });
+
+    const auto* Component = Entity->GetComponent(0);
+    ASSERT_NE(Component, nullptr);
+
+    const auto* Value = Component->GetSchemaProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(Value->GetString(), csp::common::String { "OverriddenValue" });
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetSchemaPropertyReturnsDefaultValue)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    const auto* Value = Component->GetSchemaProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(*Value, "Value");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetSchemaPropertyReturnsNullptrForUnknownKey)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_EQ(Component->GetSchemaProperty(999), nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithMatchingTypeSucceeds)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    Component->SetSchemaProperty(0, "NewValue");
+
+    const auto* Value = Component->GetSchemaProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(*Value, "NewValue");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithMismatchedTypeLeavesValueUnchanged)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    Component->SetSchemaProperty(0, int64_t { 42 });
+
+    const auto* Value = Component->GetSchemaProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(*Value, "Value");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithUnknownKeyHasNoEffect)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    Component->SetSchemaProperty(999, "SomeValue");
+
+    EXPECT_EQ(Component->GetSchemaProperty(999), nullptr);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWhenParentIsLockedHasNoEffect)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                { 0, "stringProperty", "Value" },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    Entity->Lock();
+    Component->SetSchemaProperty(0, "NewValue");
+
+    const auto* Value = Component->GetSchemaProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(*Value, "Value");
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyReflectsInTypedGetter)
+{
+    auto Fixture = TestFixture({});
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio));
+    ASSERT_NE(Component, nullptr);
+
+    const auto* AudioComponent = dynamic_cast<const csp::multiplayer::AudioSpaceComponent*>(Component);
+    ASSERT_NE(AudioComponent, nullptr);
+
+    const auto NewPosition = csp::common::Vector3 { 1.0f, 2.0f, 3.0f };
+    Component->SetSchemaProperty(static_cast<uint16_t>(csp::multiplayer::AudioPropertyKeys::Position), NewPosition);
+
+    EXPECT_EQ(AudioComponent->GetPosition(), NewPosition);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, TypedSetterReflectsInGetSchemaProperty)
+{
+    auto Fixture = TestFixture({});
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio));
+    ASSERT_NE(Component, nullptr);
+
+    auto* AudioComponent = dynamic_cast<csp::multiplayer::AudioSpaceComponent*>(Component);
+    ASSERT_NE(AudioComponent, nullptr);
+
+    const auto NewPosition = csp::common::Vector3 { 4.0f, 5.0f, 6.0f };
+    AudioComponent->SetPosition(NewPosition);
+
+    const auto* SchemaValue = Component->GetSchemaProperty(static_cast<uint16_t>(csp::multiplayer::AudioPropertyKeys::Position));
+    ASSERT_NE(SchemaValue, nullptr);
+
+    EXPECT_EQ(SchemaValue->GetVector3(), NewPosition);
+}

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TestHelpers.h"
+
+#include "CSP/Common/Systems/Log/LogSystem.h"
+#include "CSP/Multiplayer/OfflineRealtimeEngine.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/Script/ScriptSystem.h"
+
+#include <memory>
+
+namespace
+{
+
+using Schema = csp::multiplayer::ComponentSchema;
+
+class TestFixture final
+{
+public:
+    TestFixture(const csp::common::Array<Schema>& Schemas)
+        : ScriptSystem(csp::systems::ScriptSystem::MakeInitialised())
+        , Engine(LogSystem, *ScriptSystem, Schemas)
+    {
+    }
+
+    csp::multiplayer::SpaceEntity* MakeEntity(const csp::common::String& Name)
+    {
+        return std::get<0>(AWAIT(&Engine, CreateEntity, Name, csp::multiplayer::SpaceTransform {}, csp::common::Optional<uint64_t> {}));
+    }
+
+private:
+    csp::common::LogSystem LogSystem;
+    std::shared_ptr<csp::systems::ScriptSystem> ScriptSystem;
+    csp::multiplayer::OfflineRealtimeEngine Engine;
+};
+
+} // namespace
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetTypeIdMatchesComponentTypeForHardcodedComponent)
+{
+    auto Fixture = TestFixture({});
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    const auto* Component = Entity->AddComponent(csp::multiplayer::ComponentType::Audio);
+    ASSERT_NE(Component, nullptr);
+
+    EXPECT_EQ(Component->GetTypeId(), static_cast<uint64_t>(csp::multiplayer::ComponentType::Audio));
+}

--- a/Tests/src/InternalTests/MCSTests.cpp
+++ b/Tests/src/InternalTests/MCSTests.cpp
@@ -14,12 +14,68 @@
  * limitations under the License.
  */
 
+#include "CSP/Multiplayer/OfflineRealtimeEngine.h"
+#include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/Script/ScriptSystem.h"
 #include "Multiplayer/MCS/MCSTypes.h"
+#include "Multiplayer/MCSComponentPacker.h"
 #include "TestHelpers.h"
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 using namespace csp::multiplayer;
+
+CSP_INTERNAL_TEST(CSPEngine, MCSTests, ComponentPackerPreservesLargeComponentTypeId)
+{
+    constexpr auto LargeTypeId = std::numeric_limits<uint64_t>::max();
+
+    auto LogSystem = csp::common::LogSystem {};
+    auto ScriptSystem = csp::systems::ScriptSystem::MakeInitialised();
+    auto Engine = csp::multiplayer::OfflineRealtimeEngine {
+        LogSystem,
+        *ScriptSystem,
+        {
+            csp::multiplayer::ComponentSchema {
+                csp::multiplayer::ComponentSchema::TypeIdType { LargeTypeId },
+                "Example",
+                {
+                    csp::multiplayer::ComponentProperty {
+                        csp::multiplayer::ComponentProperty::KeyType { 0 },
+                        "value",
+                        "hello",
+                    },
+                },
+            },
+        },
+    };
+
+    auto [Entity] = AWAIT(&Engine, CreateEntity, "Test Entity", csp::multiplayer::SpaceTransform {}, csp::common::Optional<uint64_t> {});
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(LargeTypeId);
+    ASSERT_NE(Component, nullptr);
+    Component->SetSchemaProperty(0, "hello");
+
+    auto Packer = MCSComponentPacker {};
+    Packer.WriteValue(Component->GetId(), Component);
+
+    const auto Expected = std::map<uint16_t, mcs::ItemComponentData> {
+        {
+            Component->GetId(),
+            mcs::ItemComponentData {
+                std::map<uint16_t, mcs::ItemComponentData> {
+                    { COMPONENT_KEY_COMPONENTTYPE, mcs::ItemComponentData { LargeTypeId } },
+                    { static_cast<uint16_t>(SpaceEntityComponentKey::Name), mcs::ItemComponentData { std::string {} } },
+                    { uint16_t { 0 }, mcs::ItemComponentData { std::string { "hello" } } },
+                },
+            },
+        },
+    };
+
+    EXPECT_EQ(Packer.GetComponents(), Expected);
+}
 
 // Test constructor values of ObjectMessage are correct.
 CSP_INTERNAL_TEST(CSPEngine, MCSTests, ObjectMessageConstructorTest)

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -17,6 +17,7 @@
 #include "../SpaceSystemTestHelpers.h"
 #include "../UserSystemTestHelpers.h"
 #include "Awaitable.h"
+#include "CSP/Multiplayer/ComponentSchema.h"
 #include "CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h"
 #include "CSP/Multiplayer/Components/AudioSpaceComponent.h"
 #include "CSP/Multiplayer/Components/ButtonSpaceComponent.h"
@@ -29,12 +30,16 @@
 #include "CSP/Multiplayer/Components/ScriptSpaceComponent.h"
 #include "CSP/Multiplayer/Components/StaticModelSpaceComponent.h"
 #include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
+#include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
+#include "CSP/Systems/Script/ScriptSystem.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "TestHelpers.h"
 
 #include "gtest/gtest.h"
+
+#include <limits>
 
 using namespace csp::multiplayer;
 
@@ -302,5 +307,101 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, ComponentBaseScriptTest)
     DeleteSpace(SpaceSystem, Space.Id);
 
     // Log out
+    LogOut(UserSystem);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, ComponentTests, SchemaComponentRoundtrip)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    constexpr auto SchemaTypeId = std::numeric_limits<uint64_t>::max();
+
+    const auto ComponentSchemas = csp::common::Array<csp::multiplayer::ComponentSchema> {
+        csp::multiplayer::ComponentSchema {
+            csp::multiplayer::ComponentSchema::TypeIdType { SchemaTypeId },
+            "Example",
+            {
+                { 0, "stringProperty", "DefaultValue" },
+            },
+        },
+    };
+
+    auto UserId = csp::common::String {};
+    const auto TestUser = CreateTestUser();
+    ASSERT_FALSE(TestUser.Email.IsEmpty());
+
+    LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
+    ASSERT_FALSE(UserId.IsEmpty());
+
+    auto Space = csp::systems::Space {};
+    CreateDefaultTestSpace(SpaceSystem, Space);
+    ASSERT_FALSE(Space.Id.IsEmpty());
+
+    {
+        auto Engine = csp::multiplayer::OnlineRealtimeEngine {
+            *SystemsManager.GetMultiplayerConnection(),
+            *SystemsManager.GetLogSystem(),
+            *SystemsManager.GetEventBus(),
+            *SystemsManager.GetScriptSystem(),
+            ComponentSchemas,
+        };
+        Engine.SetEntityFetchCompleteCallback([](auto) { });
+
+        const auto [EnterResult] = AWAIT(SpaceSystem, EnterSpace, Space.Id, &Engine);
+        ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+        auto [Entity] = AWAIT(&Engine, CreateEntity, "SchemaEntity", csp::multiplayer::SpaceTransform {}, csp::common::Optional<uint64_t> {});
+        ASSERT_NE(Entity, nullptr);
+
+        auto* Component = Entity->AddComponentByTypeId(uint64_t { SchemaTypeId });
+        ASSERT_NE(Component, nullptr);
+
+        Component->SetSchemaProperty(0, csp::common::String { "RoundtripValue" });
+
+        Entity->QueueUpdate();
+        Engine.ProcessPendingEntityOperations();
+
+        AWAIT(SpaceSystem, ExitSpace);
+    }
+
+    {
+        auto Engine = csp::multiplayer::OnlineRealtimeEngine {
+            *SystemsManager.GetMultiplayerConnection(),
+            *SystemsManager.GetLogSystem(),
+            *SystemsManager.GetEventBus(),
+            *SystemsManager.GetScriptSystem(),
+            ComponentSchemas,
+        };
+
+        auto EntitiesFetched = std::promise<void> {};
+        auto EntitiesFetchedFuture = EntitiesFetched.get_future();
+        Engine.SetEntityFetchCompleteCallback([&EntitiesFetched](auto) { EntitiesFetched.set_value(); });
+
+        const auto [EnterResult] = AWAIT(SpaceSystem, EnterSpace, Space.Id, &Engine);
+        ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+        ASSERT_TRUE(WaitForFuture(EntitiesFetchedFuture));
+
+        auto* Entity = Engine.FindSpaceObject("SchemaEntity");
+        ASSERT_NE(Entity, nullptr);
+
+        const auto* Components = Entity->GetComponents();
+        ASSERT_EQ(Components->Size(), 1);
+
+        const auto* SchemaComponent = Components->begin()->second;
+        ASSERT_EQ(SchemaComponent->GetTypeId(), SchemaTypeId);
+
+        const auto* Value = SchemaComponent->GetSchemaProperty(0);
+        ASSERT_NE(Value, nullptr);
+        EXPECT_EQ(Value->GetString(), csp::common::String { "RoundtripValue" });
+
+        AWAIT(SpaceSystem, ExitSpace);
+    }
+
+    DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }

--- a/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
@@ -974,3 +974,31 @@ CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructWithComponentSch
 
     EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(ExampleSchemaId), nullptr);
 }
+
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructWithComponentSchemaBuiltInComponentTakesPrecedence)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const auto ExampleSchemaId = static_cast<ComponentSchema::TypeIdType>(csp::multiplayer::ComponentType::Audio);
+
+    const auto Components = csp::common::Array<csp::multiplayer::ComponentSchema> {
+        {
+            ExampleSchemaId,
+            "Example",
+            csp::common::Array<ComponentProperty> {
+                {
+                    ComponentProperty::KeyType { 42 },
+                    "value",
+                    "DefaultValue",
+                },
+            },
+        },
+    };
+
+    const auto Engine = OfflineRealtimeEngine { *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem(), Components };
+
+    const auto* Schema = Engine.GetComponentSchemaRegistry()->Find(ExampleSchemaId);
+    ASSERT_NE(Schema, nullptr);
+
+    EXPECT_EQ(Schema->Name, "Audio");
+}

--- a/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
@@ -950,11 +950,11 @@ CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, IsModifiableTest)
     EXPECT_EQ(Engine.IsEntityModifiable(Entity), ModifiableStatus::Modifiable);
 }
 
-CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructWithComponentSchema) 
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructWithComponentSchema)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    const auto ExampleSchemaId = ComponentSchema::TypeIdType{666};
+    const auto ExampleSchemaId = ComponentSchema::TypeIdType { 666 };
 
     const auto Components = csp::common::Array<csp::multiplayer::ComponentSchema> {
         {
@@ -972,5 +972,5 @@ CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructWithComponentSch
 
     const auto Engine = OfflineRealtimeEngine { *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem(), Components };
 
-    EXPECT_TRUE(Engine.GetComponentSchemaRegistry()->HasKey(ExampleSchemaId));
+    EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(ExampleSchemaId), nullptr);
 }

--- a/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
@@ -642,12 +642,11 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, CreateAvatarSen
         LocomotionModel::Grounded, MockCallback.AsStdFunction());
 }
 
-
-CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, ConstructWithComponentSchema) 
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, ConstructWithComponentSchema)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    const auto ExampleSchemaId = ComponentSchema::TypeIdType{666};
+    const auto ExampleSchemaId = ComponentSchema::TypeIdType { 666 };
 
     const auto Components = csp::common::Array<csp::multiplayer::ComponentSchema> {
         {
@@ -671,5 +670,5 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, ConstructWithCo
         Components,
     };
 
-    EXPECT_TRUE(Engine.GetComponentSchemaRegistry()->HasKey(ExampleSchemaId));
+    EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(ExampleSchemaId), nullptr);
 }

--- a/Tests/src/PublicAPITests/ReplicatedValueTests.cpp
+++ b/Tests/src/PublicAPITests/ReplicatedValueTests.cpp
@@ -290,6 +290,8 @@ CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, EqualityOperatorTest)
     Value2.SetInt(5);
 
     EXPECT_FALSE(Value == Value2);
+
+    EXPECT_NE(csp::common::ReplicatedValue(), csp::common::ReplicatedValue(false));
 }
 
 CSP_PUBLIC_TEST(CSPEngine, ReplicatedValueTests, InequalityOperatorTest)

--- a/cmake/multiplayer_files.cmake
+++ b/cmake/multiplayer_files.cmake
@@ -11,6 +11,7 @@ set(CSP_MULTIPLAYER_PUBLIC_INCLUDES
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/ContinuationUtils.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/ContinuationUtils.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/CSPSceneDescription.h
+    ${CSP_MULTIPLAYER_INCLUDE_DIR}/IComponentSchemaRegistry.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/MultiPlayerConnection.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/MultiplayerHubMethods.h
     ${CSP_MULTIPLAYER_INCLUDE_DIR}/NetworkEventBus.h


### PR DESCRIPTION
  This adds the following public methods:
  - `IRealtimeEngine::GetComponentSchemaRegistry()`:
    - Returns a "registry" instance, a read-only type describing the Components known by the engine. This can be used to interrogate the shape of a Component at runtime. Currently this is populated by CSP with a corresponding Schema for each of the hardcoded Component types in the library. It is still not possible to register a new schema externally, but this will come in a future release.
  - `SpaceEntity::AddComponentByTypeId(uint64_t TypeId)`:
    - Allows adding a component that corresponds to a Schema with the given TypeId.
  - `ComponentBase::GetTypeId()`:
    - This returns the unique integer ID representing the component type. For traditional hardcoded components, this corresponds to casting the `ComponentType` to its underlying integer value. This supersedes `GetComponentType` in that it allows for representing an open vs closed set of components. Details of allocating these IDs in a unique fashion is still to be defined.
  - `ComponentBase::GetSchemaProperty(uint16_t Key)`:
    - Get the value of a property corresponding to the one declared with the given Key in the Schema. The Key must be in the Schema, or null is returned. This supersedes the hardcoded wrapper methods typically written, trading off static typing for the flexibility of defining components externally.
  - `ComponentBase::SetSchemaProperty(uint16_t Key, const csp::common::ReplicatedValue& Value)`:
    - Set the value of a property corresponding to the one declared with the given Key in the Schema. The Key must be in the Schema, and the value must match the type declared there or it is ignored. This supersedes the hardcoded wrapper methods typically written, trading off static typing for the flexibility of defining components externally.

The existing methods and concrete component classes are preserved for now, and not yet considered formally deprecated.

More info in the individual commits.