### PR TITLE
[OB-5368] fix!: Guard access to login state data via a mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.43.0]
+
+### 🔥 ❗Breaking Changes
+
+- [OB-5368] fix!: Guard access to LoginState data with a mutex. By @MAG-AdamThorn.
+  The Login, Logout and Refresh Token response handlers access the LoginState object on different threads which was resulting in loginstate data race conditions. In addition the LoginState object was being passed to the response handlers by value, which resulted in the LoginState being destroyed when CSP was torn down while callbacks were still in flight. To resolve this issue the LoginState data members have been moved to a new LoginStateData class, and access to it is controlled via a mutex guard. In addition a copy of the LoginState shared_ptr is now captured by the response handler callbacks to ensure it's lifetime persists for the duration of the callback.
+
+
 ## [6.42.0]
 
 ### 🍰 🙌 New Features

--- a/Library/include/CSP/Common/LoginState.h
+++ b/Library/include/CSP/Common/LoginState.h
@@ -41,10 +41,10 @@ public:
     LoginState(const LoginState& OtherState);
     LoginState& operator=(const LoginState& OtherState);
 
-    /// @brief Get a copy of the current login state data.
+    /// @brief Get a thread-safe copy of the current login state data.
     /// This is a snapshot of the data at the time of the call, and will not update if the underlying state is mutated.
     /// @return A snapshot of the login state data.
-    CSP_NO_EXPORT LoginStateData GetSnapshot() const;
+    CSP_NO_EXPORT LoginStateData GetSnapshotThreadSafe() const;
 
     /// @brief Set the login state data. This will replace all existing data in the login state with the new data provided.
     CSP_NO_EXPORT void SetLoginStateData(csp::common::LoginStateData NewData);

--- a/Library/include/CSP/Common/LoginState.h
+++ b/Library/include/CSP/Common/LoginState.h
@@ -37,7 +37,7 @@ class CSP_API LoginState
 public:
     LoginState();
     ~LoginState();
-    
+
     LoginState(const LoginState& OtherState);
     LoginState& operator=(const LoginState& OtherState);
 
@@ -46,8 +46,9 @@ public:
     /// @return A snapshot of the login state data.
     CSP_NO_EXPORT LoginStateData GetSnapshotThreadSafe() const;
 
-    /// @brief Set the login state data. This will replace all existing data in the login state with the new data provided.
-    CSP_NO_EXPORT void SetLoginStateData(csp::common::LoginStateData NewData);
+    /// @brief Set the login state data while guarded by a mutex lock. This will replace all existing data in the login state with the new data
+    /// provided.
+    CSP_NO_EXPORT void SetLoginStateDataThreadSafe(csp::common::LoginStateData NewData);
 
     /// @brief Attempt to set the login state to LoginRequested if the current state is LoggedOut.
     /// This will prevent multiple concurrent login attempts through use of a mutex guard.
@@ -102,7 +103,7 @@ public:
 
 private:
     void CopyStateFrom(const LoginState& OtherState);
-    
+
     std::unique_ptr<LoginStateData> Data;
     CSP_START_IGNORE
     mutable std::mutex LoginStateMutex;

--- a/Library/include/CSP/Common/LoginState.h
+++ b/Library/include/CSP/Common/LoginState.h
@@ -17,49 +17,96 @@
 #pragma once
 
 #include "CSP/CSPCommon.h"
+#include "CSP/Common/List.h"
 #include "CSP/Common/Settings.h"
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Common/String.h"
 
+#include <memory>
+#include <mutex>
+
 namespace csp::common
 {
 
-class DateTime;
+class LoginStateData;
 
 /// @brief Data structure representing the user login state, including detection of access token expiry
+/// @inv All access to the underlying LoginState data happen under a mutex lock.
 class CSP_API LoginState
 {
 public:
     LoginState();
     ~LoginState();
-
+    
     LoginState(const LoginState& OtherState);
     LoginState& operator=(const LoginState& OtherState);
+
+    /// @brief Get a copy of the current login state data.
+    /// This is a snapshot of the data at the time of the call, and will not update if the underlying state is mutated.
+    /// @return A snapshot of the login state data.
+    CSP_NO_EXPORT LoginStateData GetSnapshot() const;
+
+    /// @brief Set the login state data. This will replace all existing data in the login state with the new data provided.
+    CSP_NO_EXPORT void SetLoginStateData(csp::common::LoginStateData NewData);
+
+    /// @brief Attempt to set the login state to LoginRequested if the current state is LoggedOut.
+    /// This will prevent multiple concurrent login attempts.
+    /// @return If the state was successfully changed to LoginRequested.
+    CSP_NO_EXPORT bool TrySetLoginRequested();
+
+    /// @brief Attempt to set the login state to LogoutRequested if the current state is LoggedIn.
+    /// This will prevent multiple concurrent logout attempts.
+    /// @return If the state was successfully changed to LogoutRequested.
+    CSP_NO_EXPORT bool TrySetLogoutRequested();
+
+    /// @brief Reset the login state after a failed login/logout attempt.
+    CSP_NO_EXPORT void ResetResponseLoginState(csp::common::ELoginState LoginState);
+
+    /// @brief Update the access token expiry time.
+    CSP_NO_EXPORT void UpdateAccessTokenExpiry(csp::common::String AccessTokenExpiryLength);
+
+    /// @brief Update the refresh token expiry time.
+    CSP_NO_EXPORT void UpdateRefreshTokenExpiry(csp::common::String RefreshTokenExpiryLength);
 
     /// @brief Check if the access token for the login is expired.
     /// @return Is the token expired.
     [[nodiscard]] bool RefreshNeeded() const;
 
-    ELoginState State;
-    csp::common::String AccessToken;
-    csp::common::String AccessTokenExpiryLength;
-    csp::common::String RefreshToken;
-    csp::common::String RefreshTokenExpiryLength;
-    csp::common::String UserId;
-    csp::common::String DeviceId;
+    /// @brief Get the user ID of the currently logged-in user.
+    /// @return The user ID, or an empty string if not logged in.
+    csp::common::String GetUserId() const;
 
-    /// @Brief Default, tenant-wide settings returned from the service, often used to store universal data such as feature flags.
-    csp::common::List<csp::common::ApplicationSettings> DefaultApplicationSettings;
+    /// @brief Get the device ID of the currently logged-in user.
+    /// @return The device ID, or an empty string if not logged in.
+    csp::common::String GetDeviceId() const;
 
-    /// @Brief Default settings relevant to the specific user returned from the service. Also known as "UserSettings".
-    /// @see csp::systems::SettingsSystem
-    csp::common::List<csp::common::SettingsCollection> DefaultSettings;
+    /// @brief Get the access token the currently logged-in user.
+    /// @return The access token, or an empty string if not logged in.
+    csp::common::String GetAccessToken() const;
 
-    CSP_NO_EXPORT void SetAccessTokenRefreshTime(const csp::common::DateTime& NewDateTime);
+    /// @brief Get the refresh token the currently logged-in user.
+    /// @return The refresh token, or an empty string if not logged in.
+    csp::common::String GetRefreshToken() const;
+
+    /// @brief Get the current login state value.
+    /// @return The current login state value.
+    csp::common::ELoginState GetLoginStateValue() const;
+
+    /// @brief Get the default tenant-wide application settings returned at login.
+    /// @return The default application settings.
+    csp::common::List<csp::common::ApplicationSettings> GetDefaultApplicationSettings() const;
+
+    /// @brief Get the default user settings returned at login.
+    /// @return The default user settings.
+    csp::common::List<csp::common::SettingsCollection> GetDefaultSettings() const;
 
 private:
     void CopyStateFrom(const LoginState& OtherState);
-
-    csp::common::DateTime* AccessTokenRefreshTime;
+    
+    std::unique_ptr<LoginStateData> Data;
+    CSP_START_IGNORE
+    mutable std::mutex LoginStateMutex;
+    CSP_END_IGNORE
 };
+
 } // namespace csp::common

--- a/Library/include/CSP/Common/LoginState.h
+++ b/Library/include/CSP/Common/LoginState.h
@@ -50,12 +50,12 @@ public:
     CSP_NO_EXPORT void SetLoginStateData(csp::common::LoginStateData NewData);
 
     /// @brief Attempt to set the login state to LoginRequested if the current state is LoggedOut.
-    /// This will prevent multiple concurrent login attempts.
+    /// This will prevent multiple concurrent login attempts through use of a mutex guard.
     /// @return If the state was successfully changed to LoginRequested.
     CSP_NO_EXPORT bool TrySetLoginRequested();
 
     /// @brief Attempt to set the login state to LogoutRequested if the current state is LoggedIn.
-    /// This will prevent multiple concurrent logout attempts.
+    /// This will prevent multiple concurrent logout attempts through use of a mutex guard.
     /// @return If the state was successfully changed to LogoutRequested.
     CSP_NO_EXPORT bool TrySetLogoutRequested();
 

--- a/Library/include/CSP/Common/LoginState.h
+++ b/Library/include/CSP/Common/LoginState.h
@@ -60,8 +60,8 @@ public:
     /// @return If the state was successfully changed to LogoutRequested.
     CSP_NO_EXPORT bool TrySetLogoutRequested();
 
-    /// @brief Reset the login state after a failed login/logout attempt.
-    CSP_NO_EXPORT void ResetResponseLoginState(csp::common::ELoginState LoginState);
+    /// @brief Construct a new default login state object after a failed login/logout attempt with the specified ELoginState value.
+    CSP_NO_EXPORT void ReinitializeResponseLoginState(csp::common::ELoginState LoginState);
 
     /// @brief Update the access token expiry time.
     CSP_NO_EXPORT void UpdateAccessTokenExpiry(csp::common::String AccessTokenExpiryLength);

--- a/Library/include/CSP/Systems/Users/Authentication.h
+++ b/Library/include/CSP/Systems/Users/Authentication.h
@@ -21,6 +21,7 @@
 #include "CSP/Common/String.h"
 #include "CSP/Systems/SystemsResult.h"
 
+
 namespace csp::common
 {
 
@@ -67,11 +68,11 @@ public:
     [[nodiscard]] const csp::common::LoginState& GetLoginState() const;
     CSP_NO_EXPORT LoginStateResult(csp::systems::EResultCode ResCode, uint16_t HttpResCode)
         : csp::systems::ResultBase(ResCode, HttpResCode)
-        , State(nullptr) {};
+        , State(nullptr) {}
 
 private:
     LoginStateResult();
-    LoginStateResult(csp::common::LoginState* InStatePtr);
+    LoginStateResult(csp::common::LoginState* LoginState);
 
     CSP_NO_EXPORT void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -29,6 +29,7 @@
 #include "CSP/Systems/Users/Profile.h"
 #include "CSP/Systems/Users/ThirdPartyAuthentication.h"
 
+
 namespace csp::web
 {
 
@@ -49,7 +50,7 @@ CSP_START_IGNORE
 class AuthContext : public csp::common::IAuthContext
 {
 public:
-    AuthContext(csp::services::ApiBase* AuthenticationAPI, csp::common::LoginState& LoginState);
+    AuthContext(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp::common::LoginState> LoginState);
 
     const csp::common::LoginState& GetLoginState() const override;
 
@@ -59,7 +60,7 @@ public:
 
 private:
     csp::services::ApiBase* AuthenticationAPI;
-    csp::common::LoginState* LoginState;
+    std::shared_ptr<csp::common::LoginState> LoginState;
 };
 CSP_END_IGNORE
 
@@ -338,7 +339,7 @@ private:
     csp::services::ApiBase* PingAPI;
     csp::services::ApiBase* StripeAPI;
 
-    csp::common::LoginState CurrentLoginState;
+    std::shared_ptr<csp::common::LoginState> CurrentLoginState;
 
     LoginTokenInfoResultCallback RefreshTokenChangedCallback;
 

--- a/Library/src/Common/LoginState.cpp
+++ b/Library/src/Common/LoginState.cpp
@@ -39,7 +39,7 @@ LoginState& LoginState::operator=(const LoginState& OtherState)
     return *this;
 }
 
-LoginStateData LoginState::GetSnapshot() const
+LoginStateData LoginState::GetSnapshotThreadSafe() const
 {
     std::scoped_lock lock(LoginStateMutex);
 

--- a/Library/src/Common/LoginState.cpp
+++ b/Library/src/Common/LoginState.cpp
@@ -81,7 +81,7 @@ bool LoginState::TrySetLogoutRequested()
     return false;
 }
 
-void LoginState::ResetResponseLoginState(ELoginState LoginState)
+void LoginState::ReinitializeResponseLoginState(ELoginState LoginState)
 {
     std::scoped_lock lock(LoginStateMutex);
 

--- a/Library/src/Common/LoginState.cpp
+++ b/Library/src/Common/LoginState.cpp
@@ -15,61 +15,162 @@
  */
 
 #include "CSP/Common/LoginState.h"
-
-#include "Common/DateTime.h"
+#include "Common/LoginStateData.h"
 
 namespace csp::common
 {
 
 LoginState::LoginState()
-    : State(ELoginState::LoggedOut)
-    , AccessTokenRefreshTime(new DateTime())
+    : Data(std::make_unique<LoginStateData>())
 {
 }
+
+LoginState::~LoginState() { }
 
 LoginState::LoginState(const LoginState& OtherState) { CopyStateFrom(OtherState); }
 
 LoginState& LoginState::operator=(const LoginState& OtherState)
 {
-    CopyStateFrom(OtherState);
+    if (this != &OtherState)
+    {
+        CopyStateFrom(OtherState);
+    }
 
     return *this;
 }
 
-void LoginState::SetAccessTokenRefreshTime(const csp::common::DateTime& NewDateTime)
+LoginStateData LoginState::GetSnapshot() const
 {
-    // Why this data member is a pointer is beyond me, but it's too bedded in to change right this second ... invoke the copy assignment operator.
-    *AccessTokenRefreshTime = NewDateTime;
+    std::scoped_lock lock(LoginStateMutex);
+
+    return *Data;
 }
 
-void LoginState::CopyStateFrom(const LoginState& OtherState)
+void LoginState::SetLoginStateData(LoginStateData NewData)
 {
-    State = OtherState.State;
-    AccessToken = OtherState.AccessToken;
-    AccessTokenExpiryLength = OtherState.AccessTokenExpiryLength;
-    RefreshToken = OtherState.RefreshToken;
-    RefreshTokenExpiryLength = OtherState.RefreshTokenExpiryLength;
-    UserId = OtherState.UserId;
-    DeviceId = OtherState.DeviceId;
-    DefaultApplicationSettings = OtherState.DefaultApplicationSettings;
-    DefaultSettings = OtherState.DefaultSettings;
+    std::scoped_lock lock(LoginStateMutex);
 
-    // Must reallocate the access token when copying otherwise destructor of
-    // copied state will delete the original memory pointer potentially causing corruption
-    AccessTokenRefreshTime = new DateTime(OtherState.AccessTokenRefreshTime->GetTimePoint());
+    *Data = std::move(NewData);
 }
 
-LoginState::~LoginState() { delete (AccessTokenRefreshTime); }
+bool LoginState::TrySetLoginRequested()
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    if (Data->State == csp::common::ELoginState::LoggedOut || Data->State == csp::common::ELoginState::Error)
+    {
+        Data->State = csp::common::ELoginState::LoginRequested;
+
+        return true;
+    }
+
+    return false;
+}
+
+bool LoginState::TrySetLogoutRequested()
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    if (Data->State == csp::common::ELoginState::LoggedIn)
+    {
+        Data->State = csp::common::ELoginState::LogoutRequested;
+
+        return true;
+    }
+
+    return false;
+}
+
+void LoginState::ResetResponseLoginState(ELoginState LoginState)
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    Data = std::make_unique<LoginStateData>();
+    Data->State = LoginState;
+}
+
+void LoginState::UpdateAccessTokenExpiry(csp::common::String AccessTokenExpiryLength)
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    Data->AccessTokenExpiryLength = AccessTokenExpiryLength;
+}
+
+void LoginState::UpdateRefreshTokenExpiry(csp::common::String RefreshTokenExpiryLength)
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    Data->RefreshTokenExpiryLength = RefreshTokenExpiryLength;
+}
 
 bool LoginState::RefreshNeeded() const
 {
-    if (AccessTokenRefreshTime->IsEpoch())
+    std::scoped_lock lock(LoginStateMutex);
+
+    if (Data->GetAccessTokenRefreshTime().IsEpoch())
     {
         return false;
     }
 
     const auto CurrentTime = DateTime::UtcTimeNow();
 
-    return CurrentTime >= (*AccessTokenRefreshTime);
+    return CurrentTime >= (Data->GetAccessTokenRefreshTime());
 }
