### PR TITLE
[NT-0] refac: Move DateTime header to includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file. For compile
 - [OB-5368] fix!: Guard access to LoginState data with a mutex. By @MAG-AdamThorn.
   The Login, Logout and Refresh Token response handlers access the LoginState object on different threads which was resulting in loginstate data race conditions. In addition the LoginState object was being passed to the response handlers by value, which resulted in the LoginState being destroyed when CSP was torn down while callbacks were still in flight. To resolve this issue the LoginState data members have been moved to a new LoginStateData class, and access to it is controlled via a mutex guard. In addition a copy of the LoginState shared_ptr is now captured by the response handler callbacks to ensure it's lifetime persists for the duration of the callback.
 
+### 💫 💥 Code Refactors
+- [NT-0] refac: Move Datetime header from source to public includes directory. By @MAG-AdamThorn
 
 ## [6.42.0]
 

--- a/Library/include/CSP/Common/DateTime.h
+++ b/Library/include/CSP/Common/DateTime.h
@@ -20,11 +20,6 @@
 #include "CSP/Common/String.h"
 
 #include <chrono>
-#include <ctime>
-#include <string>
-
-PRAGMA_WARNING_PUSH()
-PRAGMA_WARNING_IGNORE_MSVC(4996) // gmtime/localtime unsafe warnings
 
 namespace csp::common
 {
@@ -36,16 +31,13 @@ public:
     using Clock = std::chrono::system_clock;
 
     /// @brief Constructs an empty DateTime.
-    DateTime() { }
+    DateTime();
 
     /// @brief Constructs a DateTime from a timepoint.
-    /// @param InTimePoint Clock::time_point : Timepoint to constuct DateTime from
-    explicit DateTime(Clock::time_point InTimePoint)
-        : TimePoint(InTimePoint)
-    {
-    }
+    /// @param InTimePoint Clock::time_point : Timepoint to construct DateTime from
+    explicit DateTime(Clock::time_point InTimePoint);
 
-    /// @ brief Constructs a DateTime from a date string.
+    /// @brief Constructs a DateTime from a date string.
     ///
     /// The string parameter is expected to be of the ISO 8601 format YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
     /// where:
@@ -58,70 +50,32 @@ public:
     /// s    = one or more digits representing a decimal fraction of a second
     /// TZD  = time zone designator (Z or +hh:mm or -hh:mm)
     ///
-    /// @param DateString const csp::common::String& : Date string to constuct DateTime from.
+    /// @param DateString const csp::common::String& : Date string to construct DateTime from.
     explicit DateTime(const String& DateString);
 
     /// @brief Constructs a DateTime with the current utc time.
-    static DateTime TimeNow() { return DateTime(Clock::now()); }
+    static DateTime TimeNow();
 
-    /// @brief Constructs a Datetime with the current time.
+    /// @brief Constructs a DateTime with the current time.
     /// @return DateTime
-    static DateTime UtcTimeNow()
-    {
-        DateTime DateTimeNow;
-
-        time_t Now = time(0);
-        tm* Gmtm = gmtime(&Now);
-
-        if (Gmtm != nullptr)
-        {
-            std::string TimeString;
-            TimeString = std::to_string(1900 + Gmtm->tm_year);
-            TimeString += "-";
-            TimeString += std::to_string(Gmtm->tm_mon + 1);
-            TimeString += "-";
-            TimeString += std::to_string(Gmtm->tm_mday);
-            TimeString += "T";
-            TimeString += std::to_string(Gmtm->tm_hour);
-            TimeString += ":";
-            TimeString += std::to_string(Gmtm->tm_min);
-            TimeString += ":";
-            TimeString += std::to_string(Gmtm->tm_sec);
-            TimeString += ".";
-            TimeString += "0+";
-            TimeString += "00:00";
-
-            DateTimeNow = DateTime(String(TimeString.c_str()));
-        }
-
-        return DateTimeNow;
-    }
+    static DateTime UtcTimeNow();
 
     /// @brief Gets the time zone, represented as 1 is UTC+1, 2 is UTC+2 etc.
     /// @return int representing timezone offset
-    static int GetTimeZone()
-    {
-        time_t Now = time(0);
-        struct tm* Lctm;
-        Lctm = localtime(&Now);
-        struct tm* Gmtm;
-        Gmtm = gmtime(&Now);
-
-        return Lctm->tm_hour - Gmtm->tm_hour;
-    }
+    static int GetTimeZone();
 
     /// @brief Checks if this DateTime represents the epoch time (0 seconds since epoch).
     /// @return bool
-    bool IsEpoch() const { return TimePoint.time_since_epoch().count() == 0; }
+    bool IsEpoch() const;
 
     /// @brief Checks if this DateTime is more recent than the Other DateTime.
     /// @param const DateTime& Other : DateTime to check against
     /// @return bool : Returns true if current DateTime is greater or equal than given DateTime
-    bool operator>=(const DateTime& Other) const { return TimePoint >= Other.TimePoint; }
+    bool operator>=(const DateTime& Other) const;
 
     /// @brief Gets the time_point from the DateTime.
     /// @return Clock::time_point&
-    const Clock::time_point& GetTimePoint() const;
+    CSP_NO_EXPORT const Clock::time_point& GetTimePoint() const;
 
     /// @brief Gets Utc string which respects ISO 8601/RFC 3339 standards.
     /// @return csp::common::String
@@ -132,5 +86,3 @@ private:
 };
 
 } // namespace csp::common
