### PR TITLE
[NT-0] ci: Branch on CSP-Development

### DIFF
--- a/.github/workflows/unity-interop-tests.yml
+++ b/.github/workflows/unity-interop-tests.yml
@@ -1,12 +1,38 @@
 name: .NET Interop Binding Integration
 
 # Run a fully integrated build of the unity bindings, based on the CSP build from the current branch.
-# If breaking changes are made, push directly to the "csp-development" branch in the connected-spaces-platform-unity repo, which represents the breaking changeset of the next release.
+# Tests run against a dedicated branch in the connected-spaces-platform-unity repo, forked from
+# "csp-development" and named after the branch that triggered the run, e.g. "csp-development-my-branch".
+# If breaking changes are made, push to that branch to unblock these tests, then manually merge it
+# back into "csp-development" once the CSP change lands.
+# This workflow requires token permissions to create a branch, so will not run from forks.
+
 on:
   pull_request:
   workflow_dispatch:
 
 jobs:
+
+  # Creates the per-branch binding branch from csp-development, or reuses it if it already
+  # exists (so commits contributors have pushed to it survive re-runs). Any other failure
+  # (e.g. bad credentials, missing base branch) fails the job so it isn't silently swallowed.
+  create-binding-branch:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.DOTNET_REPO_ACCESS_TOKEN }}
+      REPO: magnopus-opensource/connected-spaces-platform-unity
+      BRANCH: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+    steps:
+      # We want this job to fail for all errors except when the branch already exists.
+      # Easiest to just not try to branch in that case, rather than doing inline error management.
+      - run: |
+          if gh api "repos/$REPO/git/ref/heads/$BRANCH" --silent; then
+            echo "$BRANCH already exists, reusing it."
+          else
+            echo "Creating $BRANCH from csp-development."
+            gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" \
+              -f sha="$(gh api "repos/$REPO/git/ref/heads/csp-development" -q .object.sha)"
+          fi
 
   # Leveraging the fact that github makes a "pull/number/head" ref for PRs.
   # Doing it this way means that PRs from both branches and forks will work.
@@ -14,6 +40,7 @@ jobs:
   # it will still be in untrusted mode, and only have read only capabilities.
   # Workflow_dispatch triggers should fall through to use github.ref_name.
   run-unity-interop-layer-integration:
+    needs: create-binding-branch
     uses: magnopus-opensource/connected-spaces-platform-unity/.github/workflows/build-desktop.yml@csp-development
     with:
       unity_ext_matrix: '[false]'
@@ -22,5 +49,4 @@ jobs:
         ${{ github.event_name == 'pull_request'
             && format('refs/pull/{0}/head', github.event.pull_request.number)
             || github.ref_name }}
-      binding_repo_branch: csp-development
-
+      binding_repo_branch: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/unity-interop-tests.yml
+++ b/.github/workflows/unity-interop-tests.yml
@@ -19,20 +19,16 @@ jobs:
   create-binding-branch:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.DOTNET_REPO_ACCESS_TOKEN }}
-      REPO: magnopus-opensource/connected-spaces-platform-unity
-      BRANCH: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+      # The usual pattern to support both PR and workflow_dispatch refs
+      BRANCH_TO: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
     steps:
-      # We want this job to fail for all errors except when the branch already exists.
-      # Easiest to just not try to branch in that case, rather than doing inline error management.
-      - run: |
-          if gh api "repos/$REPO/git/ref/heads/$BRANCH" --silent; then
-            echo "$BRANCH already exists, reusing it."
-          else
-            echo "Creating $BRANCH from csp-development."
-            gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" \
-              -f sha="$(gh api "repos/$REPO/git/ref/heads/csp-development" -q .object.sha)"
-          fi
+      - uses: GuillaumeFalourd/create-other-repo-branch-action@v1.5
+        with:
+          repository_owner: magnopus-opensource
+          repository_name: connected-spaces-platform-unity
+          new_branch_name: $BRANCH_TO
+          new_branch_ref: csp-development
+          access_token: ${{ secrets.DOTNET_REPO_ACCESS_TOKEN}}
 
   # Leveraging the fact that github makes a "pull/number/head" ref for PRs.
   # Doing it this way means that PRs from both branches and forks will work.


### PR DESCRIPTION
With our strategy of just using a single branch for the unity integration tests, there was an issue if there is more then one change in flight at once. This should resolve this, albeit with the added burden of implementors needing to remember to merge their branch when done.

**Testing**
This PR itself should serve as adequate testing.

To test this, I have made a breaking change on the generated branch, reran the tests, the fixed it, and reran the tests again, to simulate the flow.

| | CSP-Action | Branch commit |
|--|--|--|
| Initial | https://github.com/magnopus-opensource/connected-spaces-platform/actions/runs/27133192199/attempts/1 | Pristine |
| Breaking Change | https://github.com/magnopus-opensource/connected-spaces-platform/actions/runs/27133192199/attempts/2 | https://github.com/magnopus-opensource/connected-spaces-platform-unity/commit/f6e4fb5f69fc54400b3bef6162666b31efceacf1 |
| Fix | https://github.com/magnopus-opensource/connected-spaces-platform/actions/runs/27133192199/attempts/3 | https://github.com/magnopus-opensource/connected-spaces-platform-unity/commit/0d6e435c8a28c1dc769a99ca7ad70963078eee71 |

You can see in the subsequent action, that the create-branch job succeeds, despite the fact that the branch already exists.