### PR TITLE
[OF-1878] feat: Add support for federated login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file. For compile
   practice a single element containing the full JSON array is expected. Equivalent constructors accepting
   `Array<ComponentSchema>` directly are also provided.
 
+- [OF-1878] feat: Add support for federated login. @MAG-AdamThorn.
+  A new federated login flow is being added that will allow client applications to authenticate directly with MCS. They will not be authenticating through CSP as they currently do. This creates a problem, as with our current login flows we create the LoginState object via `LoginState::OnResponse`. This data is then used to; refresh the token, for secure asset download, when starting the Multiplayer Connection among other things. To support federated login CSP has added a new `UserSystem::SetLoginDetails()` method that clients can call to pass the base64 encoded AuthDto json object to CSP.
+
 ### 🔥 ❗Breaking Changes
 
 - [OB-5368] fix!: Guard access to LoginState data with a mutex. By @MAG-AdamThorn.

--- a/Library/include/CSP/Systems/Users/Authentication.h
+++ b/Library/include/CSP/Systems/Users/Authentication.h
@@ -70,9 +70,11 @@ public:
         : csp::systems::ResultBase(ResCode, HttpResCode)
         , State(nullptr) {}
 
+    LoginStateResult(csp::common::LoginState* LoginState);
+
 private:
     LoginStateResult();
-    LoginStateResult(csp::common::LoginState* LoginState);
+
 
     CSP_NO_EXPORT void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -206,8 +206,10 @@ public:
 
     /// @brief Set Login details after using federated login to authenticate with MCS.
     /// @param LoginDetailsJson : A json string containing the login details returned from the federated login.
-    /// @return bool : true if the login details were successfully set, false if there was an error parsing the json or setting the login details.
-    bool SetLoginDetails(const csp::common::String& LoginDetailsJson);
+    /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR.
+    /// @param Callback : callback that contains the result of the 3rd party authentication operation.
+    CSP_ASYNC_RESULT void SetLoginDetails(
+        const csp::common::String& LoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback);
 
     /// @brief Logout from Magnopus Cloud Services.
     /// @param Callback NullResultCallback : callback to call when a response is received

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -204,6 +204,11 @@ public:
         const csp::common::String& ThirdPartyToken, const csp::common::Optional<EThirdPartyPlatform>& ClientType, bool CreateMultiplayerConnection,
         const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback);
 
+    /// @brief Set Login details after using federated login to authenticate with MCS.
+    /// @param LoginDetailsJson : A json string containing the login details returned from the federated login.
+    /// @return bool : true if the login details were successfully set, false if there was an error parsing the json or setting the login details.
+    bool SetLoginDetails(const csp::common::String& LoginDetailsJson);
+
     /// @brief Logout from Magnopus Cloud Services.
     /// @param Callback NullResultCallback : callback to call when a response is received
     CSP_ASYNC_RESULT void Logout(NullResultCallback Callback);

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -206,8 +206,10 @@ public:
 
     /// @brief Set Login details after using federated login to authenticate with MCS.
     /// @param LoginDetailsJson : A json string containing the login details returned from the federated login.
-    /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR.
-    /// @param Callback : callback that contains the result of the 3rd party authentication operation.
+    /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
+    /// connection to backend services, and thus be unable to receive messages or events. This session will also be unable to enter online spaces via
+    /// a csp::multiplayer::OnlineRealtimeEngine. If true, this session will receive events, and may enter both online and offline spaces.
+    /// @param Callback : callback when asynchronous task finishes
     CSP_ASYNC_RESULT void SetLoginDetails(
         const csp::common::String& LoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback);
 

