### PR TITLE
[OF-1867] feat: Support injecting custom component schemas via JSON at engine construction time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file. For compile
 
 ## [6.43.0]
 
+### 🍰 🙌 New Features
+
+- [OF-1867] feat: Support injecting custom component schemas via JSON at engine construction time. By @mag-lt.
+  Both `OfflineRealtimeEngine` and `OnlineRealtimeEngine` now accept a `List<String>` of JSON documents at
+  construction, allowing custom component schemas to be registered in the engine-wide schema registry alongside
+  the built-in schemas. Each document should be a JSON array of schema objects, invalid entries are skipped with
+  a warning. The `List<String>` parameter is a wrapper generator workaround for passing large strings, in
+  practice a single element containing the full JSON array is expected. Equivalent constructors accepting
+  `Array<ComponentSchema>` directly are also provided.
+
 ### 🔥 ❗Breaking Changes
 
 - [OB-5368] fix!: Guard access to LoginState data with a mutex. By @MAG-AdamThorn.

--- a/Library/include/CSP/Multiplayer/ComponentProperty.h
+++ b/Library/include/CSP/Multiplayer/ComponentProperty.h
@@ -47,6 +47,9 @@ public:
     /// property, which is considered static i.e. if the value is a `float`, it can't be later
     /// changed to hold a `String`.
     csp::common::ReplicatedValue DefaultValue;
+
+    bool operator==(const ComponentProperty& Other) const;
+    bool operator!=(const ComponentProperty& Other) const;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/ComponentSchema.h
+++ b/Library/include/CSP/Multiplayer/ComponentSchema.h
@@ -46,6 +46,9 @@ public:
 
     /// @brief The properties of this component
     csp::common::Array<ComponentProperty> Properties;
+
+    bool operator==(const ComponentSchema& Other) const;
+    bool operator!=(const ComponentSchema& Other) const;
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/ComponentSchema.h
+++ b/Library/include/CSP/Multiplayer/ComponentSchema.h
@@ -19,6 +19,7 @@
 
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/Array.h"
+#include "CSP/Common/Optional.h"
 #include "CSP/Common/String.h"
 
 #include <cstdint>
@@ -33,6 +34,9 @@ class CSP_API ComponentSchema
 {
 public:
     using TypeIdType = uint64_t;
+
+    CSP_NO_EXPORT static csp::common::String ToJson(const ComponentSchema& Schema);
+    CSP_NO_EXPORT static csp::common::Optional<ComponentSchema> FromJson(const csp::common::String& Json);
 
     /// @brief A globally unique ID for identifiying this component type. Will ultimately be
     /// serialized and used in messages sent over the multiplayer connection.

--- a/Library/include/CSP/Multiplayer/ComponentSchema.h
+++ b/Library/include/CSP/Multiplayer/ComponentSchema.h
@@ -19,10 +19,16 @@
 
 #include "CSP/CSPCommon.h"
 #include "CSP/Common/Array.h"
+#include "CSP/Common/List.h"
 #include "CSP/Common/Optional.h"
 #include "CSP/Common/String.h"
 
 #include <cstdint>
+
+namespace csp::common
+{
+class LogSystem;
+}
 
 namespace csp::multiplayer
 {
@@ -54,5 +60,15 @@ public:
     bool operator==(const ComponentSchema& Other) const;
     bool operator!=(const ComponentSchema& Other) const;
 };
+
+/// @brief Parses a list of JSON documents into an array of component schemas.
+/// Each document is expected to be a JSON array of schema objects.
+/// Entries that fail to parse are skipped with a warning; valid entries in the same document are still returned.
+/// @param JsonDocuments One or more JSON documents, each containing an array of schema objects.
+/// The list is a wrapper generator workaround for passing large strings; in practice a single element is expected.
+/// @param LogSystem Logger for reporting skipped entries.
+/// @return An array containing all successfully parsed schemas.
+csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
+    const csp::common::List<csp::common::String>& JsonDocuments, csp::common::LogSystem& LogSystem);
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OfflineRealtimeEngine.h
@@ -70,8 +70,36 @@ public:
     /// @param RemoteScriptRunner csp::common::IJSScriptRunner& : Object capable of running a script.
     OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner);
 
-    CSP_NO_EXPORT OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner,
+    /// @brief OfflineRealtimeEngine constructor.
+    /// Creates an empty realtime engine with additional component schemas.
+    /// @param LogSystem Logger for status and debug output.
+    /// @param RemoteScriptRunner Object capable of running a script.
+    /// @param AdditionalComponents Component schemas to register alongside the built-in schemas in the engine-wide registry.
+    OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner,
         const csp::common::Array<ComponentSchema>& AdditionalComponents);
