### PR TITLE
[NT-0] chore: Misc export related fixes

### DIFF
--- a/Library/include/CSP/CSPFoundation.h
+++ b/Library/include/CSP/CSPFoundation.h
@@ -83,6 +83,9 @@ public:
 
     const csp::common::String& GetDescription() { return Description; };
 
+    bool operator==(const FeatureFlag& Other) const { return Type == Other.Type && Enabled == Other.Enabled && Description == Other.Description; }
+    bool operator!=(const FeatureFlag& Other) const { return !(*this == Other); }
+
 private:
     csp::common::String Description;
 };

--- a/Library/include/CSP/Multiplayer/ComponentSchema.h
+++ b/Library/include/CSP/Multiplayer/ComponentSchema.h
@@ -61,6 +61,8 @@ public:
     bool operator!=(const ComponentSchema& Other) const;
 };
 
+CSP_START_IGNORE
+
 /// @brief Parses a list of JSON documents into an array of component schemas.
 /// Each document is expected to be a JSON array of schema objects.
 /// Entries that fail to parse are skipped with a warning; valid entries in the same document are still returned.
@@ -70,5 +72,7 @@ public:
 /// @return An array containing all successfully parsed schemas.
 csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
     const csp::common::List<csp::common::String>& JsonDocuments, csp::common::LogSystem& LogSystem);
+
+CSP_END_IGNORE
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Systems/Assets/LOD.h
+++ b/Library/include/CSP/Systems/Assets/LOD.h
@@ -44,6 +44,9 @@ class CSP_API LODAsset
 public:
     Asset Asset;
     int Level = 0;
+
+    bool operator==(const LODAsset& Other) const;
+    bool operator!=(const LODAsset& Other) const;
 };
 
 /// @ingroup Asset System

--- a/Library/include/CSP/Systems/Maintenance/Maintenance.h
+++ b/Library/include/CSP/Systems/Maintenance/Maintenance.h
@@ -43,6 +43,9 @@ public:
     csp::common::String Description;
     csp::common::String StartDateTimestamp;
     csp::common::String EndDateTimestamp;
+
+    bool operator==(const MaintenanceInfo& Other) const;
+    bool operator!=(const MaintenanceInfo& Other) const;
 };
 
 /// @ingroup CSPFoundation

--- a/Library/src/ExplicitTypes.cpp
+++ b/Library/src/ExplicitTypes.cpp
@@ -21,6 +21,7 @@
 #include "CSP/Common/Optional.h"
 #include "CSP/Common/String.h"
 #include "CSP/Common/Vector.h"
+#include "CSP/Multiplayer/ComponentSchema.h"
 #include "CSP/Multiplayer/Conversation/Conversation.h"
 #include "CSP/Multiplayer/NetworkEventBus.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
@@ -54,6 +55,8 @@
 template class CSP_API csp::common::Array<csp::common::Map<csp::common::String, csp::common::String>>;
 template class CSP_API csp::common::Array<csp::common::String>;
 template class CSP_API csp::common::Array<csp::multiplayer::ComponentBase*>;
+template class CSP_API csp::common::Array<csp::multiplayer::ComponentProperty>;
+template class CSP_API csp::common::Array<csp::multiplayer::ComponentSchema>;
 template class CSP_API csp::common::Array<csp::multiplayer::ComponentUpdateInfo>;
 template class CSP_API csp::common::Array<csp::multiplayer::MessageInfo>;
 template class CSP_API csp::common::Array<csp::multiplayer::NetworkEventRegistration>;

--- a/Library/src/ExplicitTypes.cpp
+++ b/Library/src/ExplicitTypes.cpp
@@ -29,6 +29,7 @@
 #include "CSP/Systems/Assets/Asset.h"
 #include "CSP/Systems/Assets/AssetCollection.h"
 #include "CSP/Systems/Assets/GLTFMaterial.h"
+#include "CSP/Systems/Assets/LOD.h"
 #include "CSP/Systems/ECommerce/ECommerce.h"
 #include "CSP/Systems/EventTicketing/EventTicketing.h"
 #include "CSP/Systems/HotspotSequence/HotspotGroup.h"
