### PR TITLE
[OF-1840] Add PR checks workflow using Github Actions

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -57,12 +57,9 @@ runs:
         restore-keys: |
           ${{ env.CONAN_CACHE_PREFIX }}-
 
-    - name: Set CMake compatibility policy
-      shell: bash
-      run: |
-        echo "CMAKE_POLICY_VERSION_MINIMUM=3.5" >> "$GITHUB_ENV"
-
     - name: Conan install
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: "3.5"
       shell: bash
       run: |
         set -euxo pipefail

--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -1,0 +1,99 @@
+name: "Build and Install"
+description: "Fetch dependencies with Conan, configure CMake, build, and install"
+
+inputs:
+  host_profile:
+    description: "The name of the Conan host profile to use. See profiles/host"
+    required: true
+
+  build_type:
+    description: "CMake build type [Debug, Release, RelWithDebInfo]"
+    required: true
+
+  configure_preset:
+    description: "CMake configure preset to use. Run cmake --list-presets to list available presets."
+    required: true
+
+  build_preset:
+    description: "CMake build preset to use. Run cmake --build --list-presets to list available presets."
+    required: true
+
+  build_folder:
+    description: "CMake build directory to install from. This can change depending on the generator used."
+    required: true
+
+  output_folder:
+    description: "Conan output folder"
+    required: true
+    default: ""
+
+  install_prefix:
+    description: "The location the CSP library will be installed to"
+    required: false
+    default: "install"
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Install Conan
+      uses: conan-io/setup-conan@v1
+
+    # Setup Conan cache.
+    # Use a custom cache key instead of setup-conan's default key so matrix jobs do not conflict.
+    #
+    # The cache prefix uses: host_profile  and build_preset, which
+    # separates caches by platform, build type, and linkage.
+    #
+    # We also append a hash of our Conan recipe, host profile, and CMake presets so changes
+    # to these files creates a new cache key.
+    - name: Cache Conan packages
+      uses: actions/cache@v4
+      env:
+        CONAN_CACHE_PREFIX: conan-${{ inputs.host_profile }}-${{ inputs.build_preset }}
+      with:
+        path: ~/.conan2
+        key: ${{ env.CONAN_CACHE_PREFIX }}-${{ hashFiles('conanfile.py', format('profiles/host/{0}', inputs.host_profile)) }}
+        restore-keys: |
+          ${{ env.CONAN_CACHE_PREFIX }}-
+
+    - name: Conan install
+      shell: bash
+      run: |
+        set -eux
+
+        export CMAKE_POLICY_VERSION_MINIMUM="3.5"
+
+        PROFILE_PATH="profiles/host/${{ inputs.host_profile }}"
+
+        if [ ! -f "$PROFILE_PATH" ]; then
+          echo "Host profile not found: $PROFILE_PATH"
+          exit 1
+        fi
+
+        conan install . \
+          -of "${{ inputs.output_folder }}" \
+          -s build_type="${{ inputs.build_type }}" \
+          --build=missing \
+          --profile:host="$PROFILE_PATH"
+
+    - name: Configure CMake
+      shell: bash
+      run: |
+        set -eux
+        cmake --preset "${{ inputs.configure_preset }}"
+
+    - name: Build
+      shell: bash
+      run: |
+        set -eux
+        cmake --build --preset "${{ inputs.build_preset }}"
+
+    - name: Install
+      shell: bash
+      run: |
+        set -eux
+        cmake --install \
+          "${{ github.workspace }}/${{ inputs.build_folder }}" \
+          --config "${{ inputs.build_type }}" \
+          --prefix "${{ github.workspace }}/${{ inputs.install_prefix }}"

--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -65,7 +65,7 @@ runs:
     - name: Conan install
       shell: bash
       run: |
-        set -eux
+        set -euxo pipefail
 
         PROFILE_PATH="profiles/host/${{ inputs.host_profile }}"
 