+
+    /// @brief OfflineRealtimeEngine constructor.
+    /// Creates an empty realtime engine, registering additional component schemas from JSON.
+    /// @param LogSystem Logger for status and debug output.
+    /// @param RemoteScriptRunner Object capable of running a script.
+    /// @param JsonSchemas Component schemas to register alongside the built-in schemas in the engine-wide registry.
+    /// The list is a wrapper generator workaround for passing large strings. In practice a single element is
+    /// expected, containing a JSON array of schema objects. Multiple elements are supported for combining schemas
+    /// from independent sources. Entries that fail to parse are skipped with a warning.
+    OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner,
+        const csp::common::List<csp::common::String>& JsonSchemas);
+
+    /// @brief OfflineRealtimeEngine constructor.
+    /// Creates a realtime engine pre-populated from a scene description, with additional component schemas from JSON.
+    /// @param SceneDescription The scene description containing entities to populate in the engine.
+    /// @param LogSystem Logger for status and debug output.
+    /// @param RemoteScriptRunner Object capable of running a script.
+    /// @param JsonSchemas Component schemas to register alongside the built-in schemas in the engine-wide registry.
+    /// The list is a wrapper generator workaround for passing large strings. In practice a single element is
+    /// expected, containing a JSON array of schema objects. Multiple elements are supported for combining schemas
+    /// from independent sources. Entries that fail to parse are skipped with a warning.
+    OfflineRealtimeEngine(const CSPSceneDescription& SceneDescription, csp::common::LogSystem& LogSystem,
+        csp::common::IJSScriptRunner& RemoteScriptRunner, const csp::common::List<csp::common::String>& JsonSchemas);
 
     /// @brief OfflineRealtimeEngine destructor
     /// Removes entity script bindings and deregisters tick event listeners

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -110,9 +110,31 @@ public:
     OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
         csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& RemoteScriptRunner);
 
-    CSP_NO_EXPORT OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
+    /// @brief OnlineRealtimeEngine constructor.
+    /// Creates a realtime engine with additional component schemas.
+    /// @param InMultiplayerConnection The multiplayer connection to construct the engine with.
+    /// @param LogSystem Logger for status and debug output.
+    /// @param NetworkEventBus Reference to the network event bus, used for leadership election messaging.
+    /// @param RemoteScriptRunner Object capable of running a script.
+    /// @param AdditionalComponents Component schemas to register alongside the built-in schemas in the engine-wide registry.
+    OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
         csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& RemoteScriptRunner,
         const csp::common::Array<ComponentSchema>& AdditionalComponents);
+
+    /// @brief OnlineRealtimeEngine constructor.
+    /// Creates a realtime engine with additional component schemas from JSON.
+    /// @param InMultiplayerConnection The multiplayer connection to construct the engine with.
+    /// @param LogSystem Logger for status and debug output.
+    /// @param NetworkEventBus Reference to the network event bus, used for leadership election messaging.
+    /// @param RemoteScriptRunner Object capable of running a script.
+    /// @param JsonSchemas Component schemas to register alongside the built-in schemas in the engine-wide registry.
+    /// The list is a wrapper generator workaround for passing large strings. In practice a single element is
+    /// expected, containing a JSON array of schema objects. Multiple elements are supported for combining schemas
+    /// from independent sources. Entries that fail to parse are skipped
+    /// with a warning.
+    OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
+        csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& RemoteScriptRunner,
+        const csp::common::List<csp::common::String>& JsonSchemas);
 
     /// @brief OnlineRealtimeEngine destructor
     CSP_NO_EXPORT ~OnlineRealtimeEngine();

--- a/Library/src/Multiplayer/ComponentProperty.cpp
+++ b/Library/src/Multiplayer/ComponentProperty.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/Multiplayer/ComponentProperty.h"
+
+namespace csp::multiplayer
+{
+
+bool ComponentProperty::operator==(const ComponentProperty& Other) const
+{
+    return Key == Other.Key && Name == Other.Name && DefaultValue == Other.DefaultValue;
+}
+
+bool ComponentProperty::operator!=(const ComponentProperty& Other) const { return !(*this == Other); }
+
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -176,7 +176,7 @@ namespace
         };
     }
 
