### PR TITLE
[OF-1879] chore!: Rename to FederatedLogin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
 
+## [6.44.0]
+
+### 🔥 ❗Breaking Changes
+
+- [OF-1879] chore!: Rename `UserSystem::SetLoginDetails` -> `UserSystem::FederatedLogin` by @MAG-ElliotMorris
+
 ## [6.43.0]
 
 ### 🍰 🙌 New Features

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -204,14 +204,18 @@ public:
         const csp::common::String& ThirdPartyToken, const csp::common::Optional<EThirdPartyPlatform>& ClientType, bool CreateMultiplayerConnection,
         const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback);
 
-    /// @brief Set Login details after using federated login to authenticate with MCS.
-    /// @param LoginDetailsJson : A json string containing the login details returned from the federated login.
+    /// @brief Connect with CSP after a federated login has been completed, provided the token returned from a federated login service.
+    ///        This does not actually login to backend services, as this is managed externally by the federated login page.
+    ///        Rather, this sets up CSP's auth state, and creates the multiplayer connection if specified to do so.
+    /// @param FederatedLoginDetailsJson : Encoded login details JSON from the Magnopus federated login service. Laid out according to the Magnopus
+    /// AuthDTO format.
     /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
     /// connection to backend services, and thus be unable to receive messages or events. This session will also be unable to enter online spaces via
     /// a csp::multiplayer::OnlineRealtimeEngine. If true, this session will receive events, and may enter both online and offline spaces.
-    /// @param Callback : callback when asynchronous task finishes
-    CSP_ASYNC_RESULT void SetLoginDetails(
-        const csp::common::String& LoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback);
+    /// @param Callback : Fires when the async task finishes. Can error based on malformed FederatedLoginDetailsJson, or if an error occurs spawning
+    /// the MultiplayerConnection.
+    CSP_ASYNC_RESULT void FederatedLogin(
+        const csp::common::String& FederatedLoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback);
 
     /// @brief Logout from Magnopus Cloud Services.
     /// @param Callback NullResultCallback : callback to call when a response is received

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -790,11 +790,12 @@ void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAut
     LoginSocial(AuthenticationAPI, CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
 }
 
-void UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback)
+void UserSystem::FederatedLogin(
+    const csp::common::String& FederatedLoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback)
 {
     chs_user::AuthDto AuthDetails;
 
-    AuthDetails.FromJson(LoginDetailsJson);
+    AuthDetails.FromJson(FederatedLoginDetailsJson);
 
     if (AuthDetails.GetAccessToken().IsEmpty())
     {


### PR DESCRIPTION
The PR introducing this function was rushed through to get a release out. Improve the name to make it clearer what this is for, as well as elaborate on the docs.

This is for the next release, ie, the one after we first get this function out, as we're not delaying it for this.