@@ -83,19 +83,19 @@ runs:
     - name: Configure CMake
       shell: bash
       run: |
-        set -eux
+        set -euxo pipefail
         cmake --preset "${{ inputs.configure_preset }}"
 
     - name: Build
       shell: bash
       run: |
-        set -eux
+        set -euxo pipefail
         cmake --build --preset "${{ inputs.build_preset }}"
 
     - name: Install
       shell: bash
       run: |
-        set -eux
+        set -euxo pipefail
         cmake --install \
           "${{ github.workspace }}/${{ inputs.build_folder }}" \
           --config "${{ inputs.build_type }}" \

--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -57,12 +57,15 @@ runs:
         restore-keys: |
           ${{ env.CONAN_CACHE_PREFIX }}-
 
+    - name: Set CMake compatibility policy
+      shell: bash
+      run: |
+        echo "CMAKE_POLICY_VERSION_MINIMUM=3.5" >> "$GITHUB_ENV"
+
     - name: Conan install
       shell: bash
       run: |
         set -eux
-
-        export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 
         PROFILE_PATH="profiles/host/${{ inputs.host_profile }}"
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -126,3 +126,46 @@ jobs:
           output_folder: build/emscripten-${{ matrix.config.preset_prefix }}
           build_folder: build/emscripten-${{ matrix.config.preset_prefix }}/build/${{ matrix.config.build_type }}
           install_prefix: install/emscripten/${{ matrix.config.preset_prefix }}