-    std::optional<csp::common::ReplicatedValue> TryParseDefaultValue(const std::string& Type, const rapidjson::Value& Value)
+    std::optional<csp::common::ReplicatedValue> TryParse(const std::string& Type, const rapidjson::Value& Value)
     {
         if (Type == "string")
         {
@@ -246,7 +246,7 @@ namespace
         const auto Key = static_cast<ComponentProperty::KeyType>(Value["key"].GetUint());
         const auto* Name = Value["name"].GetString();
         const auto* Type = Value["type"].GetString();
-        const auto DefaultValue = TryParseDefaultValue(Type, Value["defaultValue"]);
+        const auto DefaultValue = TryParse(Type, Value["defaultValue"]);
 
         if (!DefaultValue)
         {

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CSP/Multiplayer/ComponentSchema.h"
+#include "CSP/Common/Systems/Log/LogSystem.h"
 #include "Common/Convert.h"
 #include "Json/JsonSerializer.h"
 
@@ -378,6 +379,39 @@ csp::common::Optional<ComponentSchema> ComponentSchema::FromJson(const csp::comm
     }
 
     return *Schema;
+}
+
+csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
+    const csp::common::List<csp::common::String>& JsonDocuments, csp::common::LogSystem& LogSystem)
+{
+    auto Collected = std::vector<ComponentSchema> {};
+
+    for (const auto& JsonDoc : JsonDocuments)
+    {
+        auto Doc = rapidjson::Document {};
+        Doc.Parse(JsonDoc.c_str());
+
+        if (Doc.HasParseError() || !Doc.IsArray())
+        {
+            LogSystem.LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping document, expected a JSON array");
+            continue;
+        }
+
+        for (const auto& Element : Doc.GetArray())
+        {
+            const auto Schema = TryParseSchema(Element);
+
+            if (!Schema)
+            {
+                LogSystem.LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping entry, failed to parse schema");
+                continue;
+            }
+
+            Collected.push_back(*Schema);
+        }
+    }
+
+    return csp::common::Convert(Collected);
 }
 
 bool ComponentSchema::operator==(const ComponentSchema& Other) const

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -15,9 +15,370 @@
  */
 
 #include "CSP/Multiplayer/ComponentSchema.h"
+#include "Common/Convert.h"
+#include "Json/JsonSerializer.h"
+
+#include <rapidjson/document.h>
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace csp::multiplayer
 {
+
+namespace
+{
+    void SerializeStringProperty(csp::json::JsonSerializer& Serializer, const csp::common::String& Value)
+    {
+        Serializer.SerializeMember("type", "string");
+        Serializer.SerializeMember("defaultValue", Value);
+    }
+
+    void SerializeFloatProperty(csp::json::JsonSerializer& Serializer, float Value)
+    {
+        Serializer.SerializeMember("type", "float");
+        Serializer.SerializeMember("defaultValue", Value);
+    }
+
+    void SerializeIntProperty(csp::json::JsonSerializer& Serializer, int64_t Value)
+    {
+        Serializer.SerializeMember("type", "int");
+        Serializer.SerializeMember("defaultValue", Value);
+    }
+
+    void SerializeBoolProperty(csp::json::JsonSerializer& Serializer, bool Value)
+    {
+        Serializer.SerializeMember("type", "bool");
+        Serializer.SerializeMember("defaultValue", Value);
+    }
+
+    void SerializeVec2Property(csp::json::JsonSerializer& Serializer, const csp::common::Vector2& Vector)
+    {
+        Serializer.SerializeMember("type", "vec2");
+        Serializer.SerializeMember("defaultValue", std::vector<float> { Vector.X, Vector.Y });
+    }
+
+    void SerializeVec3Property(csp::json::JsonSerializer& Serializer, const csp::common::Vector3& Vector)
+    {
+        Serializer.SerializeMember("type", "vec3");
+        Serializer.SerializeMember("defaultValue", std::vector<float> { Vector.X, Vector.Y, Vector.Z });
+    }
+
+    void SerializeVec4Property(csp::json::JsonSerializer& Serializer, const csp::common::Vector4& Vector)
+    {
+        Serializer.SerializeMember("type", "vec4");
+        Serializer.SerializeMember("defaultValue", std::vector<float> { Vector.X, Vector.Y, Vector.Z, Vector.W });
+    }
+
+    bool IsFloatArray(const rapidjson::Value& Value, rapidjson::SizeType ExpectedSize)
+    {
+        if (!Value.IsArray() || Value.Size() != ExpectedSize)
+        {
+            return false;
+        }
+
+        const auto& Array = Value.GetArray();
+        return std::all_of(Array.begin(), Array.end(), [](const auto& Element) { return Element.IsNumber(); });
+    }
+
+    template <typename T> std::optional<csp::common::ReplicatedValue> AsReplicatedValue(std::optional<T> Value)
+    {
+        if (!Value)
+        {
+            return std::nullopt;
+        }
+
+        return std::move(*Value);
+    }
+
+    std::optional<csp::common::String> TryParseString(const rapidjson::Value& Value)
+    {
+        if (!Value.IsString())
+        {
+            return std::nullopt;
+        }
+
+        return csp::common::String { Value.GetString() };
+    }
+
+    std::optional<float> TryParseFloat(const rapidjson::Value& Value)
+    {
+        if (!Value.IsNumber())
+        {
+            return std::nullopt;
+        }
+
+        return Value.GetFloat();
+    }
+
+    std::optional<int64_t> TryParseInt(const rapidjson::Value& Value)
+    {
+        if (!Value.IsInt64())
+        {
+            return std::nullopt;
+        }
+
+        return Value.GetInt64();
+    }
+
+    std::optional<bool> TryParseBool(const rapidjson::Value& Value)
+    {
+        if (!Value.IsBool())
+        {
+            return std::nullopt;
+        }
+
+        return Value.GetBool();
+    }
+
+    std::optional<csp::common::Vector2> TryParseVec2(const rapidjson::Value& Value)
+    {
+        if (!IsFloatArray(Value, 2))
+        {
+            return std::nullopt;
+        }
+
+        return csp::common::Vector2 {
+            Value[0].GetFloat(),
+            Value[1].GetFloat(),
+        };
+    }
+
+    std::optional<csp::common::Vector3> TryParseVec3(const rapidjson::Value& Value)
+    {
+        if (!IsFloatArray(Value, 3))
+        {
+            return std::nullopt;
+        }
+
+        return csp::common::Vector3 {
+            Value[0].GetFloat(),
+            Value[1].GetFloat(),
+            Value[2].GetFloat(),
+        };
+    }
+
+    std::optional<csp::common::Vector4> TryParseVec4(const rapidjson::Value& Value)
+    {
+        if (!IsFloatArray(Value, 4))
+        {
+            return std::nullopt;
+        }
+
+        return csp::common::Vector4 {
+            Value[0].GetFloat(),
+            Value[1].GetFloat(),
+            Value[2].GetFloat(),
+            Value[3].GetFloat(),
+        };
+    }
+
+    std::optional<csp::common::ReplicatedValue> TryParseDefaultValue(const std::string& Type, const rapidjson::Value& Value)
+    {
+        if (Type == "string")
+        {
+            return AsReplicatedValue(TryParseString(Value));
+        }
+
+        if (Type == "float")
+        {
+            return AsReplicatedValue(TryParseFloat(Value));
+        }
+
+        if (Type == "int")
+        {
+            return AsReplicatedValue(TryParseInt(Value));
+        }
+
+        if (Type == "bool")
+        {
+            return AsReplicatedValue(TryParseBool(Value));
+        }
+
+        if (Type == "vec2")
+        {
+            return AsReplicatedValue(TryParseVec2(Value));
+        }
+
+        if (Type == "vec3")
+        {
+            return AsReplicatedValue(TryParseVec3(Value));
+        }
+
+        if (Type == "vec4")
+        {
+            return AsReplicatedValue(TryParseVec4(Value));
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<ComponentProperty> TryParseProperty(const rapidjson::Value& Value)
+    {
+        if (!Value.IsObject())
+        {
+            return std::nullopt;
+        }
+
+        if (!Value.HasMember("key") || !Value["key"].IsUint())
+        {
+            return std::nullopt;
+        }
+
+        if (!Value.HasMember("name") || !Value["name"].IsString())
+        {
+            return std::nullopt;
+        }
+
+        if (!Value.HasMember("type") || !Value["type"].IsString())
+        {
+            return std::nullopt;
+        }
+
+        if (!Value.HasMember("defaultValue"))
+        {
+            return std::nullopt;
+        }
+
+        const auto Key = static_cast<ComponentProperty::KeyType>(Value["key"].GetUint());
+        const auto* Name = Value["name"].GetString();
+        const auto* Type = Value["type"].GetString();
+        const auto DefaultValue = TryParseDefaultValue(Type, Value["defaultValue"]);
+
+        if (!DefaultValue)
+        {
+            return std::nullopt;
+        }
+
+        return ComponentProperty {
+            Key,
+            Name,
+            *DefaultValue,
+        };
+    }
+
+    std::optional<csp::common::Array<ComponentProperty>> TryParseProperties(rapidjson::Value::ConstArray JsonProperties)
+    {
+        auto Properties = std::vector<ComponentProperty> {};
+
+        for (const auto& Element : JsonProperties)
+        {
+            const auto Property = TryParseProperty(Element);
+
+            if (!Property)
+            {
+                return std::nullopt;
+            }
+
+            Properties.push_back(*Property);
+        }
+
+        return csp::common::Convert(Properties);
+    }
+
+    std::optional<ComponentSchema> TryParseSchema(const rapidjson::Value& Value)
+    {
+        if (!Value.IsObject())
+        {
+            return std::nullopt;
+        }
+
+        if (!Value.HasMember("typeId") || !Value["typeId"].IsUint64())
+        {
+            return std::nullopt;
+        }
+
+        if (!Value.HasMember("name") || !Value["name"].IsString())
+        {
+            return std::nullopt;
+        }
+
+        if (!Value.HasMember("properties") || !Value["properties"].IsArray())
+        {
+            return std::nullopt;
+        }
+
+        const auto Properties = TryParseProperties(Value["properties"].GetArray());
+
+        if (!Properties)
+        {
+            return std::nullopt;
+        }
+
+        return ComponentSchema {
+            Value["typeId"].GetUint64(),
+            Value["name"].GetString(),
+            *Properties,
+        };
+    }
+
+} // namespace
+
+void ToJson(csp::json::JsonSerializer& Serializer, const ComponentProperty& Property)
+{
+    using csp::common::ReplicatedValueType;
+
+    Serializer.SerializeMember("key", static_cast<uint32_t>(Property.Key));
+    Serializer.SerializeMember("name", Property.Name);
+
+    switch (Property.DefaultValue.GetReplicatedValueType())
+    {
+    case ReplicatedValueType::String:
+        SerializeStringProperty(Serializer, Property.DefaultValue.GetString());
+        break;
+    case ReplicatedValueType::Float:
+        SerializeFloatProperty(Serializer, Property.DefaultValue.GetFloat());
+        break;
+    case ReplicatedValueType::Integer:
+        SerializeIntProperty(Serializer, Property.DefaultValue.GetInt());
+        break;
+    case ReplicatedValueType::Boolean:
+        SerializeBoolProperty(Serializer, Property.DefaultValue.GetBool());
+        break;
+    case ReplicatedValueType::Vector2:
+        SerializeVec2Property(Serializer, Property.DefaultValue.GetVector2());
+        break;
+    case ReplicatedValueType::Vector3:
+        SerializeVec3Property(Serializer, Property.DefaultValue.GetVector3());
+        break;
+    case ReplicatedValueType::Vector4:
+        SerializeVec4Property(Serializer, Property.DefaultValue.GetVector4());
+        break;
+    default:
+        break;
+    }
+}
+
+void ToJson(csp::json::JsonSerializer& Serializer, const ComponentSchema& Schema)
+{
+    Serializer.SerializeMember("typeId", Schema.TypeId);
+    Serializer.SerializeMember("name", Schema.Name);
+    Serializer.SerializeMember("properties", Schema.Properties);
+}
+
+csp::common::String ComponentSchema::ToJson(const ComponentSchema& Schema) { return csp::json::JsonSerializer::Serialize(Schema); }
+
+csp::common::Optional<ComponentSchema> ComponentSchema::FromJson(const csp::common::String& Json)
+{
+    auto Doc = rapidjson::Document {};
+    Doc.Parse(Json.c_str());
+
+    if (Doc.HasParseError())
+    {
+        return {};
+    }
+
+    const auto Schema = TryParseSchema(Doc);
+
+    if (!Schema)
+    {
+        return {};
+    }
+
+    return *Schema;
+}
 
 bool ComponentSchema::operator==(const ComponentSchema& Other) const
 {

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CSP/Multiplayer/ComponentSchema.h"
+
+namespace csp::multiplayer
+{
+
+bool ComponentSchema::operator==(const ComponentSchema& Other) const
+{
+    return TypeId == Other.TypeId && Name == Other.Name && Properties == Other.Properties;
+}
+
+bool ComponentSchema::operator!=(const ComponentSchema& Other) const { return !(*this == Other); }
+
+} // namespace csp::multiplayer

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -19,6 +19,7 @@
 #include "Common/Convert.h"
 #include "Json/JsonSerializer.h"
 
+#include <fmt/format.h>
 #include <rapidjson/document.h>
 
 #include <algorithm>
@@ -216,30 +217,55 @@ namespace
         return std::nullopt;
     }
 
-    std::optional<ComponentProperty> TryParseProperty(const rapidjson::Value& Value)
+    std::optional<ComponentProperty> TryParseProperty(const rapidjson::Value& Value, csp::common::LogSystem* LogSystem = nullptr)
     {
         if (!Value.IsObject())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: not a JSON object");
+            }
+
             return std::nullopt;
         }
 
         if (!Value.HasMember("key") || !Value["key"].IsUint())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: 'key' must be an unsigned integer");
+            }
+
             return std::nullopt;
         }
 
         if (!Value.HasMember("name") || !Value["name"].IsString())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: 'name' must be a string");
+            }
+
             return std::nullopt;
         }
 
         if (!Value.HasMember("type") || !Value["type"].IsString())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: 'type' must be a string");
