### PR TITLE
[OF-1880] feat: Add `x-auth-token` header to asset download methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to this project will be documented in this file. For compile
 - [OF-1878] feat: Add support for federated login. @MAG-AdamThorn & @MAG-mv
   A new federated login flow is being added that will allow client applications to authenticate directly with MCS. They will not be authenticating through CSP as they currently do. This creates a problem, as with our current login flows we create the LoginState object via `LoginState::OnResponse`. This data is then used to; refresh the token, for secure asset download, when starting the Multiplayer Connection among other things. To support federated login CSP has added a new `UserSystem::FederatedLogin()` method that clients can call to pass the base64 encoded AuthDto json object to CSP.
 
+- [OF-1880] feat: Add `x-auth-token` header to asset download methods by @mag-lt.
+  This ensures we set `x-auth-token` headers for the requests that are sent when calling the asset
+  download related methods on the `AssetSystem` (i.e. `DownloadAssetData`, `DownloadAssetDataEx`).
+  Most of the work for this was done in a prior release (6.34.0 as part of [OF-1844]), this just
+  updates the header set for auth (`x-auth-token` vs `Authorization` that we use for all other requests).
+
 ### 🔥 ❗Breaking Changes
 
 - [OB-5368] fix!: Guard access to LoginState data with a mutex. By @MAG-AdamThorn.

--- a/Library/src/Web/RemoteFileManager.cpp
+++ b/Library/src/Web/RemoteFileManager.cpp
@@ -65,7 +65,7 @@ void RemoteFileManager::GetFile(
 
     if (BearerToken.HasValue())
     {
-        Payload.AddHeader(CSP_TEXT("Authorization"), *BearerToken);
+        Payload.AddHeader(CSP_TEXT("x-auth-token"), *BearerToken);
     }
 
     WebClient->SendRequest(csp::web::ERequestVerb::GET, GetUri, Payload, ResponseHandler, CancellationToken);
@@ -80,7 +80,7 @@ void RemoteFileManager::GetResponseHeaders(const csp::common::String& Url, csp::
 
     if (BearerToken.HasValue())
     {
-        Payload.AddHeader(CSP_TEXT("Authorization"), *BearerToken);
+        Payload.AddHeader(CSP_TEXT("x-auth-token"), *BearerToken);
     }
 
     WebClient->SendRequest(csp::web::ERequestVerb::HEAD, GetUri, Payload, ResponseHandler, csp::common::CancellationToken::Dummy());

--- a/Tests/cmake/test_files.cmake
+++ b/Tests/cmake/test_files.cmake
@@ -25,6 +25,7 @@ set(CSP_TESTS_SOURCES
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/NewFeatureTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/PlatformTestUtils.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/PlatformTestUtils.h
+    ${CSP_TESTS_SOURCE_DIR}/InternalTests/RemoteFileManagerTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/SceneDescriptionTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/SchedulerTests.cpp
     ${CSP_TESTS_SOURCE_DIR}/InternalTests/ServicesTests.cpp

--- a/Tests/src/InternalTests/RemoteFileManagerTests.cpp
+++ b/Tests/src/InternalTests/RemoteFileManagerTests.cpp
@@ -76,7 +76,7 @@ TEST_P(GetFile, GetFileSendsCorrectRequest)
                 if (LoginState.GetLoginStateValue() == csp::common::ELoginState::LoggedIn)
                 {
                     // Verify that the Authorization header is present
-                    auto AuthIt = Headers.find("Authorization");
+                    auto AuthIt = Headers.find("x-auth-token");
                     ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
 
                     std::string BearerToken = AuthIt->second;
@@ -135,7 +135,7 @@ TEST_P(GetResponseHeaders, GetResponseHeadersSendsCorrectRequest)
                     EXPECT_EQ(Headers.size(), 2) << "Expected exactly two headers to be present in the request";
 
                     // Verify that the Authorization header is present
-                    auto AuthIt = Headers.find("Authorization");
+                    auto AuthIt = Headers.find("x-auth-token");
                     ASSERT_NE(AuthIt, Headers.end()) << "Authorization header should be present when the user is logged in";
 
                     std::string BearerToken = AuthIt->second;


### PR DESCRIPTION
There were preemptive changes added for this a few months ago in 058fc3565e8f1141f3935efd0fdff484e47f5c19.

Now the header for this is `x-auth-token` vs the `Authorization` header we use elsewhere. So, update accordingly just for these asset related methods.