+
+csp::common::String LoginState::GetUserId() const
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    return Data->UserId;
+}
+
+csp::common::String LoginState::GetDeviceId() const
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    return Data->DeviceId;
+}
+
+csp::common::String LoginState::GetAccessToken() const
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    return Data->AccessToken;
+}
+
+csp::common::String LoginState::GetRefreshToken() const
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    return Data->RefreshToken;
+}
+
+csp::common::ELoginState LoginState::GetLoginStateValue() const
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    return Data->State;
+}
+
+csp::common::List<csp::common::ApplicationSettings> LoginState::GetDefaultApplicationSettings() const
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    return Data->DefaultApplicationSettings;
+}
+
+csp::common::List<csp::common::SettingsCollection> LoginState::GetDefaultSettings() const
+{
+    std::scoped_lock lock(LoginStateMutex);
+
+    return Data->DefaultSettings;
+}
+
+void LoginState::CopyStateFrom(const LoginState& OtherState)
+{
+    std::scoped_lock lock(LoginStateMutex, OtherState.LoginStateMutex);
+
+    Data = std::make_unique<LoginStateData>(*OtherState.Data);
+}
+
 } // namespace csp::common

--- a/Library/src/Common/LoginState.cpp
+++ b/Library/src/Common/LoginState.cpp
@@ -46,7 +46,7 @@ LoginStateData LoginState::GetSnapshotThreadSafe() const
     return *Data;
 }
 