+            }
+
             return std::nullopt;
         }
 
         if (!Value.HasMember("defaultValue"))
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: missing 'defaultValue'");
+            }
+
             return std::nullopt;
         }
 
@@ -250,6 +276,12 @@ namespace
 
         if (!DefaultValue)
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(
+                    csp::common::LogLevel::Warning, fmt::format("TryParseProperty: 'defaultValue' is not valid for type '{}'", Type).c_str());
+            }
+
             return std::nullopt;
         }
 
@@ -260,13 +292,14 @@ namespace
         };
     }
 
-    std::optional<csp::common::Array<ComponentProperty>> TryParseProperties(rapidjson::Value::ConstArray JsonProperties)
+    std::optional<csp::common::Array<ComponentProperty>> TryParseProperties(
+        rapidjson::Value::ConstArray JsonProperties, csp::common::LogSystem* LogSystem = nullptr)
     {
         auto Properties = std::vector<ComponentProperty> {};
 
         for (const auto& Element : JsonProperties)
         {
-            const auto Property = TryParseProperty(Element);
+            const auto Property = TryParseProperty(Element, LogSystem);
 
             if (!Property)
             {
@@ -279,29 +312,49 @@ namespace
         return csp::common::Convert(Properties);
     }
 
-    std::optional<ComponentSchema> TryParseSchema(const rapidjson::Value& Value)
+    std::optional<ComponentSchema> TryParseSchema(const rapidjson::Value& Value, csp::common::LogSystem* LogSystem = nullptr)
     {
         if (!Value.IsObject())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseSchema: not a JSON object");
+            }
+
             return std::nullopt;
         }
 
         if (!Value.HasMember("typeId") || !Value["typeId"].IsUint64())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseSchema: 'typeId' must be a uint64");
+            }
+
             return std::nullopt;
         }
 
         if (!Value.HasMember("name") || !Value["name"].IsString())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseSchema: 'name' must be a string");