-
-PRAGMA_WARNING_POP()

--- a/Library/src/Common/DateTime.cpp
+++ b/Library/src/Common/DateTime.cpp
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 
 #include <iomanip>
 #include <sstream>
 #include <stdio.h>
+#include <string>
 
-namespace
-{
-
-#ifdef CSP_WINDOWS
-#define timegm _mkgmtime
-#endif
-
-} // namespace
+PRAGMA_WARNING_PUSH()
+PRAGMA_WARNING_IGNORE_MSVC(4996) // gmtime/localtime unsafe warnings
 
 namespace csp::common
 {
@@ -38,8 +33,7 @@ namespace csp::common
 // Based on https://stackoverflow.com/questions/530519/stdmktime-and-timezone-info.
 // Note - we rely on the `Time` parameter that is passed adhering to the cpp spec
 // https://en.cppreference.com/w/c/chrono/tm.
-
-time_t CSPTimeGM(struct tm* Time)
+static time_t CSPTimeGM(struct tm* Time)
 {
     // note - we use this constant array for calculating days into the year instead of
     // relying on tm::tm_yday, as we expect calling code to more reliably provide values for `tm::tm_mon`
@@ -74,6 +68,13 @@ time_t CSPTimeGM(struct tm* Time)
     }
 
     return Result;
+}
+
+DateTime::DateTime() { }
+
+DateTime::DateTime(Clock::time_point InTimePoint)
+    : TimePoint(InTimePoint)
+{
 }
 
 DateTime::DateTime(const csp::common::String& DateString)
@@ -114,7 +115,67 @@ DateTime::DateTime(const csp::common::String& DateString)
     TimePoint = std::chrono::system_clock::from_time_t(Time);
 }
 
-const DateTime::Clock::time_point& DateTime::GetTimePoint() const { return TimePoint; }
+DateTime DateTime::TimeNow()
+{
+    return DateTime(Clock::now());
+}
+
+DateTime DateTime::UtcTimeNow()
+{
+    DateTime DateTimeNow;
+
+    time_t Now = time(0);
+    tm* Gmtm = gmtime(&Now);
+
+    if (Gmtm != nullptr)
+    {
+        std::string TimeString;
+        TimeString = std::to_string(1900 + Gmtm->tm_year);
+        TimeString += "-";
+        TimeString += std::to_string(Gmtm->tm_mon + 1);
+        TimeString += "-";
+        TimeString += std::to_string(Gmtm->tm_mday);
+        TimeString += "T";
+        TimeString += std::to_string(Gmtm->tm_hour);
+        TimeString += ":";
+        TimeString += std::to_string(Gmtm->tm_min);
+        TimeString += ":";
+        TimeString += std::to_string(Gmtm->tm_sec);
+        TimeString += ".";
+        TimeString += "0+";
+        TimeString += "00:00";
+
+        DateTimeNow = DateTime(String(TimeString.c_str()));
+    }
+
+    return DateTimeNow;
+}
+
+int DateTime::GetTimeZone()
+{
+    time_t Now = time(0);
+    struct tm* Lctm;
+    Lctm = localtime(&Now);
+    struct tm* Gmtm;
+    Gmtm = gmtime(&Now);
+
+    return Lctm->tm_hour - Gmtm->tm_hour;
+}
+
+bool DateTime::IsEpoch() const
+{
+    return TimePoint.time_since_epoch().count() == 0;
+}
+
+bool DateTime::operator>=(const DateTime& Other) const
+{
+    return TimePoint >= Other.TimePoint;
+}
+
+const DateTime::Clock::time_point& DateTime::GetTimePoint() const
+{
+    return TimePoint;
+}
 
 csp::common::String DateTime::GetUtcString() const
 {
@@ -129,3 +190,5 @@ csp::common::String DateTime::GetUtcString() const
 }
 
 } // namespace csp::common