-void LoginState::SetLoginStateData(LoginStateData NewData)
+void LoginState::SetLoginStateDataThreadSafe(LoginStateData NewData)
 {
     std::scoped_lock lock(LoginStateMutex);
 

--- a/Library/src/Common/LoginStateData.h
+++ b/Library/src/Common/LoginStateData.h
@@ -27,6 +27,8 @@
 namespace csp::common
 {
 
+/// @brief Data structure representing the user login state.
+/// This type allows us to extract the data from the LoginState class and control access to it via a mutex lock.
 class LoginStateData
 {
 public:

--- a/Library/src/Common/LoginStateData.h
+++ b/Library/src/Common/LoginStateData.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "CSP/CSPCommon.h"
+#include "CSP/Common/Settings.h"
+#include "CSP/Common/SharedEnums.h"
+#include "CSP/Common/String.h"
+#include "Common/DateTime.h"
+
+#include <memory>
+
+namespace csp::common
+{
+
+class LoginStateData
+{
+public:
+    LoginStateData()
+        : State(ELoginState::LoggedOut)
+        , AccessTokenRefreshTime(csp::common::DateTime())
+    {
+    }
+
+    LoginStateData(const LoginStateData& Other)
+        : State(Other.State)
+        , AccessToken(Other.AccessToken)
+        , AccessTokenExpiryLength(Other.AccessTokenExpiryLength)
+        , RefreshToken(Other.RefreshToken)
+        , RefreshTokenExpiryLength(Other.RefreshTokenExpiryLength)
+        , UserId(Other.UserId)
+        , DeviceId(Other.DeviceId)
+        , DefaultApplicationSettings(Other.DefaultApplicationSettings)
+        , DefaultSettings(Other.DefaultSettings)
+        , AccessTokenRefreshTime(Other.AccessTokenRefreshTime)
+    {
+    }
+
+    LoginStateData& operator=(const LoginStateData& Other)
+    {
+        if (this == &Other)
+        {
+            return *this;
+        }
+
+        State                       = Other.State;
+        AccessToken                 = Other.AccessToken;
+        AccessTokenExpiryLength     = Other.AccessTokenExpiryLength;
+        RefreshToken                = Other.RefreshToken;
+        RefreshTokenExpiryLength    = Other.RefreshTokenExpiryLength;
+        UserId                      = Other.UserId;
+        DeviceId                    = Other.DeviceId;
+        DefaultApplicationSettings  = Other.DefaultApplicationSettings;
+        DefaultSettings             = Other.DefaultSettings;
+
+        AccessTokenRefreshTime = Other.AccessTokenRefreshTime;
+
+        return *this;
+    }
+
+    ELoginState State = ELoginState::LoggedOut;
+    csp::common::String AccessToken;
+    csp::common::String AccessTokenExpiryLength;
+    csp::common::String RefreshToken;
+    csp::common::String RefreshTokenExpiryLength;
+    csp::common::String UserId;
+    csp::common::String DeviceId;
+
+    /// @Brief Default, tenant-wide settings returned from the service, often used to store universal data such as feature flags.
+    csp::common::List<csp::common::ApplicationSettings> DefaultApplicationSettings;
+
+    /// @Brief Default settings relevant to the specific user returned from the service. Also known as "UserSettings".
+    /// @see csp::systems::SettingsSystem
+    csp::common::List<csp::common::SettingsCollection> DefaultSettings;
+
+    CSP_NO_EXPORT void SetAccessTokenRefreshTime(const csp::common::DateTime& NewDateTime) { AccessTokenRefreshTime = NewDateTime; }
+    CSP_NO_EXPORT const csp::common::DateTime& GetAccessTokenRefreshTime() const { return AccessTokenRefreshTime; }
+
+private:
+    csp::common::DateTime AccessTokenRefreshTime;
+};
+
+} // namespace csp::common

--- a/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
@@ -6,6 +6,9 @@
 #include "CSP/Systems/Users/UserSystem.h"
 #include "Systems/Spaces/SpaceSystemHelpers.h"
 
+#include "CSP/Common/LoginState.h"
+#include "Common/LoginStateData.h"
+
 #include "CSP/Multiplayer/Components/ConversationSpaceComponent.h"
 #include "Multiplayer/NetworkEventSerialisation.h"
 
@@ -349,7 +352,7 @@ ConversationSystemInternal::~ConversationSystemInternal() { }
 void ConversationSystemInternal::CreateConversation(const common::String& Message, StringResultCallback Callback)
 {
     const Space& CurrentSpace = SpaceSystem->GetCurrentSpace();
-    const common::String& UserId = UserSystem->GetLoginState().UserId;
+    const common::String& UserId = UserSystem->GetLoginState().GetUserId();
     const common::String& SpaceId = CurrentSpace.Id;
 
     // 1. Create the comment container asset collection
@@ -446,7 +449,7 @@ void ConversationSystemInternal::AddMessage(
     const common::String& ConversationId, const common::String& Message, multiplayer::MessageResultCallback Callback)
 {
     // 1. Store the conversation message
-    const common::String& UserId = UserSystem->GetLoginState().UserId;
+    const common::String& UserId = UserSystem->GetLoginState().GetUserId();
 
     const multiplayer::MessageResultCallback MessageResultCallback
         = [this, Callback, ConversationId, UserId, Message](const multiplayer::MessageResult& MessageResultCallbackResult)
@@ -495,7 +498,7 @@ void ConversationSystemInternal::DeleteMessage(const common::String& Conversatio
         multiplayer::MessageInfo Info
             = systems::ConversationSystemHelpers::GetMessageInfoFromMessageAssetCollection(GetMessageResult.GetAssetCollection());
 
-        if (EnsureUserHasPermission(UserSystem->GetLoginState().UserId, Info.UserId, false) == false)
+        if (EnsureUserHasPermission(UserSystem->GetLoginState().GetUserId(), Info.UserId, false) == false)
         {
             INVOKE_IF_NOT_NULL(Callback, MakeInvalid<NullResult>());
             return;
@@ -595,7 +598,7 @@ void ConversationSystemInternal::UpdateConversation(
         multiplayer::MessageInfo Info
             = systems::ConversationSystemHelpers::GetConversationInfoFromConversationAssetCollection(GetConversationResult.GetAssetCollection());
 
-        if (EnsureUserHasPermission(UserSystem->GetLoginState().UserId, Info.UserId, true) == false)
+        if (EnsureUserHasPermission(UserSystem->GetLoginState().GetUserId(), Info.UserId, true) == false)
         {
             INVOKE_IF_NOT_NULL(Callback, MakeInvalid<multiplayer::ConversationResult>());
             return;
@@ -687,7 +690,7 @@ void ConversationSystemInternal::UpdateMessage(const common::String& /*Conversat
         multiplayer::MessageInfo Info
             = systems::ConversationSystemHelpers::GetMessageInfoFromMessageAssetCollection(GetMessageResult.GetAssetCollection());
 
-        if (EnsureUserHasPermission(UserSystem->GetLoginState().UserId, Info.UserId, false) == false)
+        if (EnsureUserHasPermission(UserSystem->GetLoginState().GetUserId(), Info.UserId, false) == false)
         {
             INVOKE_IF_NOT_NULL(Callback, MakeInvalid<multiplayer::MessageResult>());
             return;
@@ -834,7 +837,7 @@ void ConversationSystemInternal::SetConversationAnnotation(const csp::common::St
     const systems::BufferAssetDataSource& AnnotationThumbnail, multiplayer::AnnotationResultCallback Callback)
 {
     const csp::common::String SpaceId = SpaceSystem->GetCurrentSpace().Id;
-    const csp::common::String UserId = UserSystem->GetLoginState().UserId;
+    const csp::common::String UserId = UserSystem->GetLoginState().GetUserId();
 
     const common::String UniqueAssetCollectionName = ConversationSystemHelpers::GetUniqueAnnotationAssetCollectionName(SpaceId, UserId);
     const csp::common::String UniqueAnnotationAssetName = ConversationSystemHelpers::GetUniqueAnnotationAssetName(SpaceId, UserId);
@@ -984,7 +987,7 @@ void ConversationSystemInternal::SetAnnotation(const csp::common::String& Conver
     const systems::BufferAssetDataSource& AnnotationThumbnail, multiplayer::AnnotationResultCallback Callback)
 {
     const csp::common::String SpaceId = SpaceSystem->GetCurrentSpace().Id;
-    const csp::common::String UserId = UserSystem->GetLoginState().UserId;
+    const csp::common::String UserId = UserSystem->GetLoginState().GetUserId();
 
     const common::String UniqueAssetCollectionName = ConversationSystemHelpers::GetUniqueAnnotationAssetCollectionName(SpaceId, UserId);
     const csp::common::String UniqueAnnotationAssetName = ConversationSystemHelpers::GetUniqueAnnotationAssetName(SpaceId, UserId);

--- a/Library/src/Systems/ECommerce/ECommerceSystem.cpp
+++ b/Library/src/Systems/ECommerce/ECommerceSystem.cpp
@@ -16,6 +16,8 @@
 
 #include "CSP/Systems/ECommerce/ECommerceSystem.h"
 
+#include "CSP/Common/LoginState.h"
+#include "Common/LoginStateData.h"
 #include "CSP/Systems/Users/UserSystem.h"
 #include "CallHelpers.h"
 #include "Common/Convert.h"
@@ -138,10 +140,9 @@ void ECommerceSystem::GetShopifyStores(const csp::common::Optional<bool>& IsActi
     auto& SystemsManager = SystemsManager::Get();
     const auto* UserSystem = SystemsManager.GetUserSystem();
 
-    const auto& UserId = UserSystem->GetLoginState().UserId;
-
     static_cast<chs::ShopifyApi*>(ShopifyAPI)
-        ->vendorsShopifyUsersUserIdStorefrontsGet({ UserId, ActiveParam, std::nullopt, std::nullopt }, ResponseHandler);
+        ->vendorsShopifyUsersUserIdStorefrontsGet(
+            { UserSystem->GetLoginState().GetUserId(), ActiveParam, std::nullopt, std::nullopt }, ResponseHandler);
 }
 
 void ECommerceSystem::AddShopifyStore(const common::String& StoreName, const common::String& SpaceId, const bool IsEcommerceActive,

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -53,7 +53,7 @@ QuotaSystem::~QuotaSystem()
 
 void QuotaSystem::GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback)
 {
-    auto Data = Context->GetLoginState().GetSnapshot();
+    auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
 
     if (Data.State != common::ELoginState::LoggedIn)
     {
@@ -92,7 +92,7 @@ void QuotaSystem::GetTotalSpaceSizeInKilobytes(const csp::common::String& SpaceI
 
 void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFeatures>& FeatureNames, FeaturesLimitCallback Callback)
 {
-    auto Data = Context->GetLoginState().GetSnapshot();
+    auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
 
     if (Data.State != common::ELoginState::LoggedIn)
     {
@@ -134,7 +134,7 @@ void QuotaSystem::GetTierFeatureProgressForSpace(
 
 void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
 {
-    auto Data = Context->GetLoginState().GetSnapshot();
+    auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
 
     if (Data.State != common::ELoginState::LoggedIn)
     {

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -18,6 +18,8 @@
 #include "Systems/ResultHelpers.h"
 
 #include "CSP/Common/Interfaces/IAuthContext.h"
+#include "CSP/Common/LoginState.h"
+#include "Common/LoginStateData.h"
 #include "Services/TrackingService/Api.h"
 
 namespace chs = csp::services::generated::trackingservice;
@@ -51,7 +53,9 @@ QuotaSystem::~QuotaSystem()
 
 void QuotaSystem::GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback)
 {
-    if (Context->GetLoginState().State != common::ELoginState::LoggedIn)
+    auto Data = Context->GetLoginState().GetSnapshot();
+
+    if (Data.State != common::ELoginState::LoggedIn)
     {
         LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetTotalSpacesOwnedByUser: User is not logged in. Aborting operation.");
         Callback(MakeInvalid<FeatureLimitResult>());
@@ -63,8 +67,7 @@ void QuotaSystem::GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback)
     csp::services::ResponseHandlerPtr ResponseHandler = QuotaManagementAPI->CreateHandler<FeatureLimitCallback, FeatureLimitResult, void,
         csp::services::DtoArray<chs::QuotaFeatureLimitProgressDto>>(Callback, nullptr);
 
-    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)
-        ->usersUserIdQuota_progressGet({ Context->GetLoginState().UserId, FeatureNamesList }, ResponseHandler);
+    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->usersUserIdQuota_progressGet({ Data.UserId, FeatureNamesList }, ResponseHandler);
 }
 
 void QuotaSystem::GetConcurrentUsersInSpace(const csp::common::String& SpaceId, FeatureLimitCallback Callback)
@@ -89,7 +92,9 @@ void QuotaSystem::GetTotalSpaceSizeInKilobytes(const csp::common::String& SpaceI
 
 void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFeatures>& FeatureNames, FeaturesLimitCallback Callback)
 {
-    if (Context->GetLoginState().State != common::ELoginState::LoggedIn)
+    auto Data = Context->GetLoginState().GetSnapshot();
+
+    if (Data.State != common::ELoginState::LoggedIn)
     {
         LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetTierFeatureProgressForUser: User is not logged in. Aborting operation.");
         Callback(MakeInvalid<FeaturesLimitResult>());
@@ -107,8 +112,7 @@ void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFea
         FeatureNamesList.push_back(TierFeatureEnumToString(FeatureNames[idx]));
     }
 
-    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)
-        ->usersUserIdQuota_progressGet({ Context->GetLoginState().UserId, FeatureNamesList }, ResponseHandler);
+    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->usersUserIdQuota_progressGet({ Data.UserId, FeatureNamesList }, ResponseHandler);
 }
 
 void QuotaSystem::GetTierFeatureProgressForSpace(
@@ -130,7 +134,9 @@ void QuotaSystem::GetTierFeatureProgressForSpace(
 
 void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
 {
-    if (Context->GetLoginState().State != common::ELoginState::LoggedIn)
+    auto Data = Context->GetLoginState().GetSnapshot();
+
+    if (Data.State != common::ELoginState::LoggedIn)
     {
         LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetCurrentUserTier: User is not logged in. Aborting operation.");
         Callback(MakeInvalid<UserTierResult>());
@@ -140,8 +146,7 @@ void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
     csp::services::ResponseHandlerPtr ResponseHandler
         = QuotaTierAssignmentAPI->CreateHandler<UserTierCallback, UserTierResult, void, chs::QuotaTierAssignmentDto>(Callback, nullptr);
 
-    static_cast<chs::QuotaTierAssignmentApi*>(QuotaTierAssignmentAPI)
-        ->usersUserIdTier_assignmentGet({ Context->GetLoginState().UserId }, ResponseHandler);
+    static_cast<chs::QuotaTierAssignmentApi*>(QuotaTierAssignmentAPI)->usersUserIdTier_assignmentGet({ Data.UserId }, ResponseHandler);
 }
 
 void QuotaSystem::SetUserTier(TierNames TierName, const csp::common::String& UserId, UserTierCallback Callback)

--- a/Library/src/Systems/Settings/SettingsSystem.cpp
+++ b/Library/src/Systems/Settings/SettingsSystem.cpp
@@ -18,10 +18,12 @@
 
 #include "CSP/Common/Array.h"
 #include "CSP/Common/List.h"
+#include "CSP/Common/LoginState.h"
 #include "CSP/Common/String.h"
 #include "CSP/Systems/Assets/AssetSystem.h"
 #include "CSP/Systems/Users/UserSystem.h"
 #include "CallHelpers.h"
+#include "Common/LoginStateData.h"
 #include "Services/ApiBase/ApiBase.h"
 #include "Services/UserService/Api.h"
 #include "Services/UserService/Dto.h"
@@ -29,8 +31,8 @@
 #include "Systems/Spaces/SpaceSystemHelpers.h"
 
 #include <iostream>
-#include <rapidjson/rapidjson.h>
 #include <rapidjson/error/en.h>
+#include <rapidjson/rapidjson.h>
 #include <sstream>
 
 constexpr int MAX_RECENT_SPACES = 50;
@@ -63,8 +65,6 @@ void SettingsSystem::SetSettingValue(const String& InContext, const String& InKe
     auto& SystemsManager = SystemsManager::Get();
     const auto* UserSystem = SystemsManager.GetUserSystem();
 
-    const auto& UserId = UserSystem->GetLoginState().UserId;
-
     auto InSettings = std::make_shared<chs::SettingsDto>();
     std::map<String, String> NewSettings;
     NewSettings.clear();
@@ -86,7 +86,8 @@ void SettingsSystem::SetSettingValue(const String& InContext, const String& InKe
         = SettingsAPI->CreateHandler<SettingsResultCallback, SettingsCollectionResult, void, chs::SettingsDto>(
             InternalCallback, nullptr, web::EResponseCodes::ResponseOK);
 
-    static_cast<chs::SettingsApi*>(SettingsAPI)->usersUserIdSettingsContextPut({ UserId, InContext, InSettings }, SettingsResponseHandler);
+    static_cast<chs::SettingsApi*>(SettingsAPI)
+        ->usersUserIdSettingsContextPut({ UserSystem->GetLoginState().GetUserId(), InContext, InSettings }, SettingsResponseHandler);
 }
 
 void SettingsSystem::GetSettingValue(const String& InContext, const String& InKey, StringResultCallback Callback) const
@@ -94,8 +95,6 @@ void SettingsSystem::GetSettingValue(const String& InContext, const String& InKe
     auto& SystemsManager = SystemsManager::Get();
     const auto* UserSystem = SystemsManager.GetUserSystem();
     std::vector<String> MyKey = { InKey };
-
-    const auto& UserId = UserSystem->GetLoginState().UserId;
 
     SettingsResultCallback InternalCallback = [InKey, Callback](const SettingsCollectionResult& Result)
     {
@@ -134,7 +133,8 @@ void SettingsSystem::GetSettingValue(const String& InContext, const String& InKe
         = SettingsAPI->CreateHandler<SettingsResultCallback, SettingsCollectionResult, void, chs::SettingsDto>(
             InternalCallback, nullptr, web::EResponseCodes::ResponseOK);
 
-    static_cast<chs::SettingsApi*>(SettingsAPI)->usersUserIdSettingsContextGet({ UserId, InContext, MyKey }, SettingsResponseHandler);
+    static_cast<chs::SettingsApi*>(SettingsAPI)
+        ->usersUserIdSettingsContextGet({ UserSystem->GetLoginState().GetUserId(), InContext, MyKey }, SettingsResponseHandler);
 }
 
 void SettingsSystem::SetNDAStatus(bool InValue, NullResultCallback Callback)
@@ -418,8 +418,8 @@ void SettingsSystem::UpdateAvatarPortrait(const FileAssetDataSource& NewAvatarPo
     };
 
     auto* UserSystem = SystemsManager::Get().GetUserSystem();
-    const auto& UserId = UserSystem->GetLoginState().UserId;
-    GetAvatarPortraitAssetCollection(UserId, AvatarPortraitAssetCollCallback);
+
+    GetAvatarPortraitAssetCollection(UserSystem->GetLoginState().GetUserId(), AvatarPortraitAssetCollCallback);
 }
 
 void SettingsSystem::GetAvatarPortrait(const csp::common::String InUserID, UriResultCallback Callback)
@@ -539,8 +539,8 @@ void SettingsSystem::UpdateAvatarPortraitWithBuffer(const BufferAssetDataSource&
     };
 
     auto* UserSystem = SystemsManager::Get().GetUserSystem();
-    const auto& UserId = UserSystem->GetLoginState().UserId;
-    GetAvatarPortraitAssetCollection(UserId, ThumbnailAssetCollCallback);
+
+    GetAvatarPortraitAssetCollection(UserSystem->GetLoginState().GetUserId(), ThumbnailAssetCollCallback);
 }
 
 void SettingsSystem::AddAvatarPortrait(const FileAssetDataSource& ImageDataSource, NullResultCallback Callback)
@@ -548,8 +548,6 @@ void SettingsSystem::AddAvatarPortrait(const FileAssetDataSource& ImageDataSourc
     auto& SystemsManager = SystemsManager::Get();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* UserSystem = SystemsManager.GetUserSystem();
-
-    const auto& UserId = UserSystem->GetLoginState().UserId;
 
     AssetCollectionResultCallback CreateAssetCollCallback = [=](const AssetCollectionResult& AssetCollResult)
     {
@@ -595,7 +593,7 @@ void SettingsSystem::AddAvatarPortrait(const FileAssetDataSource& ImageDataSourc
                 }
             };
 
-            const auto UniqueAssetName = AVATAR_PORTRAIT_ASSET_NAME + UserId;
+            const auto UniqueAssetName = AVATAR_PORTRAIT_ASSET_NAME + UserSystem->GetLoginState().GetUserId();
             AssetSystem->CreateAsset(PortraitAssetColl, UniqueAssetName, nullptr, nullptr, EAssetType::IMAGE, CreateAssetCallback);
         }
         else
@@ -608,7 +606,7 @@ void SettingsSystem::AddAvatarPortrait(const FileAssetDataSource& ImageDataSourc
         }
     };
 
-    const auto AvatarPortraitAssetCollectionName = AVATAR_PORTRAIT_ASSET_COLLECTION_NAME + UserId;
+    const auto AvatarPortraitAssetCollectionName = AVATAR_PORTRAIT_ASSET_COLLECTION_NAME + UserSystem->GetLoginState().GetUserId();
 
     AssetSystem->CreateAssetCollection(
         nullptr, nullptr, AvatarPortraitAssetCollectionName, nullptr, EAssetCollectionType::DEFAULT, nullptr, CreateAssetCollCallback);
@@ -619,8 +617,6 @@ void SettingsSystem::AddAvatarPortraitWithBuffer(const BufferAssetDataSource& Im
     auto& SystemsManager = SystemsManager::Get();
     auto* AssetSystem = SystemsManager.GetAssetSystem();
     auto* UserSystem = SystemsManager.GetUserSystem();
-
-    const auto& UserId = UserSystem->GetLoginState().UserId;
 
     AssetCollectionResultCallback CreateAssetCollCallback = [=](const AssetCollectionResult& AssetCollResult)
     {
@@ -656,8 +652,8 @@ void SettingsSystem::AddAvatarPortraitWithBuffer(const BufferAssetDataSource& Im
 
                     Asset AvatarPortraitAsset = CreateAssetResult.GetAsset();
 
-                    AvatarPortraitAsset.FileName
-                        = AVATAR_PORTRAIT_ASSET_NAME + UserId + SpaceSystemHelpers::GetAssetFileExtension(ImageDataSource.GetMimeType());
+                    AvatarPortraitAsset.FileName = AVATAR_PORTRAIT_ASSET_NAME + UserSystem->GetLoginState().GetUserId()
+                        + SpaceSystemHelpers::GetAssetFileExtension(ImageDataSource.GetMimeType());
                     AvatarPortraitAsset.MimeType = ImageDataSource.GetMimeType();
                     AssetSystem->UploadAssetData(PortraitAvatarAssetColl, AvatarPortraitAsset, ImageDataSource, UploadCallback);
                 }
@@ -671,7 +667,7 @@ void SettingsSystem::AddAvatarPortraitWithBuffer(const BufferAssetDataSource& Im
                 }
             };
 
-            const auto UniqueAssetName = AVATAR_PORTRAIT_ASSET_NAME + UserId;
+            const auto UniqueAssetName = AVATAR_PORTRAIT_ASSET_NAME + UserSystem->GetLoginState().GetUserId();
             AssetSystem->CreateAsset(PortraitAvatarAssetColl, UniqueAssetName, nullptr, nullptr, EAssetType::IMAGE, CreateAssetCallback);
         }
         else
@@ -684,7 +680,7 @@ void SettingsSystem::AddAvatarPortraitWithBuffer(const BufferAssetDataSource& Im
         }
     };
 
-    const String SpaceThumbnailAssetCollectionName = AVATAR_PORTRAIT_ASSET_COLLECTION_NAME + UserId;
+    const String SpaceThumbnailAssetCollectionName = AVATAR_PORTRAIT_ASSET_COLLECTION_NAME + UserSystem->GetLoginState().GetUserId();
 
     // don't associate this asset collection with a particular space so that it can be retrieved by guest users that have not joined this space
     AssetSystem->CreateAssetCollection(
@@ -821,8 +817,8 @@ void SettingsSystem::RemoveAvatarPortrait(NullResultCallback Callback)
     };
 
     auto* UserSystem = SystemsManager::Get().GetUserSystem();
-    const auto& UserId = UserSystem->GetLoginState().UserId;
-    GetAvatarPortraitAssetCollection(UserId, PortraitAvatarAssetCollCallback);
+
+    GetAvatarPortraitAssetCollection(UserSystem->GetLoginState().GetUserId(), PortraitAvatarAssetCollCallback);
 }
 
 void SettingsSystem::SetAvatarInfo(AvatarType InType, const String& InIdentifier, bool InAvatarVisible, NullResultCallback Callback)
@@ -874,7 +870,8 @@ void SettingsSystem::GetAvatarInfo(AvatarInfoResultCallback Callback)
         rapidjson::ParseResult ok = Json.Parse(Value.c_str());
         if (!ok)
         {
-            CSP_LOG_ERROR_FORMAT("Failed to parse avatar info JSON data. Error: %s, Offset: %zu", rapidjson::GetParseError_En(ok.Code()), ok.Offset());
+            CSP_LOG_ERROR_FORMAT(
+                "Failed to parse avatar info JSON data. Error: %s, Offset: %zu", rapidjson::GetParseError_En(ok.Code()), ok.Offset());
             Callback(InternalResult);
             return;
         }

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -17,6 +17,8 @@
 #include "CSP/Systems/Spaces/SpaceSystem.h"
 
 #include "CSP/CSPFoundation.h"
+#include "CSP/Common/LoginState.h"
+#include "Common/LoginStateData.h"
 #include "CSP/Common/SharedConstants.h"
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Common/StringFormat.h"
@@ -68,7 +70,7 @@ std::shared_ptr<chsaggregation::DuplicateSpaceOptions> ConstructDuplicateSpaceOp
 {
     auto Request = std::make_shared<chsaggregation::DuplicateSpaceOptions>();
     Request->SetSpaceId(SpaceId);
-    Request->SetNewGroupOwnerId(UserSystem->GetLoginState().UserId);
+    Request->SetNewGroupOwnerId(UserSystem->GetLoginState().GetUserId());
     Request->SetNewUniqueName(NewName);
     Request->SetDiscoverable(HasFlag(NewAttributes, csp::systems::SpaceAttributes::IsDiscoverable));
     Request->SetRequiresInvite(HasFlag(NewAttributes, csp::systems::SpaceAttributes::RequiresInvite));
@@ -134,7 +136,7 @@ async::task<SpaceResult> SpaceSystem::CreateSpaceGroupInfo(
     }
 
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(
-        [](const SpaceResult&) {}, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(*OnCompleteEvent.get()));
+        [](const SpaceResult&) { }, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(*OnCompleteEvent.get()));
 
     static_cast<chs::GroupApi*>(GroupAPI)->groupsPost({ GroupInfo }, ResponseHandler);
 
@@ -312,8 +314,7 @@ std::function<async::task<SpaceResult>(const SpaceResult& SpaceResult)> SpaceSys
 
                     if (Scopes.Size() < 1)
                     {
-                        this->LogSystem->LogMsg(
-                            csp::common::LogLevel::Error, "SpaceSystem::RegisterScopesInSpace: Space doesn't have a scope.");
+                        this->LogSystem->LogMsg(csp::common::LogLevel::Error, "SpaceSystem::RegisterScopesInSpace: Space doesn't have a scope.");
                         FinishedGetScopeEvent->set_exception(std::make_exception_ptr(csp::common::continuations::ResultException(
                             "SpaceSystem::RegisterScopesInSpace: Space doesn't have a scope", MakeInvalid<csp::systems::SpaceResult>())));
                         return;
@@ -321,8 +322,9 @@ std::function<async::task<SpaceResult>(const SpaceResult& SpaceResult)> SpaceSys
 
                     if (Scopes.Size() > 1)
                     {
-                        this->LogSystem->LogMsg(
-                            csp::common::LogLevel::Error, "SpaceSystem::RegisterScopesInSpace: Multiple scopes found. This version of CSP only supports spaces that have only a single global scope.");
+                        this->LogSystem->LogMsg(csp::common::LogLevel::Error,
+                            "SpaceSystem::RegisterScopesInSpace: Multiple scopes found. This version of CSP only supports spaces that have only a "
+                            "single global scope.");
                         FinishedGetScopeEvent->set_exception(std::make_exception_ptr(csp::common::continuations::ResultException(
                             "SpaceSystem::RegisterScopesInSpace: Space has multiple scopes", MakeInvalid<csp::systems::SpaceResult>())));
                         return;
@@ -330,8 +332,8 @@ std::function<async::task<SpaceResult>(const SpaceResult& SpaceResult)> SpaceSys
 
                     if (Scopes[0].PubSubType != PubSubModelType::Global)
                     {
-                        this->LogSystem->LogMsg(csp::common::LogLevel::Error,
-                            "SpaceSystem::RegisterScopesInSpace: Space doesn't contain a global scope.");
+                        this->LogSystem->LogMsg(
+                            csp::common::LogLevel::Error, "SpaceSystem::RegisterScopesInSpace: Space doesn't contain a global scope.");
                         FinishedGetScopeEvent->set_exception(std::make_exception_ptr(csp::common::continuations::ResultException(
                             "SpaceSystem::RegisterScopesInSpace: Space doesn't contain a global scope.", MakeInvalid<csp::systems::SpaceResult>())));
                         return;
@@ -339,8 +341,7 @@ std::function<async::task<SpaceResult>(const SpaceResult& SpaceResult)> SpaceSys
 
                     // No need to check validity as the above conditions guarantee a valid iterator.
                     auto DefaultScopeIt
-                        = std::find_if(Scopes.begin(), Scopes.end(),
-                        [](const Scope& Scope) { return Scope.PubSubType == PubSubModelType::Global; });
+                        = std::find_if(Scopes.begin(), Scopes.end(), [](const Scope& Scope) { return Scope.PubSubType == PubSubModelType::Global; });
 
                     const bool ManagedLeaderElection = DefaultScopeIt->ManagedLeaderElection;
 
@@ -367,7 +368,7 @@ std::function<async::task<SpaceResult>(const SpaceResult& SpaceResult)> SpaceSys
                                 return;
                             }
 
-                             const ScopeLeader& Leader = LeaderResult.GetScopeLeader();
+                            const ScopeLeader& Leader = LeaderResult.GetScopeLeader();
 
                             std::optional<uint64_t> LeaderUserId
                                 = (Leader.ScopeClientId != 0) ? std::make_optional<uint64_t>(Leader.ScopeClientId) : std::nullopt;
@@ -392,7 +393,7 @@ auto SpaceSystem::AddUserToSpaceIfNecessary(SpaceResultCallback Callback, SpaceS
         /* Once we have permissions to discover a space, attempt to enter it */
         const auto& SpaceToJoin = GetSpaceResult.GetSpace();
 
-        const String UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().UserId;
+        const String UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().GetUserId();
         const bool JoiningSpaceRequiresInvite = HasFlag(SpaceToJoin.Attributes, SpaceAttributes::RequiresInvite);
 
         // The user is known to the space if they are a user, moderator or creator. This is important if the space requires an invite.
@@ -419,8 +420,7 @@ auto SpaceSystem::AddUserToSpaceIfNecessary(SpaceResultCallback Callback, SpaceS
 
             // Use the request continuation to set the event ... to fire another continuation to allow continued chaining.
             SpaceSystem.AddUserToSpace(GetSpaceResult, UserId)
-                .then(async::inline_scheduler(),
-                    [UserAddedToSpaceChainStartEvent](const SpaceResult& AddedToSpaceResult)
+                .then(async::inline_scheduler(), [UserAddedToSpaceChainStartEvent](const SpaceResult& AddedToSpaceResult)
                     { UserAddedToSpaceChainStartEvent->set(AddedToSpaceResult); });
         }
         else
@@ -540,34 +540,35 @@ void SpaceSystem::EnterSpace(const String& SpaceId, csp::common::IRealtimeEngine
               .then(async::inline_scheduler(), FireEnterSpaceEvent(CurrentSpace)) // Neccesary?
               .then(async::inline_scheduler(), this->RegisterScopesInSpace(RealtimeEngine))
         : async::spawn(async::inline_scheduler(),
-            [SpaceId]()
-            {
-                // Offline, build a local space result
-                CSP_LOG_MSG(csp::common::LogLevel::Log, "Entering Offline Space");
+              [SpaceId]()
+              {
+                  // Offline, build a local space result
+                  CSP_LOG_MSG(csp::common::LogLevel::Log, "Entering Offline Space");
 
-                Space LocalSpace {};
+                  Space LocalSpace {};
 
-                /* Depending on how you think about this, you might think this is a bit of a bug.
-                   Consider, you still need to login to use the API, and logging in generates you a user-id from MCS.
-                   One might think we should be using that. The reason we don't is simply because we don't
-                   store that ID in the system currently, and it dosen't really matter currently.
-                   However this may be an improvement we want to make, although consider that it would get in the way
-                   of any fully-offline flows we might to add. */
-                csp::common::String LocalUser = std::to_string(csp::common::LocalClientID).c_str();
+                  /* Depending on how you think about this, you might think this is a bit of a bug.
+                     Consider, you still need to login to use the API, and logging in generates you a user-id from MCS.
+                     One might think we should be using that. The reason we don't is simply because we don't
+                     store that ID in the system currently, and it dosen't really matter currently.
+                     However this may be an improvement we want to make, although consider that it would get in the way
+                     of any fully-offline flows we might to add. */
+                  csp::common::String LocalUser = std::to_string(csp::common::LocalClientID).c_str();
 
-                LocalSpace.CreatedAt = DateTime::TimeNow().GetUtcString();
-                LocalSpace.Name = "Offline Space";
-                LocalSpace.Id = SpaceId;
-                LocalSpace.CreatedBy = LocalUser;
-                LocalSpace.OwnerId = LocalUser;
-                LocalSpace.UserIds = { LocalUser };
-                LocalSpace.ModeratorIds = { LocalUser };
+                  LocalSpace.CreatedAt = DateTime::TimeNow().GetUtcString();
+                  LocalSpace.Name = "Offline Space";
+                  LocalSpace.Id = SpaceId;
+                  LocalSpace.CreatedBy = LocalUser;
+                  LocalSpace.OwnerId = LocalUser;
+                  LocalSpace.UserIds = { LocalUser };
+                  LocalSpace.ModeratorIds = { LocalUser };
 
-                SpaceResult LocalSpaceResult {};
-                LocalSpaceResult.SetSpace(LocalSpace);
-                LocalSpaceResult.SetResult(EResultCode::Success, static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
-                return LocalSpaceResult;
-            }).then(async::inline_scheduler(), FireEnterSpaceEvent(CurrentSpace));
+                  SpaceResult LocalSpaceResult {};
+                  LocalSpaceResult.SetSpace(LocalSpace);
+                  LocalSpaceResult.SetResult(EResultCode::Success, static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
+                  return LocalSpaceResult;
+              })
+              .then(async::inline_scheduler(), FireEnterSpaceEvent(CurrentSpace));
 
     // Whether we've done an upstream online connection or just a local one, finish entering the space
     UpstreamConnectionTask
@@ -842,12 +843,10 @@ void SpaceSystem::DeleteSpace(const csp::common::String& SpaceId, NullResultCall
 
 void SpaceSystem::GetSpaces(SpacesResultCallback Callback)
 {
-    const String InUserId = UserSystem->GetLoginState().UserId;
-
     csp::services::ResponseHandlerPtr ResponseHandler
         = GroupAPI->CreateHandler<SpacesResultCallback, SpacesResult, void, csp::services::DtoArray<chs::GroupDto>>(Callback, nullptr);
 
-    static_cast<chs::GroupApi*>(GroupAPI)->usersUserIdGroupsGet({ InUserId }, ResponseHandler);
+    static_cast<chs::GroupApi*>(GroupAPI)->usersUserIdGroupsGet({ UserSystem->GetLoginState().GetUserId() }, ResponseHandler);
 }
 
 void SpaceSystem::GetSpacesByAttributes(const Optional<bool>& InIsDiscoverable, const Optional<bool>& InIsArchived,
@@ -963,7 +962,7 @@ async::task<SpaceResult> SpaceSystem::GetSpace(const String& SpaceId)
     }
 
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(
-        [](const SpaceResult&) {}, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
+        [](const SpaceResult&) { }, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(OnCompleteEvent));
 
     static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdGet({ SpaceId }, ResponseHandler);
 
@@ -1018,7 +1017,7 @@ async::task<NullResult> SpaceSystem::BulkInviteToSpace(const csp::common::String
     auto SignupUrlParam = !InviteUsers.SignupUrl.IsEmpty() ? (InviteUsers.SignupUrl) : std::optional<String>(std::nullopt);
 
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
-        [](const NullResult&) {}, nullptr, csp::web::EResponseCodes::ResponseNoContent, std::move(OnCompleteEvent));
+        [](const NullResult&) { }, nullptr, csp::web::EResponseCodes::ResponseNoContent, std::move(OnCompleteEvent));
 
     static_cast<chs::GroupApi*>(GroupAPI)->groupsGroupIdEmail_invitesBulkPost(
         { SpaceId, std::nullopt, EmailLinkUrlParam, SignupUrlParam, GroupInvites }, ResponseHandler);
@@ -1084,7 +1083,7 @@ async::task<SpaceResult> SpaceSystem::AddUserToSpace(const SpaceResult& Result, 
     const csp::common::String& SpaceCode = Result.GetSpaceCode();
 
     csp::services::ResponseHandlerPtr ResponseHandler = GroupAPI->CreateHandler<SpaceResultCallback, SpaceResult, void, chs::GroupDto>(
-        [](const SpaceResult&) {}, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(*OnCompleteEvent.get()));
+        [](const SpaceResult&) { }, nullptr, csp::web::EResponseCodes::ResponseOK, std::move(*OnCompleteEvent.get()));
 
     static_cast<chs::GroupApi*>(GroupAPI)->group_codesGroupCodeUsersUserIdPut({ SpaceCode, UserId }, ResponseHandler);
 
@@ -1877,8 +1876,9 @@ void SpaceSystem::GetSpaceGeoLocation(const csp::common::String& SpaceId, SpaceG
             return;
         }
 
+        auto UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().GetUserId();
+
         const auto& RefreshedSpace = GetSpaceResult.GetSpace();
-        const auto& UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().UserId;
 
         // First check if the user is the owner
         bool UserCanAccessSpaceDetails = !(bool)(RefreshedSpace.Attributes & SpaceAttributes::RequiresInvite) || RefreshedSpace.OwnerId == UserId;
@@ -1959,7 +1959,8 @@ void SpaceSystem::UpdateSpaceGeoLocation(const csp::common::String& SpaceId, con
         }
 
         const auto& RefreshedSpace = GetSpaceResult.GetSpace();
-        const auto& UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().UserId;
+
+        auto UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().GetUserId();
 
         // First check if the user is the owner
         bool UserCanModifySpace = RefreshedSpace.OwnerId == UserId;
@@ -2023,7 +2024,8 @@ void SpaceSystem::DeleteSpaceGeoLocation(const csp::common::String& SpaceId, Nul
         }
 
         const auto& RefreshedSpace = GetSpaceResult.GetSpace();
-        const auto& UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().UserId;
+
+        auto UserId = SystemsManager::Get().GetUserSystem()->GetLoginState().GetUserId();
 
         // First check if the user is the owner
         bool UserCanModifySpace = RefreshedSpace.OwnerId == UserId;

--- a/Library/src/Systems/Spaces/SpaceSystemHelpers.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystemHelpers.cpp
@@ -16,6 +16,8 @@
 
 #include "Systems/Spaces/SpaceSystemHelpers.h"
 
+#include "CSP/Common/LoginState.h"
+#include "Common/LoginStateData.h"
 #include "CSP/Systems/Assets/AssetSystem.h"
 #include "CSP/Systems/Spaces/UserRoles.h"
 #include "CSP/Systems/Users/UserSystem.h"
@@ -125,7 +127,7 @@ namespace SpaceSystemHelpers
         DefaultGroupInfo->SetGroupType("Space");
         DefaultGroupInfo->SetAutoModerator(false);
         const auto* UserSystem = SystemsManager::Get().GetUserSystem();
-        DefaultGroupInfo->SetGroupOwnerId(UserSystem->GetLoginState().UserId);
+        DefaultGroupInfo->SetGroupOwnerId(UserSystem->GetLoginState().GetUserId());
 
         return DefaultGroupInfo;
     }

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -16,6 +16,8 @@
 
 #include "CSP/Systems/Users/Authentication.h"
 
+#include "CSP/Common/LoginState.h"
+#include "Common/LoginStateData.h"
 #include "CSP/Common/Settings.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "CSP/Systems/Users/UserSystem.h"
@@ -44,8 +46,8 @@ LoginStateResult::LoginStateResult()
 {
 }
 
-LoginStateResult::LoginStateResult(csp::common::LoginState* InStatePtr)
-    : State(InStatePtr)
+LoginStateResult::LoginStateResult(csp::common::LoginState* LoginState)
+    : State(LoginState)
 {
 }
 
@@ -72,7 +74,7 @@ namespace
         SettingsCollection.Settings = Setting.HasSettings() ? csp::common::Convert(Setting.GetSettings()) : decltype(SettingsCollection.Settings) {};
         return SettingsCollection;
     }
-}
+} // namespace
 
 void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
@@ -88,11 +90,13 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 
         if (State)
         {
-            State->State = ELoginState::LoggedIn;
-            State->AccessToken = AuthResponse->GetAccessToken();
-            State->RefreshToken = AuthResponse->GetRefreshToken();
-            State->UserId = AuthResponse->GetUserId();
-            State->DeviceId = AuthResponse->GetDeviceId();
+            auto Data = LoginStateData();
+
+            Data.State = ELoginState::LoggedIn;
+            Data.AccessToken = AuthResponse->GetAccessToken();
+            Data.RefreshToken = AuthResponse->GetRefreshToken();
+            Data.UserId = AuthResponse->GetUserId();
+            Data.DeviceId = AuthResponse->GetDeviceId();
 
             if (AuthResponse->HasDefaultSettings())
             {
@@ -102,7 +106,7 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
                     const auto& UserSettingsDto = DefaultSettings->GetDefaultUserSettings();
                     for (const auto& SettingDto : UserSettingsDto)
                     {
-                        State->DefaultSettings.Append(MakeSettingsCollection(*SettingDto));
+                        Data.DefaultSettings.Append(MakeSettingsCollection(*SettingDto));
                     }
                 }
                 if (DefaultSettings->HasDefaultApplicationSettings())
@@ -110,7 +114,7 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
                     const auto& ApplicationSettingsDto = DefaultSettings->GetDefaultApplicationSettings();
                     for (const auto& SettingDto : ApplicationSettingsDto)
                     {
-                        State->DefaultApplicationSettings.Append(MakeApplicationSetting(*SettingDto));
+                        Data.DefaultApplicationSettings.Append(MakeApplicationSetting(*SettingDto));
                     }
                 }
             }
@@ -141,15 +145,17 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
                 return;
             }
 
-            State->SetAccessTokenRefreshTime(RefreshTime);
+            Data.SetAccessTokenRefreshTime(RefreshTime);
+
+            State->SetLoginStateData(Data);
 
             // Signal login to anyone interested
             events::Event* LoginEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGIN_EVENT_ID);
             LoginEvent->AddString("UserId", AuthResponse->GetUserId());
             events::EventSystem::Get().EnqueueEvent(LoginEvent);
-
-            SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
         }
+
+        SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
     }
     else
     {
@@ -157,11 +163,7 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
         {
             web::HttpAuth::SetAccessToken("", "", "", "");
 
-            State->State = ELoginState::Error;
-            State->AccessToken = "InvalidAccessToken";
-            State->RefreshToken = "InvalidRefreshToken";
-            State->UserId = "InvalidUserId";
-            State->DeviceId = "InvalidDeviceId";
+            State->ResetResponseLoginState(ELoginState::Error);
         }
     }
 }
@@ -171,9 +173,9 @@ LogoutResult::LogoutResult()
 {
 }
 
-LogoutResult::LogoutResult(csp::common::LoginState* InStatePtr)
-    : NullResult(InStatePtr)
-    , State(InStatePtr)
+LogoutResult::LogoutResult(csp::common::LoginState* LoginState)
+    : NullResult()
+    , State(LoginState)
 {
 }
 
@@ -185,11 +187,7 @@ void LogoutResult::OnResponse(const services::ApiResponseBase* ApiResponse)
     {
         if (State)
         {
-            State->State = ELoginState::LoggedOut;
-            State->AccessToken = "InvalidAccessToken";
-            State->RefreshToken = "InvalidRefreshToken";
-            State->UserId = "InvalidUserId";
-            State->DeviceId = "InvalidDeviceId";
+            State->ResetResponseLoginState(ELoginState::LoggedOut);
 
             web::HttpAuth::SetAccessToken("", "", "", "");
 
@@ -202,11 +200,7 @@ void LogoutResult::OnResponse(const services::ApiResponseBase* ApiResponse)
     {
         if (State)
         {
-            State->State = ELoginState::Error;
-            State->AccessToken = "InvalidAccessToken";
-            State->RefreshToken = "InvalidRefreshToken";
-            State->UserId = "InvalidUserId";
-            State->DeviceId = "InvalidDeviceId";
+            State->ResetResponseLoginState(ELoginState::Error);
 
             web::HttpAuth::SetAccessToken("", "", "", "");
         }

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -163,7 +163,7 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
         {
             web::HttpAuth::SetAccessToken("", "", "", "");
 
-            State->ResetResponseLoginState(ELoginState::Error);
+            State->ReinitializeResponseLoginState(ELoginState::Error);
         }
     }
 }
@@ -187,7 +187,7 @@ void LogoutResult::OnResponse(const services::ApiResponseBase* ApiResponse)
     {
         if (State)
         {
-            State->ResetResponseLoginState(ELoginState::LoggedOut);
+            State->ReinitializeResponseLoginState(ELoginState::LoggedOut);
 
             web::HttpAuth::SetAccessToken("", "", "", "");
 
@@ -200,7 +200,7 @@ void LogoutResult::OnResponse(const services::ApiResponseBase* ApiResponse)
     {
         if (State)
         {
-            State->ResetResponseLoginState(ELoginState::Error);
+            State->ReinitializeResponseLoginState(ELoginState::Error);
 
             web::HttpAuth::SetAccessToken("", "", "", "");
         }

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -147,7 +147,7 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 
             Data.SetAccessTokenRefreshTime(RefreshTime);
 
-            State->SetLoginStateData(Data);
+            State->SetLoginStateDataThreadSafe(Data);
 
             // Signal login to anyone interested
             events::Event* LoginEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGIN_EVENT_ID);

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -153,9 +153,9 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
             events::Event* LoginEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGIN_EVENT_ID);
             LoginEvent->AddString("UserId", AuthResponse->GetUserId());
             events::EventSystem::Get().EnqueueEvent(LoginEvent);
-        }
 
-        SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
+            SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
+        }
     }
     else
     {

--- a/Library/src/Systems/Users/Authentication.h
+++ b/Library/src/Systems/Users/Authentication.h
@@ -19,6 +19,7 @@
 #include "CSP/Common/LoginState.h"
 #include "CSP/Systems/Users/Authentication.h"
 
+
 namespace csp::systems
 {
 
@@ -34,7 +35,7 @@ class CSP_API LogoutResult : public NullResult
 
 private:
     LogoutResult();
-    LogoutResult(csp::common::LoginState* InStatePtr);
+    LogoutResult(csp::common::LoginState* LoginState);
 
     CSP_NO_EXPORT void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -17,12 +17,14 @@
 #include "CSP/Systems/Users/UserSystem.h"
 
 #include "CSP/CSPFoundation.h"
+#include "CSP/Common/LoginState.h"
 #include "CSP/Common/NetworkEventData.h"
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Common/StringFormat.h"
 #include "CSP/Systems/Users/Authentication.h"
 #include "CSP/Systems/Users/Profile.h"
 #include "Common/Convert.h"
+#include "Common/LoginStateData.h"
 #include "Common/UUIDGenerator.h"
 #include "Multiplayer/NetworkEventSerialisation.h"
 #include "Services/UserService/Api.h"
@@ -33,11 +35,6 @@
 #include <regex>
 
 namespace chs_user = csp::services::generated::userservice;
-
-namespace
-{
-
-} // namespace
 
 namespace
 {
@@ -61,8 +58,9 @@ void StartMultiplayerConnection(csp::multiplayer::MultiplayerConnection& Multipl
     if (CreateMultiplayerConnection)
     {
         LogSystem.LogMsg(csp::common::LogLevel::Log, "Starting Multiplayer Connection");
-        MultiplayerConnection.Connect(
-            ConnectionCallback, MultiplayerURI, LoginStateRes.GetLoginState().AccessToken, LoginStateRes.GetLoginState().DeviceId);
+
+        auto Data = LoginStateRes.GetLoginState().GetSnapshot();
+        MultiplayerConnection.Connect(ConnectionCallback, MultiplayerURI, Data.AccessToken, Data.DeviceId);
     }
     else
     {
@@ -125,10 +123,15 @@ std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::common:
 
 // Contains shared logic for logging in with a 3rd party provider - used by both LoginToThirdPartyAuthenticationProvider and
 // LoginToThirdPartyAuthenticationProviderWithToken.
-void LoginSocial(csp::services::ApiBase* AuthenticationAPI, csp::common::LoginState* CurrentLoginState, csp::common::LogSystem* LogSystem,
+void LoginSocial(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp::common::LoginState> CurrentLoginState, csp::common::LogSystem* LogSystem,
     const std::shared_ptr<chs_user::LoginSocialRequest>& Request, bool CreateMultiplayerConnection, csp::systems::LoginStateResultCallback Callback)
 {
-    csp::systems::LoginStateResultCallback LoginStateResCallback = [=](const csp::systems::LoginStateResult& LoginStateRes)
+    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // ResponseHandler.
+    auto LoginStateRef = CurrentLoginState;
+
+    csp::systems::LoginStateResultCallback LoginStateResCallback
+        = [LogSystem, Callback, CreateMultiplayerConnection, LoginStateRef](const csp::systems::LoginStateResult& LoginStateRes)
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
@@ -155,12 +158,28 @@ void LoginSocial(csp::services::ApiBase* AuthenticationAPI, csp::common::LoginSt
     };
 
     csp::services::ResponseHandlerPtr ResponseHandler = AuthenticationAPI->CreateHandler<csp::systems::LoginStateResultCallback,
-        csp::systems::LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(LoginStateResCallback, CurrentLoginState);
+        csp::systems::LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(LoginStateResCallback, LoginStateRef.get());
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
 }
 
+void SetTokenOptions(const csp::common::Optional<csp::systems::TokenOptions>& TokenOptions, std::shared_ptr<chs_user::TokenOptions> Options,
+    std::shared_ptr<csp::common::LoginState> LoginState)
+{
+    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
+    {
+        Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
+        LoginState->UpdateAccessTokenExpiry(TokenOptions->AccessTokenExpiryLength);
+    }
+
+    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
+    {
+        Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
+        LoginState->UpdateRefreshTokenExpiry(TokenOptions->RefreshTokenExpiryLength);
+    }
 }
+
+} // namespace
 
 namespace csp::systems
 {
@@ -202,9 +221,9 @@ csp::common::String FormatScopesForURL(csp::common::Array<csp::common::String> S
     return FormattedScopes;
 }
 
-AuthContext::AuthContext(csp::services::ApiBase* AuthenticationAPI, csp::common::LoginState& LoginState)
+AuthContext::AuthContext(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp::common::LoginState> LoginState)
     : AuthenticationAPI { AuthenticationAPI }
-    , LoginState { &LoginState }
+    , LoginState { LoginState }
 {
 }
 
@@ -212,42 +231,49 @@ const csp::common::LoginState& AuthContext::GetLoginState() const { return *Logi
 
 void AuthContext::RefreshToken(std::function<void(bool)> Callback)
 {
-    if (LoginState->State == csp::common::ELoginState::LoggedIn)
+    auto Data = LoginState->GetSnapshot();
+    if (Data.State != csp::common::ELoginState::LoggedIn)
     {
-        auto Request = std::make_shared<chs_user::RefreshRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetUserId(LoginState->UserId);
-        Request->SetRefreshToken(LoginState->RefreshToken);
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
-        Options->SetExpiryLength(LoginState->AccessTokenExpiryLength);
-        Options->SetRefreshTokenExpiryLength(LoginState->RefreshTokenExpiryLength);
-        Request->SetTokenOptions(Options);
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-        {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::InProgress)
-            {
-                return;
-            }
-            else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                const NullResult Result(csp::systems::EResultCode::Success, 200);
-                INVOKE_IF_NOT_NULL(Callback, true);
-            }
-            else
-            {
-                const NullResult Result(LoginStateRes.GetResultCode(), LoginStateRes.GetHttpResultCode());
-                INVOKE_IF_NOT_NULL(Callback, false);
-            }
-        };
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, LoginState);
-
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
+        return;
     }
+
+    auto Request = std::make_shared<chs_user::RefreshRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetUserId(Data.UserId);
+    Request->SetRefreshToken(Data.RefreshToken);
+
+    auto Options = std::make_shared<chs_user::TokenOptions>();
+    Options->SetExpiryLength(Data.AccessTokenExpiryLength);
+    Options->SetRefreshTokenExpiryLength(Data.RefreshTokenExpiryLength);
+    Request->SetTokenOptions(Options);
+
+    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // ResponseHandler.
+    auto LoginStateRef = LoginState;
+
+    LoginStateResultCallback LoginStateResCallback = [Callback, LoginStateRef](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::InProgress)
+        {
+            return;
+        }
+        else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            const NullResult Result(csp::systems::EResultCode::Success, 200);
+            INVOKE_IF_NOT_NULL(Callback, true);
+        }
+        else
+        {
+            const NullResult Result(LoginStateRes.GetResultCode(), LoginStateRes.GetHttpResultCode());
+            INVOKE_IF_NOT_NULL(Callback, false);
+        }
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
+            LoginStateResCallback, LoginStateRef.get());
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
 }
 
 UserSystem::UserSystem()
@@ -256,6 +282,8 @@ UserSystem::UserSystem()
     , ProfileAPI(nullptr)
     , PingAPI(nullptr)
     , StripeAPI { nullptr }
+    , CurrentLoginState(std::make_shared<csp::common::LoginState>())
+    , RefreshTokenChangedCallback(nullptr)
     , Auth { AuthenticationAPI, CurrentLoginState }
 {
 }
@@ -266,6 +294,7 @@ UserSystem::UserSystem(csp::web::WebClient* InWebClient, csp::multiplayer::Netwo
     , ProfileAPI { new chs_user::ProfileApi(InWebClient) }
     , PingAPI { new chs_user::PingApi(InWebClient) }
     , StripeAPI { new chs_user::StripeApi(InWebClient) }
+    , CurrentLoginState(std::make_shared<csp::common::LoginState>())
     , RefreshTokenChangedCallback(nullptr)
     , Auth { AuthenticationAPI, CurrentLoginState }
 {
@@ -286,7 +315,7 @@ void UserSystem::SetNetworkEventBus(csp::multiplayer::NetworkEventBus& EventBus)
     RegisterSystemCallback();
 }
 
-const csp::common::LoginState& UserSystem::GetLoginState() const { return CurrentLoginState; }
+const csp::common::LoginState& UserSystem::GetLoginState() const { return *CurrentLoginState; }
 
 void UserSystem::SetNewLoginTokenReceivedCallback(LoginTokenInfoResultCallback Callback) { RefreshTokenChangedCallback = Callback; }
 
@@ -306,78 +335,70 @@ void UserSystem::Login(const csp::common::String& Email, const csp::common::Stri
         return;
     }
 
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
-    {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+    auto Options = std::make_shared<chs_user::TokenOptions>();
 
-        auto Request = std::make_shared<chs_user::LoginRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetEmail(Email);
-        Request->SetPassword(Password);
-        Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-        if (UserHasVerifiedAge.HasValue())
-        {
-            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
-        }
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
-        {
-            Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
-        }
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
-        {
-            Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
-        }
-
-        Request->SetTokenOptions(Options);
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-        {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
-                {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-
-                        Callback(LoginStateRes);
-                        return;
-                    }
-
-                    Callback(LoginStateRes);
-                };
-
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                    CreateMultiplayerConnection);
-            }
-            else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
-            {
-                CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
-                Callback(LoginStateRes);
-            }
-        };
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
-
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
-    }
-    else
+    if (!CurrentLoginState->TrySetLoginRequested())
     {
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(BadResult);
+        return;
     }
+
+    SetTokenOptions(TokenOptions, Options, CurrentLoginState);
+
+    auto Request = std::make_shared<chs_user::LoginRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetEmail(Email);
+    Request->SetPassword(Password);
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
+
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    Request->SetTokenOptions(Options);
+
+    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // ResponseHandler.
+    auto LoginStateRef = CurrentLoginState;
+
+    LoginStateResultCallback LoginStateResCallback
+        = [this, Callback, CreateMultiplayerConnection, LoginStateRef](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            {
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                {
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+
+                    Callback(LoginStateRes);
+                    return;
+                }
+
+                Callback(LoginStateRes);
+            };
+
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Failed)
+        {
+            CSP_LOG_ERROR_FORMAT("Login Failed. Code: %i", LoginStateRes.GetHttpResultCode());
+            Callback(LoginStateRes);
+        }
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
+            LoginStateResCallback, LoginStateRef.get());
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const csp::common::String& RefreshToken, bool CreateMultiplayerConnection,
@@ -390,206 +411,190 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
         return;
     }
 
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
-    {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+    auto Options = std::make_shared<chs_user::TokenOptions>();
 
-        auto Request = std::make_shared<chs_user::RefreshRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetUserId(UserId);
-        Request->SetRefreshToken(RefreshToken);
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
-        {
-            Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
-        }
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
-        {
-            Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
-        }
-
-        Request->SetTokenOptions(Options);
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-        {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
-                {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-
-                        Callback(LoginStateRes);
-                        return;
-                    }
-
-                    Callback(LoginStateRes);
-                };
-
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                    CreateMultiplayerConnection);
-            }
-            else
-            {
-                Callback(LoginStateRes);
-            }
-        };
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
-
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
-    }
-    else
+    if (!CurrentLoginState->TrySetLoginRequested())
     {
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
-        BadResult.ResponseBody = "Already logged in!";
         Callback(BadResult);
+        return;
     }
