### PR TITLE
[NT-0] fix!: Rename to FederatedLogin, Fix result + optional accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
 
+## [6.44.0]
+
+### 🔥 ❗Breaking Changes
+
+- [OF-1879] chore!: Rename `UserSystem::SetLoginDetails` -> `UserSystem::FederatedLogin` by @MAG-ElliotMorris
+
 ## [6.43.0]
 
 ### 🍰 🙌 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file. For compile
 
 - [OF-1879] chore!: Rename `UserSystem::SetLoginDetails` -> `UserSystem::FederatedLogin` by @MAG-ElliotMorris
 
+### 🐛 🔨 Bug Fixes
+
+- [NT-0] fix: Fix issue where federated login results were not populating success/error values correctly by @MAG-ElliotMorris
+
 ## [6.43.0]
 
 ### 🍰 🙌 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,6 @@
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
 
-## [6.44.0]
-
-### 🔥 ❗Breaking Changes
-
-- [OF-1879] chore!: Rename `UserSystem::SetLoginDetails` -> `UserSystem::FederatedLogin` by @MAG-ElliotMorris
-
-### 🐛 🔨 Bug Fixes
-
-- [NT-0] fix: Fix issue where federated login results were not populating success/error values correctly by @MAG-ElliotMorris
-
 ## [6.43.0]
 
 ### 🍰 🙌 New Features
@@ -25,8 +15,8 @@ All notable changes to this project will be documented in this file. For compile
   practice a single element containing the full JSON array is expected. Equivalent constructors accepting
   `Array<ComponentSchema>` directly are also provided.
 
-- [OF-1878] feat: Add support for federated login. @MAG-AdamThorn.
-  A new federated login flow is being added that will allow client applications to authenticate directly with MCS. They will not be authenticating through CSP as they currently do. This creates a problem, as with our current login flows we create the LoginState object via `LoginState::OnResponse`. This data is then used to; refresh the token, for secure asset download, when starting the Multiplayer Connection among other things. To support federated login CSP has added a new `UserSystem::SetLoginDetails()` method that clients can call to pass the base64 encoded AuthDto json object to CSP.
+- [OF-1878] feat: Add support for federated login. @MAG-AdamThorn & @MAG-mv
+  A new federated login flow is being added that will allow client applications to authenticate directly with MCS. They will not be authenticating through CSP as they currently do. This creates a problem, as with our current login flows we create the LoginState object via `LoginState::OnResponse`. This data is then used to; refresh the token, for secure asset download, when starting the Multiplayer Connection among other things. To support federated login CSP has added a new `UserSystem::FederatedLogin()` method that clients can call to pass the base64 encoded AuthDto json object to CSP.
 
 ### 🔥 ❗Breaking Changes
 

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -204,14 +204,18 @@ public:
         const csp::common::String& ThirdPartyToken, const csp::common::Optional<EThirdPartyPlatform>& ClientType, bool CreateMultiplayerConnection,
         const csp::common::Optional<bool>& UserHasVerifiedAge, LoginStateResultCallback Callback);
 
-    /// @brief Set Login details after using federated login to authenticate with MCS.
-    /// @param LoginDetailsJson : A json string containing the login details returned from the federated login.
+    /// @brief Connect with CSP after a federated login has been completed, provided the token returned from a federated login service.
+    ///        This does not actually login to backend services, as this is managed externally by the federated login page.
+    ///        Rather, this sets up CSP's auth state, and creates the multiplayer connection if specified to do so.
+    /// @param FederatedLoginDetailsJson : Encoded login details JSON from the Magnopus federated login service. Laid out according to the Magnopus
+    /// AuthDTO format.
     /// @param CreateMultiplayerConnection : Whether to create a multiplayer connection. If false, this session will not establish a SignalR
     /// connection to backend services, and thus be unable to receive messages or events. This session will also be unable to enter online spaces via
     /// a csp::multiplayer::OnlineRealtimeEngine. If true, this session will receive events, and may enter both online and offline spaces.