--- a/Library/src/Common/LoginStateData.cpp
+++ b/Library/src/Common/LoginStateData.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LoginStateData.h"
+
+#include "CSP/Common/Settings.h"
+#include "Common/Convert.h"
+#include "Common/DateTime.h"
+#include "Debug/Logging.h"
+#include "Services/ApiBase/ApiBase.h"
+#include "Services/UserService/Dto.h"
+
+namespace
+{
+csp::common::ApplicationSettings MakeApplicationSetting(const csp::services::generated::userservice::ApplicationSettingsDto& Setting)
+{
+    csp::common::ApplicationSettings ApplicationSetting;
+    ApplicationSetting.ApplicationName = Setting.HasApplicationName() ? Setting.GetApplicationName() : csp::services::utility::string_t { "" };
+    ApplicationSetting.Context = Setting.HasContext() ? Setting.GetContext() : csp::services::utility::string_t { "" };
+    ApplicationSetting.AllowAnonymous = Setting.HasAllowAnonymous() ? Setting.GetAllowAnonymous() : false;
+    ApplicationSetting.Settings = Setting.HasSettings() ? csp::common::Convert(Setting.GetSettings()) : decltype(ApplicationSetting.Settings) {};
+    return ApplicationSetting;
+}
+
+// Otherwise known as a UserSetting
+csp::common::SettingsCollection MakeSettingsCollection(const csp::services::generated::userservice::SettingsDto& Setting)
+{
+    csp::common::SettingsCollection SettingsCollection;
+    SettingsCollection.UserId = Setting.HasUserId() ? Setting.GetUserId() : csp::services::utility::string_t { "" };
+    SettingsCollection.Context = Setting.HasContext() ? Setting.GetContext() : csp::services::utility::string_t { "" };
+    SettingsCollection.Settings = Setting.HasSettings() ? csp::common::Convert(Setting.GetSettings()) : decltype(SettingsCollection.Settings) {};
+    return SettingsCollection;
+}
+} // namespace
+
+namespace csp::common
+{
+
+LoginStateData AuthDtoToLoginStateData(const csp::services::generated::userservice::AuthDto* AuthResponse)
+{
+    auto Data = LoginStateData();
+
+    Data.State = ELoginState::LoggedIn;
+    Data.AccessToken = AuthResponse->GetAccessToken();
+    Data.RefreshToken = AuthResponse->GetRefreshToken();
+    Data.UserId = AuthResponse->GetUserId();
+    Data.DeviceId = AuthResponse->GetDeviceId();
+
+    if (AuthResponse->HasDefaultSettings())
+    {
+        const auto& DefaultSettings = AuthResponse->GetDefaultSettings();
+        if (DefaultSettings->HasDefaultUserSettings())
+        {
+            const auto& UserSettingsDto = DefaultSettings->GetDefaultUserSettings();
+            for (const auto& SettingDto : UserSettingsDto)
+            {
+                Data.DefaultSettings.Append(MakeSettingsCollection(*SettingDto));
+            }
+        }
+        if (DefaultSettings->HasDefaultApplicationSettings())
+        {
+            const auto& ApplicationSettingsDto = DefaultSettings->GetDefaultApplicationSettings();
+            for (const auto& SettingDto : ApplicationSettingsDto)
+            {
+                Data.DefaultApplicationSettings.Append(MakeApplicationSetting(*SettingDto));
+            }
+        }
+    }
+
+    const DateTime Expiry(AuthResponse->GetAccessTokenExpiresAt());
+    const DateTime CurrentTime(DateTime::UtcTimeNow());
+
+    if (CurrentTime >= Expiry)
+    {
+        CSP_LOG_FORMAT(
+            LogLevel::Error, "AccessToken Expired: %s %s", AuthResponse->GetAccessToken().c_str(), AuthResponse->GetAccessTokenExpiresAt().c_str());
+
+        return Data;
+    }
+
+    // Schedule a Refresh of the Token 5 minutes before it expires
+    std::chrono::system_clock::time_point RefreshTimepoint = Expiry.GetTimePoint() - std::chrono::system_clock::duration(std::chrono::minutes(5));
+    DateTime RefreshTime(RefreshTimepoint);
+
+    if (RefreshTime >= Expiry)
+    {
+        CSP_LOG_FORMAT(LogLevel::Error, "RefreshToken Expired: %s %s", AuthResponse->GetRefreshToken().c_str(),
+            AuthResponse->GetRefreshTokenExpiresAt().c_str());
+
+        return Data;
+    }
+
+    Data.SetAccessTokenRefreshTime(RefreshTime);
+
+    return Data;
+}
+
+} // namespace csp::common