+
+    SetTokenOptions(TokenOptions, Options, CurrentLoginState);
+
+    auto Request = std::make_shared<chs_user::RefreshRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetUserId(UserId);
+    Request->SetRefreshToken(RefreshToken);
+
+    Request->SetTokenOptions(Options);
+
+    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // ResponseHandler.
+    auto LoginStateRef = CurrentLoginState;
+
+    LoginStateResultCallback LoginStateResCallback
+        = [this, Callback, CreateMultiplayerConnection, LoginStateRef](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            {
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                {
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+
+                    Callback(LoginStateRes);
+                    return;
+                }
+
+                Callback(LoginStateRes);
+            };
+
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else
+        {
+            Callback(LoginStateRes);
+        }
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
+            LoginStateResCallback, LoginStateRef.get());
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::LoginAsGuest(bool CreateMultiplayerConnection, const csp::common::Optional<bool>& UserHasVerifiedAge,
     const csp::common::Optional<TokenOptions>& TokenOptions, LoginStateResultCallback Callback)
 {
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
-    {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+    auto Options = std::make_shared<chs_user::TokenOptions>();
 
-        auto Request = std::make_shared<chs_user::LoginRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-        if (UserHasVerifiedAge.HasValue())
-        {
-            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
-        }
-
-        auto Options = std::make_shared<chs_user::TokenOptions>();
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
-        {
-            Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-            CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
-        }
-
-        if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
-        {
-            Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-            CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
-        }
-
-        Request->SetTokenOptions(Options);
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-        {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
-                {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-
-                        Callback(LoginStateRes);
-                        return;
-                    }
-
-                    Callback(LoginStateRes);
-                };
-
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
-                    CreateMultiplayerConnection);
-            }
-            else
-            {
-                Callback(LoginStateRes);
-            }
-        };
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
-
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
-    }
-    else
+    if (!CurrentLoginState->TrySetLoginRequested())
     {
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(BadResult);
+        return;
     }
