### PR TITLE
[OF-1840] feat Android Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,11 @@ target_link_libraries(csp-lib
     csp-quickjs
 )
 
+if(ANDROID)
+  # Link Android's native log library for __android_log_print
+  target_link_libraries(csp-lib PRIVATE log)
+endif()
+
 # Only include POCO for non-Emscripten builds
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   target_link_libraries(csp-lib

--- a/Library/src/Common/Systems/Log/LogSystem.cpp
+++ b/Library/src/Common/Systems/Log/LogSystem.cpp
@@ -84,7 +84,7 @@ void LogSystem::LogMsg(const csp::common::LogLevel Level, const csp::common::Str
 #endif
 
 #if defined(CSP_ANDROID)
-        __android_log_print(ANDROID_LOG_VERBOSE, "CSP", InMessage.c_str());
+        __android_log_print(ANDROID_LOG_VERBOSE, "CSP", "%s", InMessage.c_str());
 #endif
     }
 }

--- a/profiles/host/android_arm
+++ b/profiles/host/android_arm
@@ -1,0 +1,16 @@
+[settings]
+os=Android
+os.api_level=27
+arch=armv8
+compiler=clang
+compiler.cppstd=17
+compiler.libcxx=c++_static
+compiler.version=17
+
+
+[tool_requires]
+ninja/1.11.1
+android-ndk/r29
+
+[conf]
+tools.cmake.cmaketoolchain:generator=Ninja

--- a/profiles/host/android_x86_64
+++ b/profiles/host/android_x86_64
@@ -1,0 +1,16 @@
+[settings]
+os=Android
+os.api_level=27
+arch=x86_64
+compiler=clang
+compiler.cppstd=17
+compiler.libcxx=c++_static
+compiler.version=17
+
+
+[tool_requires]
+ninja/1.11.1
+android-ndk/r29
+
+[conf]
+tools.cmake.cmaketoolchain:generator=Ninja


### PR DESCRIPTION
This adds a couple of fixes + host profile to allow CSP to build for Android. This includes:

- Added an extra param to fix __android_log_print. This was previously hidden using -Wno-error=format-security
- Linking Android log lib so shared libs build
- Added Android host profiles