### PR TITLE
[OF-1071] feat: Add support for third party auth with token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file. For compile
 
 - [OW-2438] feat: Properties to support cinematic camera depth of field. By @MAG-ThomasGreenhalgh.
   Adds focus distance and depth of field enabled properties to the cinematic camera space component.
+  
+- [OF-1071] feat: Add support for third party auth with token. By @MAG-AdamThorn.
+  Add support for third party authentication using a token provided by the third party provider. This is an alternate path for SSO to the one already provided, in that it expects the application to request the authorization token from the third party provider directly before passing it to CSP.
 
 ## [6.38.0]
 

--- a/Library/include/CSP/Systems/Users/ThirdPartyAuthentication.h
+++ b/Library/include/CSP/Systems/Users/ThirdPartyAuthentication.h
@@ -29,6 +29,7 @@ enum EThirdPartyAuthenticationProviders
     Google = 0,
     Discord,
     Apple,
+    Netflix,
     Num,
     Invalid = Num
 };

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -157,11 +157,10 @@ public:
     /// 3. Call @ref UserSystem::LoginToThirdPartyAuthenticationProvider() with the auth token and state Id retrieved in step 2.
     ///
     /// Calling this method will not impact your current login state.
-    /// @param AuthProvider : The Authentication Provider you want to be authenticated with (e.g. Google, Apple,
-    /// Discord).
+    /// @param AuthProvider : The Authentication Provider you want to be authenticated with (e.g. Google, Apple, Discord).
     /// @param RedirectURL : the RedirectURL you want to be used for this authentication flow.
-    /// @param ClientType : An optional parameter that allows the client to specify their platform for the
-    /// third party authentication flow. This is used for some providers to determine the format of the Authorize URL.
+    /// @param ClientType : An optional parameter that allows the client to specify their platform for the third party authentication flow. This is
+    /// used for some providers to determine the format of the Authorize URL.
     /// @param Callback : callback that contains the Authorize URL that the Client should be navigating to for step 2.
     CSP_ASYNC_RESULT void GetThirdPartyProviderAuthorizeURL(EThirdPartyAuthenticationProviders AuthProvider, const csp::common::String& RedirectURL,
         const csp::common::Optional<EThirdPartyPlatform>& ClientType, StringResultCallback Callback);
@@ -178,15 +177,31 @@ public:
     /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
     /// connection to backend services, and thus be unable to receive messages or events. This session will also be unable to enter online spaces via
     /// a csp::multiplayer::OnlineRealtimeEngine. If true, this session will receive events, and may enter both online and offline spaces.
-    /// @param UserHasVerifiedAge : An optional bool to specify whether or not the user has verified that they are
-    /// over 18.
+    /// @param UserHasVerifiedAge : An optional bool to specify whether or not the user has verified that they are over 18.
     /// @param TokenOptions : Optional override for default token options.
-    /// The default token expiry length is configured by MCS and defaults to 30 minutes. The value must be less than the default expiry length, or it will
-    /// be ignored.
+    /// The default token expiry length is configured by MCS and defaults to 30 minutes. The value must be less than the default expiry length, or it
+    /// will be ignored.
     /// @param Callback : callback that contains the result of the 3rd party authentication operation.
     CSP_ASYNC_RESULT void LoginToThirdPartyAuthenticationProvider(const csp::common::String& ThirdPartyToken,
         const csp::common::String& ThirdPartyStateId, bool CreateMultiplayerConnection, const csp::common::Optional<bool>& UserHasVerifiedAge,
         const csp::common::Optional<TokenOptions>& TokenOptions, LoginStateResultCallback Callback);
+
+    /// @brief Alternative 3rd party authentication flow using a token
+    /// Note: The steps are as follows:
+    /// 1. Client application requests an authorization token from the third party provider directly.
+    /// 3. This step. Call this method with the acquired authorization token.
+    ///
+    /// @param AuthProvider : The Authentication Provider you want to be authenticated with (e.g. Google, Apple, Discord, Netflix).
+    /// @param ThirdPartyToken : The authentication token acquired from the third party provider.
+    /// @param ClientType : The platform the client is using.
+    /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
+    /// connection to backend services, and thus be unable to receive messages or events. This session will also be unable to enter online spaces via
+    /// a csp::multiplayer::OnlineRealtimeEngine. If true, this session will receive events, and may enter both online and offline spaces.
+    /// @param UserHasVerifiedAge : An optional bool to specify whether or not the user has verified that they are over 18.
+    /// @param Callback : callback that contains the result of the 3rd party authentication operation.
+    CSP_ASYNC_RESULT void LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAuthenticationProviders AuthProvider,
+        const csp::common::String& ThirdPartyToken, const csp::common::Optional<EThirdPartyPlatform>& ClientType, bool CreateMultiplayerConnection,
+        const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback);
 
     /// @brief Logout from Magnopus Cloud Services.
     /// @param Callback NullResultCallback : callback to call when a response is received

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -123,6 +123,43 @@ std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::common:
     return std::nullopt;
 }
 