--- a/Library/src/Common/LoginStateData.cpp
+++ b/Library/src/Common/LoginStateData.cpp
@@ -49,7 +49,7 @@ csp::common::SettingsCollection MakeSettingsCollection(const csp::services::gene
 namespace csp::common
 {
 
-LoginStateData AuthDtoToLoginStateData(const csp::services::generated::userservice::AuthDto* AuthResponse)
+std::optional<LoginStateData> AuthDtoToLoginStateData(const csp::services::generated::userservice::AuthDto* AuthResponse)
 {
     auto Data = LoginStateData();
 
@@ -88,7 +88,7 @@ LoginStateData AuthDtoToLoginStateData(const csp::services::generated::userservi
         CSP_LOG_FORMAT(
             LogLevel::Error, "AccessToken Expired: %s %s", AuthResponse->GetAccessToken().c_str(), AuthResponse->GetAccessTokenExpiresAt().c_str());
 
-        return Data;
+        return std::nullopt;
     }
 
     // Schedule a Refresh of the Token 5 minutes before it expires
@@ -100,12 +100,12 @@ LoginStateData AuthDtoToLoginStateData(const csp::services::generated::userservi
         CSP_LOG_FORMAT(LogLevel::Error, "RefreshToken Expired: %s %s", AuthResponse->GetRefreshToken().c_str(),
             AuthResponse->GetRefreshTokenExpiresAt().c_str());
 
-        return Data;
+        return std::nullopt;
     }
 
     Data.SetAccessTokenRefreshTime(RefreshTime);
 
-    return Data;
+    return std::make_optional<LoginStateData>(Data);
 }
 
 } // namespace csp::common

--- a/Library/src/Common/LoginStateData.h
+++ b/Library/src/Common/LoginStateData.h
@@ -23,6 +23,7 @@
 #include "Common/DateTime.h"
 
 #include <memory>
+#include <optional>
 
 namespace csp::services::generated::userservice
 {
@@ -101,6 +102,6 @@ private:
     csp::common::DateTime AccessTokenRefreshTime;
 };
 
-LoginStateData AuthDtoToLoginStateData(const csp::services::generated::userservice::AuthDto* AuthResponse);
+std::optional<LoginStateData> AuthDtoToLoginStateData(const csp::services::generated::userservice::AuthDto* AuthResponse);
 
 } // namespace csp::common

--- a/Library/src/Common/LoginStateData.h
+++ b/Library/src/Common/LoginStateData.h
@@ -24,6 +24,11 @@
 
 #include <memory>
 
+namespace csp::services::generated::userservice
+{
+    class AuthDto;
+}
+
 namespace csp::common
 {
 
@@ -95,5 +100,7 @@ public:
 private:
     csp::common::DateTime AccessTokenRefreshTime;
 };
+
+LoginStateData AuthDtoToLoginStateData(const csp::services::generated::userservice::AuthDto* AuthResponse);
 
 } // namespace csp::common

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -29,11 +29,8 @@
 #include "Services/UserService/Dto.h"
 #include "Systems/Users/Authentication.h"
 
-#include "Common/Convert.h"
-
 using namespace csp;
 using namespace csp::common;
-using namespace std::chrono;
 
 namespace chs = csp::services::generated::userservice;
 namespace chs_aggregation = csp::services::generated::aggregationservice;
@@ -53,29 +50,6 @@ LoginStateResult::LoginStateResult(csp::common::LoginState* LoginState)
 
 const csp::common::LoginState& LoginStateResult::GetLoginState() const { return *State; }
 