+
+    SetTokenOptions(TokenOptions, Options, CurrentLoginState);
+
+    auto Request = std::make_shared<chs_user::LoginRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
+
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    Request->SetTokenOptions(Options);
+
+    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // ResponseHandler.
+    auto LoginStateRef = CurrentLoginState;
+
+    LoginStateResultCallback LoginStateResCallback
+        = [this, Callback, CreateMultiplayerConnection, LoginStateRef](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            {
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                {
+                    CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+
+                    Callback(LoginStateRes);
+                    return;
+                }
+
+                Callback(LoginStateRes);
+            };
+
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem,
+                CreateMultiplayerConnection);
+        }
+        else
+        {
+            Callback(LoginStateRes);
+        }
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
+            LoginStateResCallback, LoginStateRef.get());
+
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
 }
 
 void UserSystem::LoginAsGuestWithDeferredProfileCreation(const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback)
 {
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedOut || CurrentLoginState.State == csp::common::ELoginState::Error)
-    {
-        CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
-
-        auto Request = std::make_shared<chs_user::LoginGuestRequest>();
-        Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-        Request->SetTenant(csp::CSPFoundation::GetTenant());
-
-        if (UserHasVerifiedAge.HasValue())
-        {
-            Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
-        }
-
-        LoginStateResultCallback LoginStateResCallback = [=](const LoginStateResult& LoginStateRes)
-        {
-            if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
-            {
-                csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
-                    = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
-                {
-                    if (ErrCode != csp::multiplayer::ErrorCode::None)
-                    {
-                        // It would be extremely strange to hit this branch, but it remains here just in case.
-                        CSP_LOG_ERROR_FORMAT("Unexpected error connecting MultiplayerConnection. This is strange! : %s",
-                            csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-                        Callback(LoginStateRes);
-                        return;
-                    }
-
-                    Callback(LoginStateRes);
-                };
-
-                // Do not start a multiplayer connection, need to call through this to trigger all the callbacks though.
-                StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
-                    CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem, false);
-            }
-            else
-            {
-                Callback(LoginStateRes);
-            }
-        };
-
-        csp::services::ResponseHandlerPtr ResponseHandler
-            = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-                LoginStateResCallback, &CurrentLoginState);
-
-        // Despite the naming, "login-guest" is the deferred, optimized, non-standard guest login.
-        // The regular login endpoint that "loginAsGuest" uses is the "real" one.
-        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_guestPost({ Request }, ResponseHandler);
-    }
-    else
+    if (!CurrentLoginState->TrySetLoginRequested())
     {
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(BadResult);
+        return;
     }
