### PR TITLE
Initialize material result as nullptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.45.0]
+
+### 🔨 🔨 Chore
+
+- [NT-0] chore: Initialize pointer value in material result to nullptr. By @MAG-ElliotMorris
+
 ## [6.44.0]
 
 ### 🐛 🔨 Bug Fixes

--- a/Library/include/CSP/Systems/Assets/Material.h
+++ b/Library/include/CSP/Systems/Assets/Material.h
@@ -180,7 +180,7 @@ private:
 
     CSP_NO_EXPORT void OnResponse(const csp::services::ApiResponseBase* ApiResponse) override;
 
-    Material* Material;
+    Material* Material = nullptr;
 };
 
 /// @ingroup Asset System


### PR DESCRIPTION
There's no harm to doing this, and there are failure paths where incomplete results are passed through. (Ie, results that haven't called SetMaterial ... not the best interface design as it allows these half-constructed states)

Don't think this will directly fix anything, but makes the data more sanitized.
