### PR TITLE
[NT-0] feat: Only send cookies if hosts match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file. For compile
   Those changes accidentally made it so component accessors called on entities that are looked up by name or id returned the wrong information
   i.e. they returned the information of the entity that owns the script instead.
 
+- [NT-0] fix: Fix Download asset calls failing. By @MAG-mv
+  Cookies are now handled better by only sending them to hosts that match. DownloadAsset is using a different host than other calls,
+  so sending cookies to this endpoint was causing calls to be rejected.
+
 ## [6.43.0]
 
 ### 🍰 🙌 New Features

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
@@ -222,7 +222,7 @@ void POCOWebClient::Send(HttpRequest& Request)
     }
 }
 
-void POCOWebClient::AddCookie(Poco::Net::HTTPRequest & PocoRequest, const std::string& Domain)
+void POCOWebClient::AddCookie(Poco::Net::HTTPRequest& PocoRequest, const std::string& Domain)
 {
     {
         std::scoped_lock Lock(CookiesMutex);

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
@@ -242,6 +242,9 @@ void POCOWebClient::AddCookie(Poco::Net::HTTPRequest& PocoRequest, const std::st
 
         for (const auto& Cookie : *Cookies)
         {
+            // Only send cookies whose domain scope matches the request host.
+            // This prevents cookies set by one endpoint from being sent to
+            // another endpoint that did not expect them.
             if (Domain == Cookie.Domain)
             {
                 CookieCollection.add(Cookie.Name, Cookie.Value);

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.cpp
@@ -99,7 +99,7 @@ bool POCOWebClient::PrepareAndSendRequest(
         PocoRequest.add(Header.first.c_str(), Header.second.c_str());
     }
 
-    AddCookie(PocoRequest);
+    AddCookie(PocoRequest, ClientSession->getHost());
 
     switch (SendBodyMode)
     {
@@ -144,7 +144,14 @@ std::istream& POCOWebClient::ReceiveResponse(Poco::Net::HTTPClientSession* Clien
 
     {
         std::scoped_lock Lock(CookiesMutex);
-        PocoResponse.getCookies(*Cookies);
+
+        std::vector<Poco::Net::HTTPCookie> ResponseCookies;
+        PocoResponse.getCookies(ResponseCookies);
+
+        for (const auto& ResponseCookie : ResponseCookies)
+        {
+            Cookies->push_back(CookieData { ResponseCookie.getName(), ResponseCookie.getValue(), ClientSession->getHost() });
+        }
     }
 
     return ResponseStream;
@@ -215,7 +222,7 @@ void POCOWebClient::Send(HttpRequest& Request)
     }
 }
 
-void POCOWebClient::AddCookie(Poco::Net::HTTPRequest& PocoRequest)
+void POCOWebClient::AddCookie(Poco::Net::HTTPRequest & PocoRequest, const std::string& Domain)
 {
     {
         std::scoped_lock Lock(CookiesMutex);
@@ -233,9 +240,12 @@ void POCOWebClient::AddCookie(Poco::Net::HTTPRequest& PocoRequest)
     {
         std::scoped_lock Lock(CookiesMutex);
 
-        for (const Poco::Net::HTTPCookie& Cookie : *Cookies)
+        for (const auto& Cookie : *Cookies)
         {
-            CookieCollection.add(Cookie.getName(), Cookie.getValue());
+            if (Domain == Cookie.Domain)
+            {
+                CookieCollection.add(Cookie.Name, Cookie.Value);
+            }
         }
     }
 

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
@@ -35,7 +35,6 @@ struct CookieData
 {
     std::string Name;
     std::string Value;
-
     std::string Domain;
 };
 

--- a/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
+++ b/Library/src/Common/Web/POCOWebClient/POCOWebClient.h
@@ -31,6 +31,15 @@ class LogSystem;
 namespace csp::web
 {
 
+struct CookieData
+{
+    std::string Name;
+    std::string Value;
+
+    std::string Domain;
+};
+
+
 class PocoPrivateKeyHandler : public Poco::Net::PrivateKeyPassphraseHandler
 {
 public:
@@ -67,7 +76,7 @@ protected:
     void Send(HttpRequest& Request) override;
 
     void Get(HttpRequest& Request);
-    void AddCookie(Poco::Net::HTTPRequest& PocoRequest);
+    void AddCookie(Poco::Net::HTTPRequest& PocoRequest, const std::string& Domain);
     void Post(HttpRequest& Request);
     void Put(HttpRequest& Request);
     void Delete(HttpRequest& Request);
@@ -81,7 +90,7 @@ protected:
 
     Poco::Net::Context::Ptr PocoContext;
 
-    std::vector<Poco::Net::HTTPCookie>* Cookies;
+    std::vector<CookieData>* Cookies;
     std::mutex CookiesMutex;
 
 private:

--- a/Tests/src/Awaitable.h
+++ b/Tests/src/Awaitable.h
@@ -26,7 +26,7 @@ using namespace std::chrono_literals;
 
 #define STRIP(__Type_) std::remove_const_t<std::remove_reference_t<__Type_>>
 
-constexpr std::chrono::duration<int> DefaultTimeout = 40s;
+constexpr std::chrono::duration<int> DefaultTimeout = 60s;
 
 class timeout_exception : public std::runtime_error
 {

--- a/Tests/src/Awaitable.h
+++ b/Tests/src/Awaitable.h
@@ -26,7 +26,7 @@ using namespace std::chrono_literals;
 
 #define STRIP(__Type_) std::remove_const_t<std::remove_reference_t<__Type_>>
 
-constexpr std::chrono::duration<int> DefaultTimeout = 60s;
+constexpr std::chrono::duration<int> DefaultTimeout = 120s;
 
 class timeout_exception : public std::runtime_error
 {

--- a/Tests/src/PublicAPITests/AssetSystemTests.cpp
+++ b/Tests/src/PublicAPITests/AssetSystemTests.cpp
@@ -2216,7 +2216,7 @@ CSP_PUBLIC_TEST(CSPEngine, AssetSystemTests, DownloadAssetDataInvalidURLTest)
         auto [Result] = AWAIT_PRE(AssetSystem, DownloadAssetData, RequestPredicate, Asset);
 
         EXPECT_EQ(Result.GetResultCode(), csp::systems::EResultCode::Failed);
-        EXPECT_EQ(Result.GetHttpResultCode(), 403);
+        EXPECT_EQ(Result.GetHttpResultCode(), 404);
     }
 
     // Log out


### PR DESCRIPTION
This addresses and issue with cookies being sent to incorrect endpoints. We were previously storing all cookies and sending them in all future calls. Now, we always check to make sure the hosts match before sending.

This also increases our async timeout, as some calls are taking longer than the current 40 seconds.

This also updates InvalidURLTest to expect a 404 instead of 403. This is likely due to recent MCS changes that we will discuss