### PR TITLE
[OB-5368] fix: Address forward declaration issue

### DIFF
--- a/Library/include/CSP/Common/LoginState.h
+++ b/Library/include/CSP/Common/LoginState.h
@@ -44,11 +44,12 @@ public:
     /// @brief Get a thread-safe copy of the current login state data.
     /// This is a snapshot of the data at the time of the call, and will not update if the underlying state is mutated.
     /// @return A snapshot of the login state data.
-    CSP_NO_EXPORT LoginStateData GetSnapshotThreadSafe() const;
+    CSP_NO_EXPORT std::unique_ptr<LoginStateData> GetSnapshotThreadSafe() const;
 
     /// @brief Set the login state data while guarded by a mutex lock. This will replace all existing data in the login state with the new data
     /// provided.
-    CSP_NO_EXPORT void SetLoginStateDataThreadSafe(csp::common::LoginStateData NewData);
+    /// @param NewData : The new login state data to set.
+    CSP_NO_EXPORT void SetLoginStateDataThreadSafe(const csp::common::LoginStateData& NewData);
 
     /// @brief Attempt to set the login state to LoginRequested if the current state is LoggedOut.
     /// This will prevent multiple concurrent login attempts through use of a mutex guard.
@@ -61,12 +62,15 @@ public:
     CSP_NO_EXPORT bool TrySetLogoutRequested();
 
     /// @brief Construct a new default login state object after a failed login/logout attempt with the specified ELoginState value.
+    /// @param LoginState : The ELoginState the LoginStateData object should have after reinitialization.
     CSP_NO_EXPORT void ReinitializeResponseLoginState(csp::common::ELoginState LoginState);
 
     /// @brief Update the access token expiry time.
+    /// @param AccessTokenExpiryLength : The new access token expiry time length to set.
     CSP_NO_EXPORT void UpdateAccessTokenExpiry(csp::common::String AccessTokenExpiryLength);
 
     /// @brief Update the refresh token expiry time.
+    /// @param RefreshTokenExpiryLength : The new refresh token expiry time length to set.
     CSP_NO_EXPORT void UpdateRefreshTokenExpiry(csp::common::String RefreshTokenExpiryLength);
 
     /// @brief Check if the access token for the login is expired.

--- a/Library/src/Common/LoginState.cpp
+++ b/Library/src/Common/LoginState.cpp
@@ -39,18 +39,25 @@ LoginState& LoginState::operator=(const LoginState& OtherState)
     return *this;
 }
 
-LoginStateData LoginState::GetSnapshotThreadSafe() const
+std::unique_ptr<LoginStateData> LoginState::GetSnapshotThreadSafe() const
 {
     std::scoped_lock lock(LoginStateMutex);
 
-    return *Data;
+    return std::make_unique<LoginStateData>(*Data);
 }
 
-void LoginState::SetLoginStateDataThreadSafe(LoginStateData NewData)
+void LoginState::SetLoginStateDataThreadSafe(const csp::common::LoginStateData& NewData)
 {
     std::scoped_lock lock(LoginStateMutex);
 
-    *Data = std::move(NewData);
+    if (Data == nullptr)
+    {
+        Data = std::make_unique<LoginStateData>(NewData);
+
+        return;
+    }
+    
+    *Data = NewData;
 }
 
 bool LoginState::TrySetLoginRequested()