@@ -84,6 +85,7 @@ template class CSP_API csp::common::Array<csp::systems::CartLine>;
 template class CSP_API csp::common::Array<csp::systems::FeatureLimitInfo>;
 template class CSP_API csp::common::Array<csp::systems::FeatureQuotaInfo>;
 template class CSP_API csp::common::Array<csp::systems::HotspotGroup>;
+template class CSP_API csp::common::Array<csp::systems::LODAsset>;
 template class CSP_API csp::common::Array<csp::systems::ProductInfo>;
 template class CSP_API csp::common::Array<csp::systems::ProductMediaInfo>;
 template class CSP_API csp::common::Array<csp::systems::ProductVariantInfo>;

--- a/Library/src/ExplicitTypes.cpp
+++ b/Library/src/ExplicitTypes.cpp
@@ -33,6 +33,7 @@
 #include "CSP/Systems/ECommerce/ECommerce.h"
 #include "CSP/Systems/EventTicketing/EventTicketing.h"
 #include "CSP/Systems/HotspotSequence/HotspotGroup.h"
+#include "CSP/Systems/Maintenance/Maintenance.h"
 #include "CSP/Systems/Multiplayer/Scope.h"
 #include "CSP/Systems/Quota/Quota.h"
 #include "CSP/Systems/Sequence/Sequence.h"
@@ -77,11 +78,13 @@ template class CSP_API csp::common::Array<csp::systems::PointOfInterest>;
 template class CSP_API csp::common::Array<csp::systems::Site>;
 template class CSP_API csp::common::Array<csp::systems::Space>;
 template class CSP_API csp::common::Array<csp::systems::UserRoleInfo>;
+template class CSP_API csp::common::Array<csp::systems::MaintenanceInfo>;
 template class CSP_API csp::common::Array<csp::systems::Material*>;
 template class CSP_API csp::common::Array<csp::systems::Scope>;
 template class CSP_API csp::common::Array<csp::systems::SpaceUserRole>;
 template class CSP_API csp::common::Array<csp::systems::EAssetCollectionType>;
 template class CSP_API csp::common::Array<csp::systems::CartLine>;
+template class CSP_API csp::common::Array<csp::FeatureFlag>;
 template class CSP_API csp::common::Array<csp::systems::FeatureLimitInfo>;
 template class CSP_API csp::common::Array<csp::systems::FeatureQuotaInfo>;
 template class CSP_API csp::common::Array<csp::systems::HotspotGroup>;

--- a/Library/src/Systems/Assets/LOD.cpp
+++ b/Library/src/Systems/Assets/LOD.cpp
@@ -17,6 +17,11 @@
 
 namespace csp::systems
 {
+
+bool LODAsset::operator==(const LODAsset& Other) const { return Asset == Other.Asset && Level == Other.Level; }
+
+bool LODAsset::operator!=(const LODAsset& Other) const { return !(*this == Other); }
+
 const LODChain& LODChainResult::GetLODChain() const { return Chain; }
 
 void LODChainResult::SetLODChain(const LODChain& InChain) { Chain = InChain; }

--- a/Library/src/Systems/Maintenance/Maintenance.cpp
+++ b/Library/src/Systems/Maintenance/Maintenance.cpp
@@ -23,6 +23,13 @@
 namespace csp::systems
 {
 
+bool MaintenanceInfo::operator==(const MaintenanceInfo& Other) const
+{
+    return Description == Other.Description && StartDateTimestamp == Other.StartDateTimestamp && EndDateTimestamp == Other.EndDateTimestamp;
+}
+
+bool MaintenanceInfo::operator!=(const MaintenanceInfo& Other) const { return !(*this == Other); }
+
 bool MaintenanceInfo::IsInsideWindow() const
 {
     if (StartDateTimestamp.IsEmpty() || EndDateTimestamp.IsEmpty())


### PR DESCRIPTION
Minor fixes to resolve issues in downstream bindings repo relating to Component Schema
* Explicitly instantiate `Array` templates for these types and export
* Hide a helper function

Failures [here](https://github.com/magnopus-opensource/connected-spaces-platform-unity/actions/runs/28383317029/job/84091393363?pr=77) for reference

Additional fixes for `Array<FeatureFlag>`, `Array<LODAsset>`, `Array<MaintenanceInfo>` which appear to have been introduced recently following ea478cc1dc5a59c5a13188b822a59baa3bde1adf