### PR TITLE
[NT-0] test: Refresh Token Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. For compile
 
 - [NT-0] chore: Initialize pointer value in material result to nullptr. By @MAG-ElliotMorris
 
+- [NT-0] chore: Remove redundant `RealtimeEngine` shared_ptr in `SystemsManager`. By @MAG-ElliotMorris
+
 ## [6.44.0]
 
 ### 🐛 🔨 Bug Fixes

--- a/Library/include/CSP/Systems/SystemsManager.h
+++ b/Library/include/CSP/Systems/SystemsManager.h
@@ -201,7 +201,6 @@ private:
     csp::web::WebClient* WebClient;
 
     csp::multiplayer::MultiplayerConnection* MultiplayerConnection;
-    std::shared_ptr<csp::common::IRealtimeEngine> RealtimeEngine;
     UserSystem* UserSystem;
     SpaceSystem* SpaceSystem;
     AssetSystem* AssetSystem;

--- a/Library/src/Systems/SystemsManager.cpp
+++ b/Library/src/Systems/SystemsManager.cpp
@@ -133,7 +133,6 @@ csp::common::IRealtimeEngine* SystemsManager::MakeRealtimeEngine(csp::common::Re
 SystemsManager::SystemsManager()
     : WebClient(nullptr)
     , MultiplayerConnection(nullptr)
-    , RealtimeEngine(nullptr)
     , UserSystem(nullptr)
     , SpaceSystem(nullptr)
     , AssetSystem(nullptr)

--- a/Tests/src/PublicAPITests/UserSystemTests.cpp
+++ b/Tests/src/PublicAPITests/UserSystemTests.cpp
@@ -336,6 +336,43 @@ CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LogInAsGuestDeferredProfileCreationT
     LogOut(UserSystem);
 }
 
+CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, LoginWithRefreshToken)
+{
+    auto* UserSystem = csp::systems::SystemsManager::Get().GetUserSystem();
+
+    // Login to backend services in order to get the information to get a refresh token
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId, false); // No need to create a multiplayer connection here
+
+    const auto RefreshToken = csp::web::HttpAuth::GetRefreshToken();
+
+    // Shutdown and restart CSP. To simulate closing the app/tab and wanting to auto-login via refresh
+    // This is just taken from the fixture code we run at the start of every test.
+    csp::CSPFoundation::Shutdown();
+
+    InitialiseFoundationWithUserAgentInfo(EndpointBaseURI());
+
+    csp::common::LogSystem* LogSystem = csp::systems::SystemsManager::Get().GetLogSystem();
+    LogSystem->SetSystemLevel(csp::common::LogLevel::VeryVerbose);
+    LogSystem->SetLogCallback([](csp::common::LogLevel, csp::common::String Message) { fprintf(stderr, "%s\n", Message.c_str()); });
+    LogSystem->LogMsg(csp::common::LogLevel::Verbose, "Foundation initialised!");
+
+    // New CSP, new objects.
+    auto* Connection = csp::systems::SystemsManager::Get().GetMultiplayerConnection();
+    UserSystem = csp::systems::SystemsManager::Get().GetUserSystem();
+
+    AWAIT(Connection, SetAllowSelfMessagingFlag, false);
+
+    // Login with our new token
+    auto [Result] = AWAIT_PRE(UserSystem, LoginWithRefreshToken, RequestPredicate, UserId.c_str(), RefreshToken, true, nullptr);
+
+    ASSERT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Success);
+    ASSERT_EQ(Result.GetHttpResultCode(), static_cast<uint16_t>(csp::web::EResponseCodes::ResponseOK));
+    ASSERT_EQ(Result.GetLoginState().GetLoginStateValue(), csp::common::ELoginState::LoggedIn);
+    ASSERT_EQ(Result.GetLoginState().GetUserId(), UserId);
+    ASSERT_EQ(Connection->GetConnectionState(), csp::multiplayer::ConnectionState::Connected);
+}
+
 CSP_PUBLIC_TEST(CSPEngine, UserSystemTests, BadTokenLogInTest)
 {
     auto& SystemsManager = csp::systems::SystemsManager::Get();


### PR DESCRIPTION
Add an automated refresh token test. Patching a hole in our test coverage.

~~Whilst shutting down/restarting CSP as part of this test, I noted there was some bad behaviour with a completely redundant shared ptr in Systems Manager. I have deleted it to prevent flakiness.~~
Actually there isn't, I think I was misinterpreting a failure from an earlier version of the test function that had a use after free. Have rerun the tests both with and without the removal 20x and can find no crashes.

Nonetheless, going to merge this, as it's a redundant unnecesary data member. Will split it out if anyone feels super strongly but tbh going through the whole PR/CI cycle is _ugh_

