### PR TITLE
[OB-5368] fix: Guard against race conditions caused by realtime engine destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.44.0]
+
+### 🐛 🔨 Bug Fixes
+
+- [OB-5368] fix: Guard against race conditions caused by RealtimeEngine destruction. @MAG-AdamThorn.
+  The OnlineRealtimeEngine::CreateRetrieveAllEntitiesCallback method returns a callback which is used to process all Entities fetched when joining a Space. While we support paged retrieval of Entities we do not currently use that feature. This means that when entering a Space with many Entities, the callback can take a long time to execute. If during this time the OnlineRealtimeEngine is destroyed, CSP will hit an exception when trying to access it within the callback body. There are a number of potential solutions to this issue, but the situation is complicated by the fact that we:
+    1. Do not own the OnlineRealtimeEngine or manage its lifetime.
+    2. We cannot block the main thread.
+  We have work planned to introduce a task queue to shepherd callbacks to the main thread which will make this issue a lot easier to address. In the meantime this change introduces a sentinel which is checked at key points in the body of the callback. This does not address the potential for a race condition but it does limit the window within which it may occur.
 
 ## [6.43.0]
 

--- a/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
+++ b/Library/include/CSP/Multiplayer/OnlineRealtimeEngine.h
@@ -520,6 +520,9 @@ private:
 
     std::recursive_mutex* TickEntitiesLock;
     std::mutex LeadershipElectionLock;
+    // Guards against a race condition whereby the OnlineRealtimeEngine dtor is called after the SignalR thread executing the
+    // CreateRetrieveAllEntitiesCallback callback has checked the cancellation token, but BEFORE it has finished executing the callback.
+    std::shared_ptr<std::mutex> EngineLifetimeGuard;
 
     std::deque<csp::multiplayer::SpaceEntity*>* PendingAdds;
     std::deque<csp::multiplayer::SpaceEntity*>* PendingRemoves;

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -170,6 +170,7 @@ OnlineRealtimeEngine::OnlineRealtimeEngine()
     , EventHandler(nullptr)
     , ElectionManager(nullptr)
     , TickEntitiesLock(new std::recursive_mutex)
+    , EngineLifetimeGuard(std::make_shared<std::mutex>())
     , PendingAdds(nullptr)
     , PendingRemoves(nullptr)
     , PendingOutgoingUpdateUniqueSet(nullptr)
@@ -204,6 +205,7 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
     , EventHandler(new SpaceEntityEventHandler(this))
     , ElectionManager(nullptr)
     , TickEntitiesLock(new std::recursive_mutex)
+    , EngineLifetimeGuard(std::make_shared<std::mutex>())
     , PendingAdds(new(std::deque<csp::multiplayer::SpaceEntity*>))
     , PendingRemoves(new(std::deque<csp::multiplayer::SpaceEntity*>))
     , PendingOutgoingUpdateUniqueSet(new(std::set<csp::multiplayer::SpaceEntity*>))
