### PR TITLE
[OB-5464] chore: Remove legacy identifier type parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+
 ## [6.43.0]
 
 ### 🔥 ❗Breaking Changes
@@ -9,6 +10,9 @@ All notable changes to this project will be documented in this file. For compile
 - [OB-5368] fix!: Guard access to LoginState data with a mutex. By @MAG-AdamThorn.
   The Login, Logout and Refresh Token response handlers access the LoginState object on different threads which was resulting in loginstate data race conditions. In addition the LoginState object was being passed to the response handlers by value, which resulted in the LoginState being destroyed when CSP was torn down while callbacks were still in flight. To resolve this issue the LoginState data members have been moved to a new LoginStateData class, and access to it is controlled via a mutex guard. In addition a copy of the LoginState shared_ptr is now captured by the response handler callbacks to ensure it's lifetime persists for the duration of the callback.
 
+### 🔨 🔨 Chore
+
+- [OB-5464] chore: Removed backwards compatibility parsing of AvatarData `identifierType`. All identifiers are strings now, data has been migrated. By @MAG-ElliotMorris
 
 ## [6.42.0]
 

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -886,22 +886,10 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
             CSP_LOG_ERROR_MSG("Whilst avatar info was successfully returned with data, no avatar type was included.");
         }
 
-        // Avatar identifier type (used to identify or locate the actual avatar asset)
+        // Avatar identifier (used to identify or locate the actual avatar asset)
         if (Json.HasMember("identifier"))
         {
-            if (Json.HasMember("identifierType") && static_cast<VariantType>(Json["identifierType"].GetInt()) == VariantType::Integer)
-            {
-                // Integer type is no longer supported -- convert to string
-                InternalResult.SetAvatarIdentifier(std::to_string(Json["identifier"].GetInt()).c_str());
-            }
-            else if (!Json.HasMember("identifierType") || (static_cast<VariantType>(Json["identifierType"].GetInt()) == VariantType::String))
-            {
                 InternalResult.SetAvatarIdentifier(Json["identifier"].GetString());
-            }
-            else
-            {
-                CSP_LOG_ERROR_MSG("Invalid avatar identifier type!");
-            }
         }
         else
         {

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -887,9 +887,9 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
         }
 
         // Avatar identifier (used to identify or locate the actual avatar asset)
-        if (Json.HasMember("identifier"))
+        if (Json.HasMember("identifier") && Json["identifier"].IsString())
         {
-                InternalResult.SetAvatarIdentifier(Json["identifier"].GetString());
+            InternalResult.SetAvatarIdentifier(Json["identifier"].GetString());
         }
         else
         {


### PR DESCRIPTION
Made this change right in the web editor :P No doubt CI will tell me of tests that need updated.

Will merge this once Jake confirms the migration is done. No need to handle this backwards compatibility anymore as CHS has purged all the data of this format.