+// Contains shared logic for logging in with a 3rd party provider - used by both LoginToThirdPartyAuthenticationProvider and
+// LoginToThirdPartyAuthenticationProviderWithToken.
+void LoginSocial(csp::services::ApiBase* AuthenticationAPI, csp::common::LoginState* CurrentLoginState, csp::common::LogSystem* LogSystem,
+    const std::shared_ptr<chs_user::LoginSocialRequest>& Request, bool CreateMultiplayerConnection, csp::systems::LoginStateResultCallback Callback)
+{
+    csp::systems::LoginStateResultCallback LoginStateResCallback = [=](const csp::systems::LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            {
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                {
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+                }
+
+                Callback(LoginStateRes);
+            };
+
+            StartMultiplayerConnection(*csp::systems::SystemsManager::Get().GetMultiplayerConnection(),
+                csp::CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
+        {
+            CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
+            Callback(LoginStateRes);
+        }
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler = AuthenticationAPI->CreateHandler<csp::systems::LoginStateResultCallback,
+        csp::systems::LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(LoginStateResCallback, CurrentLoginState);
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
+}
+
 }
 
 namespace csp::systems
@@ -140,6 +177,8 @@ csp::common::String ConvertExternalAuthProvidersToString(EThirdPartyAuthenticati
         return "Discord";
     case EThirdPartyAuthenticationProviders::Apple:
         return "Apple";
+    case EThirdPartyAuthenticationProviders::Netflix:
+        return "Netflix";
     default:
     {
         CSP_LOG_FORMAT(common::LogLevel::Error, "Unsupported Provider Type requested: %d, returning Google", static_cast<uint8_t>(Provider));
@@ -677,32 +716,6 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
 
     CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
 
-    LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-    {
-        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-        {
-            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
-            {
-                if (ErrCode != csp::multiplayer::ErrorCode::None)
-                {
-                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-                }
-
-                Callback(LoginStateRes);
-            };
-
-            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                CreateMultiplayerConnection);
-        }
-        else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
-        {
-            CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
-            Callback(LoginStateRes);
-        }
-    };
-
     const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
     Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
     Request->SetOAuthRedirectUri(ThirdPartyAuthRedirectURL);
@@ -732,13 +745,66 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
 
     Request->SetTokenOptions(Options);
 
+    LoginSocial(AuthenticationAPI, &CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
+}
+
+void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAuthenticationProviders AuthProvider,
+    const csp::common::String& ThirdPartyToken, const csp::common::Optional<EThirdPartyPlatform>& ClientType, bool CreateMultiplayerConnection,
+    const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback)
+{
+    if (AuthProvider == EThirdPartyAuthenticationProviders::Invalid)
+    {
+        CSP_LOG_ERROR_MSG("UserSystem::LoginToThirdPartyAuthenticationProviderWithToken() - EThirdPartyAuthenticationProviders::Invalid was passed "
+                          "as an AuthProvider.");
+
+        csp::systems::LoginStateResult ErrorResult;
+        ErrorResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(ErrorResult);
+
+        return;
+    }
+
+    if (ThirdPartyToken.IsEmpty())
+    {
+        CSP_LOG_ERROR_MSG("UserSystem::LoginToThirdPartyAuthenticationProviderWithToken() - a ThirdPartyToken must be provided. Please acquire a "
+                          "token from the third party provider directly before making this call.");
+
+        csp::systems::LoginStateResult ErrorResult;
+        ErrorResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(ErrorResult);
+
+        return;
+    }
+
+    if (CurrentLoginState.State != csp::common::ELoginState::LoggedOut && CurrentLoginState.State != csp::common::ELoginState::Error)
+    {
+        CSP_LOG_MSG(csp::common::LogLevel::Warning, "You are not in the correct login state to proceed with third-party authentication.");
+
+        csp::systems::LoginStateResult BadResult;
+        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(BadResult);
+    }
+
     CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
 
-    csp::services::ResponseHandlerPtr ResponseHandler
-        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, &CurrentLoginState);
+    const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetProvider(ConvertExternalAuthProvidersToString(AuthProvider));
+    Request->SetToken(ThirdPartyToken);
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
 
-    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
+    std::optional<csp::common::String> Client = ThirdPartyPlatformToString(ClientType);
+    if (Client.has_value())
+    {
+        Request->SetClient(Client.value());
+    }
+
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    LoginSocial(AuthenticationAPI, &CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
 }
 
 void UserSystem::Logout(NullResultCallback Callback)

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -924,11 +924,12 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetThirdPartySupportedProvidersTest)
 
     // Check the FDN supported providers
     auto SupportedProviders = UserSystem->GetSupportedThirdPartyAuthenticationProviders();