+            }
+
             return std::nullopt;
         }
 
         if (!Value.HasMember("properties") || !Value["properties"].IsArray())
         {
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseSchema: 'properties' must be an array");
+            }
+
             return std::nullopt;
         }
 
-        const auto Properties = TryParseProperties(Value["properties"].GetArray());
+        const auto Properties = TryParseProperties(Value["properties"].GetArray(), LogSystem);
 
         if (!Properties)
         {
@@ -393,13 +446,13 @@ csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
 
         if (Doc.HasParseError() || !Doc.IsArray())
         {
-            LogSystem.LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping document, expected a JSON array");
+            LogSystem.LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping document, expected a top-level JSON array");
             continue;
         }
 
         for (const auto& Element : Doc.GetArray())
         {
-            const auto Schema = TryParseSchema(Element);
+            const auto Schema = TryParseSchema(Element, &LogSystem);
 
             if (!Schema)
             {

--- a/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
@@ -19,6 +19,7 @@
 #include "CSP/Common/SharedConstants.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Multiplayer/CSPSceneDescription.h"
+#include "CSP/Multiplayer/ComponentSchema.h"
 #include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
 #include "Common/UUIDGenerator.h"
@@ -86,7 +87,13 @@ namespace
 
 OfflineRealtimeEngine::OfflineRealtimeEngine(
     const CSPSceneDescription& SceneDescription, csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner)
-    : OfflineRealtimeEngine(LogSystem, RemoteScriptRunner)
+    : OfflineRealtimeEngine(SceneDescription, LogSystem, RemoteScriptRunner, {})
+{
+}
+
+OfflineRealtimeEngine::OfflineRealtimeEngine(const CSPSceneDescription& SceneDescription, csp::common::LogSystem& LogSystem,
+    csp::common::IJSScriptRunner& RemoteScriptRunner, const csp::common::List<csp::common::String>& JsonSchemas)
+    : OfflineRealtimeEngine(LogSystem, RemoteScriptRunner, JsonSchemas)
 {
     std::scoped_lock EntitiesLocker(EntitiesLock);
 
@@ -107,7 +114,13 @@ OfflineRealtimeEngine::OfflineRealtimeEngine(
 }
 
 OfflineRealtimeEngine::OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner)
-    : OfflineRealtimeEngine(LogSystem, RemoteScriptRunner, {})
+    : OfflineRealtimeEngine(LogSystem, RemoteScriptRunner, csp::common::Array<ComponentSchema> {})
+{
+}
+
+OfflineRealtimeEngine::OfflineRealtimeEngine(
+    csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner, const csp::common::List<csp::common::String>& JsonSchemas)
+    : OfflineRealtimeEngine(LogSystem, RemoteScriptRunner, ComponentSchemasFromJson(JsonSchemas, LogSystem))
 {
 }
 

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
+#include "CSP/Multiplayer/ComponentSchema.h"
 
 #include "CSP/Common/List.h"
 #include "CSP/Common/LoginState.h"
@@ -183,7 +184,14 @@ OnlineRealtimeEngine::OnlineRealtimeEngine()
 
 OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
     csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& ScriptRunner)
-    : OnlineRealtimeEngine(InMultiplayerConnection, LogSystem, NetworkEventBus, ScriptRunner, {})
+    : OnlineRealtimeEngine(InMultiplayerConnection, LogSystem, NetworkEventBus, ScriptRunner, csp::common::Array<ComponentSchema> {})
+{
+}
+
+OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
+    csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& ScriptRunner,
+    const csp::common::List<csp::common::String>& JsonSchemas)
+    : OnlineRealtimeEngine(InMultiplayerConnection, LogSystem, NetworkEventBus, ScriptRunner, ComponentSchemasFromJson(JsonSchemas, LogSystem))
 {
 }
 

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -876,3 +876,378 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, ComponentSchemaEquality)
         EXPECT_NE(A, B);
     }
 }
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonParsesAllPropertyTypes)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123,
+        "name": "Example",
+        "properties": [
+            {
+                "key": 0,
+                "name": "stringProperty",
+                "type": "string",
+                "defaultValue": "hello"
+            },
+            {
+                "key": 1,
+                "name": "floatProperty",
+                "type": "float",
+                "defaultValue": 1.5
+            },
+            {
+                "key": 2,
+                "name": "intProperty",
+                "type": "int",
+                "defaultValue": 42
+            },
+            {
+                "key": 3,
+                "name": "boolProperty",
+                "type": "bool",
+                "defaultValue": true
+            },
+            {
+                "key": 4,
+                "name": "vec2Property",
+                "type": "vec2",
+                "defaultValue": [1.0, 2.0]
+            },
+            {
+                "key": 5,
+                "name": "vec3Property",
+                "type": "vec3",
+                "defaultValue": [1.0, 2.0, 3.0]
+            },
+            {
+                "key": 6,
+                "name": "vec4Property",
+                "type": "vec4",
+                "defaultValue": [1.0, 2.0, 3.0, 4.0]
+            }
+        ]
+    })";
+
+    const auto Expected = Schema {
+        Schema::TypeIdType { 123 },
+        "Example",
+        {
+            {
+                0,
+                "stringProperty",
+                csp::common::String { "hello" },
+            },
+            {
+                1,
+                "floatProperty",
+                1.5f,
+            },
+            {
+                2,
+                "intProperty",
+                int64_t { 42 },
+            },
+            {
+                3,
+                "boolProperty",
+                true,
+            },
+            {
+                4,
+                "vec2Property",
+                csp::common::Vector2 { 1.0f, 2.0f },
+            },
+            {
+                5,
+                "vec3Property",
+                csp::common::Vector3 { 1.0f, 2.0f, 3.0f },
+            },
+            {
+                6,
+                "vec4Property",
+                csp::common::Vector4 { 1.0f, 2.0f, 3.0f, 4.0f },
+            },
+        },
+    };
+
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+
+    ASSERT_TRUE(Result.HasValue());
+    EXPECT_EQ(*Result, Expected);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, JsonSerializationRoundTrip)
+{
+    const auto Original = Schema {
+        Schema::TypeIdType { 123 },
+        "Example",
+        {
+            {
+                0,
+                "stringProperty",
+                "value",
+            },
+        },
+    };
+
+    const auto Json = Schema::ToJson(Original);
+    const auto Result = Schema::FromJson(Json);
+
+    ASSERT_TRUE(Result.HasValue());
+    EXPECT_EQ(*Result, Original);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonAcceptsSchemaWithNoProperties)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123,
+        "name": "Example",
+        "properties": []
+    })";
+
+    const auto Expected = Schema {
+        Schema::TypeIdType { 123 },
+        "Example",
+        {},
+    };
+
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+
+    ASSERT_TRUE(Result.HasValue());
+    EXPECT_EQ(*Result, Expected);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsNonJsonInput)
+{
+    constexpr auto RawJson = R"(not json)";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsEmptyString)
+{
+    const auto Result = Schema::FromJson(csp::common::String { "" });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsMissingTypeId)
+{
+    constexpr auto RawJson = R"({ "name": "Example", "properties": [] })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsMissingName)
+{
+    constexpr auto RawJson = R"({ "typeId": 123, "properties": [] })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsMissingProperties)
+{
+    constexpr auto RawJson = R"({ "typeId": 123, "name": "Example" })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsNonNumericTypeId)
+{
+    constexpr auto RawJson = R"({ "typeId": "123", "name": "Example", "properties": [] })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsNonStringName)
+{
+    constexpr auto RawJson = R"({ "typeId": 123, "name": 42, "properties": [] })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsNonArrayProperties)
+{
+    constexpr auto RawJson = R"({ "typeId": 123, "name": "Example", "properties": {} })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsPropertyWithMissingKey)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "name": "prop", "type": "string", "defaultValue": "hello" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsPropertyWithMissingName)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "type": "string", "defaultValue": "hello" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsPropertyWithMissingType)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "defaultValue": "hello" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsPropertyWithMissingDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "string" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsPropertyWithUnrecognisedType)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "colour", "defaultValue": "red" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsStringPropertyWithMismatchedDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "string", "defaultValue": 42 }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsFloatPropertyWithMismatchedDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "float", "defaultValue": "hello" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsIntPropertyWithMismatchedDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "int", "defaultValue": "hello" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsBoolPropertyWithMismatchedDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "bool", "defaultValue": "hello" }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec2PropertyWithMismatchedDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec2", "defaultValue": 42 }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec3PropertyWithMismatchedDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec3", "defaultValue": 42 }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec4PropertyWithMismatchedDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec4", "defaultValue": 42 }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec2PropertyWithWrongLengthDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec2", "defaultValue": [1.0] }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec3PropertyWithWrongLengthDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec3", "defaultValue": [1.0, 2.0] }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec4PropertyWithWrongLengthDefaultValue)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec4", "defaultValue": [1.0, 2.0, 3.0] }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec2PropertyWithNonNumericElements)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec2", "defaultValue": [1.0, "hello"] }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec3PropertyWithNonNumericElements)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec3", "defaultValue": [1.0, "hello", 3.0] }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec4PropertyWithNonNumericElements)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123, "name": "Example",
+        "properties": [{ "key": 0, "name": "prop", "type": "vec4", "defaultValue": [1.0, "hello", 3.0, 4.0] }]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -695,3 +695,184 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, TypedSetterReflectsInGetSchem
 
     EXPECT_EQ(SchemaValue->GetVector3(), NewPosition);
 }
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, ComponentPropertyEquality)
+{
+    using Property = csp::multiplayer::ComponentProperty;
+
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+        };
+        const auto B = Property {
+            0,
+            "name",
+            "value",
+        };
+        EXPECT_EQ(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+        };
+        const auto B = Property {
+            1,
+            "name",
+            "value",
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+        };
+        const auto B = Property {
+            0,
+            "other",
+            "value",
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+        };
+        const auto B = Property {
+            0,
+            "name",
+            "other",
+        };
+        EXPECT_NE(A, B);
+    }
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, ComponentSchemaEquality)
+{
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        EXPECT_EQ(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 456 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Other",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "value",
+                },
+            },
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "prop",
+                    "other",
+                },
+            },
+        };
+        EXPECT_NE(A, B);
+    }
+}