-namespace
-{
-    csp::common::ApplicationSettings MakeApplicationSetting(const csp::services::generated::userservice::ApplicationSettingsDto& Setting)
-    {
-        csp::common::ApplicationSettings ApplicationSetting;
-        ApplicationSetting.ApplicationName = Setting.HasApplicationName() ? Setting.GetApplicationName() : services::utility::string_t { "" };
-        ApplicationSetting.Context = Setting.HasContext() ? Setting.GetContext() : services::utility::string_t { "" };
-        ApplicationSetting.AllowAnonymous = Setting.HasAllowAnonymous() ? Setting.GetAllowAnonymous() : false;
-        ApplicationSetting.Settings = Setting.HasSettings() ? csp::common::Convert(Setting.GetSettings()) : decltype(ApplicationSetting.Settings) {};
-        return ApplicationSetting;
-    }
-
-    // Otherwise known as a UserSetting
-    csp::common::SettingsCollection MakeSettingsCollection(const csp::services::generated::userservice::SettingsDto& Setting)
-    {
-        csp::common::SettingsCollection SettingsCollection;
-        SettingsCollection.UserId = Setting.HasUserId() ? Setting.GetUserId() : services::utility::string_t { "" };
-        SettingsCollection.Context = Setting.HasContext() ? Setting.GetContext() : services::utility::string_t { "" };
-        SettingsCollection.Settings = Setting.HasSettings() ? csp::common::Convert(Setting.GetSettings()) : decltype(SettingsCollection.Settings) {};
-        return SettingsCollection;
-    }
-} // namespace
-
 void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 {
     ResultBase::OnResponse(ApiResponse);
@@ -90,64 +64,12 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 
         if (State)
         {
-            auto Data = LoginStateData();
+            auto Data = csp::common::AuthDtoToLoginStateData(AuthResponse);
 
-            Data.State = ELoginState::LoggedIn;
-            Data.AccessToken = AuthResponse->GetAccessToken();
-            Data.RefreshToken = AuthResponse->GetRefreshToken();
-            Data.UserId = AuthResponse->GetUserId();
-            Data.DeviceId = AuthResponse->GetDeviceId();
-
-            if (AuthResponse->HasDefaultSettings())
-            {
-                const auto& DefaultSettings = AuthResponse->GetDefaultSettings();
-                if (DefaultSettings->HasDefaultUserSettings())
-                {
-                    const auto& UserSettingsDto = DefaultSettings->GetDefaultUserSettings();
-                    for (const auto& SettingDto : UserSettingsDto)
-                    {
-                        Data.DefaultSettings.Append(MakeSettingsCollection(*SettingDto));
-                    }
-                }
-                if (DefaultSettings->HasDefaultApplicationSettings())
-                {
-                    const auto& ApplicationSettingsDto = DefaultSettings->GetDefaultApplicationSettings();
-                    for (const auto& SettingDto : ApplicationSettingsDto)
-                    {
-                        Data.DefaultApplicationSettings.Append(MakeApplicationSetting(*SettingDto));
-                    }
-                }
-            }
-
-            const DateTime Expiry(AuthResponse->GetAccessTokenExpiresAt());
-            const DateTime CurrentTime(DateTime::UtcTimeNow());
-
-            if (CurrentTime >= Expiry)
-            {
-                CSP_LOG_FORMAT(LogLevel::Error, "AccessToken Expired: %s %s", AuthResponse->GetAccessToken().c_str(),
-                    AuthResponse->GetAccessTokenExpiresAt().c_str());
-
-                return;
-            }
+            State->SetLoginStateDataThreadSafe(Data);
 
             web::HttpAuth::SetAccessToken(AuthResponse->GetAccessToken(), AuthResponse->GetAccessTokenExpiresAt(), AuthResponse->GetRefreshToken(),
                 AuthResponse->GetRefreshTokenExpiresAt());
-
-            // Schedule a Refresh of the Token 5 minutes before it expires
-            system_clock::time_point RefreshTimepoint = Expiry.GetTimePoint() - system_clock::duration(5min);
-            DateTime RefreshTime(RefreshTimepoint);
-
-            if (RefreshTime >= Expiry)
-            {
-                CSP_LOG_FORMAT(LogLevel::Error, "RefreshToken Expired: %s %s", AuthResponse->GetRefreshToken().c_str(),
-                    AuthResponse->GetRefreshTokenExpiresAt().c_str());
-
-                return;
-            }
-
-            Data.SetAccessTokenRefreshTime(RefreshTime);
-
-            State->SetLoginStateDataThreadSafe(Data);
 
             // Signal login to anyone interested
             events::Event* LoginEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGIN_EVENT_ID);

--- a/Library/src/Systems/Users/Authentication.cpp
+++ b/Library/src/Systems/Users/Authentication.cpp
@@ -64,7 +64,14 @@ void LoginStateResult::OnResponse(const services::ApiResponseBase* ApiResponse)
 
         if (State)
         {
-            auto Data = csp::common::AuthDtoToLoginStateData(AuthResponse);
+            auto DataOpt = csp::common::AuthDtoToLoginStateData(AuthResponse);
+
+            if (DataOpt.has_value() == false)
+            {
+                return;
+            }
+
+            auto Data = *DataOpt;
 
             State->SetLoginStateDataThreadSafe(Data);
 

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -840,7 +840,18 @@ void UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson, bo
         return;
     }
 
-    auto Data = csp::common::AuthDtoToLoginStateData(&AuthDetails);
+    auto DataOpt = csp::common::AuthDtoToLoginStateData(&AuthDetails);
+
+    if (DataOpt.has_value() == false)
+    {
+        csp::systems::LoginStateResult BadResult;
+        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(BadResult);
+
+        return;
+    }
+
+    auto Data = *DataOpt;
 
     CurrentLoginState->SetLoginStateDataThreadSafe(Data);
 

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -26,6 +26,7 @@
 #include "Common/Convert.h"
 #include "Common/LoginStateData.h"
 #include "Common/UUIDGenerator.h"
+#include "Events/EventSystem.h"
 #include "Multiplayer/NetworkEventSerialisation.h"
 #include "Services/UserService/Api.h"
 #include "Systems/ResultHelpers.h"
@@ -787,6 +788,57 @@ void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAut
     }
 
     LoginSocial(AuthenticationAPI, CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
+}
+
+bool UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson)
+{
+    chs_user::AuthDto AuthDetails;
+
+    AuthDetails.FromJson(LoginDetailsJson);
+
+    if (AuthDetails.GetAccessToken().IsEmpty())
+    {
+        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: AccessToken was not provided.");
+
+        return false;
+    }
+
+    if (AuthDetails.GetRefreshToken().IsEmpty())
+    {
+        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: RefreshToken was not provided.");
+
+        return false;
+    }
+
+    if (AuthDetails.GetUserId().IsEmpty())
+    {
+        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: UserId was not provided.");
+
+        return false;
+    }
+
+    if (AuthDetails.GetDeviceId().IsEmpty())
+    {
+        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: DeviceId was not provided.");
+
+        return false;
+    }
+
+    auto Data = csp::common::AuthDtoToLoginStateData(&AuthDetails);
+
+    CurrentLoginState->SetLoginStateDataThreadSafe(Data);
+
+    web::HttpAuth::SetAccessToken(
+        AuthDetails.GetAccessToken(), AuthDetails.GetAccessTokenExpiresAt(), AuthDetails.GetRefreshToken(), AuthDetails.GetRefreshTokenExpiresAt());
+
+    // Signal login to anyone interested
+    events::Event* LoginEvent = events::EventSystem::Get().AllocateEvent(events::USERSERVICE_LOGIN_EVENT_ID);
+    LoginEvent->AddString("UserId", AuthDetails.GetUserId());
+    events::EventSystem::Get().EnqueueEvent(LoginEvent);
+
+    SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
+
+    return true;
 }
 
 void UserSystem::Logout(NullResultCallback Callback)

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -790,7 +790,7 @@ void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAut
     LoginSocial(AuthenticationAPI, CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
 }
 