@@ -313,8 +315,8 @@ std::function<void(uint64_t)> OnlineRealtimeEngine::CreateNewLocalAvatar(const c
          * Note also however, that we don't double fetch the network ID, which is the main cost of constructing these things anyhow.
          * (Stricter interface segregation for our serializers would also have solved this problem, but only in the local sense)
          */
-        auto NewAvatar = RealtimeEngineUtils::BuildNewAvatar(UserId, *this, *ScriptRunner, *LogSystem, NetworkId, Name,
-            Transform, IsVisible, MultiplayerConnectionInst->GetClientId(), false, false, AvatarId, AvatarState, AvatarPlayMode, LocomotionModel);
+        auto NewAvatar = RealtimeEngineUtils::BuildNewAvatar(UserId, *this, *ScriptRunner, *LogSystem, NetworkId, Name, Transform, IsVisible,
+            MultiplayerConnectionInst->GetClientId(), false, false, AvatarId, AvatarState, AvatarPlayMode, LocomotionModel);
 
         std::scoped_lock EntitiesLocker(*EntitiesLock);
         // Release to vague ownership. True ownership is blurry here. It could be shared between both Entities and Objects, or just owned by
@@ -662,9 +664,9 @@ void OnlineRealtimeEngine::OnRequestToSendObject(const signalr::value& Params)
 
 void OnlineRealtimeEngine::OnElectedScopeLeader(const signalr::value& Params)
 {
-    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by calling
-    // DisableLeadershipElection. These checks could be removed if the election events were bound inside the ScopeLeadershipManager. However, I
-    // decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
+    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by
+    // calling DisableLeadershipElection. These checks could be removed if the election events were bound inside the ScopeLeadershipManager. However,
+    // I decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
     if (LeaderElectionManager == nullptr)
     {
         return;
@@ -686,10 +688,9 @@ void OnlineRealtimeEngine::OnElectedScopeLeader(const signalr::value& Params)
 
 void OnlineRealtimeEngine::OnVacatedAsScopeLeader(const signalr::value& Params)
 {
-    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by calling
-    // DisableLeadershipElection.
-    // These checks could be removed if the election events were bound inside the ScopeLeadershipManager.
-    // However, I decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
+    // This could be nullptr if server-side leader election is enabled for the scope within the backend services, but turned off client-side by
+    // calling DisableLeadershipElection. These checks could be removed if the election events were bound inside the ScopeLeadershipManager. However,
+    // I decided to follow our standard pattern of binding to events once, inside the MultiplayerConnection initialization.
     if (LeaderElectionManager == nullptr)
     {
         return;
@@ -724,8 +725,15 @@ void OnlineRealtimeEngine::GetEntitiesPaged(int Skip, int Limit, const std::func
 std::function<void(const signalr::value&, std::exception_ptr)> OnlineRealtimeEngine::CreateRetrieveAllEntitiesCallback(
     int Skip, csp::common::EntityFetchCompleteCallback FetchCompleteCallback)
 {
-    const std::function Callback = [this, Skip, FetchCompleteCallback](const signalr::value& Result, std::exception_ptr Except)
+    const std::function Callback = [this, Skip, EngineLifetimeGuardWeak = std::weak_ptr<std::mutex>(EngineLifetimeGuard), FetchCompleteCallback](
+                                       const signalr::value& Result, std::exception_ptr Except)
     {
+        // Ensure the OnlineEngine is still alive by locking the weak pointer to the guard.
+        if (!EngineLifetimeGuardWeak.lock())
+        {
+            return;
+        }
+
         HandleException(Except, "Failed to retrieve paged entities.");
 
         const auto& Results = Result.as_array();
@@ -734,6 +742,11 @@ std::function<void(const signalr::value&, std::exception_ptr)> OnlineRealtimeEng
 
         for (const auto& EntityMessage : Items)
         {
+            if (!EngineLifetimeGuardWeak.lock())
+            {
+                return;
+            }
+
             SpaceEntity* NewEntity = CreateRemotelyRetrievedEntity(EntityMessage);
             FireRemoteSpaceEntityCreatedCallback(NewEntity, RemoteSpaceEntityCreatedCallback, *LogSystem);
         }
@@ -746,6 +759,11 @@ std::function<void(const signalr::value&, std::exception_ptr)> OnlineRealtimeEng
         }
         else
         {
+            if (!EngineLifetimeGuardWeak.lock())
+            {
+                return;
+            }
+
             std::scoped_lock EntitiesLocker(*EntitiesLock);
             // Ensure entity list is up to date
             ProcessPendingEntityOperations();
@@ -769,7 +787,15 @@ std::function<void(const signalr::value&, std::exception_ptr)> OnlineRealtimeEng
                     // We will receive these if we are the leader and another client modifies a script or sends an event.
                     this->NetworkEventBus->ListenNetworkEvent(
                         csp::multiplayer::NetworkEventRegistration { "CSPInternal::ClientElectionManager", RemoteRunScriptMessage },
-                        [this](const csp::common::NetworkEventData& EventData) { this->OnRemoteRunScriptEvent(EventData.EventValues); });
+                        [EngineLifetimeGuardWeak, this](const csp::common::NetworkEventData& EventData)
+                        {
+                            if (!EngineLifetimeGuardWeak.lock())
+                            {
+                                return;
+                            }
+                            
+                           this->OnRemoteRunScriptEvent(EventData.EventValues);
+                        });
 
                     // To match the behaviour of the client-side leader election, the ScriptSystemReadyCallback should fire here.
                     // We may want to move this to earlier in the initialization in the future.
@@ -826,7 +852,7 @@ ModifiableStatus OnlineRealtimeEngine::IsEntityModifiable(const csp::multiplayer
     // This should definitely be true at this point, but be defensive.
     assert(SpaceEntity->GetStatePatcher() != nullptr);
 
-    // In order to unlock an entity, we need to modify it. 
+    // In order to unlock an entity, we need to modify it.
     // So we need to check if we are about to unlock the entity, and treat it as modifiabe if so, otherwise we cannot unlock a locked entity.
     // Note : This will stop working if we ever add another lock type
     const bool AboutToUnlock = SpaceEntity->GetStatePatcher()->GetDirtyProperties().count(SpaceEntityComponentKey::LockType) > 0;
@@ -871,7 +897,7 @@ void OnlineRealtimeEngine::LocalDestroyAllEntities()
         // as these are only ever valid for a single connected session
         if (Entity->GetIsTransient() && Entity->GetOwnerId() == GetMultiplayerConnectionInstance()->GetClientId())
         {
-            DestroyEntity(Entity, [](bool /*Ok*/) {});
+            DestroyEntity(Entity, [](bool /*Ok*/) { });
         }
         // Otherwise we clear up all all locally represented entities
         else

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -224,6 +224,11 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
 
 OnlineRealtimeEngine::~OnlineRealtimeEngine()
 {
+    // We currently have a number of potential race conditions caused by callbacks trying to access the OnlineRealtimeEngine after it has been
+    // destroyed. The following does not resolve the race condition for callback logic executed after tear down, but it does reduce the window for
+    // those situations to arise. We have work planned for an upcoming sprint to prototype a proper solution to this issue.
+    MultiplayerConnectionInst->SetOnlineRealtimeEngine(nullptr);
+
     DisableLeaderElection();
     LocalDestroyAllEntities();
 

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -1471,3 +1471,75 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginStateMutexGuardTest)
         LogOut(UserSystem);
     }
 }
+
+// Regression test to ensure that the EntityFetchCancellationToken sentinel in the
+// OnlineRealtimeEngine prevents the RetrieveAllEntities callback from accessing a destroyed RealtimeEngine.
+//
+// This issue was occuring under the following conditions:
+//   1. A user enters a space containing many entities.
+//   2. The OnlineRealtimeEngine is destroyed before the RetrieveAllEntitiesCallback has completed.
+//   3. Entities being created in the loop try to access the LogSystem member of the OnlineRealtimeEngine causing a crash.
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, EnterSpaceTeardownDuringEntityFetchTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    csp::systems::Space Space;
+    CreateDefaultTestSpace(SpaceSystem, Space);
+
+    // Setup: Populate the Space with several SpaceEntities and then exit cleanly.
+    {
+        std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(csp::common::RealtimeEngineType::Online) };
+
+        std::atomic<bool> FetchComplete { false };
+        RealtimeEngine->SetEntityFetchCompleteCallback([&FetchComplete](uint32_t) { FetchComplete = true; });
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+        EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+        EXPECT_TRUE(ResponseWaiter::WaitFor([&FetchComplete] { return FetchComplete.load(); }, 30s));
+
+        const csp::multiplayer::SpaceTransform EntityTransform
+            = { csp::common::Vector3::Zero(), csp::common::Vector4::Identity(), csp::common::Vector3::One() };
+
+        for (int i = 0; i < 3; ++i)
+        {
+            char EntityName[64];
+            SPRINTF(EntityName, "CSP-UNITTEST-ENTITY-%d", i);
+            auto [Entity] = AWAIT(RealtimeEngine.get(), CreateEntity, EntityName, EntityTransform, csp::common::Optional<uint64_t> {});
+            EXPECT_NE(Entity, nullptr);
+        }
+
+        auto [ExitResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+        EXPECT_EQ(ExitResult.GetResultCode(), csp::systems::EResultCode::Success);
+        RealtimeEngine.reset();
+    }
+
+    // Enter the Space once more and destroy the RealtimeEngine without waiting for the RetrieveAllEntities callback to complete.
+    // Ensure the FetchPromise is not ready and then exit the space.
+    {
+        std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(csp::common::RealtimeEngineType::Online) };
+
+        std::promise<bool> FetchPromise;
+        std::future<bool> FetchFuture = FetchPromise.get_future();
+
+        RealtimeEngine->SetEntityFetchCompleteCallback([&FetchPromise](uint32_t) { FetchPromise.set_value(true); });
+
+        auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+        EXPECT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+        RealtimeEngine.reset();
+
+        EXPECT_EQ(FetchFuture._Is_ready(), false);
+
+        auto [ExitResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+        EXPECT_EQ(ExitResult.GetResultCode(), csp::systems::EResultCode::Success);
+    }
+
+    DeleteSpace(SpaceSystem, Space.Id);
+    LogOut(UserSystem);
+}


### PR DESCRIPTION
The `OnlineRealtimeEngine::CreateRetrieveAllEntitiesCallback` method returns a callback which is used to process all Entities fetched when joining a Space. While we support paged retrieval of Entities we do not currently use that feature. This means that when entering a Space with many Entities, the callback can take a long time to execute.

If during this time the `OnlineRealtimeEngine` is destroyed, CSP will hit an exception when trying to access it within the callback body. There are a number of potential solutions to this issue, but the situation is complicated by the fact that we:
    1. Do not own the OnlineRealtimeEngine or manage its lifetime.
    2. We cannot block the main thread.

We have work planned to introduce a task queue to shepherd callbacks to the main thread which will make this issue a lot easier to address. In the meantime this change introduces a sentinel which is checked at key points in the body of the callback. This does not address the potential for a race condition but it does limit the window within which it may occur.

In addition to this change, while investigating race conditions caused by destruction of the realtime engine, I encountered an issue when running the new test I had introduced (`EnterSpaceTeardownDuringEntityFetchTest`) relating to LeadershipElection.

The issue occurred in the `BindOnElectedScopeLeaderCallback()` and `BindOnVacatedScopeLeaderCallback()` methods of the `MultiplayerConnection`. When entering a Space the user passes in the `OnlineRealtimeEngine`, which internally is passed to the `MultiplayerConnection` via `SetOnlineRealtimeEngine()`. The two bind methods would check that the `MultiplayerRealtimeEngine` member was not nullptr before calling a method on them. However, when the `OnlineRealtimeEngine` is destroyed, the ptr that `MultiplayerConnection` holds is not set to nullptr.

The fix was was to call the `SetOnlineRealtimeEngine()` method again in the `OnlineRealtimeEngine` dtor passing nullptr, just as we do in our existing `ExitSpace` flow.