--- a/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OfflineRealtimeEngineTests.cpp
@@ -975,6 +975,97 @@ CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructWithComponentSch
     EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(ExampleSchemaId), nullptr);
 }
 
+CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructFromJsonWithComponentSchemas)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const auto AllPropertyTypesSchemaId = ComponentSchema::TypeIdType { 123 };
+    const auto InvalidSchemaId = ComponentSchema::TypeIdType { 789 };
+    const auto EmptySchemaId = ComponentSchema::TypeIdType { 456 };
+
+    constexpr auto RawJsonFirstFile = R"([
+        {
+            "typeId": 123,
+            "name": "AllPropertyTypesComponent",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "stringProperty",
+                    "type": "string",
+                    "defaultValue": "hello"
+                },
+                {
+                    "key": 1,
+                    "name": "floatProperty",
+                    "type": "float",
+                    "defaultValue": 1.5
+                },
+                {
+                    "key": 2,
+                    "name": "intProperty",
+                    "type": "int",
+                    "defaultValue": 42
+                },
+                {
+                    "key": 3,
+                    "name": "boolProperty",
+                    "type": "bool",
+                    "defaultValue": true
+                },
+                {
+                    "key": 4,
+                    "name": "vec2Property",
+                    "type": "vec2",
+                    "defaultValue": [1.0, 2.0]
+                },
+                {
+                    "key": 5,
+                    "name": "vec3Property",
+                    "type": "vec3",
+                    "defaultValue": [1.0, 2.0, 3.0]
+                },
+                {
+                    "key": 6,
+                    "name": "vec4Property",
+                    "type": "vec4",
+                    "defaultValue": [1.0, 2.0, 3.0, 4.0]
+                }
+            ]
+        }
+    ])";
+
+    constexpr auto RawJsonThirdFile = R"([
+        {
+            "typeId": 789,
+            "name": "InvalidComponent",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "missingTypeProperty",
+                    "defaultValue": "hello"
+                }
+            ]
+        },
+        {
+            "typeId": 456,
+            "name": "EmptyComponent",
+            "properties": []
+        }
+    ])";
+
+    const auto JsonSchemas = csp::common::List<csp::common::String> {
+        csp::common::String { RawJsonFirstFile },
+        csp::common::String { "this is not json at all" },
+        csp::common::String { RawJsonThirdFile },
+    };
+
+    const auto Engine = OfflineRealtimeEngine { *SystemsManager.GetLogSystem(), *SystemsManager.GetScriptSystem(), JsonSchemas };
+
+    EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(AllPropertyTypesSchemaId), nullptr);
+    EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(EmptySchemaId), nullptr);
+    EXPECT_EQ(Engine.GetComponentSchemaRegistry()->Find(InvalidSchemaId), nullptr);
+}
+
 CSP_PUBLIC_TEST(CSPEngine, OfflineRealtimeEngineTests, ConstructWithComponentSchemaBuiltInComponentTakesPrecedence)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();