-    EXPECT_EQ(SupportedProviders.Size(), 3L);
+    EXPECT_EQ(SupportedProviders.Size(), 4L);
 
     bool FoundGoogle = false;
     bool FoundDiscord = false;
     bool FoundApple = false;
+    bool FoundNetflix = false;
     for (size_t idx = 0; idx < SupportedProviders.Size(); ++idx)
     {
         if (SupportedProviders[idx] == csp::systems::EThirdPartyAuthenticationProviders::Google)
@@ -943,13 +944,17 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetThirdPartySupportedProvidersTest)
         {
             FoundApple = true;
         }
+        else if (SupportedProviders[idx] == csp::systems::EThirdPartyAuthenticationProviders::Netflix)
+        {
+            FoundNetflix = true;
+        }
         else
         {
             ASSERT_TRUE(false) << "Please update this test with this new FDN auth provider: " << SupportedProviders[idx];
         }
     }
 
-    EXPECT_TRUE(FoundGoogle && FoundDiscord && FoundApple);
+    EXPECT_TRUE(FoundGoogle && FoundDiscord && FoundApple && FoundNetflix);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, GetAuthorizeURLForGoogleTest)
@@ -1183,6 +1188,49 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, AppleLogInTest)
 
 	// Log out
 	LogOut(UserSystem);
+}
+#endif
+
+// This is a manual only test as it requires an SSO token from a third party provider to be stored in a text file in a specific location.
+// Further details below.
+#if 0
+// Requires a SSO token placed in a file named "sso_token.txt" in the parent directory of the repository.
+// The file should contain only the raw token string.
+// Obtain the token from the third party provider before running this test.
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, SSOLoginWithTokenTest)
+{
+    // Will look for the token file in the parent directory of the repository.
+    const std::filesystem::path TokenFilePath
+        = std::filesystem::path(__FILE__).parent_path().parent_path().parent_path().parent_path().parent_path() / "sso_token.txt";
+
+    if (!std::filesystem::exists(TokenFilePath))
+    {
+        GTEST_SKIP() << "sso_token.txt not found at " << TokenFilePath
+                     << ". Place the SSO token in that file to run this test.";
+    }
+
+    std::ifstream TokenFile(TokenFilePath);
+    std::string SSOToken;
+    TokenFile >> SSOToken;
+
+    ASSERT_FALSE(SSOToken.empty()) << "sso_token.txt exists but is empty.";
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+
+    auto [LoginResult] = AWAIT_PRE(UserSystem, LoginToThirdPartyAuthenticationProviderWithToken, RequestPredicate,
+        csp::systems::EThirdPartyAuthenticationProviders::Netflix, csp::common::String(SSOToken.c_str()), csp::systems::EThirdPartyPlatform::Unreal, true, true);
+    
+    EXPECT_EQ(LoginResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    if (LoginResult.GetResultCode() == csp::systems::EResultCode::Success)
+    {
+        const auto UserId = LoginResult.GetLoginState().UserId;
+        auto Profile = GetFullProfileByUserId(UserSystem, UserId);
+        EXPECT_FALSE(Profile.UserId.IsEmpty());
+
+        LogOut(UserSystem);
+    }
 }
 #endif
 


### PR DESCRIPTION
Add support for third party authentication using a token provided by the third party provider.

This is an alternate path for SSO to the one already provided, in that it expects the application to request the authorization token from the third party provider directly before passing it to CSP.

A test has been added, but as noted in `UserSystemTests` this has to be run manually as it requires an SSO token from a third party provider to be stored in a text file in a specific location.

Results of the test run shown below:

<img width="1470" height="430" alt="image" src="https://github.com/user-attachments/assets/81df7f1b-2fa3-4b42-bee7-7cb757088f70" />