--- a/Library/src/Systems/Quota/QuotaSystem.cpp
+++ b/Library/src/Systems/Quota/QuotaSystem.cpp
@@ -53,9 +53,9 @@ QuotaSystem::~QuotaSystem()
 
 void QuotaSystem::GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback)
 {
-    auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
+    const auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
 
-    if (Data.State != common::ELoginState::LoggedIn)
+    if (Data->State != common::ELoginState::LoggedIn)
     {
         LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetTotalSpacesOwnedByUser: User is not logged in. Aborting operation.");
         Callback(MakeInvalid<FeatureLimitResult>());
@@ -67,7 +67,7 @@ void QuotaSystem::GetTotalSpacesOwnedByUser(FeatureLimitCallback Callback)
     csp::services::ResponseHandlerPtr ResponseHandler = QuotaManagementAPI->CreateHandler<FeatureLimitCallback, FeatureLimitResult, void,
         csp::services::DtoArray<chs::QuotaFeatureLimitProgressDto>>(Callback, nullptr);
 
-    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->usersUserIdQuota_progressGet({ Data.UserId, FeatureNamesList }, ResponseHandler);
+    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->usersUserIdQuota_progressGet({ Data->UserId, FeatureNamesList }, ResponseHandler);
 }
 
 void QuotaSystem::GetConcurrentUsersInSpace(const csp::common::String& SpaceId, FeatureLimitCallback Callback)
@@ -92,9 +92,9 @@ void QuotaSystem::GetTotalSpaceSizeInKilobytes(const csp::common::String& SpaceI
 
 void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFeatures>& FeatureNames, FeaturesLimitCallback Callback)
 {
-    auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
+    const auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
 
-    if (Data.State != common::ELoginState::LoggedIn)
+    if (Data->State != common::ELoginState::LoggedIn)
     {
         LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetTierFeatureProgressForUser: User is not logged in. Aborting operation.");
         Callback(MakeInvalid<FeaturesLimitResult>());
@@ -112,7 +112,7 @@ void QuotaSystem::GetTierFeatureProgressForUser(const csp::common::Array<TierFea
         FeatureNamesList.push_back(TierFeatureEnumToString(FeatureNames[idx]));
     }
 
-    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->usersUserIdQuota_progressGet({ Data.UserId, FeatureNamesList }, ResponseHandler);
+    static_cast<chs::QuotaActivityApi*>(QuotaManagementAPI)->usersUserIdQuota_progressGet({ Data->UserId, FeatureNamesList }, ResponseHandler);
 }
 
 void QuotaSystem::GetTierFeatureProgressForSpace(
@@ -134,9 +134,9 @@ void QuotaSystem::GetTierFeatureProgressForSpace(
 
 void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
 {
-    auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
+    const auto Data = Context->GetLoginState().GetSnapshotThreadSafe();
 
-    if (Data.State != common::ELoginState::LoggedIn)
+    if (Data->State != common::ELoginState::LoggedIn)
     {
         LogSystem->LogMsg(common::LogLevel::Warning, "QuotaSystem::GetCurrentUserTier: User is not logged in. Aborting operation.");
         Callback(MakeInvalid<UserTierResult>());
@@ -146,7 +146,7 @@ void QuotaSystem::GetCurrentUserTier(UserTierCallback Callback)
     csp::services::ResponseHandlerPtr ResponseHandler
         = QuotaTierAssignmentAPI->CreateHandler<UserTierCallback, UserTierResult, void, chs::QuotaTierAssignmentDto>(Callback, nullptr);
 
-    static_cast<chs::QuotaTierAssignmentApi*>(QuotaTierAssignmentAPI)->usersUserIdTier_assignmentGet({ Data.UserId }, ResponseHandler);
+    static_cast<chs::QuotaTierAssignmentApi*>(QuotaTierAssignmentAPI)->usersUserIdTier_assignmentGet({ Data->UserId }, ResponseHandler);
 }
 
 void QuotaSystem::SetUserTier(TierNames TierName, const csp::common::String& UserId, UserTierCallback Callback)

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -60,7 +60,7 @@ void StartMultiplayerConnection(csp::multiplayer::MultiplayerConnection& Multipl
         LogSystem.LogMsg(csp::common::LogLevel::Log, "Starting Multiplayer Connection");
 
         const auto Data = LoginStateRes.GetLoginState().GetSnapshotThreadSafe();
-        MultiplayerConnection.Connect(ConnectionCallback, MultiplayerURI, Data.AccessToken, Data.DeviceId);
+        MultiplayerConnection.Connect(ConnectionCallback, MultiplayerURI, Data->AccessToken, Data->DeviceId);
     }
     else
     {
@@ -230,20 +230,20 @@ const csp::common::LoginState& AuthContext::GetLoginState() const { return *Logi
 
 void AuthContext::RefreshToken(std::function<void(bool)> Callback)
 {
-    auto Data = LoginState->GetSnapshotThreadSafe();
-    if (Data.State != csp::common::ELoginState::LoggedIn)
+    const auto Data = LoginState->GetSnapshotThreadSafe();
+    if (Data->State != csp::common::ELoginState::LoggedIn)
     {
         return;
     }
 
     auto Request = std::make_shared<chs_user::RefreshRequest>();
     Request->SetDeviceId(csp::CSPFoundation::GetDeviceId());
-    Request->SetUserId(Data.UserId);
-    Request->SetRefreshToken(Data.RefreshToken);
+    Request->SetUserId(Data->UserId);
+    Request->SetRefreshToken(Data->RefreshToken);
 
     auto Options = std::make_shared<chs_user::TokenOptions>();
-    Options->SetExpiryLength(Data.AccessTokenExpiryLength);
-    Options->SetRefreshTokenExpiryLength(Data.RefreshTokenExpiryLength);
+    Options->SetExpiryLength(Data->AccessTokenExpiryLength);
+    Options->SetRefreshTokenExpiryLength(Data->RefreshTokenExpiryLength);
     Request->SetTokenOptions(Options);
 
     // LoginState captured by value in callback below. This ensures the shared_ptr stays alive until the callback is executed via the
@@ -809,11 +809,11 @@ void UserSystem::Logout(NullResultCallback Callback)
             CSP_LOG_ERROR_FORMAT("Error disconnecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
         }
 
-        auto Data = CurrentLoginState->GetSnapshotThreadSafe();
+        const auto Data = CurrentLoginState->GetSnapshotThreadSafe();
 
         auto Request = std::make_shared<chs_user::LogoutRequest>();
-        Request->SetUserId(Data.UserId);
-        Request->SetDeviceId(Data.DeviceId);
+        Request->SetUserId(Data->UserId);
+        Request->SetDeviceId(Data->DeviceId);
 
         // CurrentLoginState captured by value in the wrapped callback below. This ensures the shared_ptr stays alive until the callback is executed
         // via the ResponseHandler.

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -28,13 +28,13 @@ namespace
 {
 csp::common::Optional<csp::common::String> ConstructAuthorizationHeader(const csp::common::IAuthContext& InAuthContext)
 {
-    auto Data = InAuthContext.GetLoginState().GetSnapshotThreadSafe();
+    const auto Data = InAuthContext.GetLoginState().GetSnapshotThreadSafe();
 
     csp::common::Optional<csp::common::String> BearerToken;
 
-    if (Data.State == csp::common::ELoginState::LoggedIn)
+    if (Data->State == csp::common::ELoginState::LoggedIn)
     {
-        csp::common::String AccessToken = Data.AccessToken;
+        csp::common::String AccessToken = Data->AccessToken;
         BearerToken = csp::common::String(fmt::format("Bearer {}", AccessToken.c_str()).c_str());
     }
 

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -52,10 +52,10 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
     // Construct a LoginState object with the correct state.
     csp::common::LoginState LoginState;
     {
-        csp::common::LoginStateData Data = LoginState.GetSnapshotThreadSafe();
-        Data.State = std::get<0>(GetParam());
-        Data.AccessToken = std::get<1>(GetParam());
-        LoginState.SetLoginStateDataThreadSafe(Data);
+        const auto Data = LoginState.GetSnapshotThreadSafe();
+        Data->State = std::get<0>(GetParam());
+        Data->AccessToken = std::get<1>(GetParam());
+        LoginState.SetLoginStateDataThreadSafe(*Data);
     }
 
     EXPECT_CALL(MockClient, SendRequest)
@@ -113,10 +113,10 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
     // Construct a LoginState object with the correct state.
     csp::common::LoginState LoginState;
     {
-        csp::common::LoginStateData Data = LoginState.GetSnapshotThreadSafe();
-        Data.State = std::get<0>(GetParam());
-        Data.AccessToken = std::get<1>(GetParam());
-        LoginState.SetLoginStateDataThreadSafe(Data);
+        const auto Data = LoginState.GetSnapshotThreadSafe();
+        Data->State = std::get<0>(GetParam());
+        Data->AccessToken = std::get<1>(GetParam());
+        LoginState.SetLoginStateDataThreadSafe(*Data);
     }
 
     EXPECT_CALL(MockClient, SendRequest)

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -1443,23 +1443,23 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginStateMutexGuardTest)
     EXPECT_EQ(LogoutResultCode, csp::systems::EResultCode::Success);
 
     // The LoginState must be in a valid state, not partially overwritten by concurrent writes from the two response handlers.
-    auto Data = UserSystem->GetLoginState().GetSnapshotThreadSafe();
+    const auto Data = UserSystem->GetLoginState().GetSnapshotThreadSafe();
 
-    const csp::common::ELoginState FinalState = Data.State;
+    const csp::common::ELoginState FinalState = Data->State;
 
     if (FinalState == csp::common::ELoginState::LoggedIn)
     {
-        EXPECT_NE(Data.AccessToken, "");
-        EXPECT_NE(Data.RefreshToken, "");
-        EXPECT_NE(Data.UserId, "");
-        EXPECT_NE(Data.DeviceId, "");
+        EXPECT_NE(Data->AccessToken, "");
+        EXPECT_NE(Data->RefreshToken, "");
+        EXPECT_NE(Data->UserId, "");
+        EXPECT_NE(Data->DeviceId, "");
     }
     else if (FinalState == csp::common::ELoginState::LoggedOut || FinalState == csp::common::ELoginState::Error)
     {
-        EXPECT_EQ(Data.AccessToken, "");
-        EXPECT_EQ(Data.RefreshToken, "");
-        EXPECT_EQ(Data.UserId, "");
-        EXPECT_EQ(Data.DeviceId, "");
+        EXPECT_EQ(Data->AccessToken, "");
+        EXPECT_EQ(Data->RefreshToken, "");
+        EXPECT_EQ(Data->UserId, "");
+        EXPECT_EQ(Data->DeviceId, "");
     }
     else
     {


### PR DESCRIPTION
`LoginStateData` was being forward declared in `LoginState.h`, but this type was being returned by value via a getter as well as being taken by value in a setter. This was working because these methods were marked `NO_EXPORT` and because the internal call sites included the `LoginStateData` header.

I have addressed this issue by having the getter return a unique ptr and the setter take a const ref.

In addition I have made a couple of updates for const correctness.