+
+    auto Request = std::make_shared<chs_user::LoginGuestRequest>();
+    Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
+    Request->SetTenant(csp::CSPFoundation::GetTenant());
+
+    if (UserHasVerifiedAge.HasValue())
+    {
+        Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
+    }
+
+    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // ResponseHandler.
+    auto LoginStateRef = CurrentLoginState;
+
+    LoginStateResultCallback LoginStateResCallback = [this, Callback, LoginStateRef](const LoginStateResult& LoginStateRes)
+    {
+        if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
+        {
+            csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+                = [Callback, LoginStateRes](csp::multiplayer::ErrorCode ErrCode)
+            {
+                if (ErrCode != csp::multiplayer::ErrorCode::None)
+                {
+                    // It would be extremely strange to hit this branch, but it remains here just in case.
+                    CSP_LOG_ERROR_FORMAT("Unexpected error connecting MultiplayerConnection. This is strange! : %s",
+                        csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+                    Callback(LoginStateRes);
+                    return;
+                }
+
+                Callback(LoginStateRes);
+            };
+
+            // Do not start a multiplayer connection, need to call through this to trigger all the callbacks though.
+            StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(),
+                CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(), ConnectionCallback, LoginStateRes, *LogSystem, false);
+        }
+        else
+        {
+            Callback(LoginStateRes);
+        }
+    };
+
+    csp::services::ResponseHandlerPtr ResponseHandler
+        = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
+            LoginStateResCallback, LoginStateRef.get());
+
+    // Despite the naming, "login-guest" is the deferred, optimized, non-standard guest login.
+    // The regular login endpoint that "loginAsGuest" uses is the "real" one.
+    static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_guestPost({ Request }, ResponseHandler);
 }
 
 csp::common::Array<EThirdPartyAuthenticationProviders> UserSystem::GetSupportedThirdPartyAuthenticationProviders() const
@@ -703,18 +708,22 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
         csp::systems::LoginStateResult ErrorResult;
         ErrorResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(ErrorResult);
+
+        return;
     }
 
-    if (CurrentLoginState.State != csp::common::ELoginState::LoggedOut && CurrentLoginState.State != csp::common::ELoginState::Error)
-    {
-        CSP_LOG_MSG(csp::common::LogLevel::Warning, "You are not in the correct login state to proceed with third-party authentication.");
+    auto Options = std::make_shared<chs_user::TokenOptions>();
 
+    if (!CurrentLoginState->TrySetLoginRequested())
+    {
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(BadResult);
+
+        return;
     }
 
-    CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+    SetTokenOptions(TokenOptions, Options, CurrentLoginState);
 
     const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
     Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
@@ -729,23 +738,9 @@ void UserSystem::LoginToThirdPartyAuthenticationProvider(const csp::common::Stri
         Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
     }
 
-    auto Options = std::make_shared<chs_user::TokenOptions>();
-
-    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->AccessTokenExpiryLength))
-    {
-        Options->SetExpiryLength(TokenOptions->AccessTokenExpiryLength);
-        CurrentLoginState.AccessTokenExpiryLength = TokenOptions->AccessTokenExpiryLength;
-    }
-
-    if (TokenOptions.HasValue() && CheckExpiryLengthFormat(TokenOptions->RefreshTokenExpiryLength))
-    {
-        Options->SetRefreshTokenExpiryLength(TokenOptions->RefreshTokenExpiryLength);
-        CurrentLoginState.RefreshTokenExpiryLength = TokenOptions->RefreshTokenExpiryLength;
-    }
-
     Request->SetTokenOptions(Options);
 
-    LoginSocial(AuthenticationAPI, &CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
+    LoginSocial(AuthenticationAPI, CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
 }
 
 void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAuthenticationProviders AuthProvider,
@@ -776,16 +771,14 @@ void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAut
         return;
     }
 
-    if (CurrentLoginState.State != csp::common::ELoginState::LoggedOut && CurrentLoginState.State != csp::common::ELoginState::Error)
+    if (!CurrentLoginState->TrySetLoginRequested())
     {
-        CSP_LOG_MSG(csp::common::LogLevel::Warning, "You are not in the correct login state to proceed with third-party authentication.");
-
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(BadResult);
-    }
 
-    CurrentLoginState.State = csp::common::ELoginState::LoginRequested;
+        return;
+    }
 
     const auto Request = std::make_shared<chs_user::LoginSocialRequest>();
     Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
@@ -804,43 +797,49 @@ void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAut
         Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
     }
 
