### PR TITLE
[OF-1850] fix: Fix script event test

### DIFF
--- a/ThirdParty/quickjs/CMakeLists.txt
+++ b/ThirdParty/quickjs/CMakeLists.txt
@@ -57,7 +57,9 @@ target_compile_definitions(csp-quickjs
     $<$<COMPILE_LANG_AND_ID:C,Clang>:_GNU_SOURCE>
 
     # This is a CSP macro that was added to our version of the QuickJS library
-    # which Prevents QuickJS from defining methods that do stack checking.
+    # which prevents QuickJS from defining methods that do stack checking.
+    # This macro only applies to non-Emscripten and non-MSVC builds, although we have only
+    # observed this issue on Linux builds.
     # The stack checking was causing invalid stack overflow exceptions to be thrown.
     # Related to this error: https://forum.juce.com/t/stack-overflow-error-with-quickjs/67427/12
     $<$<CXX_COMPILER_ID:GNU>:CSP_DISABLE_STACK_CHECK_QJS>

--- a/ThirdParty/quickjs/CMakeLists.txt
+++ b/ThirdParty/quickjs/CMakeLists.txt
@@ -55,6 +55,13 @@ target_compile_definitions(csp-quickjs
     # Needed for glibc to expose sighandler_t in <signal.h>
     $<$<COMPILE_LANG_AND_ID:C,GNU>:_GNU_SOURCE>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:_GNU_SOURCE>
+
+    # This is a CSP macro that was added to our version of the QuickJS library
+    # which Prevents QuickJS from defining methods that do stack checking.
+    # The stack checking was causing invalid stack overflow exceptions to be thrown.
+    # Related to this error: https://forum.juce.com/t/stack-overflow-error-with-quickjs/67427/12
+    $<$<CXX_COMPILER_ID:GNU>:CSP_DISABLE_STACK_CHECK_QJS>
+
   PUBLIC
     JS_STRICT_NAN_BOXING
 )

--- a/ThirdParty/quickjs/src/quickjs.c
+++ b/ThirdParty/quickjs/src/quickjs.c
@@ -75,7 +75,7 @@
 #define CONFIG_ATOMICS
 #endif
 
-#if !defined(EMSCRIPTEN) && !defined(_MSC_VER)
+#if !defined(EMSCRIPTEN) && !defined(_MSC_VER) && !defined(CSP_DISABLE_STACK_CHECK_QJS)
 /* enable stack limitation */
 #define CONFIG_STACK_CHECK
 #endif


### PR DESCRIPTION
This was failing due to invalid exceptions being thrown from quicjs on Linux. Our theory is that this is happening de to us running scripts on different threads they were created on. We will test removing this again once we have handled our callbacks