--- a/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
@@ -672,3 +672,100 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, ConstructWithCo
 
     EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(ExampleSchemaId), nullptr);
 }
+
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, ConstructFromJsonWithComponentSchemas)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const auto AllPropertyTypesSchemaId = ComponentSchema::TypeIdType { 123 };
+    const auto InvalidSchemaId = ComponentSchema::TypeIdType { 789 };
+    const auto EmptySchemaId = ComponentSchema::TypeIdType { 456 };
+
+    constexpr auto RawJsonFirstFile = R"([
+        {
+            "typeId": 123,
+            "name": "AllPropertyTypesComponent",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "stringProperty",
+                    "type": "string",
+                    "defaultValue": "hello"
+                },
+                {
+                    "key": 1,
+                    "name": "floatProperty",
+                    "type": "float",
+                    "defaultValue": 1.5
+                },
+                {
+                    "key": 2,
+                    "name": "intProperty",
+                    "type": "int",
+                    "defaultValue": 42
+                },
+                {
+                    "key": 3,
+                    "name": "boolProperty",
+                    "type": "bool",
+                    "defaultValue": true
+                },
+                {
+                    "key": 4,
+                    "name": "vec2Property",
+                    "type": "vec2",
+                    "defaultValue": [1.0, 2.0]
+                },
+                {
+                    "key": 5,
+                    "name": "vec3Property",
+                    "type": "vec3",
+                    "defaultValue": [1.0, 2.0, 3.0]
+                },
+                {
+                    "key": 6,
+                    "name": "vec4Property",
+                    "type": "vec4",
+                    "defaultValue": [1.0, 2.0, 3.0, 4.0]
+                }
+            ]
+        }
+    ])";
+
+    constexpr auto RawJsonThirdFile = R"([
+        {
+            "typeId": 789,
+            "name": "InvalidComponent",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "missingTypeProperty",
+                    "defaultValue": "hello"
+                }
+            ]
+        },
+        {
+            "typeId": 456,
+            "name": "EmptyComponent",
+            "properties": []
+        }
+    ])";
+
+    const auto JsonSchemas = csp::common::List<csp::common::String> {
+        csp::common::String { RawJsonFirstFile },
+        csp::common::String { "this is not json at all" },
+        csp::common::String { RawJsonThirdFile },
+    };
+
+    const auto Engine = OnlineRealtimeEngine {
+        *SystemsManager.GetMultiplayerConnection(),
+        *SystemsManager.GetLogSystem(),
+        *SystemsManager.GetEventBus(),
+        *SystemsManager.GetScriptSystem(),
+        JsonSchemas,
+    };
+
+    EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(AllPropertyTypesSchemaId), nullptr);
+    EXPECT_NE(Engine.GetComponentSchemaRegistry()->Find(EmptySchemaId), nullptr);
+    EXPECT_EQ(Engine.GetComponentSchemaRegistry()->Find(InvalidSchemaId), nullptr);
+}