+
+PRAGMA_WARNING_POP()

--- a/Library/src/Common/LoginStateData.h
+++ b/Library/src/Common/LoginStateData.h
@@ -20,7 +20,7 @@
 #include "CSP/Common/Settings.h"
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Common/String.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 
 #include <memory>
 

--- a/Library/src/Common/Scheduler.h
+++ b/Library/src/Common/Scheduler.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 
 #include <assert.h>
 #include <chrono>

--- a/Library/src/Common/Web/HttpAuth.h
+++ b/Library/src/Common/Web/HttpAuth.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "CSP/Common/String.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 
 namespace csp::web
 {

--- a/Library/src/Systems/Conversation/ConversationSystemHelpers.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemHelpers.cpp
@@ -19,7 +19,7 @@
 #include "CSP/Common/StringFormat.h"
 #include "CSP/Multiplayer/Conversation/Conversation.h"
 #include "CSP/Systems/Assets/AssetCollection.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "Debug/Logging.h"
 
 namespace csp::systems::ConversationSystemHelpers

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -21,7 +21,7 @@
 #include "CSP/Common/Settings.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "CSP/Systems/Users/UserSystem.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "Debug/Logging.h"
 #include "Events/EventSystem.h"
 #include "Services/AggregationService/Api.h"

--- a/Library/src/Web/RemoteFileManager.h
+++ b/Library/src/Web/RemoteFileManager.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "CSP/Common/CancellationToken.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "Common/Web/WebClient.h"
 #include "Services/PrototypeService/AssetFileDto.h"
 

--- a/Tests/src/InternalTests/SchedulerTests.cpp
+++ b/Tests/src/InternalTests/SchedulerTests.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "Common/Scheduler.h"
 #include "TestHelpers.h"
 

--- a/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ConversationComponentTests.cpp
@@ -27,7 +27,7 @@
 #include "CSP/Multiplayer/SpaceEntity.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "CSP/Systems/Users/UserSystem.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "MultiplayerTestRunnerProcess.h"
 #include "RAIIMockLogger.h"
 #include "TestHelpers.h"

--- a/Tests/src/PublicAPITests/DateTimeTests.cpp
+++ b/Tests/src/PublicAPITests/DateTimeTests.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "TestHelpers.h"
 
 #include "gtest/gtest.h"

--- a/Tests/src/PublicAPITests/MaintenanceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/MaintenanceSystemTests.cpp
@@ -18,7 +18,7 @@
 #include "CSP/CSPFoundation.h"
 #include "CSP/Systems/Maintenance/MaintenanceSystem.h"
 #include "CSP/Systems/SystemsManager.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "SpaceSystemTestHelpers.h"
 #include "TestHelpers.h"
 #include "UserSystemTestHelpers.h"

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -22,7 +22,7 @@
 #include "CSP/Systems/SystemsManager.h"
 #include "CSP/Systems/Users/Profile.h"
 #include "CSP/Systems/Users/UserSystem.h"
-#include "Common/DateTime.h"
+#include "CSP/Common/DateTime.h"
 #include "Common/LoginStateData.h"
 #include "Common/Web/HttpPayload.h"
 #include "RAIIMockLogger.h"


### PR DESCRIPTION
I would like to be able to include datetime in a public header file but am currently unable to do so. This change moves the datetime.h file to the public includes folder.

The motivation for this change is a desire to move the `LoginStateData` header from the source file. It currently exposes the `DateTime` by value. I cannot make the member in LoginStateData a pointer as it is being constructed with the LoginStateData ctor and updating the ctor to take it as an argument would complicate the lifetime management story.