-    LoginSocial(AuthenticationAPI, &CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
+    LoginSocial(AuthenticationAPI, CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
 }
 
 void UserSystem::Logout(NullResultCallback Callback)
 {
-    if (CurrentLoginState.State == csp::common::ELoginState::LoggedIn)
-    {
-        CurrentLoginState.State = csp::common::ELoginState::LogoutRequested;
-
-        // Disconnect MultiplayerConnection before logging out
-        csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ErrorCallback = [Callback, this](csp::multiplayer::ErrorCode ErrCode)
-        {
-            if (ErrCode != csp::multiplayer::ErrorCode::None)
-            {
-                CSP_LOG_ERROR_FORMAT("Error disconnecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-            }
-
-            auto Request = std::make_shared<chs_user::LogoutRequest>();
-            Request->SetUserId(CurrentLoginState.UserId);
-            Request->SetDeviceId(CurrentLoginState.DeviceId);
-
-            csp::services::ResponseHandlerPtr ResponseHandler
-                = AuthenticationAPI->CreateHandler<NullResultCallback, LogoutResult, csp::common::LoginState, csp::services::NullDto>(
-                    Callback, &CurrentLoginState, csp::web::EResponseCodes::ResponseNoContent);
-
-            static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogoutPost({ Request }, ResponseHandler);
-        };
-
-        auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
-        MultiplayerConnection->Disconnect(ErrorCallback);
-    }
-    else
+    // Confirm we are in the correct state to proceed with logout.
+    if (!CurrentLoginState->TrySetLogoutRequested())
     {
         csp::systems::LogoutResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
         Callback(BadResult);
+
+        return;
     }
+
+    // Disconnect MultiplayerConnection before logging out
+    csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ErrorCallback = [Callback, this](csp::multiplayer::ErrorCode ErrCode)
+    {
+        if (ErrCode != csp::multiplayer::ErrorCode::None)
+        {
+            CSP_LOG_ERROR_FORMAT("Error disconnecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+        }
+
+        auto Data = CurrentLoginState->GetSnapshot();
+
+        auto Request = std::make_shared<chs_user::LogoutRequest>();
+        Request->SetUserId(Data.UserId);
+        Request->SetDeviceId(Data.DeviceId);
+
+        // Local copy made and captured by value in the wrapped callback below. This ensures the shared_ptr stays alive until the callback is executed
+        // via the ResponseHandler.
+        auto LoginStateRef = CurrentLoginState;
+        NullResultCallback WrappedCallback = [Callback, LoginStateRef](const NullResult& Result) { Callback(Result); };
+
+        csp::services::ResponseHandlerPtr ResponseHandler
+            = AuthenticationAPI->CreateHandler<NullResultCallback, LogoutResult, csp::common::LoginState, csp::services::NullDto>(
+                WrappedCallback, LoginStateRef.get(), csp::web::EResponseCodes::ResponseNoContent);
+
+        static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogoutPost({ Request }, ResponseHandler);
+    };
+
+    auto* MultiplayerConnection = SystemsManager::Get().GetMultiplayerConnection();
+    MultiplayerConnection->Disconnect(ErrorCallback);
 }
 
 void UserSystem::CreateUser(const csp::common::Optional<csp::common::String>& DisplayName, const csp::common::String& Email,
@@ -884,7 +883,7 @@ void UserSystem::CreateUser(const csp::common::Optional<csp::common::String>& Di
 void UserSystem::UpgradeGuestAccount(
     const csp::common::String& DisplayName, const csp::common::String& Email, const csp::common::String& Password, ProfileResultCallback Callback)
 {
-    const csp::common::String UserId = CurrentLoginState.UserId;
+    auto UserId = CurrentLoginState->GetUserId();
 
     auto Request = std::make_shared<chs_user::UpgradeGuestRequest>();
 
@@ -901,7 +900,7 @@ void UserSystem::UpgradeGuestAccount(
 
 void UserSystem::ConfirmUserEmail(NullResultCallback Callback)
 {
-    const csp::common::String UserId = CurrentLoginState.UserId;
+    auto UserId = CurrentLoginState->GetUserId();
 
     csp::services::ResponseHandlerPtr ResponseHandler = ProfileAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(
         Callback, nullptr, csp::web::EResponseCodes::ResponseNoContent);
@@ -912,7 +911,6 @@ void UserSystem::ConfirmUserEmail(NullResultCallback Callback)
 void UserSystem::ResetUserPassword(
     const csp::common::String& Token, const csp::common::String& UserId, const csp::common::String& NewPassword, NullResultCallback Callback)
 {
-
     auto Request = std::make_shared<chs_user::TokenResetPasswordRequest>();
 
     Request->SetToken(Token);
@@ -1103,4 +1101,5 @@ void UserSystem::OnAccessControlChangedEvent(const csp::common::NetworkEventData
 }
 
 csp::common::IAuthContext& UserSystem::GetAuthContext() { return Auth; }
+
 } // namespace csp::systems

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -59,7 +59,7 @@ void StartMultiplayerConnection(csp::multiplayer::MultiplayerConnection& Multipl
     {
         LogSystem.LogMsg(csp::common::LogLevel::Log, "Starting Multiplayer Connection");
 
-        auto Data = LoginStateRes.GetLoginState().GetSnapshotThreadSafe();
+        const auto Data = LoginStateRes.GetLoginState().GetSnapshotThreadSafe();
         MultiplayerConnection.Connect(ConnectionCallback, MultiplayerURI, Data.AccessToken, Data.DeviceId);
     }
     else
@@ -123,15 +123,14 @@ std::optional<csp::common::String> ThirdPartyPlatformToString(const csp::common:
 
 // Contains shared logic for logging in with a 3rd party provider - used by both LoginToThirdPartyAuthenticationProvider and
 // LoginToThirdPartyAuthenticationProviderWithToken.
-void LoginSocial(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp::common::LoginState> CurrentLoginState, csp::common::LogSystem* LogSystem,
-    const std::shared_ptr<chs_user::LoginSocialRequest>& Request, bool CreateMultiplayerConnection, csp::systems::LoginStateResultCallback Callback)
+void LoginSocial(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp::common::LoginState> CurrentLoginState,
+    csp::common::LogSystem* LogSystem, const std::shared_ptr<chs_user::LoginSocialRequest>& Request, bool CreateMultiplayerConnection,
+    csp::systems::LoginStateResultCallback Callback)
 {
-    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // CurrentLoginState captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
     // ResponseHandler.
-    auto LoginStateRef = CurrentLoginState;
-
     csp::systems::LoginStateResultCallback LoginStateResCallback
-        = [LogSystem, Callback, CreateMultiplayerConnection, LoginStateRef](const csp::systems::LoginStateResult& LoginStateRes)
+        = [LogSystem, Callback, CreateMultiplayerConnection, LoginStateRef = CurrentLoginState](const csp::systems::LoginStateResult& LoginStateRes)
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
@@ -158,7 +157,7 @@ void LoginSocial(csp::services::ApiBase* AuthenticationAPI, std::shared_ptr<csp:
     };
 
     csp::services::ResponseHandlerPtr ResponseHandler = AuthenticationAPI->CreateHandler<csp::systems::LoginStateResultCallback,
-        csp::systems::LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(LoginStateResCallback, LoginStateRef.get());
+        csp::systems::LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(LoginStateResCallback, CurrentLoginState.get());
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogin_socialPost({ Request }, ResponseHandler);
 }
@@ -247,11 +246,9 @@ void AuthContext::RefreshToken(std::function<void(bool)> Callback)
     Options->SetRefreshTokenExpiryLength(Data.RefreshTokenExpiryLength);
     Request->SetTokenOptions(Options);
 
-    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // LoginState captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
     // ResponseHandler.
-    auto LoginStateRef = LoginState;
-
-    LoginStateResultCallback LoginStateResCallback = [Callback, LoginStateRef](const LoginStateResult& LoginStateRes)
+    LoginStateResultCallback LoginStateResCallback = [Callback, LoginStateRef = LoginState](const LoginStateResult& LoginStateRes)
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::InProgress)
         {
@@ -271,7 +268,7 @@ void AuthContext::RefreshToken(std::function<void(bool)> Callback)
 
     csp::services::ResponseHandlerPtr ResponseHandler
         = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, LoginStateRef.get());
+            LoginStateResCallback, LoginState.get());
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
 }
@@ -360,12 +357,10 @@ void UserSystem::Login(const csp::common::String& Email, const csp::common::Stri
 
     Request->SetTokenOptions(Options);
 
-    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // CurrentLoginState captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
     // ResponseHandler.
-    auto LoginStateRef = CurrentLoginState;
-
     LoginStateResultCallback LoginStateResCallback
-        = [this, Callback, CreateMultiplayerConnection, LoginStateRef](const LoginStateResult& LoginStateRes)
+        = [this, Callback, CreateMultiplayerConnection, LoginStateRef = CurrentLoginState](const LoginStateResult& LoginStateRes)
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
@@ -396,7 +391,7 @@ void UserSystem::Login(const csp::common::String& Email, const csp::common::Stri
 
     csp::services::ResponseHandlerPtr ResponseHandler
         = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, LoginStateRef.get());
+            LoginStateResCallback, CurrentLoginState.get());
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
 }
@@ -430,12 +425,10 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
 
     Request->SetTokenOptions(Options);
 
-    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // CurrentLoginState captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
     // ResponseHandler.
-    auto LoginStateRef = CurrentLoginState;
-
     LoginStateResultCallback LoginStateResCallback
-        = [this, Callback, CreateMultiplayerConnection, LoginStateRef](const LoginStateResult& LoginStateRes)
+        = [this, Callback, CreateMultiplayerConnection, LoginStateRef = CurrentLoginState](const LoginStateResult& LoginStateRes)
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
@@ -465,7 +458,7 @@ void UserSystem::LoginWithRefreshToken(const csp::common::String& UserId, const 
 
     csp::services::ResponseHandlerPtr ResponseHandler
         = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, LoginStateRef.get());
+            LoginStateResCallback, CurrentLoginState.get());
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersRefreshPost({ Request }, ResponseHandler);
 }
@@ -496,12 +489,10 @@ void UserSystem::LoginAsGuest(bool CreateMultiplayerConnection, const csp::commo
 
     Request->SetTokenOptions(Options);
 
-    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // CurrentLoginState captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
     // ResponseHandler.
-    auto LoginStateRef = CurrentLoginState;
-
     LoginStateResultCallback LoginStateResCallback
-        = [this, Callback, CreateMultiplayerConnection, LoginStateRef](const LoginStateResult& LoginStateRes)
+        = [this, Callback, CreateMultiplayerConnection, LoginStateRef = CurrentLoginState](const LoginStateResult& LoginStateRes)
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
@@ -531,7 +522,7 @@ void UserSystem::LoginAsGuest(bool CreateMultiplayerConnection, const csp::commo
 
     csp::services::ResponseHandlerPtr ResponseHandler
         = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, LoginStateRef.get());
+            LoginStateResCallback, CurrentLoginState.get());
 
     static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLoginPost({ Request }, ResponseHandler);
 }
@@ -555,11 +546,9 @@ void UserSystem::LoginAsGuestWithDeferredProfileCreation(const csp::common::Opti
         Request->SetVerifiedAgeEighteen(*UserHasVerifiedAge);
     }
 
-    // Local copy made and captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
+    // CurrentLoginState captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
     // ResponseHandler.
-    auto LoginStateRef = CurrentLoginState;
-
-    LoginStateResultCallback LoginStateResCallback = [this, Callback, LoginStateRef](const LoginStateResult& LoginStateRes)
+    LoginStateResultCallback LoginStateResCallback = [this, Callback, LoginStateRef = CurrentLoginState](const LoginStateResult& LoginStateRes)
     {
         if (LoginStateRes.GetResultCode() == csp::systems::EResultCode::Success)
         {
@@ -590,7 +579,7 @@ void UserSystem::LoginAsGuestWithDeferredProfileCreation(const csp::common::Opti
 
     csp::services::ResponseHandlerPtr ResponseHandler
         = AuthenticationAPI->CreateHandler<LoginStateResultCallback, LoginStateResult, csp::common::LoginState, chs_user::AuthDto>(
-            LoginStateResCallback, LoginStateRef.get());
+            LoginStateResCallback, CurrentLoginState.get());
 
     // Despite the naming, "login-guest" is the deferred, optimized, non-standard guest login.
     // The regular login endpoint that "loginAsGuest" uses is the "real" one.
@@ -826,14 +815,13 @@ void UserSystem::Logout(NullResultCallback Callback)
         Request->SetUserId(Data.UserId);
         Request->SetDeviceId(Data.DeviceId);
 
-        // Local copy made and captured by value in the wrapped callback below. This ensures the shared_ptr stays alive until the callback is executed
+        // CurrentLoginState captured by value in the wrapped callback below. This ensures the shared_ptr stays alive until the callback is executed
         // via the ResponseHandler.
-        auto LoginStateRef = CurrentLoginState;
-        NullResultCallback WrappedCallback = [Callback, LoginStateRef](const NullResult& Result) { Callback(Result); };
+        NullResultCallback WrappedCallback = [Callback, LoginStateRef = CurrentLoginState](const NullResult& Result) { Callback(Result); };
 
         csp::services::ResponseHandlerPtr ResponseHandler
             = AuthenticationAPI->CreateHandler<NullResultCallback, LogoutResult, csp::common::LoginState, csp::services::NullDto>(
-                WrappedCallback, LoginStateRef.get(), csp::web::EResponseCodes::ResponseNoContent);
+                WrappedCallback, CurrentLoginState.get(), csp::web::EResponseCodes::ResponseNoContent);
 
         static_cast<chs_user::AuthenticationApi*>(AuthenticationAPI)->usersLogoutPost({ Request }, ResponseHandler);
     };

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -59,7 +59,7 @@ void StartMultiplayerConnection(csp::multiplayer::MultiplayerConnection& Multipl
     {
         LogSystem.LogMsg(csp::common::LogLevel::Log, "Starting Multiplayer Connection");
 
-        auto Data = LoginStateRes.GetLoginState().GetSnapshot();
+        auto Data = LoginStateRes.GetLoginState().GetSnapshotThreadSafe();
         MultiplayerConnection.Connect(ConnectionCallback, MultiplayerURI, Data.AccessToken, Data.DeviceId);
     }
     else
@@ -231,7 +231,7 @@ const csp::common::LoginState& AuthContext::GetLoginState() const { return *Logi
 
 void AuthContext::RefreshToken(std::function<void(bool)> Callback)
 {
-    auto Data = LoginState->GetSnapshot();
+    auto Data = LoginState->GetSnapshotThreadSafe();
     if (Data.State != csp::common::ELoginState::LoggedIn)
     {
         return;
@@ -820,7 +820,7 @@ void UserSystem::Logout(NullResultCallback Callback)
             CSP_LOG_ERROR_FORMAT("Error disconnecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
         }
 
-        auto Data = CurrentLoginState->GetSnapshot();
+        auto Data = CurrentLoginState->GetSnapshotThreadSafe();
 
         auto Request = std::make_shared<chs_user::LogoutRequest>();
         Request->SetUserId(Data.UserId);

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -16,6 +16,8 @@
 #include "Web/RemoteFileManager.h"
 
 #include "CSP/Common/Interfaces/IAuthContext.h"
+#include "CSP/Common/LoginState.h"
+#include "Common/LoginStateData.h"
 #include "Common/Web/HttpAuth.h"
 #include "Common/Web/HttpPayload.h"
 #include "Common/Web/WebClient.h"
@@ -26,11 +28,13 @@ namespace
 {
 csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(const csp::common::IAuthContext& InAuthContext)
 {
+    auto Data = InAuthContext.GetLoginState().GetSnapshot();
+
     csp::common::Optional<csp::common::String> BearerToken;
 
-    if (InAuthContext.GetLoginState().State == csp::common::ELoginState::LoggedIn)
+    if (Data.State == csp::common::ELoginState::LoggedIn)
     {
-        csp::common::String AccessToken = InAuthContext.GetLoginState().AccessToken;
+        csp::common::String AccessToken = Data.AccessToken;
         BearerToken = csp::common::String(fmt::format("Bearer {}", AccessToken.c_str()).c_str());
     }
 

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -28,7 +28,7 @@ namespace
 {
 csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(const csp::common::IAuthContext& InAuthContext)
 {
-    auto Data = InAuthContext.GetLoginState().GetSnapshot();
+    auto Data = InAuthContext.GetLoginState().GetSnapshotThreadSafe();
 
     csp::common::Optional<csp::common::String> BearerToken;
 

--- a/MultiplayerTestRunner/src/LoginRAII.cpp
+++ b/MultiplayerTestRunner/src/LoginRAII.cpp
@@ -48,7 +48,7 @@ csp::common::String LogIn(csp::systems::UserSystem& UserSystem, const csp::commo
     if (LoginResult.GetResultCode() == csp::systems::EResultCode::Success)
     {
         MultiplayerTestRunner::ProcessDescriptors::PrintProcessDescriptor(MultiplayerTestRunner::ProcessDescriptors::LOGGED_IN_DESCRIPTOR);
-        return LoginResult.GetLoginState().UserId;
+        return LoginResult.GetLoginState().GetUserId();
     }
     else
     {

--- a/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/CreateAvatar.cpp
@@ -53,9 +53,8 @@ void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine)
     std::promise<csp::multiplayer::SpaceEntity*> ResultPromise;
     std::future<csp::multiplayer::SpaceEntity*> ResultFuture = ResultPromise.get_future();
 
-    const auto LoginState = UserSystem.GetLoginState();
-
-    RealtimeEngine.CreateAvatar(UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId, UserAvatarPlayMode,
+    RealtimeEngine.CreateAvatar(UserName, UserSystem.GetLoginState().GetUserId(), UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+        UserAvatarPlayMode,
         LocomotionModel::Grounded, [&ResultPromise](csp::multiplayer::SpaceEntity* Result) { ResultPromise.set_value(Result); });
 
     csp::multiplayer::SpaceEntity* CreatedAvatar = ResultFuture.get();

--- a/MultiplayerTestRunner/src/RunnableTests/LeaderElection.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/LeaderElection.cpp
@@ -38,7 +38,7 @@ void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine)
     auto& MultiplayerSystem = *SystemsManager.GetMultiplayerSystem();
 
     csp::common::String SpaceId = SpaceSystem.GetCurrentSpace().Id;
-    csp::common::String UserId = UserSystem.GetLoginState().UserId;
+    csp::common::String UserId = UserSystem.GetLoginState().GetUserId();
 
     std::cout << "Client listening: " << UserId << std::endl;
 

--- a/MultiplayerTestRunner/src/RunnableTests/LeaderElectionTick.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/LeaderElectionTick.cpp
@@ -38,7 +38,7 @@ void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine)
     auto& MultiplayerSystem = *SystemsManager.GetMultiplayerSystem();
 
     csp::common::String SpaceId = SpaceSystem.GetCurrentSpace().Id;
-    csp::common::String UserId = UserSystem.GetLoginState().UserId;
+    csp::common::String UserId = UserSystem.GetLoginState().GetUserId();
 
     std::cout << "Client listening: " << UserId << std::endl;
 

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CSP/CSPFoundation.h"
+#include "Common/LoginStateData.h"
 #include "Mocks/AuthContextMock.h"
 #include "Mocks/WebClientMock.h"
 #include "PlatformTestUtils.h"
@@ -50,8 +51,12 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
 
     // Construct a LoginState object with the correct state.
     csp::common::LoginState LoginState;
-    LoginState.State = std::get<0>(GetParam());
-    LoginState.AccessToken = std::get<1>(GetParam());
+    {
+        csp::common::LoginStateData Data = LoginState.GetSnapshot();
+        Data.State = std::get<0>(GetParam());
+        Data.AccessToken = std::get<1>(GetParam());
+        LoginState.SetLoginStateData(Data);
+    }
 
     EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
@@ -68,7 +73,7 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
                 ASSERT_NE(ContentTypeIt, Headers.end());
                 EXPECT_EQ(ContentTypeIt->second, "text/json");
 
-                if (LoginState.State == csp::common::ELoginState::LoggedIn)
+                if (LoginState.GetLoginStateValue() == csp::common::ELoginState::LoggedIn)
                 {
                     // Verify that the Authorization header is present
                     auto AuthIt = Headers.find("Authorization");
@@ -107,8 +112,12 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
 
     // Construct a LoginState object with the correct state.
     csp::common::LoginState LoginState;
-    LoginState.State = std::get<0>(GetParam());
-    LoginState.AccessToken = std::get<1>(GetParam());
+    {
+        csp::common::LoginStateData Data = LoginState.GetSnapshot();
+        Data.State = std::get<0>(GetParam());
+        Data.AccessToken = std::get<1>(GetParam());
+        LoginState.SetLoginStateData(Data);
+    }
 
     EXPECT_CALL(MockClient, SendRequest)
         .WillOnce(
@@ -119,7 +128,7 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
 
                 EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
 
-                if (LoginState.State == csp::common::ELoginState::LoggedIn)
+                if (LoginState.GetLoginStateValue() == csp::common::ELoginState::LoggedIn)
                 {
                     // The X-AssetPlatform header is added to all HTTP requests. In addition the Authorization header should have been set
                     const auto& Headers = Payload.GetHeaders();

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -55,7 +55,7 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
         csp::common::LoginStateData Data = LoginState.GetSnapshotThreadSafe();
         Data.State = std::get<0>(GetParam());
         Data.AccessToken = std::get<1>(GetParam());
-        LoginState.SetLoginStateData(Data);
+        LoginState.SetLoginStateDataThreadSafe(Data);
     }
 
     EXPECT_CALL(MockClient, SendRequest)
@@ -116,7 +116,7 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
         csp::common::LoginStateData Data = LoginState.GetSnapshotThreadSafe();
         Data.State = std::get<0>(GetParam());
         Data.AccessToken = std::get<1>(GetParam());
-        LoginState.SetLoginStateData(Data);
+        LoginState.SetLoginStateDataThreadSafe(Data);
     }
 
     EXPECT_CALL(MockClient, SendRequest)

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -52,7 +52,7 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
     // Construct a LoginState object with the correct state.
     csp::common::LoginState LoginState;
     {
-        csp::common::LoginStateData Data = LoginState.GetSnapshot();
+        csp::common::LoginStateData Data = LoginState.GetSnapshotThreadSafe();
         Data.State = std::get<0>(GetParam());
         Data.AccessToken = std::get<1>(GetParam());
         LoginState.SetLoginStateData(Data);
@@ -113,7 +113,7 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
     // Construct a LoginState object with the correct state.
     csp::common::LoginState LoginState;
     {
-        csp::common::LoginStateData Data = LoginState.GetSnapshot();
+        csp::common::LoginStateData Data = LoginState.GetSnapshotThreadSafe();
         Data.State = std::get<0>(GetParam());
         Data.AccessToken = std::get<1>(GetParam());
         LoginState.SetLoginStateData(Data);

--- a/Tests/src/InternalTests/SpaceEntityTests.cpp
+++ b/Tests/src/InternalTests/SpaceEntityTests.cpp
@@ -58,7 +58,7 @@ void CreateAvatarForLeaderElection(csp::common::IRealtimeEngine* EntitySystem)
 
     const auto LoginState = csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState();
 
-    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(EntitySystem, CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState, UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 

--- a/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/AvatarComponentTests.cpp
@@ -81,7 +81,8 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarComponentTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, UserAvatarLocomotionModel);
     EXPECT_NE(Avatar, nullptr);
 
@@ -218,7 +219,8 @@ CSP_PUBLIC_TEST(CSPEngine, AvatarTests, AvatarScriptInterfaceTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, UserAvatarLocomotionModel);
     EXPECT_NE(Avatar, nullptr);
 

--- a/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/PortalComponentTests.cpp
@@ -83,7 +83,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         const auto LoginState = UserSystem->GetLoginState();
 
-        auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState,
+        auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
             UserAvatarId, UserAvatarPlayMode, LocomotionModel::Grounded);
 
         // Create object to represent the portal
@@ -116,7 +116,7 @@ CSP_PUBLIC_TEST(CSPEngine, PortalTests, UsePortalTest)
 
         const auto LoginState = UserSystem->GetLoginState();
 
-        auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState,
+        auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
             UserAvatarId, UserAvatarPlayMode, LocomotionModel::Grounded);
 
         auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);

--- a/Tests/src/PublicAPITests/MultiPlayerTests.cpp
+++ b/Tests/src/PublicAPITests/MultiPlayerTests.cpp
@@ -131,7 +131,7 @@ void OnConnect(OnlineRealtimeEngine* RealtimeEngine)
 
     const auto LoginState = csp::systems::SystemsManager::Get().GetUserSystem()->GetLoginState();
 
-    RealtimeEngine->CreateAvatar(UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode,
+    RealtimeEngine->CreateAvatar(UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserState, UserAvatarId, UserAvatarPlayMode,
         LocomotionModel::Grounded,
         [RealtimeEngine](SpaceEntity* NewAvatar)
         {
@@ -624,7 +624,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, MultiplayerTests, ConnectionInterruptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = Awaitable(&OnlineRealtimeEngine::CreateAvatar, RealtimeEngine.get(), UserName, LoginState.UserId, UserTransform, IsVisible,
+    auto [Avatar] = Awaitable(&OnlineRealtimeEngine::CreateAvatar, RealtimeEngine.get(), UserName, LoginState.GetUserId(), UserTransform, IsVisible,
         UserAvatarState, UserAvatarId, UserAvatarPlayMode, LocomotionModel::Grounded)
                         .Await();
 
@@ -1682,7 +1682,7 @@ CSP_PUBLIC_TEST(CSPEngine, MultiplayerTests, ConnectionInterruptedTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = Awaitable(&OnlineRealtimeEngine::CreateAvatar, RealtimeEngine.get(), UserName, LoginState.UserId, UserTransform, IsVisible,
+    auto [Avatar] = Awaitable(&OnlineRealtimeEngine::CreateAvatar, RealtimeEngine.get(), UserName, LoginState.GetUserId(), UserTransform, IsVisible,
         UserAvatarState, UserAvatarId, UserAvatarPlayMode, LocomotionModel::Grounded)
                         .Await();
 

--- a/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
@@ -160,8 +160,8 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestSuccessInSe
 
     async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
         .then(async::inline_scheduler(),
-            RealtimeEngine->SendNewAvatarObjectMessage(
-                "Username", LoginState.UserId, UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default, LocomotionModel::Grounded))
+            RealtimeEngine->SendNewAvatarObjectMessage("Username", LoginState.GetUserId(), UserTransform, IsVisible, "AvatarId", AvatarState::Idle,
+                AvatarPlayMode::Default, LocomotionModel::Grounded))
         .then(async::inline_scheduler(),
             [](async::task<uint64_t> Id)
             {
@@ -201,8 +201,8 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorInSend
 
     async::spawn(async::inline_scheduler(), []() { return uint64_t(55); }) // This continuation takes the ID as its input
         .then(async::inline_scheduler(),
-            RealtimeEngine->SendNewAvatarObjectMessage(
-                "Username", LoginState.UserId, UserTransform, IsVisible, "AvatarId", AvatarState::Idle, AvatarPlayMode::Default, LocomotionModel::Grounded))
+            RealtimeEngine->SendNewAvatarObjectMessage("Username", LoginState.GetUserId(), UserTransform, IsVisible, "AvatarId", AvatarState::Idle,
+                AvatarPlayMode::Default, LocomotionModel::Grounded))
         .then(async::inline_scheduler(),
             [](async::task<uint64_t> Id)
             {
@@ -271,8 +271,8 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestSuccessInCr
         []()
         { return async::make_task(uint64_t { 55 }); }) // This continuation takes the ID (and another void return from a when_all branch) as its input
         .then(async::inline_scheduler(),
-            RealtimeEngine->CreateNewLocalAvatar(
-                Username, LoginState.UserId, UserTransform, IsVisible, AvatarId, AvatarState, AvatarPlayMode, LocomotionModel, MockCallback.AsStdFunction()));
+            RealtimeEngine->CreateNewLocalAvatar(Username, LoginState.GetUserId(), UserTransform, IsVisible, AvatarId, AvatarState, AvatarPlayMode,
+                LocomotionModel, MockCallback.AsStdFunction()));
 }
 
 CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorLoggedFromWholeCreateAvatarChain)
@@ -312,7 +312,7 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, TestErrorLogged
 
     const auto LoginState = SystemsManager.GetUserSystem()->GetLoginState();
 
-    RealtimeEngine->CreateAvatar("Username", LoginState.UserId, UserTransform, IsVisible, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default,
+    RealtimeEngine->CreateAvatar("Username", LoginState.GetUserId(), UserTransform, IsVisible, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default,
         LocomotionModel::Grounded, MockCallback.AsStdFunction());
 }
 
@@ -572,7 +572,7 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, CreateAvatarGen
     const SpaceTransform Transform = { csp::common::Vector3::Zero(), csp::common::Vector4::Identity(), csp::common::Vector3::One() };
     const auto LoginState = SystemsManager.GetUserSystem()->GetLoginState();
 
-    RealtimeEngine->CreateAvatar("Username", LoginState.UserId, Transform, true, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default,
+    RealtimeEngine->CreateAvatar("Username", LoginState.GetUserId(), Transform, true, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default,
         LocomotionModel::Grounded, MockCallback.AsStdFunction());
 }
 
@@ -638,7 +638,7 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, CreateAvatarSen
     const SpaceTransform Transform = { csp::common::Vector3::Zero(), csp::common::Vector4::Identity(), csp::common::Vector3::One() };
     const auto LoginState = SystemsManager.GetUserSystem()->GetLoginState();
 
-    RealtimeEngine->CreateAvatar("Username", LoginState.UserId, Transform, true, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default,
+    RealtimeEngine->CreateAvatar("Username", LoginState.GetUserId(), Transform, true, AvatarState::Idle, "AvatarId", AvatarPlayMode::Default,
         LocomotionModel::Grounded, MockCallback.AsStdFunction());
 }
 

--- a/Tests/src/PublicAPITests/RealtimeEngineEntityTests.cpp
+++ b/Tests/src/PublicAPITests/RealtimeEngineEntityTests.cpp
@@ -191,7 +191,8 @@ TEST_P(CreateAvatar, CreateAvatarTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, UserAvatarLocomotionModel);
     EXPECT_NE(Avatar, nullptr);
 
@@ -270,7 +271,8 @@ TEST_P(CreateCreatorAvatar, CreateCreatorAvatarTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, UserAvatarLocomotionModel);
     EXPECT_NE(Avatar, nullptr);
 
@@ -348,7 +350,8 @@ TEST_P(AvatarMovementDirection, AvatarMovementDirectionTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 
@@ -903,7 +906,8 @@ TEST_P(EntitySelection, EntitySelectionTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -308,7 +308,7 @@ TEST_P(RunScript, RunScriptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserState, UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 
@@ -425,7 +425,8 @@ TEST_P(AvatarScript, AvatarScriptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -524,7 +525,8 @@ TEST_P(ScriptLog, ScriptLogTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserAvatarState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserAvatarState,
+        UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
 
     EXPECT_EQ(Avatar->GetEntityType(), SpaceEntityType::Avatar);
@@ -612,7 +614,7 @@ TEST_P(DeleteScript, DeleteScriptTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserState, UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 
@@ -724,7 +726,7 @@ TEST_P(DeleteAndChangeComponent, DeleteAndChangeComponentTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserState, UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 
@@ -964,7 +966,7 @@ TEST_P(ScriptDeltaTime, ScriptDeltaTimeTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserState, UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 
@@ -1087,7 +1089,7 @@ TEST_P(CustomComponentScriptInterfaceSubscription, CustomComponentScriptInterfac
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserState, UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 
@@ -1208,7 +1210,7 @@ TEST_P(MultipleScriptComponent, MultipleScriptComponentTest)
 
     const auto LoginState = UserSystem->GetLoginState();
 
-    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.UserId, UserTransform, IsVisible, UserState, UserAvatarId,
+    auto [Avatar] = AWAIT(RealtimeEngine.get(), CreateAvatar, UserName, LoginState.GetUserId(), UserTransform, IsVisible, UserState, UserAvatarId,
         UserAvatarPlayMode, LocomotionModel::Grounded);
     EXPECT_NE(Avatar, nullptr);
 

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -15,6 +15,7 @@
  */
 #include "Awaitable.h"
 #include "CSP/CSPFoundation.h"
+#include "CSP/Common/LoginState.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Systems/Settings/SettingsSystem.h"
 #include "CSP/Systems/Spaces/Space.h"
@@ -22,6 +23,7 @@
 #include "CSP/Systems/Users/Profile.h"
 #include "CSP/Systems/Users/UserSystem.h"
 #include "Common/DateTime.h"
+#include "Common/LoginStateData.h"
 #include "Common/Web/HttpPayload.h"
 #include "RAIIMockLogger.h"
 #include "SpaceSystemTestHelpers.h"
@@ -81,7 +83,7 @@ void LogIn(csp::systems::UserSystem* UserSystem, csp::common::String& OutUserId,
 
     if (Result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        OutUserId = Result.GetLoginState().UserId;
+        OutUserId = Result.GetLoginState().GetUserId();
     }
 }
 
@@ -95,7 +97,7 @@ void LogInAsGuest(csp::systems::UserSystem* UserSystem, csp::common::String& Out
 
     if (Result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        OutUserId = Result.GetLoginState().UserId;
+        OutUserId = Result.GetLoginState().GetUserId();
     }
 }
 
@@ -108,7 +110,7 @@ void LogInAsGuestWithDeferredProfileCreation(
 
     if (Result.GetResultCode() == csp::systems::EResultCode::Success)
     {
-        OutUserId = Result.GetLoginState().UserId;
+        OutUserId = Result.GetLoginState().GetUserId();
     }
 }
 
@@ -157,7 +159,7 @@ struct AuthorizeURLTokens
 AuthorizeURLTokens ExtractTokensFromAuthorizeURL(const csp::common::String& AuthorizeURL)
 {
     AuthorizeURLTokens URLTokens;
-    
+
     const char* STATE_ID_URL_PARAM = "state=";
     const char* CLIENT_ID_URL_PARAM = "client_id=";
     const char* SCOPE_URL_PARAM = "scope=";
@@ -551,10 +553,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, ValidExpiryLengthInTokenOptionsTest)
     std::future<csp::systems::LoginTokenInfoResult> TokenFuture = TokenPromise.get_future();
 
     UserSystem->SetNewLoginTokenReceivedCallback(
-        [&TokenPromise](const csp::systems::LoginTokenInfoResult& Result)
-        {
-            TokenPromise.set_value(Result);
-        });
+        [&TokenPromise](const csp::systems::LoginTokenInfoResult& Result) { TokenPromise.set_value(Result); });
 
     // Log in
     csp::common::String UserId;
@@ -1358,10 +1357,10 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DefaultApplicationSettingsTest)
     csp::common::LoginState LoginState = SettingsFuture.get();
 
     // OKO_TESTS Tenant has a default applications settings setup. All these values are arbitrary just for tests
-    ASSERT_EQ(LoginState.DefaultApplicationSettings.Size(), 1);
-    ASSERT_EQ(LoginState.DefaultSettings.Size(), 0);
+    ASSERT_EQ(LoginState.GetDefaultApplicationSettings().Size(), 1);
+    ASSERT_EQ(LoginState.GetDefaultSettings().Size(), 0);
 
-    csp::common::ApplicationSettings ApplicationSetting = LoginState.DefaultApplicationSettings[0];
+    csp::common::ApplicationSettings ApplicationSetting = LoginState.GetDefaultApplicationSettings()[0];
     ASSERT_EQ(ApplicationSetting.AllowAnonymous, false);
     ASSERT_EQ(ApplicationSetting.Context, "checkpoint");
     // application name not listed because it uses a project codename which is secret ... it's six characters long though :P Ooooh what could it be?
@@ -1370,4 +1369,105 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DefaultApplicationSettingsTest)
     ASSERT_EQ(ApplicationSetting.Settings.Size(), 1);
     ASSERT_TRUE(ApplicationSetting.Settings.HasKey("URL"));
     ASSERT_EQ(ApplicationSetting.Settings["URL"], "https://www.google.com/search?q=why+google");
+}
+
+// Regression test for the LoginStateMutex guard in UserSystem.
+//
+// The crash was occurring under the following conditions:
+//   1. A user calls Logout().
+//   2. Before the logout response is received, Login() is called again.
+//   3. Both OnResponse handlers execute concurrently on different threads and write to
+//      CurrentLoginState without synchronization, causing a data race.
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginStateMutexGuardTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+
+    csp::common::String UserId;
+    csp::systems::Profile TestUser = CreateTestUser();
+    LogIn(UserSystem, UserId, TestUser.Email, GeneratedTestAccountPassword);
+
+    // Call Logout without blocking, then immediately call Login for the same user.
+    // Without the LoginStateMutex, the concurrent OnResponse callbacks would produce a data
+    // race on CurrentLoginState � potentially crashing or corrupting the login state.
+    std::promise<bool> LogoutPromise;
+    std::future<bool> LogoutFuture = LogoutPromise.get_future();
+    std::promise<bool> LoginPromise;
+    std::future<bool> LoginFuture = LoginPromise.get_future();
+
+    csp::systems::EResultCode LogoutResultCode { csp::systems::EResultCode::InProgress };
+    csp::systems::EResultCode LoginResultCode { csp::systems::EResultCode::InProgress };
+
+    UserSystem->Logout(
+        [&](const csp::systems::NullResult& Result)
+        {
+            if (Result.GetResultCode() != csp::systems::EResultCode::InProgress)
+            {
+                LogoutResultCode = Result.GetResultCode();
+                LogoutPromise.set_value(true);
+            }
+        });
+
+    UserSystem->Login(TestUser.Email, GeneratedTestAccountPassword, true, true, csp::systems::TokenOptions(),
+        [&](const csp::systems::LoginStateResult& Result)
+        {
+            if (Result.GetResultCode() != csp::systems::EResultCode::InProgress)
+            {
+                LoginResultCode = Result.GetResultCode();
+                LoginPromise.set_value(true);
+            }
+        });
+
+    std::future_status LogoutStatus = LogoutFuture.wait_for(30s);
+    std::future_status LoginStatus = LoginFuture.wait_for(30s);
+
+    if (LogoutStatus == std::future_status::ready)
+    {
+        EXPECT_TRUE(LogoutFuture.get());
+    }
+    else
+    {
+        FAIL() << "Logout did not complete successfully.";
+    }
+
+    if (LoginStatus == std::future_status::ready)
+    {
+        EXPECT_TRUE(LoginFuture.get());
+    }
+    else
+    {
+        FAIL() << "Login did not complete successfully.";
+    }
+
+    // Ensure the call to Logout was successful and that we were correctly logged in when it was dispatched.
+    EXPECT_EQ(LogoutResultCode, csp::systems::EResultCode::Success);
+
+    // The LoginState must be in a valid state, not partially overwritten by concurrent writes from the two response handlers.
+    auto Data = UserSystem->GetLoginState().GetSnapshot();
+
+    const csp::common::ELoginState FinalState = Data.State;
+
+    if (FinalState == csp::common::ELoginState::LoggedIn)
+    {
+        EXPECT_NE(Data.AccessToken, "");
+        EXPECT_NE(Data.RefreshToken, "");
+        EXPECT_NE(Data.UserId, "");
+        EXPECT_NE(Data.DeviceId, "");
+    }
+    else if (FinalState == csp::common::ELoginState::LoggedOut || FinalState == csp::common::ELoginState::Error)
+    {
+        EXPECT_EQ(Data.AccessToken, "");
+        EXPECT_EQ(Data.RefreshToken, "");
+        EXPECT_EQ(Data.UserId, "");
+        EXPECT_EQ(Data.DeviceId, "");
+    }
+    else
+    {
+        FAIL() << "Final LoginState is incorrect.";
+    }
+
+    if (LoginResultCode == csp::systems::EResultCode::Success)
+    {
+        LogOut(UserSystem);
+    }
 }

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -1443,7 +1443,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginStateMutexGuardTest)
     EXPECT_EQ(LogoutResultCode, csp::systems::EResultCode::Success);
 
     // The LoginState must be in a valid state, not partially overwritten by concurrent writes from the two response handlers.
-    auto Data = UserSystem->GetLoginState().GetSnapshot();
+    auto Data = UserSystem->GetLoginState().GetSnapshotThreadSafe();
 
     const csp::common::ELoginState FinalState = Data.State;
 

--- a/WasmTesting/html_tests/CreateAvatar.html
+++ b/WasmTesting/html_tests/CreateAvatar.html
@@ -58,11 +58,11 @@
         // Try and create the avatar
         const entity = await realtimeEngine.createAvatar(
           'Test Player',
-          authState.userId,
+          authState.getUserId(),
           playerTransform,
           true,
           Multiplayer.AvatarState.Idle,
-          authState.userId,
+          authState.getUserId(),
           Multiplayer.AvatarPlayMode.Default,
           Multiplayer.LocomotionModel.Grounded
         );

--- a/WasmTesting/html_tests/CrossThreadConnectionInterrupted.html
+++ b/WasmTesting/html_tests/CrossThreadConnectionInterrupted.html
@@ -51,11 +51,11 @@
       // Try and create the avatar
       const entity = await realtimeEngine.createAvatar(
         'Test Player',
-        authState.userId,
+        authState.getUserId(),
         playerTransform,
         true,
         Multiplayer.AvatarState.Idle,
-        authState.userId,
+        authState.getUserId(),
         Multiplayer.AvatarPlayMode.Default
       );
 

--- a/WasmTesting/html_tests/EnterSpaceFromCheckpoint.html
+++ b/WasmTesting/html_tests/EnterSpaceFromCheckpoint.html
@@ -72,11 +72,11 @@
 
         const entity = await realtimeEngine.createAvatar(
           'Offline Player',
-          authState.userId,
+          authState.getUserId(),
           playerTransform,
           true,
           Multiplayer.AvatarState.Idle,
-          authState.userId,
+          authState.getUserId(),
           Multiplayer.AvatarPlayMode.Default
         );
 

--- a/WasmTesting/html_tests/Offline.html
+++ b/WasmTesting/html_tests/Offline.html
@@ -51,11 +51,11 @@
 
         const entity = await realtimeEngine.createAvatar(
           'Offline Player',
-          authState.userId,
+          authState.getUserId(),
           playerTransform,
           true,
           Multiplayer.AvatarState.Idle,
-          authState.userId,
+          authState.getUserId(),
           Multiplayer.AvatarPlayMode.Default
         );
 


### PR DESCRIPTION
The Login, Logout and Refresh Token response handlers access the `LoginState` object on different threads which was resulting in login state data race conditions. In addition the `LoginState` object was being passed to the response handlers by value, which resulted in the `LoginState` being destroyed when CSP was torn down while callbacks were still in flight.

To resolve this issue the `LoginState` data members have been moved to a new `LoginStateData` class, and access to it is controlled via a mutex guard. In addition a copy of the `LoginState` shared_ptr is now captured by the response handler callbacks to ensure it's lifetime persists for the duration of the callback.

**Breaking change**
The `LoginState` class now provides a new api for accessing the underlying data. While before you could get/set members such as `State` and `UserId` directly, now you you have to go through the dedicated getters. These are:

- GetUserId()
- GetDeviceId()
- GetAccessToken()
- GetRefreshToken()
- GetLoginStateValue()
- GetDefaultApplicationSettings()
- GetDefaultSettings()