-    /// @param Callback : callback when asynchronous task finishes
-    CSP_ASYNC_RESULT void SetLoginDetails(
-        const csp::common::String& LoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback);
+    /// @param Callback : Fires when the async task finishes. Can error based on malformed FederatedLoginDetailsJson, or if an error occurs spawning
+    /// the MultiplayerConnection.
+    CSP_ASYNC_RESULT void FederatedLogin(
+        const csp::common::String& FederatedLoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback);
 
     /// @brief Logout from Magnopus Cloud Services.
     /// @param Callback NullResultCallback : callback to call when a response is received

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -867,6 +867,7 @@ void UserSystem::FederatedLogin(
     SystemsManager::Get().GetUserSystem()->NotifyRefreshTokenHasChanged();
 
     LoginStateResult Result { CurrentLoginState.get() };
+    Result.SetResult(EResultCode::Success, static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
 
     csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback = [Callback, Result](csp::multiplayer::ErrorCode ErrCode)
     {

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -797,9 +797,9 @@ void UserSystem::FederatedLogin(
 
     AuthDetails.FromJson(FederatedLoginDetailsJson);
 
-    if (AuthDetails.GetAccessToken().IsEmpty())
+    if (!AuthDetails.HasAccessToken())
     {
-        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: AccessToken was not provided.");
+        CSP_LOG_ERROR_MSG("UserSystem::FederatedLogin() - Parsing error: AccessToken was not provided.");
 
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
@@ -808,9 +808,9 @@ void UserSystem::FederatedLogin(
         return;
     }
 
-    if (AuthDetails.GetRefreshToken().IsEmpty())
+    if (!AuthDetails.HasRefreshToken())
     {
-        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: RefreshToken was not provided.");
+        CSP_LOG_ERROR_MSG("UserSystem::FederatedLogin() - Parsing error: RefreshToken was not provided.");
 
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
@@ -819,9 +819,9 @@ void UserSystem::FederatedLogin(
         return;
     }
 
-    if (AuthDetails.GetUserId().IsEmpty())
+    if (!AuthDetails.HasUserId())
     {
-        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: UserId was not provided.");
+        CSP_LOG_ERROR_MSG("UserSystem::FederatedLogin() - Parsing error: UserId was not provided.");
 
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
@@ -830,9 +830,9 @@ void UserSystem::FederatedLogin(
         return;
     }
 
-    if (AuthDetails.GetDeviceId().IsEmpty())
+    if (!AuthDetails.HasDeviceId())
     {
-        CSP_LOG_ERROR_MSG("UserSystem::SetLoginDetails() - Parsing error: DeviceId was not provided.");
+        CSP_LOG_ERROR_MSG("UserSystem::FederatedLogin() - Parsing error: DeviceId was not provided.");
 
         csp::systems::LoginStateResult BadResult;
         BadResult.SetResult(csp::systems::EResultCode::Failed, (uint16_t)csp::web::EResponseCodes::ResponseBadRequest);
@@ -869,17 +869,19 @@ void UserSystem::FederatedLogin(
     LoginStateResult Result { CurrentLoginState.get() };
     Result.SetResult(EResultCode::Success, static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
 
-    csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback = [Callback, Result](csp::multiplayer::ErrorCode ErrCode)
+    csp::multiplayer::MultiplayerConnection::ErrorCodeCallbackHandler ConnectionCallback
+        = [Callback, CurrentLoginState = this->CurrentLoginState](csp::multiplayer::ErrorCode ErrCode)
     {
         if (ErrCode != csp::multiplayer::ErrorCode::None)
         {
             CSP_LOG_ERROR_FORMAT("Error connecting MultiplayerConnection: %s", csp::multiplayer::ErrorCodeToString(ErrCode).c_str());
-
-            Callback(Result);
+            Callback(MakeInvalid<LoginStateResult>());
             return;
         }
 
-        Callback(Result);
+        LoginStateResult SuccessResult { CurrentLoginState.get() };
+        SuccessResult.SetResult(EResultCode::Success, static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
+        Callback(SuccessResult);
     };
 
     StartMultiplayerConnection(*SystemsManager::Get().GetMultiplayerConnection(), CSPFoundation::GetEndpoints().MultiplayerConnection.GetURI(),
@@ -1095,7 +1097,7 @@ void UserSystem::Ping(NullResultCallback Callback)
 {
     csp::services::ResponseHandlerPtr PingResponseHandler
         = PingAPI->CreateHandler<NullResultCallback, NullResult, void, csp::services::NullDto>(Callback, nullptr);
-    static_cast<chs_user::PingApi*>(PingAPI)->pingGet({}, PingResponseHandler);
+    static_cast<chs_user::PingApi*>(PingAPI)->pingGet({ }, PingResponseHandler);
 }
 
 void UserSystem::ResendVerificationEmail(

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -790,11 +790,12 @@ void UserSystem::LoginToThirdPartyAuthenticationProviderWithToken(EThirdPartyAut
     LoginSocial(AuthenticationAPI, CurrentLoginState, LogSystem, Request, CreateMultiplayerConnection, Callback);
 }
 
-void UserSystem::SetLoginDetails(const csp::common::String& LoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback)
+void UserSystem::FederatedLogin(
+    const csp::common::String& FederatedLoginDetailsJson, bool CreateMultiplayerConnection, LoginStateResultCallback Callback)
 {
     chs_user::AuthDto AuthDetails;
 
-    AuthDetails.FromJson(LoginDetailsJson);
+    AuthDetails.FromJson(FederatedLoginDetailsJson);
 
     if (AuthDetails.GetAccessToken().IsEmpty())
     {

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -524,6 +524,39 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, FederatedLoginTest)
     LogOut(UserSystem);
 }
 
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, FederatedLoginTestBadJson)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // Login to backend services in order to get the information to build an AuthDTO
+    // We're simulating a successful federated login here, it's all the same stuff at the end of the day.
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId, false); // No need to create a multiplayer connection here
+
+    // Assemble the AuthDTO
+    csp::services::generated::userservice::AuthDto AuthDetails;
+    AuthDetails.SetUserId(UserId.c_str());
+    AuthDetails.SetDeviceId(csp::CSPFoundation::GetDeviceId().c_str());
+    // Deliberately don't set the access token to trigger a failure
+    // AuthDetails.SetAccessToken(csp::web::HttpAuth::GetAccessToken().c_str());
+    AuthDetails.SetAccessTokenExpiresAt(csp::web::HttpAuth::GetTokenExpiry().c_str());
+    AuthDetails.SetRefreshToken(csp::web::HttpAuth::GetRefreshToken().c_str());
+    AuthDetails.SetRefreshTokenExpiresAt(csp::web::HttpAuth::GetRefreshTokenExpiry().c_str());
+
+    const csp::common::String FederatedLoginDetailsJson(AuthDetails.ToJson().c_str());
+
+    // Logout so we can login again
+    LogOut(UserSystem);
+
+    // Login with the "federated JSON response" - this will fail
+    auto [Result] = AWAIT_PRE(UserSystem, FederatedLogin, RequestPredicate, FederatedLoginDetailsJson, true);
+
+    ASSERT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
+    ASSERT_EQ(Connection->GetConnectionState(), csp::multiplayer::ConnectionState::Disconnected);
+}
+
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, RefreshTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();
@@ -573,7 +606,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, UserSystemTests, RefreshTokenFailedTest)
     csp::common::String UserId;
     LogInAsNewTestUser(UserSystem, UserId, true, true, TokenOptions);
 
-    RAIIMockLogger MockLogger {};
+    RAIIMockLogger MockLogger { };
     csp::systems::SystemsManager::Get().GetLogSystem()->SetSystemLevel(csp::common::LogLevel::Fatal);
     csp::common::String Msg = "User authentication token refresh failed!";
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Fatal, Msg)).Times(1);
@@ -626,7 +659,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, InvalidExpiryLengthInTokenOptionsTes
 
     SystemsManager.GetLogSystem()->SetSystemLevel(csp::common::LogLevel::Warning);
 
-    RAIIMockLogger MockLogger {};
+    RAIIMockLogger MockLogger { };
     csp::common::String WarningLog = "Expiry length token option does not match the expected format, and has been ignored.";
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Warning, WarningLog)).Times(2);
 
@@ -1394,7 +1427,7 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, DefaultApplicationSettingsTest)
     std::promise<csp::common::LoginState> SettingsPromise;
     std::future<csp::common::LoginState> SettingsFuture = SettingsPromise.get_future();
 
-    UserSystem->Login(TestUser.Email, GeneratedTestAccountPassword, false, true, {},
+    UserSystem->Login(TestUser.Email, GeneratedTestAccountPassword, false, true, { },
         [&SettingsPromise](const csp::systems::LoginStateResult& Result) { SettingsPromise.set_value(Result.GetLoginState()); });
 
     csp::common::LoginState LoginState = SettingsFuture.get();

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -24,8 +24,10 @@
 #include "CSP/Systems/Users/UserSystem.h"
 #include "Common/DateTime.h"
 #include "Common/LoginStateData.h"
+#include "Common/Web/HttpAuth.h"
 #include "Common/Web/HttpPayload.h"
 #include "RAIIMockLogger.h"
+#include "Services/UserService/Dto.h"
 #include "SpaceSystemTestHelpers.h"
 #include "TestHelpers.h"
 #include "UserSystemTestHelpers.h"
@@ -477,6 +479,46 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginErrorTest)
 
     // Log in
     LogInAsNewTestUser(UserSystem, UserId);
+
+    // Log out
+    LogOut(UserSystem);
+}
+
+/* The federated login was a last-minute pre release addition
+ * It should probably have more tests than just this. */
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, FederatedLoginTest)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    // Login to backend services in order to get the information to build an AuthDTO
+    // We're simulating a successful federated login here, it's all the same stuff at the end of the day.
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId, false); // No need to create a multiplayer connection here
+
+    // Assemble the AuthDTO
+    csp::services::generated::userservice::AuthDto AuthDetails;
+    AuthDetails.SetUserId(UserId.c_str());
+    AuthDetails.SetDeviceId(csp::CSPFoundation::GetDeviceId().c_str());
+    AuthDetails.SetAccessToken(csp::web::HttpAuth::GetAccessToken().c_str());
+    AuthDetails.SetAccessTokenExpiresAt(csp::web::HttpAuth::GetTokenExpiry().c_str());
+    AuthDetails.SetRefreshToken(csp::web::HttpAuth::GetRefreshToken().c_str());
+    AuthDetails.SetRefreshTokenExpiresAt(csp::web::HttpAuth::GetRefreshTokenExpiry().c_str());
+
+    const csp::common::String FederatedLoginDetailsJson(AuthDetails.ToJson().c_str());
+
+    // Logout so we can login again
+    LogOut(UserSystem);
+
+    // Login with the "federated JSON response"
+    auto [Result] = AWAIT_PRE(UserSystem, FederatedLogin, RequestPredicate, FederatedLoginDetailsJson, true);
+
+    ASSERT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+    ASSERT_EQ(Result.GetHttpResultCode(), static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
+    ASSERT_EQ(Result.GetLoginState().GetLoginStateValue(), csp::common::ELoginState::LoggedIn);
+    ASSERT_EQ(Result.GetLoginState().GetUserId(), UserId);
+    ASSERT_EQ(Connection->GetConnectionState(), csp::multiplayer::ConnectionState::Connected);
 
     // Log out
     LogOut(UserSystem);


### PR DESCRIPTION
We rushed the initial change through a bit. Add some tests and work out some edge case errors, including potential crashes in the failure case.

Rename from `SetLoginDetails` -> `FederatedLogin`, as well as expand the documentation a tad.