-bool UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson)
+void UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback)
 {
     chs_user::AuthDto AuthDetails;
 
@@ -800,28 +800,44 @@ bool UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson)
     {
         CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: AccessToken was not provided.");
 
-        return false;
+        csp::systems::LoginStateResult BadResult;
+        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(BadResult);
+
+        return;
     }
 
     if (AuthDetails.GetRefreshToken().IsEmpty())
     {
         CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: RefreshToken was not provided.");
 
-        return false;
+        csp::systems::LoginStateResult BadResult;
+        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(BadResult);
+
+        return;
     }
 
     if (AuthDetails.GetUserId().IsEmpty())
     {
         CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: UserId was not provided.");
 
-        return false;
+        csp::systems::LoginStateResult BadResult;
+        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(BadResult);
+
+        return;
     }
 
     if (AuthDetails.GetDeviceId().IsEmpty())
     {
         CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: DeviceId was not provided.");
 
-        return false;
+        csp::systems::LoginStateResult BadResult;
+        BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
+        Callback(BadResult);
+
+        return;
     }
 
     auto Data = csp::common::AuthDtoToLoginStateData(&AuthDetails);
@@ -838,7 +854,23 @@ bool UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson)
 
     SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
 
-    return true;
+    LoginStateResult Result { CurrentLoginState.get() };
+
+    csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback = [Callback, Result](csp::multiplayer::ErrorCode ErrCode)
+    {
+        if (ErrCode != csp::multiplayer::ErrorCode::None)
+        {
+            CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
+
+            Callback(Result);
+            return;
+        }
+
+        Callback(Result);
+    };
+
+    StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(), CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(),
+        ConnectionCallback, Result, *LogSystem, CreateMultiplayerConnection);
 }
 
 void UserSystem::Logout(NullResultCallback Callback)

