### PR TITLE
[OF-1880] chore: Add `x-auth-token` header in addition to `Authorization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.44.0]
+
+- [OF-1880] chore: Add `x-auth-token` header in addition to `Authorization` by @mag-lt.
+  This is a preemptive change for upcoming CHS changes. We conservatively set this auth header in
+  addition to the existing `Authorization` header. This is done in all cases where we currently set
+  the existing header, with no additional refactoring (so this doesn't cover any additional cases
+  that weren't covered before, and deliberately minimises other code churn).
 
 ## [6.43.0]
 

--- a/Library/src/Common/Web/HttpPayload.cpp
+++ b/Library/src/Common/Web/HttpPayload.cpp
@@ -146,6 +146,7 @@ void HttpPayload::RefreshBearerToken()
         char Str[1024];
         snprintf(Str, 1024, "Bearer %s", HttpAuth::GetAccessToken().c_str());
         AddHeader(CSP_TEXT("Authorization"), CSP_TEXT(Str));
+        AddHeader(CSP_TEXT("x-auth-token"), CSP_TEXT(Str));
     }
 }
 

--- a/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
+++ b/Library/src/Multiplayer/SignalR/POCOSignalRClient/POCOSignalRClient.cpp
@@ -106,6 +106,7 @@ void CSPWebSocketClientPOCO::Start(const std::string& /*Url*/, CallbackHandler C
         char Str[1024];
         snprintf(Str, 1024, "Bearer %s", AccessToken.c_str());
         request.set("Authorization", Str);
+        request.set("x-auth-token", Str);
 
         StopFlag = false;
 

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -66,6 +66,7 @@ void RemoteFileManager::GetFile(
     if (BearerToken.HasValue())
     {
         Payload.AddHeader(CSP_TEXT("Authorization"), *BearerToken);
+        Payload.AddHeader(CSP_TEXT("x-auth-token"), *BearerToken);
     }
 
     WebClient->SendRequest(csp::web::ERequestVerb::GET, GetUri, Payload, ResponseHandler, CancellationToken);
@@ -81,6 +82,7 @@ void RemoteFileManager::GetResponseHeaders(const csp::common::String& Url, csp::
     if (BearerToken.HasValue())
     {
         Payload.AddHeader(CSP_TEXT("Authorization"), *BearerToken);
+        Payload.AddHeader(CSP_TEXT("x-auth-token"), *BearerToken);
     }
 
     WebClient->SendRequest(csp::web::ERequestVerb::HEAD, GetUri, Payload, ResponseHandler, csp::common::CancellationToken::Dummy());

--- a/Tests/cmake/test_files.cmake
+++ b/Tests/cmake/test_files.cmake
@@ -25,6 +25,7 @@ set(CSP_TESTS_SOURCES
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/NewFeatureTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/PlatformTestUtils.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/PlatformTestUtils.h
+    ${CSP_TESTS_SOURCE_DIR}/InternalTests/RemoteFileManagerTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/SceneDescriptionTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/SchedulerTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/ServicesTests.cpp

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -102,6 +102,7 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
                 if (LoginState.GetLoginStateValue() == csp::common::ELoginState::LoggedIn)
                 {
                     EXPECT_TRUE(HasAuthHeader(Headers, "Authorization"));
+                    EXPECT_TRUE(HasAuthHeader(Headers, "x-auth-token"));
                 }
             });
 
@@ -149,6 +150,7 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
                 if (LoginState.GetLoginStateValue() == csp::common::ELoginState::LoggedIn)
                 {
                     EXPECT_TRUE(HasAuthHeader(Headers, "Authorization"));
+                    EXPECT_TRUE(HasAuthHeader(Headers, "x-auth-token"));
                 }
             });
 

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -39,6 +39,32 @@ class GetResponseHeaders : public PublicTestBaseInternalWithParam<std::tuple<csp
 {
 };
 
+static ::testing::AssertionResult HasAuthHeader(const HttpPayload::HeadersMap& Headers, const std::string& AuthHeaderName)
+{
+    // Verify that the Authorization header is present
+    auto AuthIt = Headers.find(AuthHeaderName);
+    if (AuthIt == Headers.end())
+    {
+        return ::testing::AssertionFailure() << "Authorization header should be present when the user is logged in";
+    }
+
+    const auto& BearerToken = AuthIt->second;
+
+    // Verify the token is not empty after "Bearer "
+    const auto Prefix = std::string("Bearer ");
+    if (BearerToken.length() <= Prefix.length())
+    {
+        return ::testing::AssertionFailure() << "Bearer token should not be empty";
+    }
+
+    if (BearerToken.compare(0, Prefix.length(), Prefix) != 0)
+    {
+        return ::testing::AssertionFailure() << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
+    }
+
+    return ::testing::AssertionSuccess();
+}
+
 TEST_P(GetFile, GetFileSendsCorrectRequest)
 {
     InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
@@ -75,19 +101,7 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
 
                 if (LoginState.GetLoginStateValue() == csp::common::ELoginState::LoggedIn)
                 {
-                    // Verify that the Authorization header is present
-                    auto AuthIt = Headers.find("Authorization");
-                    ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
-
-                    std::string BearerToken = AuthIt->second;
-
-                    // Verify the token is not empty after "Bearer "
-                    EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
-
-                    const std::string Prefix("Bearer ");
-
-                    EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
-                        << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
+                    EXPECT_TRUE(HasAuthHeader(Headers, "Authorization"));
                 }
             });
 
@@ -128,31 +142,13 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
 
                 EXPECT_STREQ(InUri.GetAsString(), FileUrl.c_str());
 
+                // The X-AssetPlatform header is added to all HTTP requests. In addition the Authorization header should have been set
+                const auto& Headers = Payload.GetHeaders();
+                ASSERT_NE(Headers.find("X-AssetPlatform"), Headers.end());
+
                 if (LoginState.GetLoginStateValue() == csp::common::ELoginState::LoggedIn)
                 {
-                    // The X-AssetPlatform header is added to all HTTP requests. In addition the Authorization header should have been set
-                    const auto& Headers = Payload.GetHeaders();
-                    EXPECT_EQ(Headers.size(), 2) << "Expected exactly two headers to be present in the request";
-
-                    // Verify that the Authorization header is present
-                    auto AuthIt = Headers.find("Authorization");
-                    ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
-
-                    std::string BearerToken = AuthIt->second;
-
-                    // Verify the token is not empty after "Bearer "
-                    EXPECT_TRUE(BearerToken.length() > 7) << "Bearer token should not be empty";
-
-                    const std::string Prefix("Bearer ");
-
-                    EXPECT_TRUE(BearerToken.compare(0, Prefix.length(), Prefix) == 0)
-                        << "Authorization header should start with 'Bearer ', but was: " << BearerToken;
-                }
-                else
-                {
-                    // The X-AssetPlatform header is added to all HTTP requests. There should be no additional Authorization header set
-                    const auto& Headers = Payload.GetHeaders();
-                    EXPECT_EQ(Headers.size(), 1) << "Expected exactly one header to be present in the request";
+                    EXPECT_TRUE(HasAuthHeader(Headers, "Authorization"));
                 }
             });
 


### PR DESCRIPTION
WIP

This is a rote change that explicitly doesn't try to add a centralised place for this. Wherever we set `Authorization`, now also add `x-auth-token`.

This is also a preemptive and somewhat speculative change, as the server changes for this have not yet been made.

It does seem like some of these paths may be redundant. In WebClient we call `SetBearerToken()` on the payload in `ProcessRequest`, which should end up in all requests having auth headers. However, it does look as if the WASM path doesn't come through this method, so we are likely already behaving differently on web, which will need to be investigated separately.

It is also similarly curious that we are adding an auth header to the websocket upgrade request sent by POCO, but not for the web client. Some cursory research reveals it may not be possible to set a header there even if we wanted to, so if auth is required in some way, I have to assume it is being done another way outside of CSP.