+  
+  build-android:
+    name: Build android ${{ matrix.config.build_type }} ${{ matrix.linkage.name }}
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      
+      matrix:
+        config:
+          - build_type: Debug
+            preset_prefix: debug
+
+          - build_type: Release
+            preset_prefix: release
+
+          - build_type: RelWithDebInfo
+            preset_prefix: relwithdebinfo
+
+        linkage:
+          - name: static
+            shared: false
+
+          - name: shared
+            shared: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Ensure we fetch tags so our automatic versioning script picks up the version.
+          fetch-tags: true
+
+      - name: Build and install
+        uses: ./.github/actions/build-and-install
+        with:
+          host_profile: android_arm
+          build_type: ${{ matrix.config.build_type }}
+          configure_preset: ${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          build_preset: ${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          output_folder: build/android-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          build_folder: build/android-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
+          install_prefix: install/android/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,10 @@ name: PR Checks
 # This workflow performs the following actions:
 #  - Builds all desktop platforms
 #  - Uploads the install tree as a workflow artifact
+#  - Builds csp as emscripten static lib
+#  - Builds csp for android
+#  - Builds csp for iOS and visionOS
+#  - Runs csp locsl tests on Linux
 
 on:
   pull_request:
@@ -245,6 +249,13 @@ jobs:
 
   tests-local-mcs:
     name: Run Tests (Local MCS) Linux
+    ## Why Local MCS cannot run on GitHub Windows runners
+
+    # MCS Docker stack uses Linux container images.
+    # GitHub windows-2022 runners do not provide the same Docker Desktop Linux-container environment.
+    # When Docker runs there, it attempts to pull Windows container images.
+    # Because the MCS images are Linux images, Docker fails with "no matching manifest for windows(10.0.20348)/amd64"
+    # For this reason, we currently run our local tests on Linux.
     runs-on: ubuntu-latest
     needs: build-desktop
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -77,3 +77,52 @@ jobs:
           name: ${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
           path: ${{ github.workspace }}/install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
           if-no-files-found: error
+    
+  build-emscripten:
+    name: Build emscripten ${{ matrix.config.build_type }}
+    runs-on: windows-latest
+    
+    env:
+      EMSDK_VERSION: 5.0.2
+    
+    strategy:
+      fail-fast: false
+      
+      matrix:
+        config:
+          - build_type: Debug
+            preset_prefix: debug
+
+          - build_type: Release
+            preset_prefix: release
+
+          - build_type: RelWithDebInfo
+            preset_prefix: relwithdebinfo
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Ensure we fetch tags so our automatic versioning script picks up the version.
+          fetch-tags: true
+
+      - name: Set up MSVC (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup emsdk
+        uses: emscripten-core/setup-emsdk@v15
+        with:
+          version: ${{ env.EMSDK_VERSION }}
+          actions-cache-folder: 'emsdk-cache'
+
+      - name: Build and install
+        uses: ./.github/actions/build-and-install
+        with:
+          host_profile: emscripten
+          build_type: ${{ matrix.config.build_type }}
+          configure_preset: ${{ matrix.config.preset_prefix }}-static
+          build_preset: ${{ matrix.config.preset_prefix }}-static
+          output_folder: build/emscripten-${{ matrix.config.preset_prefix }}
+          build_folder: build/emscripten-${{ matrix.config.preset_prefix }}/build/${{ matrix.config.build_type }}
+          install_prefix: install/emscripten/${{ matrix.config.preset_prefix }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -169,3 +169,67 @@ jobs:
           output_folder: build/android-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
           build_folder: build/android-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
           install_prefix: install/android/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+
+  ios-visionos-build:
+    name: Build ${{ matrix.platform.name }} ${{ matrix.config.build_type }} ${{ matrix.linkage.name }}
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: ios
+            host_profile: ios_arm64
+
+          - name: visionos
+            host_profile: visionos_arm64
+
+        config:
+          - build_type: Debug
+            preset_prefix: debug
+
+          - build_type: Release
+            preset_prefix: release
+
+          - build_type: RelWithDebInfo
+            preset_prefix: relwithdebinfo
+
+        linkage:
+          - name: static
+            shared: false
+
+          - name: shared
+            shared: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Ensure we fetch tags so our automatic versioning script picks up the version.
+          fetch-tags: true
+
+      - name: Initialize Xcode
+        shell: bash
+        run: |
+          set -eux
+          xcodebuild -version
+          sudo xcodebuild -runFirstLaunch
+
+      # Manually specify the OpenSSL configure target used by the Conan recipe,
+      # as the OpenSSL 1.1 recipe does not fully support visionOS.
+      - name: Set OpenSSL configuration for visionOS
+        if: matrix.platform.name == 'visionos'
+        shell: bash
+        run: |
+          echo "CONAN_OPENSSL_CONFIGURATION=ios64-xcrun" >> "$GITHUB_ENV"
+
+      - name: Build and install
+        uses: ./.github/actions/build-and-install
+        with:
+          host_profile: ${{ matrix.platform.host_profile }}
+          build_type: ${{ matrix.config.build_type }}
+          configure_preset: ${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          build_preset: ${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          output_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          build_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
+          install_prefix: install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,79 @@
+name: PR Checks
+
+# This workflow performs the following actions:
+#  - Builds all desktop platforms
+#  - Uploads the install tree as a workflow artifact
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-desktop:
+    name: Build ${{ matrix.platform.name }} ${{ matrix.config.build_type }} ${{ matrix.linkage.name }}
+    runs-on: ${{ matrix.platform.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: windows
+            runner: windows-2022
+            host_profile: windows_ninja
+            
+          - name: linux
+            runner: ubuntu-latest
+            host_profile: linux_gcc
+
+          - name: macos
+            runner: macos-latest
+            host_profile: osx_arm
+
+        config:
+          - build_type: Debug
+            preset_prefix: debug
+
+          - build_type: Release
+            preset_prefix: release
+
+          - build_type: RelWithDebInfo
+            preset_prefix: relwithdebinfo
+
+        linkage:
+          - name: static
+            shared: false
+            preset_postfix: -tests
+
+          - name: shared
+            shared: true
+            preset_postfix: ""
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Ensure we fetch tags so our automatic versioning script picks up the version.
+          fetch-tags: true
+
+      - name: Set up MSVC (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build and install
+        uses: ./.github/actions/build-and-install
+        with:
+          host_profile: ${{ matrix.platform.host_profile }}
+          build_type: ${{ matrix.config.build_type }}
+          configure_preset: ${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}${{ matrix.linkage.preset_postfix }}
+          build_preset: ${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}${{ matrix.linkage.preset_postfix }}
+          output_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          build_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
+          install_prefix: install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+
+      - name: Upload install tree
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          path: ${{ github.workspace }}/install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          if-no-files-found: error

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,11 +27,11 @@ jobs:
             host_profile: windows_ninja
             
           - name: linux
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             host_profile: linux_gcc
 
           - name: macos
-            runner: macos-latest
+            runner: macos-15
             host_profile: osx_arm
 
         config:
@@ -93,7 +93,7 @@ jobs:
     
   build-emscripten:
     name: Build emscripten ${{ matrix.config.build_type }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     
     env:
       EMSDK_VERSION: 5.0.2
@@ -142,7 +142,7 @@ jobs:
   
   build-android:
     name: Build android ${{ matrix.config.build_type }} ${{ matrix.linkage.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     
     strategy:
       fail-fast: false
@@ -185,7 +185,7 @@ jobs:
 
   ios-visionos-build:
     name: Build ${{ matrix.platform.name }} ${{ matrix.config.build_type }} ${{ matrix.linkage.name }}
-    runs-on: macos-latest
+    runs-on: macos-15
 
     strategy:
       fail-fast: false
@@ -256,7 +256,7 @@ jobs:
     # When Docker runs there, it attempts to pull Windows container images.
     # Because the MCS images are Linux images, Docker fails with "no matching manifest for windows(10.0.20348)/amd64"
     # For this reason, we currently run our local tests on Linux.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build-desktop
 
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,6 +60,14 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Resolve LFS
+        shell: bash
+        run: |
+          set -eux
+          git lfs ls-files
+          git lfs pull
+          git lfs checkout
+
       - name: Build and install
         uses: ./.github/actions/build-and-install
         with:
@@ -71,11 +79,12 @@ jobs:
           build_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
           install_prefix: install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
 
-      - name: Upload install tree
+      - name: Upload build
+        if: matrix.config.preset_prefix == 'relwithdebinfo' && matrix.linkage.name == 'static'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
-          path: ${{ github.workspace }}/install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          name: ${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}-build
+          path: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
           if-no-files-found: error
     
   build-emscripten:
@@ -233,3 +242,67 @@ jobs:
           output_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
           build_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
           install_prefix: install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+
+  tests-local-mcs:
+    name: Run Tests (Local MCS) Linux
+    runs-on: ubuntu-latest
+    needs: build-desktop
+
+    steps:
+      - name: Enable Git long paths
+        run: git config --global core.longpaths true
+
+      - uses: actions/checkout@v4
+        with:
+          repository: magnopus/Magnopus.Services
+          ssh-key: ${{ secrets.MSC_DEPLOY_KEY }}
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5
+
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker diagnostics
+        shell: bash
+        run: |
+          docker version
+          docker info
+          docker compose version
+
+      - name: Pull CHS
+        shell: bash
+        env:
+          COMPOSE_ANSI: never
+          COMPOSE_PROGRESS: plain
+        run: |
+          set -euxo pipefail
+          pip install requests
+          python Build/LocalContainers/start_current_o2dev.py
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: linux-relwithdebinfo-static-build
+          path: ${{ github.workspace }}/build/linux-relwithdebinfo-static/build/RelWithDebInfo
+
+      - name: Set endpoint var
+        shell: bash
+        run: |
+          echo "MAGNOPUS_SERVICES_ENDPOINT=http://localhost:8081/" >> "$GITHUB_ENV" 
+
+      - name: Run Tests
+        shell: bash
+        run: |
+          set -eux
+
+          cd "${{ github.workspace }}/build/linux-relwithdebinfo-static/build/RelWithDebInfo"
+
+          chmod +x ./MultiplayerTestRunner/MultiplayerTestRunner
+          chmod +x ./csp-tests
+          ./csp-tests

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Resolve LFS
         shell: bash
         run: |
-          set -eux
+          set -euxo pipefail
+
           git lfs ls-files
           git lfs pull
           git lfs checkout
@@ -224,7 +225,8 @@ jobs:
       - name: Initialize Xcode
         shell: bash
         run: |
-          set -eux
+          set -euxo pipefail
+
           xcodebuild -version
           sudo xcodebuild -runFirstLaunch
 
@@ -234,6 +236,7 @@ jobs:
         if: matrix.platform.name == 'visionos'
         shell: bash
         run: |
+          set -euo pipefail
           echo "CONAN_OPENSSL_CONFIGURATION=ios64-xcrun" >> "$GITHUB_ENV"
 
       - name: Build and install
@@ -283,6 +286,8 @@ jobs:
       - name: Docker diagnostics
         shell: bash
         run: |
+          set -euxo pipefail
+
           docker version
           docker info
           docker compose version
@@ -293,7 +298,8 @@ jobs:
           COMPOSE_ANSI: never
           COMPOSE_PROGRESS: plain
         run: |
-          set -euxo pipefail
+          set -euo pipefail
+
           pip install requests
           python Build/LocalContainers/start_current_o2dev.py
 
@@ -305,12 +311,13 @@ jobs:
       - name: Set endpoint var
         shell: bash
         run: |
+          set -euo pipefail
           echo "MAGNOPUS_SERVICES_ENDPOINT=http://localhost:8081/" >> "$GITHUB_ENV" 
 
       - name: Run Tests
         shell: bash
         run: |
-          set -eux
+          set -euxo pipefail
 
           cd "${{ github.workspace }}/build/linux-relwithdebinfo-static/build/RelWithDebInfo"
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -287,7 +287,7 @@ jobs:
           docker info
           docker compose version
 
-      - name: Pull CHS
+      - name: Pull and run CHS container
         shell: bash
         env:
           COMPOSE_ANSI: never

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,10 @@ if(BUILD_TESTING)
       -Wextra
       -Wno-error=changes-meaning
       -Wno-error=deprecated-declarations
+      # uninitialized and maybe-uninitialized are needed our test project.
+      # This to avoid treating GCC uninitialized warnings from GoogleTest headers as errors in Linux release builds.
+      -Wno-error=uninitialized
+      -Wno-error=maybe-uninitialized
       -Wno-missing-field-initializers
       -Wno-ignored-qualifiers
       -fpermissive

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -1230,7 +1230,9 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileTest)
     FILE* File = fopen(FilePath.string().c_str(), "rb");
     uintmax_t FileSize = std::filesystem::file_size(FilePath);
     auto* FileData = new unsigned char[FileSize];
-    fread(FileData, FileSize, 1, File);
+    size_t ElementCount = fread(FileData, FileSize, 1, File);
+    EXPECT_EQ(ElementCount, 1);
+    
     fclose(File);
 
     EXPECT_EQ(DownloadedAssetDataSize, FileSize);
@@ -1399,7 +1401,8 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsFileNoSpaceTest)
     FILE* File = fopen(FilePath.string().c_str(), "rb");
     uintmax_t FileSize = std::filesystem::file_size(FilePath);
     auto* FileData = new unsigned char[FileSize];
-    fread(FileData, FileSize, 1, File);
+    size_t ElementCount = fread(FileData, FileSize, 1, File);
+    EXPECT_EQ(ElementCount, 1);
     fclose(File);
 
     EXPECT_EQ(DownloadedAssetDataSize, FileSize);
@@ -1600,7 +1603,8 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UploadAssetAsBufferTest)
     FILE* UploadFile = fopen(UploadFilePath.string().c_str(), "rb");
     uintmax_t UploadFileSize = std::filesystem::file_size(UploadFilePath);
     auto* UploadFileData = new unsigned char[UploadFileSize];
-    fread(UploadFileData, UploadFileSize, 1, UploadFile);
+    size_t ElementCount = fread(UploadFileData, UploadFileSize, 1, UploadFile);
+    EXPECT_EQ(ElementCount, 1);
     fclose(UploadFile);
 
     csp::systems::BufferAssetDataSource BufferSource;
@@ -1792,7 +1796,9 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, UpdateAssetDataAsBufferTest)
     FILE* UpdateFile = fopen(UpdateFilePath.string().c_str(), "rb");
     uintmax_t UpdateFileSize = std::filesystem::file_size(UpdateFilePath);
     auto* UpdateFileData = new unsigned char[UpdateFileSize];
-    fread(UpdateFileData, UpdateFileSize, 1, UpdateFile);
+    size_t ElementCount = fread(UpdateFileData, UpdateFileSize, 1, UpdateFile);
+    EXPECT_EQ(ElementCount, 1);
+    
     fclose(UpdateFile);
 
     csp::systems::BufferAssetDataSource BufferSource;
@@ -2328,7 +2334,8 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, AssetSystemTests, CopyAssetCollectionTest)
         FILE* File = fopen(FilePath.string().c_str(), "rb");
         uintmax_t FileSize = std::filesystem::file_size(FilePath);
         auto* FileData = new unsigned char[FileSize];
-        fread(FileData, FileSize, 1, File);
+        size_t ElementCount = fread(FileData, FileSize, 1, File);
+        EXPECT_EQ(ElementCount, 1);
         fclose(File);
 
         EXPECT_EQ(DownloadedAssetDataSize, FileSize);

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -382,6 +382,10 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, SchemaComponentRoundtrip)
         Engine.ProcessPendingEntityOperations();
 
         AWAIT(SpaceSystem, ExitSpace);
+
+        // Ensure component data has been written to database by chs before entering the space again
+        // This is due to an enforced 2 second chs database write delay
+        std::this_thread::sleep_for(7s);
     }
 
     {

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,6 +38,7 @@ class CSP(ConanFile):
             # Override Pocos default OpenSSL to use OpenSSL 1.1
             # This is currently needed for support with Unreals OpenSSL lib.
             self.requires("openssl/1.1.1t", override=True)
+            self.requires("pcre2/10.44", override=True)
             self.requires("poco/1.14.2")
 
     def config_options(self):

--- a/profiles/host/ios_arm64
+++ b/profiles/host/ios_arm64
@@ -1,0 +1,9 @@
+[settings]
+os=iOS
+arch=armv8
+compiler=apple-clang
+compiler.cppstd=17
+compiler.version=15
+compiler.libcxx=libc++
+os.version=17.0
+os.sdk=iphoneos

--- a/profiles/host/visionos_arm64
+++ b/profiles/host/visionos_arm64
@@ -1,0 +1,14 @@
+[settings]
+os=visionOS
+os.sdk=xros
+os.version=1.0
+arch=armv8
+compiler=apple-clang
+compiler.version=15
+compiler.cppstd=17
+compiler.libcxx=libc++
+
+[buildenv]
+# Manually specify the OpenSSL configure target used by the Conan recipe,
+# as the OpenSSL 1.1 recipe does not fully support visionOS.
+CONAN_OPENSSL_CONFIGURATION=ios64-xcrun


### PR DESCRIPTION
This PR sets up a PR check workflow using Github Actions by building all of our supported platforms except wasm which is included in the next PR.

It then runs our Linux RelWithDebInfo tests. A comment was added explaining the reason we used Linux over Windows - Essentially the GitHub hosted Windows runners does not give you that same Linux container runtime that Dockwer Desktop does.

- Also adds missing iOS and visionIS Conan host profiles
- Also fixes a couple of bugs