--- a/cmake/common_files.cmake
+++ b/cmake/common_files.cmake
@@ -52,6 +52,7 @@ set(CSP_COMMON_SOURCES
     ${CSP_COMMON_SOURCE_DIR}/Encode.cpp
     ${CSP_COMMON_SOURCE_DIR}/Hash.cpp
     ${CSP_COMMON_SOURCE_DIR}/LoginState.cpp
+    ${CSP_COMMON_SOURCE_DIR}/LoginStateData.cpp
     ${CSP_COMMON_SOURCE_DIR}/MimeTypeHelper.cpp
     ${CSP_COMMON_SOURCE_DIR}/ReplicatedValue.cpp
     ${CSP_COMMON_SOURCE_DIR}/Scheduler.cpp
@@ -111,6 +112,7 @@ set(CSP_COMMON_PRIVATE_INCLUDES
     ${CSP_COMMON_SOURCE_DIR}/DateTime.h
     ${CSP_COMMON_SOURCE_DIR}/Encode.h
     ${CSP_COMMON_SOURCE_DIR}/Logger.h
+    ${CSP_COMMON_SOURCE_DIR}/LoginStateData.h
     ${CSP_COMMON_SOURCE_DIR}/NumberFormatter.h
     ${CSP_COMMON_SOURCE_DIR}/Queue.h
     ${CSP_COMMON_SOURCE_DIR}/Scheduler.h


### PR DESCRIPTION
With the new federated login flow clients will be authenticating directly with MCS. They will not be authenticating through CSP as they currently do. This creates a problem, as with our current login flows we create the LoginState object via `LoginState::OnResponse`. This data is then used to; refresh the token, for secure asset download, when starting the Multiplayer Connection among other things.

To support federated login CSP needs to add a new `SetLoginDetails()` method that clients can call to pass the base64 encoded AuthDto json object to CSP.