--- a/cmake/multiplayer_files.cmake
+++ b/cmake/multiplayer_files.cmake
@@ -68,6 +68,8 @@ set(CSP_MULTIPLAYER_PUBLIC_INCLUDES
 
 set(CSP_MULTIPLAYER_SOURCES
     ${CSP_MULTIPLAYER_SOURCE_DIR}/ComponentBase.cpp
+    ${CSP_MULTIPLAYER_SOURCE_DIR}/ComponentProperty.cpp
+    ${CSP_MULTIPLAYER_SOURCE_DIR}/ComponentSchema.cpp
     ${CSP_MULTIPLAYER_SOURCE_DIR}/ComponentSchemaRegistry.cpp
     ${CSP_MULTIPLAYER_SOURCE_DIR}/CSPSceneDescription.cpp
     ${CSP_MULTIPLAYER_SOURCE_DIR}/MCSComponentPacker.cpp


### PR DESCRIPTION
This introduces a JSON schema format for describing components, exemplified in the tests. Both engine types now accept this JSON at construction time, registering the described schemas in the engine-wide registry. Constructors accepting `Array<ComponentSchema>` directly are also exposed, though it is worth discussing whether JSON should be the sole interface, including for registry introspection, as programmatic construction of `ComponentSchema` is likely to be more awkward than raw JSON particularly in JavaScript.

A JSON Schema definition for the format would be a useful follow-up to enable editor tooling support.           
  
So, following this clients can inject and use entirely new components. However, modifying or extending existing built-in components is not yet supported, as we conservatively instantiate hardcoded component classes for legacy
TypeIds to ensure their existing behaviour is preserved. We'll need to address this in follow up work, as that is surely the more common use case.

More info in the individual commits.