### PR TITLE
[NT-0] ci: Create new branch for unity integration in PRs

### DIFF
--- a/.github/workflows/unity-interop-tests.yml
+++ b/.github/workflows/unity-interop-tests.yml
@@ -1,12 +1,38 @@
 name: .NET Interop Binding Integration
 
 # Run a fully integrated build of the unity bindings, based on the CSP build from the current branch.
-# If breaking changes are made, push directly to the "csp-development" branch in the connected-spaces-platform-unity repo, which represents the breaking changeset of the next release.
+# Tests run against a dedicated branch in the connected-spaces-platform-unity repo, forked from
+# "csp-development" and named after the branch that triggered the run, e.g. "csp-development-my-branch".
+# If breaking changes are made, push to that branch to unblock these tests, then manually merge it
+# back into "csp-development" once the CSP change lands.
+# This workflow requires token permissions to create a branch, so will not run from forks.
+
 on:
   pull_request:
   workflow_dispatch:
 
 jobs:
+
+  # Creates the per-branch binding branch from csp-development, or reuses it if it already
+  # exists (so commits contributors have pushed to it survive re-runs). Any other failure
+  # (e.g. bad credentials, missing base branch) fails the job so it isn't silently swallowed.
+  create-binding-branch:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.DOTNET_REPO_ACCESS_TOKEN }}
+      REPO: magnopus-opensource/connected-spaces-platform-unity
+      BRANCH: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+    steps:
+      # We want this job to fail for all errors except when the branch already exists.
+      # Easiest to just not try to branch in that case, rather than doing inline error management.
+      - run: |
+          if gh api "repos/$REPO/git/ref/heads/$BRANCH" --silent; then
+            echo "$BRANCH already exists, reusing it."
+          else
+            echo "Creating $BRANCH from csp-development."
+            gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" \
+              -f sha="$(gh api "repos/$REPO/git/ref/heads/csp-development" -q .object.sha)"
+          fi
 
   # Leveraging the fact that github makes a "pull/number/head" ref for PRs.
   # Doing it this way means that PRs from both branches and forks will work.
@@ -14,6 +40,7 @@ jobs:
   # it will still be in untrusted mode, and only have read only capabilities.
   # Workflow_dispatch triggers should fall through to use github.ref_name.
   run-unity-interop-layer-integration:
+    needs: create-binding-branch
     uses: magnopus-opensource/connected-spaces-platform-unity/.github/workflows/build-desktop.yml@csp-development
     with:
       unity_ext_matrix: '[false]'
@@ -22,5 +49,4 @@ jobs:
         ${{ github.event_name == 'pull_request'
             && format('refs/pull/{0}/head', github.event.pull_request.number)
             || github.ref_name }}
-      binding_repo_branch: csp-development
-
+      binding_repo_branch: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/unity-interop-tests.yml
+++ b/.github/workflows/unity-interop-tests.yml
@@ -19,20 +19,17 @@ jobs:
   create-binding-branch:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.DOTNET_REPO_ACCESS_TOKEN }}
-      REPO: magnopus-opensource/connected-spaces-platform-unity
-      BRANCH: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+      # The usual pattern to support both PR and workflow_dispatch refs
+      BRANCH_TO: csp-development-${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
     steps:
-      # We want this job to fail for all errors except when the branch already exists.
-      # Easiest to just not try to branch in that case, rather than doing inline error management.
-      - run: |
-          if gh api "repos/$REPO/git/ref/heads/$BRANCH" --silent; then
-            echo "$BRANCH already exists, reusing it."
-          else
-            echo "Creating $BRANCH from csp-development."
-            gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" \
-              -f sha="$(gh api "repos/$REPO/git/ref/heads/csp-development" -q .object.sha)"
-          fi
+      - uses: GuillaumeFalourd/create-other-repo-branch-action@v1.5
+        with:
+          repository_owner: magnopus-opensource
+          repository_name: connected-spaces-platform-unity
+          new_branch_name: ${{env.BRANCH_TO}} # Need to expand this here because there's a minor quoting bug in the action, trivial.
+          new_branch_ref: csp-development
+          access_token: ${{ secrets.DOTNET_REPO_ACCESS_TOKEN}}
+          ignore_branch_exists: true
 
   # Leveraging the fact that github makes a "pull/number/head" ref for PRs.
   # Doing it this way means that PRs from both branches and forks will work.


### PR DESCRIPTION
Create a branch to run the unity integrations against, rather than always using `csp-development`, as that can have overlap problems. If developers make pushes to the ephemeral branch, it is up to them to merge them into `csp-development`.

This is a new PR, there was a previous one, but I needed a new ref to test against. The changeset is almost identical. _except_ for how we're now using an off the shelf action to create the branch, rather than trying to do it through API commands. I was trying to avoid checking out the unity repo in order to branch, but it became rather complicated. This action does checkout the unity repo, which in the scheme of things is actually fine, and it documents what we're doing in the action much better than the direct REST api which is less than good.

I actually did end up with a fully working API version ... but it got so complex that I wanted to put it in a `.sh` script, which meant checking out this repo to access the script ... which made me realize I was getting tied in knots over nothing.

> [!TIP]
>
> The first commit shows the old way, which we migrated away from. Don't spend too much time thinking about it.

## Testing

- You can see the first run [here](https://github.com/magnopus-opensource/connected-spaces-platform/actions/runs/28027670067/job/82959533356), which creates a new branch.
- The second run [here ](https://github.com/magnopus-opensource/connected-spaces-platform/actions/runs/28036381624/job/82990749684?pr=994) does not fail, but does log that the branch creation is skipped as the branch already exists.
- You can see the branch is created on the target repo [here](https://github.com/magnopus-opensource/connected-spaces-platform-unity/tree/csp-development-work/csp-development-branch). (it even managed to deal with the weird slashes i do in my branch names)
- You can see the action using the new branch [here](https://github.com/magnopus-opensource/connected-spaces-platform/actions/runs/28036381624/job/82990781046?pr=994), although you'll have to expand into the checkout step a bit.
