### PR TITLE
[OB-5522] fix: Setup entity script component accessors to use correct instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.44.0]
+
+### 🐛 🔨 Bug Fixes
+
+- [OB-5522] fix: Setup entity script component accessors to use correct instance. @mag-lt.
+  This addresses a regression introduced in 6.38.0 made in the context of binding components created w/ Schemas into scripts automatically.
+  Those changes accidentally made it so component accessors called on entities that are looked up by name or id returned the wrong information
+  i.e. they returned the information of the entity that owns the script instead.
 
 ## [6.43.0]
 

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -75,6 +75,12 @@ namespace
         UnlockFuncValueT _UnlockFunc;
     };
 
+    template <typename T> qjs::Value GetClassPrototype(qjs::Context& Context)
+    {
+        const auto ClassId = qjs::js_traits<std::shared_ptr<T>>::QJSClassId;
+        return qjs::Value { Context.ctx, JS_GetClassProto(Context.ctx, ClassId) };
+    }
+
     // Creates a JS prototype for a specific component type, baking in specialized accessors
     // that map directly to the correctly typed proxy property.
     template <typename ScriptInterfaceType = ComponentScriptInterface>
@@ -82,8 +88,7 @@ namespace
     {
         static_assert(std::is_base_of_v<ComponentScriptInterface, ScriptInterfaceType>);
 
-        const auto ClassId = qjs::js_traits<std::shared_ptr<ScriptInterfaceType>>::QJSClassId;
-        const auto BasePrototype = qjs::Value { Context.ctx, JS_GetClassProto(Context.ctx, ClassId) };
+        const auto BasePrototype = GetClassPrototype<ScriptInterfaceType>(Context);
         const auto SchemaDerivedPrototype = qjs::Value { Context.ctx, JS_NewObjectProto(Context.ctx, BasePrototype.v) };
 
         auto CreateAccessors = [](const auto& V) -> std::optional<std::pair<JSCFunctionMagic*, JSCFunctionMagic*>>
@@ -486,7 +491,7 @@ void EntityScriptBinding::Bind(int64_t ContextId, csp::common::IJSScriptRunner& 
 
     Module->function("Log", [&LogSystem = this->LogSystem](qjs::rest<std::string> Args) { EntityScriptLog(std::move(Args), LogSystem); });
 
-    const auto RegisterDynamicComponentGetters = [this, Context, ContextId](auto&& ClassRegistrar) -> decltype(auto)
+    const auto RegisterDynamicComponentGetters = [this, Context](auto Proto)
     {
         for (const auto& Schema : EntitySystem->GetComponentSchemaRegistry()->GetAll())
         {
@@ -495,23 +500,24 @@ void EntityScriptBinding::Bind(int64_t ContextId, csp::common::IJSScriptRunner& 
                 const auto& ComponentScriptName = Schema.Name;
                 const auto GetterName = fmt::format("get{}Components", ComponentScriptName.c_str());
 
-                ClassRegistrar.fun(GetterName.c_str(),
-                    [this, Schema = Schema, Context, ContextId]() -> std::vector<qjs::Value>
-                    {
-                        if (auto* Entity = EntitySystem->FindSpaceEntityById(ContextId))
-                        {
-                            return SchemaCache->GetComponents(*Context, *Entity->GetScriptInterface(), Schema);
-                        }
+                const auto GetterImpl
+                    = [this, Schema, Context](EntityScriptInterface* Entity) { return SchemaCache->GetComponents(*Context, *Entity, Schema); };
 
-                        return {};
-                    });
+                const auto Getter
+                    = [](JSContext* Context, JSValueConst This, int /*ArgC*/, JSValueConst* /*ArgV*/, int /*Magic*/, JSValue* FnData) -> JSValue
+                {
+                    const auto GetterImpl = FnData[0];
+                    return JS_Call(Context, GetterImpl, JS_UNDEFINED, 1, &This);
+                };
+
+                auto FnData = Context->newValue(GetterImpl);
+
+                JS_SetPropertyStr(Context->ctx, Proto.v, GetterName.c_str(), JS_NewCFunctionData(Context->ctx, Getter, 0, 0, 1, &FnData.v));
             }
         }
-
-        return std::forward<decltype(ClassRegistrar)>(ClassRegistrar);
     };
 
-    RegisterDynamicComponentGetters(Module->class_<EntityScriptInterface>("Entity"))
+    Module->class_<EntityScriptInterface>("Entity")
         .constructor<>()
         .fun<&EntityScriptInterface::SubscribeToPropertyChange>("subscribeToPropertyChange")
         .fun<&EntityScriptInterface::SubscribeToMessage>("subscribeToMessage")
@@ -530,6 +536,8 @@ void EntityScriptBinding::Bind(int64_t ContextId, csp::common::IJSScriptRunner& 
         .property<&EntityScriptInterface::GetId>("id")
         .property<&EntityScriptInterface::GetName>("name")
         .property<&EntityScriptInterface::GetParentId, &EntityScriptInterface::SetParentId>("parentId");
+
+    RegisterDynamicComponentGetters(GetClassPrototype<EntityScriptInterface>(*Context));
 
     Module->class_<ComponentScriptInterface>("Component")
         .constructor<>()

--- a/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
@@ -715,7 +715,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleEntityIn
     const auto& EntityOneComponent = EntityOne.SchemaComponents.front();
     EXPECT_EQ(EntityOneComponent.GetProperty(0), "1");
 
-    auto EntityTwo = Fixture.MakeEntity("Test Entity",
+    auto EntityTwo = Fixture.MakeEntity("Test Entity 2",
         {
             TestFixture::Entity::ComponentCreationArgs {
                 Schema::TypeIdType { 123 },
@@ -743,6 +743,15 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleEntityIn
         const example = ThisEntity.getExampleComponents()[0];
 
         assert(example.stringProperty === "1", "first entity remains unchanged");
+    )"));
+
+    EXPECT_TRUE(Fixture.InvokeScript(EntityTwo, R"(
+        import { assert } from "CSPTest";
+
+        const otherEntity = TheEntitySystem.getEntityByName("Test Entity");
+        const example = otherEntity.getExampleComponents()[0];
+
+        assert(example.stringProperty === "1", "first entity when looked up dynamically on second entity returns correct component state ");
     )"));
 }
 


### PR DESCRIPTION
The automatic script registration from component schema in 289c271103b622e22de83c0f1413511e192200f9 accidentally regressed the behaviour when looking up other entities in scripts.

The fix here requires dropping down to the quickjs C API again to setup these instance methods dynamically in such a way that all the context is available (the approach used initially to setup a function on the quickjspp class_registrar is flawed, as we don't seem to be able to get a reference to the actual instance, and it isn't safe to assume it is the entity instance that owns the script, which is what was being done with the captured state in the lambda and was the cause of this regression).

More info in the individual commits.