### PR TITLE
[OF-1840] feat: Add legacy wrapper gen macro

### DIFF
--- a/Library/premake5.lua
+++ b/Library/premake5.lua
@@ -118,7 +118,8 @@ if not Project then
             "POCO_NET_NO_IPv6",
 			"LIBASYNC_STATIC",
             "LIBASYNC_CUSTOM_DEFAULT_SCHEDULER",
-            "FMT_HEADER_ONLY"
+            "FMT_HEADER_ONLY",
+            "USE_LEGACY_WRAPPER_GEN"
         }
 
         filter "platforms:not wasm"

--- a/Library/src/CSPFoundation.cpp
+++ b/Library/src/CSPFoundation.cpp
@@ -15,7 +15,10 @@
  */
 #include "CSP/CSPFoundation.h"
 
+#if defined(USE_LEGACY_WRAPPER_GEN)
 #include "../../Tools/WrapperGenerator/Output/C/generated_wrapper.h"
+#endif
+
 #include "CSP/Common/StringFormat.h"
 #include "CSP/Common/fmt_Formatters.h"
 #include "CSP/Systems/ServiceStatus.h"


### PR DESCRIPTION
This finally adds a macro around the generated macro header, meaning we won't need to call generate_solution in the new build system for development..

CSPFoundation contains an autogenerated header file from the wrapper generator. We don't need to use this in circumstances where the wrapper generator isn't used, so guard with a macro.