### PR TITLE
[NT-0] refac!: Rename Schema based property accessors on ComponentBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.46.0]
+
+### 💫 💥 Code Refactors
+
+- [NT-0] refac!: Rename `GetSchemaProperty`/`SetSchemaProperty` on `ComponentBase` to `GetProperty`/`SetProperty`. By @mag-lt.
+  As clients haven't adopted data driven components yet, there shouldn't be any impact as a result of these changes,
+  but it is still technically a breaking change.
+  The protected `GetProperty`/`SetProperty` overloads previously used by derived component classes have been
+  renamed to `GetPropertyDirect`/`SetPropertyDirect` to avoid ambiguity and make way for these.
+  Developers making changes within CSP should use `GetPropertyDirect`/`SetPropertyDirect` in the cases they'd
+  traditionally have used the original methods.
+
 ## [6.45.0]
 
 ### 🍰 🙌 New Features

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -185,11 +185,11 @@ public:
 
     /// @brief Get a property value by schema key.
     /// @return A pointer to the value, or nullptr if the key is not in this component's schema.
-    const csp::common::ReplicatedValue* GetSchemaProperty(uint16_t Key) const;
+    const csp::common::ReplicatedValue* GetProperty(uint16_t Key) const;
 
     /// @brief Set a property value by schema key.
     /// Silently ignored if the key is absent from this component's schema or the value type does not match the schema definition.
-    void SetSchemaProperty(uint16_t Key, const csp::common::ReplicatedValue& Value);
+    void SetProperty(uint16_t Key, const csp::common::ReplicatedValue& Value);
 
 protected:
     ComponentBase();

--- a/Library/include/CSP/Multiplayer/ComponentBase.h
+++ b/Library/include/CSP/Multiplayer/ComponentBase.h
@@ -195,7 +195,7 @@ protected:
     ComponentBase();
     ComponentBase(uint64_t TypeId, csp::common::LogSystem* LogSystem, SpaceEntity* Parent);
 
-    const csp::common::ReplicatedValue& GetProperty(uint32_t Key) const;
+    const csp::common::ReplicatedValue& GetPropertyDirect(uint32_t Key) const;
     bool GetBooleanProperty(uint32_t Key) const;
     int64_t GetIntegerProperty(uint32_t Key) const;
     float GetFloatProperty(uint32_t Key) const;
@@ -205,7 +205,7 @@ protected:
     const csp::common::Vector4& GetVector4Property(uint32_t Key) const;
     const csp::common::Map<csp::common::String, csp::common::ReplicatedValue>& GetStringMapProperty(uint32_t Key) const;
 
-    void SetProperty(uint32_t Key, const csp::common::ReplicatedValue& Value);
+    void SetPropertyDirect(uint32_t Key, const csp::common::ReplicatedValue& Value);
     void RemoveProperty(uint32_t Key);
     void SetProperties(const csp::common::Map<uint32_t, csp::common::ReplicatedValue>& Value);
 

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -108,7 +108,7 @@ const csp::common::ReplicatedValue* ComponentBase::GetSchemaProperty(uint16_t Ke
         return nullptr;
     }
 
-    const auto& Value = GetProperty(Key);
+    const auto& Value = GetPropertyDirect(Key);
     return Value != InvalidValue ? &Value : nullptr;
 }
 
@@ -122,13 +122,13 @@ void ComponentBase::SetSchemaProperty(uint16_t Key, const csp::common::Replicate
     if (const auto* Property = FindSchemaProperty(*CachedSchema, Key);
         Property && Value.GetReplicatedValueType() == Property->DefaultValue.GetReplicatedValueType())
     {
-        SetProperty(Key, Value);
+        SetPropertyDirect(Key, Value);
     }
 }
 
 const csp::common::Map<uint32_t, csp::common::ReplicatedValue>* ComponentBase::GetProperties() const { return &Properties; }
 
-const csp::common::ReplicatedValue& ComponentBase::GetProperty(uint32_t Key) const
+const csp::common::ReplicatedValue& ComponentBase::GetPropertyDirect(uint32_t Key) const
 {
     if (Properties.HasKey(Key))
     {
@@ -145,7 +145,7 @@ const csp::common::ReplicatedValue& ComponentBase::GetProperty(uint32_t Key) con
 
 bool ComponentBase::GetBooleanProperty(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::Boolean)
     {
@@ -162,7 +162,7 @@ bool ComponentBase::GetBooleanProperty(uint32_t Key) const
 
 int64_t ComponentBase::GetIntegerProperty(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::Integer)
     {
@@ -179,7 +179,7 @@ int64_t ComponentBase::GetIntegerProperty(uint32_t Key) const
 
 float ComponentBase::GetFloatProperty(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::Float)
     {
@@ -196,7 +196,7 @@ float ComponentBase::GetFloatProperty(uint32_t Key) const
 
 const csp::common::String& ComponentBase::GetStringProperty(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::String)
     {
@@ -213,7 +213,7 @@ const csp::common::String& ComponentBase::GetStringProperty(uint32_t Key) const
 
 const csp::common::Vector2& ComponentBase::GetVector2Property(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::Vector2)
     {
@@ -230,7 +230,7 @@ const csp::common::Vector2& ComponentBase::GetVector2Property(uint32_t Key) cons
 
 const csp::common::Vector3& ComponentBase::GetVector3Property(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::Vector3)
     {
@@ -247,7 +247,7 @@ const csp::common::Vector3& ComponentBase::GetVector3Property(uint32_t Key) cons
 
 const csp::common::Vector4& ComponentBase::GetVector4Property(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::Vector4)
     {
@@ -264,7 +264,7 @@ const csp::common::Vector4& ComponentBase::GetVector4Property(uint32_t Key) cons
 
 const csp::common::Map<csp::common::String, csp::common::ReplicatedValue>& ComponentBase::GetStringMapProperty(uint32_t Key) const
 {
-    const auto& RepVal = GetProperty(Key);
+    const auto& RepVal = GetPropertyDirect(Key);
 
     if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::StringMap)
     {
@@ -279,7 +279,7 @@ const csp::common::Map<csp::common::String, csp::common::ReplicatedValue>& Compo
     return csp::common::ReplicatedValue::GetDefaultStringMap();
 }
 
-void ComponentBase::SetProperty(uint32_t Key, const csp::common::ReplicatedValue& Value)
+void ComponentBase::SetPropertyDirect(uint32_t Key, const csp::common::ReplicatedValue& Value)
 {
     if (Properties.HasKey(Key) && Value.GetReplicatedValueType() != Properties[Key].GetReplicatedValueType())
     {
@@ -395,7 +395,7 @@ void ComponentBase::InvokeAction(const csp::common::String& InAction, const csp:
 
 const csp::common::String& ComponentBase::GetComponentName() const { return GetStringProperty(COMPONENT_KEY_NAME); }
 
-void ComponentBase::SetComponentName(const csp::common::String& Value) { SetProperty(COMPONENT_KEY_NAME, Value); }
+void ComponentBase::SetComponentName(const csp::common::String& Value) { SetPropertyDirect(COMPONENT_KEY_NAME, Value); }
 
 void ComponentBase::InitialiseProperties() { Properties[COMPONENT_KEY_NAME] = ""; }
 

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -96,7 +96,7 @@ namespace
     }
 } // namespace
 
-const csp::common::ReplicatedValue* ComponentBase::GetSchemaProperty(uint16_t Key) const
+const csp::common::ReplicatedValue* ComponentBase::GetProperty(uint16_t Key) const
 {
     if (!CachedSchema)
     {
@@ -112,7 +112,7 @@ const csp::common::ReplicatedValue* ComponentBase::GetSchemaProperty(uint16_t Ke
     return Value != InvalidValue ? &Value : nullptr;
 }
 
-void ComponentBase::SetSchemaProperty(uint16_t Key, const csp::common::ReplicatedValue& Value)
+void ComponentBase::SetProperty(uint16_t Key, const csp::common::ReplicatedValue& Value)
 {
     if (!CachedSchema)
     {

--- a/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
+++ b/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
@@ -76,7 +76,10 @@ const csp::common::String& AIChatbotSpaceComponent::GetVoice() const
     return GetStringProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::Voice));
 }
 
-void AIChatbotSpaceComponent::SetVoice(const csp::common::String& Value) { SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::Voice), Value); }
+void AIChatbotSpaceComponent::SetVoice(const csp::common::String& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(AIChatbotPropertyKeys::Voice), Value);
+}
 
 const csp::common::String& AIChatbotSpaceComponent::GetGuardrailAssetCollectionId() const
 {
@@ -85,7 +88,7 @@ const csp::common::String& AIChatbotSpaceComponent::GetGuardrailAssetCollectionI
 
 void AIChatbotSpaceComponent::SetGuardrailAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::GuardrailAssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AIChatbotPropertyKeys::GuardrailAssetCollectionId), Value);
 }
 
 AIChatbotVisualState AIChatbotSpaceComponent::GetVisualState() const
@@ -95,7 +98,7 @@ AIChatbotVisualState AIChatbotSpaceComponent::GetVisualState() const
 
 void AIChatbotSpaceComponent::SetVisualState(AIChatbotVisualState Value)
 {
-    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::VisualState), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(AIChatbotPropertyKeys::VisualState), static_cast<int64_t>(Value));
 }
 
 /* ITransformComponent */
@@ -107,7 +110,7 @@ const csp::common::Vector3& AIChatbotSpaceComponent::GetPosition() const
 
 void AIChatbotSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(AIChatbotPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AIChatbotPropertyKeys::Position), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -142,7 +142,7 @@ const csp::common::String& AnimatedModelSpaceComponent::GetExternalResourceAsset
 
 void AnimatedModelSpaceComponent::SetExternalResourceAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ExternalResourceAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::ExternalResourceAssetId), Value);
 }
 
 const csp::common::String& AnimatedModelSpaceComponent::GetExternalResourceAssetCollectionId() const
@@ -152,7 +152,7 @@ const csp::common::String& AnimatedModelSpaceComponent::GetExternalResourceAsset
 
 void AnimatedModelSpaceComponent::SetExternalResourceAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ExternalResourceAssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::ExternalResourceAssetCollectionId), Value);
 }
 
 /* ITransformComponent */
@@ -164,7 +164,7 @@ const csp::common::Vector3& AnimatedModelSpaceComponent::GetPosition() const
 
 void AnimatedModelSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& AnimatedModelSpaceComponent::GetRotation() const
@@ -174,7 +174,7 @@ const csp::common::Vector4& AnimatedModelSpaceComponent::GetRotation() const
 
 void AnimatedModelSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& AnimatedModelSpaceComponent::GetScale() const
@@ -184,7 +184,7 @@ const csp::common::Vector3& AnimatedModelSpaceComponent::GetScale() const
 
 void AnimatedModelSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::Scale), Value);
 }
 
 SpaceTransform AnimatedModelSpaceComponent::GetTransform() const
@@ -211,12 +211,12 @@ bool AnimatedModelSpaceComponent::GetIsLoopPlayback() const
 
 void AnimatedModelSpaceComponent::SetIsLoopPlayback(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsLoopPlayback), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsLoopPlayback), Value);
 }
 
 bool AnimatedModelSpaceComponent::GetIsPlaying() const { return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsPlaying)); }
 
-void AnimatedModelSpaceComponent::SetIsPlaying(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsPlaying), Value); }
+void AnimatedModelSpaceComponent::SetIsPlaying(bool Value) { SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsPlaying), Value); }
 
 int64_t AnimatedModelSpaceComponent::GetAnimationIndex() const
 {
@@ -225,7 +225,7 @@ int64_t AnimatedModelSpaceComponent::GetAnimationIndex() const
 
 void AnimatedModelSpaceComponent::SetAnimationIndex(int64_t Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::AnimationIndex), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::AnimationIndex), Value);
 }
 
 csp::common::Map<csp::common::String, csp::common::String> AnimatedModelSpaceComponent::GetMaterialOverrides() const
@@ -252,7 +252,7 @@ void AnimatedModelSpaceComponent::AddMaterialOverride(const csp::common::String&
     auto ReplicatedOverrides = GetStringMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
     ReplicatedOverrides[ModelPath] = MaterialId;
 
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }
 
 void AnimatedModelSpaceComponent::RemoveMaterialOverride(const csp::common::String& ModelPath)
@@ -260,18 +260,21 @@ void AnimatedModelSpaceComponent::RemoveMaterialOverride(const csp::common::Stri
     auto ReplicatedOverrides = GetStringMapProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides));
     ReplicatedOverrides.Remove(ModelPath);
 
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }
 
 /* IVisibleComponent */
 
 bool AnimatedModelSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVisible)); }
 
-void AnimatedModelSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVisible), Value); }
+void AnimatedModelSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVisible), Value); }
 
 bool AnimatedModelSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible)); }
 
-void AnimatedModelSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible), Value); }
+void AnimatedModelSpaceComponent::SetIsARVisible(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsARVisible), Value);
+}
 
 bool AnimatedModelSpaceComponent::GetIsVirtualVisible() const
 {
@@ -280,7 +283,7 @@ bool AnimatedModelSpaceComponent::GetIsVirtualVisible() const
 
 void AnimatedModelSpaceComponent::SetIsVirtualVisible(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsVirtualVisible), Value);
 }
 
 /* IThirdPartyRefComponent */
@@ -292,7 +295,7 @@ const csp::common::String& AnimatedModelSpaceComponent::GetThirdPartyComponentRe
 
 void AnimatedModelSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 /* IShadowCasterComponent */
@@ -304,7 +307,7 @@ bool AnimatedModelSpaceComponent::GetIsShadowCaster() const
 
 void AnimatedModelSpaceComponent::SetIsShadowCaster(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::IsShadowCaster), Value);
 }
 
 /* IRenderBehaviourComponent */
@@ -316,7 +319,7 @@ bool AnimatedModelSpaceComponent::GetShowAsHoldoutInAR() const
 
 void AnimatedModelSpaceComponent::SetShowAsHoldoutInAR(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR), Value);
 }
 
 bool AnimatedModelSpaceComponent::GetShowAsHoldoutInVirtual() const
@@ -326,7 +329,7 @@ bool AnimatedModelSpaceComponent::GetShowAsHoldoutInVirtual() const
 
 void AnimatedModelSpaceComponent::SetShowAsHoldoutInVirtual(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
@@ -124,7 +124,10 @@ const csp::common::Vector3& AudioSpaceComponent::GetPosition() const
     return GetVector3Property(static_cast<uint32_t>(AudioPropertyKeys::Position));
 }
 
-void AudioSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::Position), Value); }
+void AudioSpaceComponent::SetPosition(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::Position), Value);
+}
 
 AudioPlaybackState AudioSpaceComponent::GetPlaybackState() const
 {
@@ -133,7 +136,7 @@ AudioPlaybackState AudioSpaceComponent::GetPlaybackState() const
 
 void AudioSpaceComponent::SetPlaybackState(AudioPlaybackState Value)
 {
-    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::PlaybackState), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::PlaybackState), static_cast<int64_t>(Value));
 }
 
 const csp::common::String& AudioSpaceComponent::GetAudioAssetId() const
@@ -143,7 +146,7 @@ const csp::common::String& AudioSpaceComponent::GetAudioAssetId() const
 
 void AudioSpaceComponent::SetAudioAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AudioAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::AudioAssetId), Value);
 }
 
 const csp::common::String& AudioSpaceComponent::GetAssetCollectionId() const
@@ -153,20 +156,20 @@ const csp::common::String& AudioSpaceComponent::GetAssetCollectionId() const
 
 void AudioSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::AssetCollectionId), Value);
 }
 
 bool AudioSpaceComponent::GetIsLoopPlayback() const { return GetBooleanProperty(static_cast<uint32_t>(AudioPropertyKeys::IsLoopPlayback)); }
 
-void AudioSpaceComponent::SetIsLoopPlayback(bool Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::IsLoopPlayback), Value); }
+void AudioSpaceComponent::SetIsLoopPlayback(bool Value) { SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::IsLoopPlayback), Value); }
 
 float AudioSpaceComponent::GetTimeSincePlay() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::TimeSincePlay)); }
 
-void AudioSpaceComponent::SetTimeSincePlay(float Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::TimeSincePlay), Value); }
+void AudioSpaceComponent::SetTimeSincePlay(float Value) { SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::TimeSincePlay), Value); }
 
 bool AudioSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(AudioPropertyKeys::IsEnabled)); }
 
-void AudioSpaceComponent::SetIsEnabled(bool InValue) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::IsEnabled), InValue); }
+void AudioSpaceComponent::SetIsEnabled(bool InValue) { SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::IsEnabled), InValue); }
 
 const csp::common::String& AudioSpaceComponent::GetThirdPartyComponentRef() const
 {
@@ -175,14 +178,14 @@ const csp::common::String& AudioSpaceComponent::GetThirdPartyComponentRef() cons
 
 void AudioSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 /* IAudioControlComponent */
 
 float AudioSpaceComponent::GetAttenuationRadius() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius)); }
 
-void AudioSpaceComponent::SetAttenuationRadius(float Value) { SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius), Value); }
+void AudioSpaceComponent::SetAttenuationRadius(float Value) { SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::AttenuationRadius), Value); }
 
 AudioType AudioSpaceComponent::GetAudioType() const
 {
@@ -191,7 +194,7 @@ AudioType AudioSpaceComponent::GetAudioType() const
 
 void AudioSpaceComponent::SetAudioType(AudioType Value)
 {
-    SetProperty(static_cast<uint32_t>(AudioPropertyKeys::AudioType), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::AudioType), static_cast<int64_t>(Value));
 }
 
 float AudioSpaceComponent::GetVolume() const { return GetFloatProperty(static_cast<uint32_t>(AudioPropertyKeys::Volume)); }
@@ -200,7 +203,7 @@ void AudioSpaceComponent::SetVolume(float Value)
 {
     if (Value >= 0.f && Value <= 1.f)
     {
-        SetProperty(static_cast<uint32_t>(AudioPropertyKeys::Volume), Value);
+        SetPropertyDirect(static_cast<uint32_t>(AudioPropertyKeys::Volume), Value);
     }
     else
     {

--- a/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
@@ -152,7 +152,7 @@ const csp::common::String& AvatarSpaceComponent::GetAvatarId() const
 
 void AvatarSpaceComponent::SetAvatarId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarId), Value);
 }
 
 const csp::common::String& AvatarSpaceComponent::GetUserId() const
@@ -162,7 +162,7 @@ const csp::common::String& AvatarSpaceComponent::GetUserId() const
 
 void AvatarSpaceComponent::SetUserId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::UserId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::UserId), Value);
 }
 
 AvatarState AvatarSpaceComponent::GetState() const
@@ -172,7 +172,7 @@ AvatarState AvatarSpaceComponent::GetState() const
 
 void AvatarSpaceComponent::SetState(AvatarState Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::State), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::State), static_cast<int64_t>(Value));
 }
 
 AvatarPlayMode AvatarSpaceComponent::GetAvatarPlayMode() const
@@ -182,7 +182,7 @@ AvatarPlayMode AvatarSpaceComponent::GetAvatarPlayMode() const
 
 void AvatarSpaceComponent::SetAvatarPlayMode(AvatarPlayMode Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarPlayMode), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarPlayMode), static_cast<int64_t>(Value));
 }
 
 const csp::common::String& AvatarSpaceComponent::GetAgoraUserId() const
@@ -192,7 +192,7 @@ const csp::common::String& AvatarSpaceComponent::GetAgoraUserId() const
 
 void AvatarSpaceComponent::SetAgoraUserId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::AgoraUserId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::AgoraUserId), Value);
 }
 
 bool AvatarSpaceComponent::GetIsHandIKEnabled() const
@@ -200,7 +200,10 @@ bool AvatarSpaceComponent::GetIsHandIKEnabled() const
     return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsHandIKEnabled));
 }
 
-void AvatarSpaceComponent::SetIsHandIKEnabled(bool Value) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsHandIKEnabled), Value); }
+void AvatarSpaceComponent::SetIsHandIKEnabled(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsHandIKEnabled), Value);
+}
 
 const csp::common::Vector3& AvatarSpaceComponent::GetTargetHandIKTargetLocation() const
 {
@@ -209,7 +212,7 @@ const csp::common::Vector3& AvatarSpaceComponent::GetTargetHandIKTargetLocation(
 
 void AvatarSpaceComponent::SetTargetHandIKTargetLocation(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::TargetHandIKTargetLocation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::TargetHandIKTargetLocation), Value);
 }
 
 const csp::common::Vector4& AvatarSpaceComponent::GetHandRotation() const
@@ -219,7 +222,7 @@ const csp::common::Vector4& AvatarSpaceComponent::GetHandRotation() const
 
 void AvatarSpaceComponent::SetHandRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::HandRotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::HandRotation), Value);
 }
 
 const csp::common::Vector4& AvatarSpaceComponent::GetHeadRotation() const
@@ -229,7 +232,7 @@ const csp::common::Vector4& AvatarSpaceComponent::GetHeadRotation() const
 
 void AvatarSpaceComponent::SetHeadRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::HeadRotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::HeadRotation), Value);
 }
 
 float AvatarSpaceComponent::GetWalkRunBlendPercentage() const
@@ -239,7 +242,7 @@ float AvatarSpaceComponent::GetWalkRunBlendPercentage() const
 
 void AvatarSpaceComponent::SetWalkRunBlendPercentage(float Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::WalkRunBlendPercentage), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::WalkRunBlendPercentage), Value);
 }
 
 float AvatarSpaceComponent::GetTorsoTwistAlpha() const
@@ -249,7 +252,7 @@ float AvatarSpaceComponent::GetTorsoTwistAlpha() const
 
 void AvatarSpaceComponent::SetTorsoTwistAlpha(float Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::TorsoTwistAlpha), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::TorsoTwistAlpha), Value);
 }
 
 const csp::common::Vector3& csp::multiplayer::AvatarSpaceComponent::GetMovementDirection() const
@@ -259,7 +262,7 @@ const csp::common::Vector3& csp::multiplayer::AvatarSpaceComponent::GetMovementD
 
 void csp::multiplayer::AvatarSpaceComponent::SetMovementDirection(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::MovementDirection), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::MovementDirection), Value);
 }
 
 LocomotionModel AvatarSpaceComponent::GetLocomotionModel() const
@@ -269,16 +272,19 @@ LocomotionModel AvatarSpaceComponent::GetLocomotionModel() const
 
 void AvatarSpaceComponent::SetLocomotionModel(LocomotionModel Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::LocomotionModel), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::LocomotionModel), static_cast<int64_t>(Value));
 }
 
 bool AvatarSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible)); }
 
-void AvatarSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible), InValue); }
+void AvatarSpaceComponent::SetIsVisible(bool InValue) { SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVisible), InValue); }
 
 bool AvatarSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible)); }
 
-void AvatarSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible), InValue); }
+void AvatarSpaceComponent::SetIsARVisible(bool InValue)
+{
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsARVisible), InValue);
+}
 
 bool AvatarSpaceComponent::GetIsVirtualVisible() const
 {
@@ -287,7 +293,7 @@ bool AvatarSpaceComponent::GetIsVirtualVisible() const
 
 void AvatarSpaceComponent::SetIsVirtualVisible(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::IsVirtualVisible), InValue);
 }
 
 const csp::common::String& AvatarSpaceComponent::GetAvatarUrl() const
@@ -297,7 +303,7 @@ const csp::common::String& AvatarSpaceComponent::GetAvatarUrl() const
 
 void AvatarSpaceComponent::SetAvatarUrl(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarUrl), Value);
+    SetPropertyDirect(static_cast<uint32_t>(AvatarComponentPropertyKeys::AvatarUrl), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
@@ -107,7 +107,7 @@ const csp::common::String& ButtonSpaceComponent::GetLabelText() const
 
 void ButtonSpaceComponent::SetLabelText(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::LabelText), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::LabelText), Value);
 }
 
 const csp::common::String& ButtonSpaceComponent::GetIconAssetId() const
@@ -117,7 +117,7 @@ const csp::common::String& ButtonSpaceComponent::GetIconAssetId() const
 
 void ButtonSpaceComponent::SetIconAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IconAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::IconAssetId), Value);
 }
 
 const csp::common::String& ButtonSpaceComponent::GetAssetCollectionId() const
@@ -127,7 +127,7 @@ const csp::common::String& ButtonSpaceComponent::GetAssetCollectionId() const
 
 void ButtonSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::AssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::AssetCollectionId), Value);
 }
 
 /* ITransformComponent */
@@ -137,18 +137,24 @@ const csp::common::Vector3& ButtonSpaceComponent::GetPosition() const
     return GetVector3Property(static_cast<uint32_t>(ButtonPropertyKeys::Position));
 }
 
-void ButtonSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::Position), Value); }
+void ButtonSpaceComponent::SetPosition(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::Position), Value);
+}
 
 const csp::common::Vector4& ButtonSpaceComponent::GetRotation() const
 {
     return GetVector4Property(static_cast<uint32_t>(ButtonPropertyKeys::Rotation));
 }
 
-void ButtonSpaceComponent::SetRotation(const csp::common::Vector4& Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::Rotation), Value); }
+void ButtonSpaceComponent::SetRotation(const csp::common::Vector4& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::Rotation), Value);
+}
 
 const csp::common::Vector3& ButtonSpaceComponent::GetScale() const { return GetVector3Property(static_cast<uint32_t>(ButtonPropertyKeys::Scale)); }
 
-void ButtonSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::Scale), Value); }
+void ButtonSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::Scale), Value); }
 
 SpaceTransform ButtonSpaceComponent::GetTransform() const
 {
@@ -171,20 +177,20 @@ void ButtonSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool ButtonSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsEnabled)); }
 
-void ButtonSpaceComponent::SetIsEnabled(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsEnabled), Value); }
+void ButtonSpaceComponent::SetIsEnabled(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::IsEnabled), Value); }
 
 /* IVisibleComponent */
 
 bool ButtonSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVisible)); }
 
-void ButtonSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVisible), Value); }
+void ButtonSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::IsVisible), Value); }
 
 bool ButtonSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible)); }
 
-void ButtonSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible), Value); }
+void ButtonSpaceComponent::SetIsARVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::IsARVisible), Value); }
 
 bool ButtonSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible)); }
 
-void ButtonSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible), Value); }
+void ButtonSpaceComponent::SetIsVirtualVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ButtonPropertyKeys::IsVirtualVisible), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
@@ -150,7 +150,7 @@ const csp::common::Vector3& CinematicCameraSpaceComponent::GetPosition() const
 
 void CinematicCameraSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& CinematicCameraSpaceComponent::GetRotation() const
@@ -160,7 +160,7 @@ const csp::common::Vector4& CinematicCameraSpaceComponent::GetRotation() const
 
 void CinematicCameraSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::Rotation), Value);
 }
 
 // Focal Length
@@ -171,7 +171,7 @@ float CinematicCameraSpaceComponent::GetFocalLength() const
 
 void CinematicCameraSpaceComponent::SetFocalLength(float Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::FocalLength), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::FocalLength), Value);
 }
 
 // Aspect Ratio
@@ -182,7 +182,7 @@ float CinematicCameraSpaceComponent::GetAspectRatio() const
 
 void CinematicCameraSpaceComponent::SetAspectRatio(float Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::AspectRatio), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::AspectRatio), Value);
 }
 
 // Sensor Size
@@ -193,23 +193,26 @@ const csp::common::Vector2& CinematicCameraSpaceComponent::GetSensorSize() const
 
 void CinematicCameraSpaceComponent::SetSensorSize(const csp::common::Vector2& Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::SensorSize), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::SensorSize), Value);
 }
 
 // Near Clip
 float CinematicCameraSpaceComponent::GetNearClip() const { return GetFloatProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::NearClip)); }
 
-void CinematicCameraSpaceComponent::SetNearClip(float Value) { SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::NearClip), Value); }
+void CinematicCameraSpaceComponent::SetNearClip(float Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::NearClip), Value);
+}
 
 // Far Clip
 float CinematicCameraSpaceComponent::GetFarClip() const { return GetFloatProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::FarClip)); }
 
-void CinematicCameraSpaceComponent::SetFarClip(float Value) { SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::FarClip), Value); }
+void CinematicCameraSpaceComponent::SetFarClip(float Value) { SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::FarClip), Value); }
 
 // ISO
 float CinematicCameraSpaceComponent::GetIso() const { return GetFloatProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Iso)); }
 
-void CinematicCameraSpaceComponent::SetIso(float Value) { SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Iso), Value); }
+void CinematicCameraSpaceComponent::SetIso(float Value) { SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::Iso), Value); }
 
 // Shutter Speed
 float CinematicCameraSpaceComponent::GetShutterSpeed() const
@@ -219,13 +222,16 @@ float CinematicCameraSpaceComponent::GetShutterSpeed() const
 
 void CinematicCameraSpaceComponent::SetShutterSpeed(float Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::ShutterSpeed), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::ShutterSpeed), Value);
 }
 
 // Aperture
 float CinematicCameraSpaceComponent::GetAperture() const { return GetFloatProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Aperture)); }
 
-void CinematicCameraSpaceComponent::SetAperture(float Value) { SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::Aperture), Value); }
+void CinematicCameraSpaceComponent::SetAperture(float Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::Aperture), Value);
+}
 
 // Focus Distance
 float CinematicCameraSpaceComponent::GetFocusDistance() const
@@ -235,7 +241,7 @@ float CinematicCameraSpaceComponent::GetFocusDistance() const
 
 void CinematicCameraSpaceComponent::SetFocusDistance(float Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::FocusDistance), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::FocusDistance), Value);
 }
 
 // Depth of Field Enabled
@@ -246,7 +252,7 @@ bool CinematicCameraSpaceComponent::GetDepthOfFieldEnabled() const
 
 void CinematicCameraSpaceComponent::SetDepthOfFieldEnabled(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::DepthOfFieldEnabled), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::DepthOfFieldEnabled), Value);
 }
 
 // Is Viewer Camera
@@ -257,13 +263,16 @@ bool CinematicCameraSpaceComponent::GetIsViewerCamera() const
 
 void CinematicCameraSpaceComponent::SetIsViewerCamera(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::IsViewerCamera), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::IsViewerCamera), Value);
 }
 
 // Is Enabled
 bool CinematicCameraSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::IsEnabled)); }
 
-void CinematicCameraSpaceComponent::SetIsEnabled(bool Value) { SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::IsEnabled), Value); }
+void CinematicCameraSpaceComponent::SetIsEnabled(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::IsEnabled), Value);
+}
 
 // Third Party Component
 const csp::common::String& CinematicCameraSpaceComponent::GetThirdPartyComponentRef() const
@@ -273,7 +282,7 @@ const csp::common::String& CinematicCameraSpaceComponent::GetThirdPartyComponent
 
 void CinematicCameraSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(CinematicCameraPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(CinematicCameraPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/CollisionSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CollisionSpaceComponent.cpp
@@ -116,7 +116,7 @@ const csp::common::Vector3& CollisionSpaceComponent::GetPosition() const
 
 void CollisionSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& CollisionSpaceComponent::GetRotation() const
@@ -126,7 +126,7 @@ const csp::common::Vector4& CollisionSpaceComponent::GetRotation() const
 
 void CollisionSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& CollisionSpaceComponent::GetScale() const
@@ -134,7 +134,10 @@ const csp::common::Vector3& CollisionSpaceComponent::GetScale() const
     return GetVector3Property(static_cast<uint32_t>(CollisionPropertyKeys::Scale));
 }
 
-void CollisionSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::Scale), Value); }
+void CollisionSpaceComponent::SetScale(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::Scale), Value);
+}
 
 SpaceTransform CollisionSpaceComponent::GetTransform() const
 {
@@ -160,7 +163,7 @@ CollisionShape CollisionSpaceComponent::GetCollisionShape() const
 
 void CollisionSpaceComponent::SetCollisionShape(CollisionShape collisionShape)
 {
-    SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::CollisionShape), static_cast<int64_t>(collisionShape));
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::CollisionShape), static_cast<int64_t>(collisionShape));
 }
 
 CollisionMode CollisionSpaceComponent::GetCollisionMode() const
@@ -170,7 +173,7 @@ CollisionMode CollisionSpaceComponent::GetCollisionMode() const
 
 void CollisionSpaceComponent::SetCollisionMode(CollisionMode collisionMode)
 {
-    SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::CollisionMode), static_cast<int64_t>(collisionMode));
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::CollisionMode), static_cast<int64_t>(collisionMode));
 }
 
 const csp::common::String& CollisionSpaceComponent::GetCollisionAssetId() const
@@ -180,7 +183,7 @@ const csp::common::String& CollisionSpaceComponent::GetCollisionAssetId() const
 
 void CollisionSpaceComponent::SetCollisionAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::CollisionAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::CollisionAssetId), Value);
 }
 
 const csp::common::String& CollisionSpaceComponent::GetAssetCollectionId() const
@@ -190,7 +193,7 @@ const csp::common::String& CollisionSpaceComponent::GetAssetCollectionId() const
 
 void CollisionSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::AssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::AssetCollectionId), Value);
 }
 
 const csp::common::Vector3 CollisionSpaceComponent::GetUnscaledBoundingBoxMin() { return csp::common::Vector3(-0.5f, -0.5f, -0.5f); }
@@ -220,11 +223,11 @@ const csp::common::String& CollisionSpaceComponent::GetThirdPartyComponentRef() 
 
 void CollisionSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 bool CollisionSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(CollisionPropertyKeys::IsEnabled)); }
 
-void CollisionSpaceComponent::SetIsEnabled(bool Value) { SetProperty(static_cast<uint32_t>(CollisionPropertyKeys::IsEnabled), Value); }
+void CollisionSpaceComponent::SetIsEnabled(bool Value) { SetPropertyDirect(static_cast<uint32_t>(CollisionPropertyKeys::IsEnabled), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ConversationSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ConversationSpaceComponent.cpp
@@ -446,7 +446,10 @@ void ConversationSpaceComponent::SetConversationUpdateCallback(ConversationUpdat
 
 bool ConversationSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ConversationPropertyKeys::IsVisible)); }
 
-void ConversationSpaceComponent::SetIsVisible(const bool Value) { SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::IsVisible), Value); }
+void ConversationSpaceComponent::SetIsVisible(const bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::IsVisible), Value);
+}
 
 bool ConversationSpaceComponent::GetIsActive() const { return GetBooleanProperty(static_cast<uint32_t>(ConversationPropertyKeys::IsActive)); }
 
@@ -459,7 +462,7 @@ const csp::common::Vector3& ConversationSpaceComponent::GetPosition() const
 
 void ConversationSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::Position), Value);
 }
 
 /* IRotationComponent */
@@ -471,14 +474,17 @@ const csp::common::Vector4& ConversationSpaceComponent::GetRotation() const
 
 void ConversationSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::Rotation), Value);
 }
 
-void ConversationSpaceComponent::SetIsActive(const bool Value) { SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::IsActive), Value); }
+void ConversationSpaceComponent::SetIsActive(const bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::IsActive), Value);
+}
 
 void ConversationSpaceComponent::SetTitle(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::Title), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::Title), Value);
 }
 
 const csp::common::String& ConversationSpaceComponent::GetTitle() const
@@ -486,13 +492,13 @@ const csp::common::String& ConversationSpaceComponent::GetTitle() const
     return GetStringProperty(static_cast<uint32_t>(ConversationPropertyKeys::Title));
 }
 
-void ConversationSpaceComponent::SetResolved(bool Value) { SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::Resolved), Value); }
+void ConversationSpaceComponent::SetResolved(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::Resolved), Value); }
 
 bool ConversationSpaceComponent::GetResolved() const { return GetBooleanProperty(static_cast<uint32_t>(ConversationPropertyKeys::Resolved)); }
 
 void ConversationSpaceComponent::SetConversationCameraPosition(const csp::common::Vector3& InValue)
 {
-    SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::ConversationCameraPosition), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::ConversationCameraPosition), InValue);
 }
 
 const csp::common::Vector3& ConversationSpaceComponent::GetConversationCameraPosition() const
@@ -502,7 +508,7 @@ const csp::common::Vector3& ConversationSpaceComponent::GetConversationCameraPos
 
 void ConversationSpaceComponent::SetConversationCameraRotation(const csp::common::Vector4& InValue)
 {
-    SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::ConversationCameraRotation), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::ConversationCameraRotation), InValue);
 }
 
 const csp::common::Vector4& ConversationSpaceComponent::GetConversationCameraRotation() const
@@ -549,7 +555,7 @@ void ConversationSpaceComponent::SetPropertyFromPatch(uint32_t Key, const csp::c
 
 void ConversationSpaceComponent::SetConversationId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ConversationPropertyKeys::ConversationId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ConversationPropertyKeys::ConversationId), Value);
 }
 
 void ConversationSpaceComponent::RemoveConversationId() { RemoveProperty(static_cast<uint32_t>(ConversationPropertyKeys::ConversationId)); }

--- a/Library/src/Multiplayer/Components/CustomSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CustomSpaceComponent.cpp
@@ -68,7 +68,7 @@ const csp::common::String& CustomSpaceComponent::GetApplicationOrigin() const
 
 void CustomSpaceComponent::SetApplicationOrigin(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::ApplicationOrigin), Value);
+    SetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::ApplicationOrigin), Value);
 }
 
 uint32_t CustomSpaceComponent::GetCustomPropertySubscriptionKey(const csp::common::String& Key) const
@@ -89,7 +89,7 @@ const csp::common::ReplicatedValue& CustomSpaceComponent::GetCustomProperty(cons
 {
     const uint32_t PropertyKey = GetCustomPropertySubscriptionKey(Key);
 
-    return GetProperty(PropertyKey);
+    return GetPropertyDirect(PropertyKey);
 }
 
 void CustomSpaceComponent::SetCustomProperty(const csp::common::String& Key, const csp::common::ReplicatedValue& Value)
@@ -101,7 +101,7 @@ void CustomSpaceComponent::SetCustomProperty(const csp::common::String& Key, con
         {
             AddKey(Key);
         }
-        SetProperty(PropertyKey, Value);
+        SetPropertyDirect(PropertyKey, Value);
     }
 }
 
@@ -120,11 +120,11 @@ csp::common::List<csp::common::String> CustomSpaceComponent::GetCustomPropertyKe
 {
     if (Properties.HasKey(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList)))
     {
-        const auto& RepVal = GetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList));
+        const auto& RepVal = GetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList));
 
         if (RepVal.GetReplicatedValueType() == csp::common::ReplicatedValueType::String && !RepVal.GetString().IsEmpty())
         {
-            return GetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList)).GetString().Split(',');
+            return GetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList)).GetString().Split(',');
         }
     }
 
@@ -147,7 +147,7 @@ void CustomSpaceComponent::AddKey(const csp::common::String& Value)
 {
     if (Properties.HasKey(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList)))
     {
-        const auto& RepVal = GetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList));
+        const auto& RepVal = GetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList));
 
         if (RepVal.GetReplicatedValueType() != csp::common::ReplicatedValueType::String)
         {
@@ -159,16 +159,16 @@ void CustomSpaceComponent::AddKey(const csp::common::String& Value)
         if (!ReturnKeys.IsEmpty())
         {
             ReturnKeys = ReturnKeys + "," + Value;
-            SetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), ReturnKeys);
+            SetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), ReturnKeys);
         }
         else
         {
-            SetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), Value);
+            SetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), Value);
         }
     }
     else
     {
-        SetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), Value);
+        SetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), Value);
     }
 }
 
@@ -195,7 +195,7 @@ void CustomSpaceComponent::RemoveKey(const csp::common::String& Key)
             }
         }
 
-        SetProperty(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), ReturnKeys);
+        SetPropertyDirect(static_cast<uint32_t>(CustomComponentPropertyKeys::CustomPropertyList), ReturnKeys);
     }
     else
     {

--- a/Library/src/Multiplayer/Components/ECommerceSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ECommerceSpaceComponent.cpp
@@ -70,7 +70,7 @@ const csp::common::Vector3& ECommerceSpaceComponent::GetPosition() const
 
 void ECommerceSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ECommercePropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ECommercePropertyKeys::Position), Value);
 }
 
 csp::common::String ECommerceSpaceComponent::GetProductId() const
@@ -78,6 +78,9 @@ csp::common::String ECommerceSpaceComponent::GetProductId() const
     return GetStringProperty(static_cast<uint32_t>(ECommercePropertyKeys::ProductId));
 }
 
-void ECommerceSpaceComponent::SetProductId(csp::common::String Value) { SetProperty(static_cast<uint32_t>(ECommercePropertyKeys::ProductId), Value); }
+void ECommerceSpaceComponent::SetProductId(csp::common::String Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ECommercePropertyKeys::ProductId), Value);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
@@ -107,7 +107,7 @@ const csp::common::String& ExternalLinkSpaceComponent::GetName() const
 
 void ExternalLinkSpaceComponent::SetName(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::Name_DEPRECATED), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::Name_DEPRECATED), Value);
 }
 
 const csp::common::String& ExternalLinkSpaceComponent::GetLinkUrl() const
@@ -117,7 +117,7 @@ const csp::common::String& ExternalLinkSpaceComponent::GetLinkUrl() const
 
 void ExternalLinkSpaceComponent::SetLinkUrl(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::LinkUrl), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::LinkUrl), Value);
 }
 
 /* ITransformComponent */
@@ -129,7 +129,7 @@ const csp::common::Vector3& ExternalLinkSpaceComponent::GetPosition() const
 
 void ExternalLinkSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& ExternalLinkSpaceComponent::GetRotation() const
@@ -139,7 +139,7 @@ const csp::common::Vector4& ExternalLinkSpaceComponent::GetRotation() const
 
 void ExternalLinkSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& ExternalLinkSpaceComponent::GetScale() const
@@ -149,7 +149,7 @@ const csp::common::Vector3& ExternalLinkSpaceComponent::GetScale() const
 
 void ExternalLinkSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::Scale), Value);
 }
 
 SpaceTransform ExternalLinkSpaceComponent::GetTransform() const
@@ -176,22 +176,28 @@ const csp::common::String& ExternalLinkSpaceComponent::GetDisplayText() const
 
 void ExternalLinkSpaceComponent::SetDisplayText(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::DisplayText), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::DisplayText), Value);
 }
 
 /* IClickableComponent */
 
 bool ExternalLinkSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsEnabled)); }
 
-void ExternalLinkSpaceComponent::SetIsEnabled(bool Value) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsEnabled), Value); }
+void ExternalLinkSpaceComponent::SetIsEnabled(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsEnabled), Value); }
 
 bool ExternalLinkSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVisible)); }
 
-void ExternalLinkSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVisible), InValue); }
+void ExternalLinkSpaceComponent::SetIsVisible(bool InValue)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVisible), InValue);
+}
 
 bool ExternalLinkSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible)); }
 
-void ExternalLinkSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible), InValue); }
+void ExternalLinkSpaceComponent::SetIsARVisible(bool InValue)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsARVisible), InValue);
+}
 
 bool ExternalLinkSpaceComponent::GetIsVirtualVisible() const
 {
@@ -200,7 +206,7 @@ bool ExternalLinkSpaceComponent::GetIsVirtualVisible() const
 
 void ExternalLinkSpaceComponent::SetIsVirtualVisible(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(ExternalLinkPropertyKeys::IsVirtualVisible), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
@@ -103,7 +103,7 @@ const csp::common::String& FiducialMarkerSpaceComponent::GetMarkerAssetId() cons
 
 void FiducialMarkerSpaceComponent::SetMarkerAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::MarkerAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::MarkerAssetId), Value);
 }
 
 const csp::common::String& FiducialMarkerSpaceComponent::GetAssetCollectionId() const
@@ -113,7 +113,7 @@ const csp::common::String& FiducialMarkerSpaceComponent::GetAssetCollectionId() 
 
 void FiducialMarkerSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::AssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::AssetCollectionId), Value);
 }
 
 const csp::common::String& FiducialMarkerSpaceComponent::GetName() const
@@ -123,7 +123,7 @@ const csp::common::String& FiducialMarkerSpaceComponent::GetName() const
 
 void FiducialMarkerSpaceComponent::SetName(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Name_DEPRECATED), Value);
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Name_DEPRECATED), Value);
 }
 
 /* ITransformComponent */
@@ -135,7 +135,7 @@ const csp::common::Vector3& FiducialMarkerSpaceComponent::GetPosition() const
 
 void FiducialMarkerSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& FiducialMarkerSpaceComponent::GetRotation() const
@@ -145,7 +145,7 @@ const csp::common::Vector4& FiducialMarkerSpaceComponent::GetRotation() const
 
 void FiducialMarkerSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& FiducialMarkerSpaceComponent::GetScale() const
@@ -155,7 +155,7 @@ const csp::common::Vector3& FiducialMarkerSpaceComponent::GetScale() const
 
 void FiducialMarkerSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::Scale), Value);
 }
 
 SpaceTransform FiducialMarkerSpaceComponent::GetTransform() const
@@ -179,14 +179,20 @@ void FiducialMarkerSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool FiducialMarkerSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVisible)); }
 
-void FiducialMarkerSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVisible), Value); }
+void FiducialMarkerSpaceComponent::SetIsVisible(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVisible), Value);
+}
 
 bool FiducialMarkerSpaceComponent::GetIsARVisible() const
 {
     return GetBooleanProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible));
 }
 
-void FiducialMarkerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible), Value); }
+void FiducialMarkerSpaceComponent::SetIsARVisible(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsARVisible), Value);
+}
 
 bool FiducialMarkerSpaceComponent::GetIsVirtualVisible() const
 {
@@ -195,7 +201,7 @@ bool FiducialMarkerSpaceComponent::GetIsVirtualVisible() const
 
 void FiducialMarkerSpaceComponent::SetIsVirtualVisible(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible), Value);
+    SetPropertyDirect(static_cast<uint32_t>(FiducialMarkerPropertyKeys::IsVirtualVisible), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
@@ -126,21 +126,21 @@ FogSpaceComponent::FogSpaceComponent(const ComponentSchema& InSchema, csp::commo
 
 FogMode FogSpaceComponent::GetFogMode() const { return static_cast<FogMode>(GetIntegerProperty(static_cast<uint32_t>(FogPropertyKeys::FogMode))); }
 
-void FogSpaceComponent::SetFogMode(FogMode Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::FogMode), static_cast<int64_t>(Value)); }
+void FogSpaceComponent::SetFogMode(FogMode Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::FogMode), static_cast<int64_t>(Value)); }
 
 /* ITransformComponent */
 
 const csp::common::Vector3& FogSpaceComponent::GetPosition() const { return GetVector3Property(static_cast<uint32_t>(FogPropertyKeys::Position)); }
 
-void FogSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::Position), Value); }
+void FogSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::Position), Value); }
 
 const csp::common::Vector4& FogSpaceComponent::GetRotation() const { return GetVector4Property(static_cast<uint32_t>(FogPropertyKeys::Rotation)); }
 
-void FogSpaceComponent::SetRotation(const csp::common::Vector4& Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::Rotation), Value); }
+void FogSpaceComponent::SetRotation(const csp::common::Vector4& Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::Rotation), Value); }
 
 const csp::common::Vector3& FogSpaceComponent::GetScale() const { return GetVector3Property(static_cast<uint32_t>(FogPropertyKeys::Scale)); }
 
-void FogSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::Scale), Value); }
+void FogSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::Scale), Value); }
 
 SpaceTransform FogSpaceComponent::GetTransform() const
 {
@@ -161,45 +161,45 @@ void FogSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 float FogSpaceComponent::GetStartDistance() const { return GetFloatProperty(static_cast<uint32_t>(FogPropertyKeys::StartDistance)); }
 
-void FogSpaceComponent::SetStartDistance(float Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::StartDistance), Value); }
+void FogSpaceComponent::SetStartDistance(float Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::StartDistance), Value); }
 
 float FogSpaceComponent::GetEndDistance() const { return GetFloatProperty(static_cast<uint32_t>(FogPropertyKeys::EndDistance)); }
 
-void FogSpaceComponent::SetEndDistance(float Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::EndDistance), Value); }
+void FogSpaceComponent::SetEndDistance(float Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::EndDistance), Value); }
 
 const csp::common::Vector3& FogSpaceComponent::GetColor() const { return GetVector3Property(static_cast<uint32_t>(FogPropertyKeys::Color)); }
 
-void FogSpaceComponent::SetColor(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::Color), Value); }
+void FogSpaceComponent::SetColor(const csp::common::Vector3& Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::Color), Value); }
 
 float FogSpaceComponent::GetDensity() const { return GetFloatProperty(static_cast<uint32_t>(FogPropertyKeys::Density)); }
 
-void FogSpaceComponent::SetDensity(float Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::Density), Value); }
+void FogSpaceComponent::SetDensity(float Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::Density), Value); }
 
 float FogSpaceComponent::GetHeightFalloff() const { return GetFloatProperty(static_cast<uint32_t>(FogPropertyKeys::HeightFalloff)); }
 
-void FogSpaceComponent::SetHeightFalloff(float Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::HeightFalloff), Value); }
+void FogSpaceComponent::SetHeightFalloff(float Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::HeightFalloff), Value); }
 
 float FogSpaceComponent::GetMaxOpacity() const { return GetFloatProperty(static_cast<uint32_t>(FogPropertyKeys::MaxOpacity)); }
 
-void FogSpaceComponent::SetMaxOpacity(float Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::MaxOpacity), Value); }
+void FogSpaceComponent::SetMaxOpacity(float Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::MaxOpacity), Value); }
 
 bool FogSpaceComponent::GetIsVolumetric() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVolumetric)); }
 
-void FogSpaceComponent::SetIsVolumetric(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVolumetric), Value); }
+void FogSpaceComponent::SetIsVolumetric(bool Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::IsVolumetric), Value); }
 
 /* IVisibleComponent */
 
 bool FogSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVisible)); }
 
-void FogSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVisible), Value); }
+void FogSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::IsVisible), Value); }
 
 bool FogSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsARVisible)); }
 
-void FogSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsARVisible), Value); }
+void FogSpaceComponent::SetIsARVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::IsARVisible), Value); }
 
 bool FogSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible)); }
 
-void FogSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible), Value); }
+void FogSpaceComponent::SetIsVirtualVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::IsVirtualVisible), Value); }
 
 const csp::common::String& FogSpaceComponent::GetThirdPartyComponentRef() const
 {
@@ -208,7 +208,7 @@ const csp::common::String& FogSpaceComponent::GetThirdPartyComponentRef() const
 
 void FogSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(FogPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(FogPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
@@ -110,7 +110,7 @@ const csp::common::String& GaussianSplatSpaceComponent::GetExternalResourceAsset
 
 void GaussianSplatSpaceComponent::SetExternalResourceAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetId), Value);
 }
 
 const csp::common::String& GaussianSplatSpaceComponent::GetExternalResourceAssetCollectionId() const
@@ -120,7 +120,7 @@ const csp::common::String& GaussianSplatSpaceComponent::GetExternalResourceAsset
 
 void GaussianSplatSpaceComponent::SetExternalResourceAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::ExternalResourceAssetCollectionId), Value);
 }
 
 /* ITransformComponent */
@@ -132,7 +132,7 @@ const csp::common::Vector3& GaussianSplatSpaceComponent::GetPosition() const
 
 void GaussianSplatSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& GaussianSplatSpaceComponent::GetRotation() const
@@ -142,7 +142,7 @@ const csp::common::Vector4& GaussianSplatSpaceComponent::GetRotation() const
 
 void GaussianSplatSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& GaussianSplatSpaceComponent::GetScale() const
@@ -152,7 +152,7 @@ const csp::common::Vector3& GaussianSplatSpaceComponent::GetScale() const
 
 void GaussianSplatSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::Scale), Value);
 }
 
 SpaceTransform GaussianSplatSpaceComponent::GetTransform() const
@@ -176,13 +176,16 @@ void GaussianSplatSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool GaussianSplatSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVisible)); }
 
-void GaussianSplatSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVisible), InValue); }
+void GaussianSplatSpaceComponent::SetIsVisible(bool InValue)
+{
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVisible), InValue);
+}
 
 bool GaussianSplatSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible)); }
 
 void GaussianSplatSpaceComponent::SetIsARVisible(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsARVisible), InValue);
 }
 
 bool GaussianSplatSpaceComponent::GetIsVirtualVisible() const
@@ -192,7 +195,7 @@ bool GaussianSplatSpaceComponent::GetIsVirtualVisible() const
 
 void GaussianSplatSpaceComponent::SetIsVirtualVisible(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsVirtualVisible), InValue);
 }
 
 bool GaussianSplatSpaceComponent::GetIsShadowCaster() const
@@ -202,7 +205,7 @@ bool GaussianSplatSpaceComponent::GetIsShadowCaster() const
 
 void GaussianSplatSpaceComponent::SetIsShadowCaster(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster_DEPRECATED), Value);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::IsShadowCaster_DEPRECATED), Value);
 }
 
 const csp::common::Vector3& GaussianSplatSpaceComponent::GetTint() const
@@ -212,7 +215,7 @@ const csp::common::Vector3& GaussianSplatSpaceComponent::GetTint() const
 
 void GaussianSplatSpaceComponent::SetTint(const csp::common::Vector3& TintValue)
 {
-    SetProperty(static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint), TintValue);
+    SetPropertyDirect(static_cast<uint32_t>(GaussianSplatPropertyKeys::Tint), TintValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -100,16 +100,16 @@ const csp::common::String& HotspotSpaceComponent::GetName() const
 
 void HotspotSpaceComponent::SetName(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::Name_DEPRECATED), Value);
+    SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::Name_DEPRECATED), Value);
 }
 
 bool HotspotSpaceComponent::GetIsTeleportPoint() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsTeleportPoint)); }
 
-void HotspotSpaceComponent::SetIsTeleportPoint(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsTeleportPoint), Value); }
+void HotspotSpaceComponent::SetIsTeleportPoint(bool Value) { SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::IsTeleportPoint), Value); }
 
 bool HotspotSpaceComponent::GetIsSpawnPoint() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint)); }
 
-void HotspotSpaceComponent::SetIsSpawnPoint(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint), Value); }
+void HotspotSpaceComponent::SetIsSpawnPoint(bool Value) { SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::IsSpawnPoint), Value); }
 
 csp::common::String HotspotSpaceComponent::GetUniqueComponentId() const
 {
@@ -129,7 +129,7 @@ const csp::common::Vector3& HotspotSpaceComponent::GetPosition() const
 
 void HotspotSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::Position), Value);
 }
 
 /* IRotationComponent */
@@ -141,21 +141,24 @@ const csp::common::Vector4& HotspotSpaceComponent::GetRotation() const
 
 void HotspotSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::Rotation), Value);
 }
 
 /* IVisibleComponent */
 
 bool HotspotSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVisible)); }
 
-void HotspotSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVisible), Value); }
+void HotspotSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::IsVisible), Value); }
 
 bool HotspotSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible)); }
 
-void HotspotSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible), Value); }
+void HotspotSpaceComponent::SetIsARVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::IsARVisible), Value); }
 
 bool HotspotSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible)); }
 
-void HotspotSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible), Value); }
+void HotspotSpaceComponent::SetIsVirtualVisible(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(HotspotPropertyKeys::IsVirtualVisible), Value);
+}
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
@@ -117,7 +117,7 @@ const csp::common::String& ImageSpaceComponent::GetImageAssetId() const
 
 void ImageSpaceComponent::SetImageAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ImagePropertyKeys::ImageAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::ImageAssetId), Value);
 }
 
 const csp::common::String& ImageSpaceComponent::GetAssetCollectionId() const
@@ -127,7 +127,7 @@ const csp::common::String& ImageSpaceComponent::GetAssetCollectionId() const
 
 void ImageSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ImagePropertyKeys::AssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::AssetCollectionId), Value);
 }
 
 const csp::common::String& ImageSpaceComponent::GetName() const
@@ -135,7 +135,10 @@ const csp::common::String& ImageSpaceComponent::GetName() const
     return GetStringProperty(static_cast<uint32_t>(ImagePropertyKeys::Name_DEPRECATED));
 }
 
-void ImageSpaceComponent::SetName(const csp::common::String& Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::Name_DEPRECATED), Value); }
+void ImageSpaceComponent::SetName(const csp::common::String& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::Name_DEPRECATED), Value);
+}
 
 /* ITransformComponent */
 
@@ -144,18 +147,24 @@ const csp::common::Vector3& ImageSpaceComponent::GetPosition() const
     return GetVector3Property(static_cast<uint32_t>(ImagePropertyKeys::Position));
 }
 
-void ImageSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::Position), Value); }
+void ImageSpaceComponent::SetPosition(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::Position), Value);
+}
 
 const csp::common::Vector4& ImageSpaceComponent::GetRotation() const
 {
     return GetVector4Property(static_cast<uint32_t>(ImagePropertyKeys::Rotation));
 }
 
-void ImageSpaceComponent::SetRotation(const csp::common::Vector4& Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::Rotation), Value); }
+void ImageSpaceComponent::SetRotation(const csp::common::Vector4& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::Rotation), Value);
+}
 
 const csp::common::Vector3& ImageSpaceComponent::GetScale() const { return GetVector3Property(static_cast<uint32_t>(ImagePropertyKeys::Scale)); }
 
-void ImageSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::Scale), Value); }
+void ImageSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::Scale), Value); }
 
 SpaceTransform ImageSpaceComponent::GetTransform() const
 {
@@ -176,21 +185,21 @@ void ImageSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool ImageSpaceComponent::GetIsEmissive() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsEmissive)); }
 
-void ImageSpaceComponent::SetIsEmissive(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsEmissive), Value); }
+void ImageSpaceComponent::SetIsEmissive(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::IsEmissive), Value); }
 
 /* IVisibleComponent */
 
 bool ImageSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVisible)); }
 
-void ImageSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVisible), Value); }
+void ImageSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::IsVisible), Value); }
 
 bool ImageSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsARVisible)); }
 
-void ImageSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsARVisible), Value); }
+void ImageSpaceComponent::SetIsARVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::IsARVisible), Value); }
 
 bool ImageSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible)); }
 
-void ImageSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible), Value); }
+void ImageSpaceComponent::SetIsVirtualVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::IsVirtualVisible), Value); }
 
 BillboardMode ImageSpaceComponent::GetBillboardMode() const
 {
@@ -199,7 +208,7 @@ BillboardMode ImageSpaceComponent::GetBillboardMode() const
 
 void ImageSpaceComponent::SetBillboardMode(BillboardMode Value)
 {
-    SetProperty(static_cast<uint32_t>(ImagePropertyKeys::BillboardMode), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::BillboardMode), static_cast<int64_t>(Value));
 }
 
 DisplayMode ImageSpaceComponent::GetDisplayMode() const
@@ -209,6 +218,6 @@ DisplayMode ImageSpaceComponent::GetDisplayMode() const
 
 void ImageSpaceComponent::SetDisplayMode(DisplayMode Value)
 {
-    SetProperty(static_cast<uint32_t>(ImagePropertyKeys::DisplayMode), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(ImagePropertyKeys::DisplayMode), static_cast<int64_t>(Value));
 }
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
@@ -137,28 +137,28 @@ LightType LightSpaceComponent::GetLightType() const
 
 void LightSpaceComponent::SetLightType(LightType Value)
 {
-    SetProperty(static_cast<uint32_t>(LightPropertyKeys::LightType), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::LightType), static_cast<int64_t>(Value));
 }
 
 const csp::common::Vector3& LightSpaceComponent::GetColor() const { return GetVector3Property(static_cast<uint32_t>(LightPropertyKeys::Color)); }
 
-void LightSpaceComponent::SetColor(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::Color), Value); }
+void LightSpaceComponent::SetColor(const csp::common::Vector3& Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::Color), Value); }
 
 float LightSpaceComponent::GetIntensity() const { return GetFloatProperty(static_cast<uint32_t>(LightPropertyKeys::Intensity)); }
 
-void LightSpaceComponent::SetIntensity(float Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::Intensity), Value); }
+void LightSpaceComponent::SetIntensity(float Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::Intensity), Value); }
 
 float LightSpaceComponent::GetRange() const { return GetFloatProperty(static_cast<uint32_t>(LightPropertyKeys::Range)); }
 
-void LightSpaceComponent::SetRange(float Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::Range), Value); }
+void LightSpaceComponent::SetRange(float Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::Range), Value); }
 
 float LightSpaceComponent::GetInnerConeAngle() const { return GetFloatProperty(static_cast<uint32_t>(LightPropertyKeys::InnerConeAngle)); }
 
-void LightSpaceComponent::SetInnerConeAngle(float Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::InnerConeAngle), Value); }
+void LightSpaceComponent::SetInnerConeAngle(float Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::InnerConeAngle), Value); }
 
 float LightSpaceComponent::GetOuterConeAngle() const { return GetFloatProperty(static_cast<uint32_t>(LightPropertyKeys::OuterConeAngle)); }
 
-void LightSpaceComponent::SetOuterConeAngle(float Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::OuterConeAngle), Value); }
+void LightSpaceComponent::SetOuterConeAngle(float Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::OuterConeAngle), Value); }
 
 /* IPositionComponent */
 
@@ -167,7 +167,10 @@ const csp::common::Vector3& LightSpaceComponent::GetPosition() const
     return GetVector3Property(static_cast<uint32_t>(LightPropertyKeys::Position));
 }
 
-void LightSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::Position), Value); }
+void LightSpaceComponent::SetPosition(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::Position), Value);
+}
 
 /* IRotationComponent */
 
@@ -176,21 +179,24 @@ const csp::common::Vector4& LightSpaceComponent::GetRotation() const
     return GetVector4Property(static_cast<uint32_t>(LightPropertyKeys::Rotation));
 }
 
-void LightSpaceComponent::SetRotation(const csp::common::Vector4& Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::Rotation), Value); }
+void LightSpaceComponent::SetRotation(const csp::common::Vector4& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::Rotation), Value);
+}
 
 /* IVisibleComponent */
 
 bool LightSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsVisible)); }
 
-void LightSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsVisible), Value); }
+void LightSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::IsVisible), Value); }
 
 bool LightSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsARVisible)); }
 
-void LightSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsARVisible), Value); }
+void LightSpaceComponent::SetIsARVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::IsARVisible), Value); }
 
 bool LightSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible)); }
 
-void LightSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible), Value); }
+void LightSpaceComponent::SetIsVirtualVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::IsVirtualVisible), Value); }
 
 const csp::common::String& LightSpaceComponent::GetLightCookieAssetId() const
 {
@@ -199,7 +205,7 @@ const csp::common::String& LightSpaceComponent::GetLightCookieAssetId() const
 
 void LightSpaceComponent::SetLightCookieAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(LightPropertyKeys::LightCookieAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::LightCookieAssetId), Value);
 }
 
 const csp::common::String& LightSpaceComponent::GetLightCookieAssetCollectionId() const
@@ -209,7 +215,7 @@ const csp::common::String& LightSpaceComponent::GetLightCookieAssetCollectionId(
 
 void LightSpaceComponent::SetLightCookieAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(LightPropertyKeys::LightCookieAssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::LightCookieAssetCollectionId), Value);
 }
 
 LightCookieType LightSpaceComponent::GetLightCookieType() const
@@ -219,7 +225,7 @@ LightCookieType LightSpaceComponent::GetLightCookieType() const
 
 void LightSpaceComponent::SetLightCookieType(LightCookieType Value)
 {
-    SetProperty(static_cast<uint32_t>(LightPropertyKeys::LightCookieType), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::LightCookieType), static_cast<int64_t>(Value));
 }
 
 const csp::common::String& LightSpaceComponent::GetThirdPartyComponentRef() const
@@ -229,7 +235,7 @@ const csp::common::String& LightSpaceComponent::GetThirdPartyComponentRef() cons
 
 void LightSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(LightPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 LightShadowType LightSpaceComponent::GetLightShadowType() const
@@ -239,7 +245,7 @@ LightShadowType LightSpaceComponent::GetLightShadowType() const
 
 void LightSpaceComponent::SetLightShadowType(LightShadowType Value)
 {
-    SetProperty(static_cast<uint32_t>(LightPropertyKeys::LightShadowType), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(LightPropertyKeys::LightShadowType), static_cast<int64_t>(Value));
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/PortalSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/PortalSpaceComponent.cpp
@@ -87,7 +87,10 @@ PortalSpaceComponent::PortalSpaceComponent(const ComponentSchema& InSchema, csp:
 
 const csp::common::String& PortalSpaceComponent::GetSpaceId() const { return GetStringProperty(static_cast<uint32_t>(PortalPropertyKeys::SpaceId)); }
 
-void PortalSpaceComponent::SetSpaceId(const csp::common::String& Value) { SetProperty(static_cast<uint32_t>(PortalPropertyKeys::SpaceId), Value); }
+void PortalSpaceComponent::SetSpaceId(const csp::common::String& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(PortalPropertyKeys::SpaceId), Value);
+}
 
 /* IPositionComponent */
 
@@ -96,14 +99,17 @@ const csp::common::Vector3& PortalSpaceComponent::GetPosition() const
     return GetVector3Property(static_cast<uint32_t>(PortalPropertyKeys::Position));
 }
 
-void PortalSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(PortalPropertyKeys::Position), Value); }
+void PortalSpaceComponent::SetPosition(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(PortalPropertyKeys::Position), Value);
+}
 
 float PortalSpaceComponent::GetRadius() const { return GetFloatProperty(static_cast<uint32_t>(PortalPropertyKeys::Radius)); }
 
-void PortalSpaceComponent::SetRadius(float Value) { SetProperty(static_cast<uint32_t>(PortalPropertyKeys::Radius), Value); }
+void PortalSpaceComponent::SetRadius(float Value) { SetPropertyDirect(static_cast<uint32_t>(PortalPropertyKeys::Radius), Value); }
 
 bool PortalSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(PortalPropertyKeys::IsEnabled)); }
 
-void PortalSpaceComponent::SetIsEnabled(bool Value) { SetProperty(static_cast<uint32_t>(PortalPropertyKeys::IsEnabled), Value); }
+void PortalSpaceComponent::SetIsEnabled(bool Value) { SetPropertyDirect(static_cast<uint32_t>(PortalPropertyKeys::IsEnabled), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ReflectionSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ReflectionSpaceComponent.cpp
@@ -95,7 +95,7 @@ const csp::common::String& ReflectionSpaceComponent::GetReflectionAssetId() cons
 
 void ReflectionSpaceComponent::SetReflectionAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ReflectionPropertyKeys::ReflectionAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ReflectionPropertyKeys::ReflectionAssetId), Value);
 }
 
 const csp::common::String& ReflectionSpaceComponent::GetAssetCollectionId() const
@@ -105,7 +105,7 @@ const csp::common::String& ReflectionSpaceComponent::GetAssetCollectionId() cons
 
 void ReflectionSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ReflectionPropertyKeys::AssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ReflectionPropertyKeys::AssetCollectionId), Value);
 }
 
 const csp::common::String& ReflectionSpaceComponent::GetName() const
@@ -115,7 +115,7 @@ const csp::common::String& ReflectionSpaceComponent::GetName() const
 
 void ReflectionSpaceComponent::SetName(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ReflectionPropertyKeys::Name_DEPRECATED), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ReflectionPropertyKeys::Name_DEPRECATED), Value);
 }
 
 /* IPositionComponent */
@@ -127,7 +127,7 @@ const csp::common::Vector3& ReflectionSpaceComponent::GetPosition() const
 
 void ReflectionSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ReflectionPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ReflectionPropertyKeys::Position), Value);
 }
 
 /* IScaleComponent */
@@ -139,7 +139,7 @@ const csp::common::Vector3& ReflectionSpaceComponent::GetScale() const
 
 void ReflectionSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ReflectionPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ReflectionPropertyKeys::Scale), Value);
 }
 
 ReflectionShape ReflectionSpaceComponent::GetReflectionShape() const
@@ -149,7 +149,7 @@ ReflectionShape ReflectionSpaceComponent::GetReflectionShape() const
 
 void ReflectionSpaceComponent::SetReflectionShape(ReflectionShape Value)
 {
-    SetProperty(static_cast<uint32_t>(ReflectionPropertyKeys::ReflectionShape), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(ReflectionPropertyKeys::ReflectionShape), static_cast<int64_t>(Value));
 }
 
 const csp::common::String& ReflectionSpaceComponent::GetThirdPartyComponentRef() const
@@ -159,7 +159,7 @@ const csp::common::String& ReflectionSpaceComponent::GetThirdPartyComponentRef()
 
 void ReflectionSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(ReflectionPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(ReflectionPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
@@ -118,7 +118,7 @@ const csp::common::String& ScreenSharingSpaceComponent::GetUserId() const
 
 void ScreenSharingSpaceComponent::SetUserId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::UserId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::UserId), Value);
 }
 
 const csp::common::String& ScreenSharingSpaceComponent::GetDefaultImageCollectionId() const
@@ -128,7 +128,7 @@ const csp::common::String& ScreenSharingSpaceComponent::GetDefaultImageCollectio
 
 void ScreenSharingSpaceComponent::SetDefaultImageCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageCollectionId), Value);
 }
 
 const csp::common::String& ScreenSharingSpaceComponent::GetDefaultImageAssetId() const
@@ -138,7 +138,7 @@ const csp::common::String& ScreenSharingSpaceComponent::GetDefaultImageAssetId()
 
 void ScreenSharingSpaceComponent::SetDefaultImageAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::DefaultImageAssetId), Value);
 }
 
 float ScreenSharingSpaceComponent::GetAttenuationRadius() const
@@ -148,7 +148,7 @@ float ScreenSharingSpaceComponent::GetAttenuationRadius() const
 
 void ScreenSharingSpaceComponent::SetAttenuationRadius(float Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::AttenuationRadius), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::AttenuationRadius), Value);
 }
 
 /* ITransformComponent */
@@ -160,7 +160,7 @@ const csp::common::Vector3& ScreenSharingSpaceComponent::GetPosition() const
 
 void ScreenSharingSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& ScreenSharingSpaceComponent::GetRotation() const
@@ -170,7 +170,7 @@ const csp::common::Vector4& ScreenSharingSpaceComponent::GetRotation() const
 
 void ScreenSharingSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& ScreenSharingSpaceComponent::GetScale() const
@@ -180,7 +180,7 @@ const csp::common::Vector3& ScreenSharingSpaceComponent::GetScale() const
 
 void ScreenSharingSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::Scale), Value);
 }
 
 SpaceTransform ScreenSharingSpaceComponent::GetTransform() const
@@ -204,11 +204,14 @@ void ScreenSharingSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool ScreenSharingSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVisible)); }
 
-void ScreenSharingSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVisible), Value); }
+void ScreenSharingSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVisible), Value); }
 
 bool ScreenSharingSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsARVisible)); }
 
-void ScreenSharingSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsARVisible), Value); }
+void ScreenSharingSpaceComponent::SetIsARVisible(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsARVisible), Value);
+}
 
 bool ScreenSharingSpaceComponent::GetIsVirtualVisible() const
 {
@@ -217,7 +220,7 @@ bool ScreenSharingSpaceComponent::GetIsVirtualVisible() const
 
 void ScreenSharingSpaceComponent::SetIsVirtualVisible(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsVirtualVisible), Value);
 }
 
 /* IShadowCaster */
@@ -229,7 +232,7 @@ bool ScreenSharingSpaceComponent::GetIsShadowCaster() const
 
 void ScreenSharingSpaceComponent::SetIsShadowCaster(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsShadowCaster), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScreenSharingPropertyKeys::IsShadowCaster), Value);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp
@@ -78,13 +78,13 @@ void ScriptSpaceComponent::SetScriptSource(const csp::common::String& Value)
 {
     // CSP_LOG_WARN_FORMAT("ScriptSpaceComponent::SetScriptSource '%s'", Value.c_str());
 
-    SetProperty(static_cast<uint32_t>(ScriptComponentPropertyKeys::ScriptSource), Value);
+    SetPropertyDirect(static_cast<uint32_t>(ScriptComponentPropertyKeys::ScriptSource), Value);
     Parent->GetScript().OnSourceChanged(Value);
 }
 
 int64_t ScriptSpaceComponent::GetOwnerId() const { return GetIntegerProperty(static_cast<uint32_t>(ScriptComponentPropertyKeys::OwnerId)); }
 
-void ScriptSpaceComponent::SetOwnerId(int64_t OwnerId) { SetProperty(static_cast<uint32_t>(ScriptComponentPropertyKeys::OwnerId), OwnerId); }
+void ScriptSpaceComponent::SetOwnerId(int64_t OwnerId) { SetPropertyDirect(static_cast<uint32_t>(ScriptComponentPropertyKeys::OwnerId), OwnerId); }
 
 ScriptScope ScriptSpaceComponent::GetScriptScope() const
 {
@@ -93,7 +93,7 @@ ScriptScope ScriptSpaceComponent::GetScriptScope() const
 
 void ScriptSpaceComponent::SetScriptScope(ScriptScope Scope)
 {
-    SetProperty(static_cast<uint32_t>(ScriptComponentPropertyKeys::ScriptScope), static_cast<int64_t>(Scope));
+    SetPropertyDirect(static_cast<uint32_t>(ScriptComponentPropertyKeys::ScriptScope), static_cast<int64_t>(Scope));
 }
 
 void ScriptSpaceComponent::SetPropertyFromPatch(uint32_t Key, const csp::common::ReplicatedValue& Value)

--- a/Library/src/Multiplayer/Components/SplineSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/SplineSpaceComponent.cpp
@@ -154,11 +154,11 @@ csp::common::List<csp::common::Vector3> SplineSpaceComponent::GetWaypoints() con
 
 void SplineSpaceComponent::SetWaypoints(const csp::common::List<csp::common::Vector3>& Waypoints)
 {
-    SetProperty(static_cast<uint32_t>(SplinePropertyKeys::Waypoints), (int64_t)Waypoints.Size());
+    SetPropertyDirect(static_cast<uint32_t>(SplinePropertyKeys::Waypoints), (int64_t)Waypoints.Size());
 
     for (size_t i = 0; i < Waypoints.Size(); ++i)
     {
-        SetProperty(static_cast<uint32_t>((static_cast<int>(SplinePropertyKeys::Waypoints) + 1) + i), Waypoints[i]);
+        SetPropertyDirect(static_cast<uint32_t>((static_cast<int>(SplinePropertyKeys::Waypoints) + 1) + i), Waypoints[i]);
     }
 }
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -127,7 +127,7 @@ const csp::common::String& StaticModelSpaceComponent::GetExternalResourceAssetId
 
 void StaticModelSpaceComponent::SetExternalResourceAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ExternalResourceAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::ExternalResourceAssetId), Value);
 }
 
 const csp::common::String& StaticModelSpaceComponent::GetExternalResourceAssetCollectionId() const
@@ -137,7 +137,7 @@ const csp::common::String& StaticModelSpaceComponent::GetExternalResourceAssetCo
 
 void StaticModelSpaceComponent::SetExternalResourceAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ExternalResourceAssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::ExternalResourceAssetCollectionId), Value);
 }
 
 csp::common::Map<csp::common::String, csp::common::String> StaticModelSpaceComponent::GetMaterialOverrides() const
@@ -166,7 +166,7 @@ void StaticModelSpaceComponent::AddMaterialOverride(const csp::common::String& M
 
     ReplicatedOverrides[ModelPath] = MaterialId;
 
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }
 
 void StaticModelSpaceComponent::RemoveMaterialOverride(const csp::common::String& ModelPath)
@@ -174,7 +174,7 @@ void StaticModelSpaceComponent::RemoveMaterialOverride(const csp::common::String
     auto ReplicatedOverrides = GetStringMapProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides));
     ReplicatedOverrides.Remove(ModelPath);
 
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::MaterialOverrides), ReplicatedOverrides);
 }
 
 /* ITransformComponent */
@@ -186,7 +186,7 @@ const csp::common::Vector3& StaticModelSpaceComponent::GetPosition() const
 
 void StaticModelSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& StaticModelSpaceComponent::GetRotation() const
@@ -196,7 +196,7 @@ const csp::common::Vector4& StaticModelSpaceComponent::GetRotation() const
 
 void StaticModelSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& StaticModelSpaceComponent::GetScale() const
@@ -206,7 +206,7 @@ const csp::common::Vector3& StaticModelSpaceComponent::GetScale() const
 
 void StaticModelSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::Scale), Value);
 }
 
 SpaceTransform StaticModelSpaceComponent::GetTransform() const
@@ -230,11 +230,14 @@ void StaticModelSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool StaticModelSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVisible)); }
 
-void StaticModelSpaceComponent::SetIsVisible(bool InValue) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVisible), InValue); }
+void StaticModelSpaceComponent::SetIsVisible(bool InValue) { SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::IsVisible), InValue); }
 
 bool StaticModelSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible)); }
 
-void StaticModelSpaceComponent::SetIsARVisible(bool InValue) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible), InValue); }
+void StaticModelSpaceComponent::SetIsARVisible(bool InValue)
+{
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::IsARVisible), InValue);
+}
 
 bool StaticModelSpaceComponent::GetIsVirtualVisible() const
 {
@@ -243,7 +246,7 @@ bool StaticModelSpaceComponent::GetIsVirtualVisible() const
 
 void StaticModelSpaceComponent::SetIsVirtualVisible(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::IsVirtualVisible), InValue);
 }
 
 const csp::common::String& StaticModelSpaceComponent::GetThirdPartyComponentRef() const
@@ -253,7 +256,7 @@ const csp::common::String& StaticModelSpaceComponent::GetThirdPartyComponentRef(
 
 void StaticModelSpaceComponent::SetThirdPartyComponentRef(const csp::common::String& InValue)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::ThirdPartyComponentRef), InValue);
 }
 
 bool StaticModelSpaceComponent::GetIsShadowCaster() const
@@ -261,7 +264,10 @@ bool StaticModelSpaceComponent::GetIsShadowCaster() const
     return GetBooleanProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster));
 }
 
-void StaticModelSpaceComponent::SetIsShadowCaster(bool Value) { SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster), Value); }
+void StaticModelSpaceComponent::SetIsShadowCaster(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::IsShadowCaster), Value);
+}
 
 /* IRenderBehaviourComponent */
 
@@ -272,7 +278,7 @@ bool StaticModelSpaceComponent::GetShowAsHoldoutInAR() const
 
 void StaticModelSpaceComponent::SetShowAsHoldoutInAR(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInAR), InValue);
 }
 
 bool StaticModelSpaceComponent::GetShowAsHoldoutInVirtual() const
@@ -282,7 +288,7 @@ bool StaticModelSpaceComponent::GetShowAsHoldoutInVirtual() const
 
 void StaticModelSpaceComponent::SetShowAsHoldoutInVirtual(bool InValue)
 {
-    SetProperty(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual), InValue);
+    SetPropertyDirect(static_cast<uint32_t>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual), InValue);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
@@ -119,14 +119,17 @@ TextSpaceComponent::TextSpaceComponent(const ComponentSchema& InSchema, csp::com
 
 const csp::common::String& TextSpaceComponent::GetText() const { return GetStringProperty(static_cast<uint32_t>(TextPropertyKeys::Text)); }
 
-void TextSpaceComponent::SetText(const csp::common::String& Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::Text), Value); }
+void TextSpaceComponent::SetText(const csp::common::String& Value) { SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::Text), Value); }
 
 const csp::common::Vector3& TextSpaceComponent::GetTextColor() const
 {
     return GetVector3Property(static_cast<uint32_t>(TextPropertyKeys::TextColor));
 }
 
-void TextSpaceComponent::SetTextColor(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::TextColor), Value); }
+void TextSpaceComponent::SetTextColor(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::TextColor), Value);
+}
 
 const csp::common::Vector3& TextSpaceComponent::GetBackgroundColor() const
 {
@@ -135,32 +138,41 @@ const csp::common::Vector3& TextSpaceComponent::GetBackgroundColor() const
 
 void TextSpaceComponent::SetBackgroundColor(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(TextPropertyKeys::BackgroundColor), Value);
+    SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::BackgroundColor), Value);
 }
 
 bool TextSpaceComponent::GetIsBackgroundVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsBackgroundVisible)); }
 
-void TextSpaceComponent::SetIsBackgroundVisible(bool InValue) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsBackgroundVisible), InValue); }
+void TextSpaceComponent::SetIsBackgroundVisible(bool InValue)
+{
+    SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::IsBackgroundVisible), InValue);
+}
 
 float TextSpaceComponent::GetWidth() const { return GetFloatProperty(static_cast<uint32_t>(TextPropertyKeys::Width)); }
 
-void TextSpaceComponent::SetWidth(float InValue) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::Width), InValue); }
+void TextSpaceComponent::SetWidth(float InValue) { SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::Width), InValue); }
 
 float TextSpaceComponent::GetHeight() const { return GetFloatProperty(static_cast<uint32_t>(TextPropertyKeys::Height)); }
 
-void TextSpaceComponent::SetHeight(float InValue) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::Height), InValue); }
+void TextSpaceComponent::SetHeight(float InValue) { SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::Height), InValue); }
 
 const csp::common::Vector3& TextSpaceComponent::GetPosition() const { return GetVector3Property(static_cast<uint32_t>(TextPropertyKeys::Position)); }
 
-void TextSpaceComponent::SetPosition(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::Position), Value); }
+void TextSpaceComponent::SetPosition(const csp::common::Vector3& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::Position), Value);
+}
 
 const csp::common::Vector4& TextSpaceComponent::GetRotation() const { return GetVector4Property(static_cast<uint32_t>(TextPropertyKeys::Rotation)); }
 
-void TextSpaceComponent::SetRotation(const csp::common::Vector4& Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::Rotation), Value); }
+void TextSpaceComponent::SetRotation(const csp::common::Vector4& Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::Rotation), Value);
+}
 
 const csp::common::Vector3& TextSpaceComponent::GetScale() const { return GetVector3Property(static_cast<uint32_t>(TextPropertyKeys::Scale)); }
 
-void TextSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::Scale), Value); }
+void TextSpaceComponent::SetScale(const csp::common::Vector3& Value) { SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::Scale), Value); }
 
 SpaceTransform TextSpaceComponent::GetTransform() const
 {
@@ -183,15 +195,15 @@ void TextSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool TextSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsVisible)); }
 
-void TextSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsVisible), Value); }
+void TextSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::IsVisible), Value); }
 
 bool TextSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsARVisible)); }
 
-void TextSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsARVisible), Value); }
+void TextSpaceComponent::SetIsARVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::IsARVisible), Value); }
 
 bool TextSpaceComponent::GetIsVirtualVisible() const { return GetBooleanProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible)); }
 
-void TextSpaceComponent::SetIsVirtualVisible(bool Value) { SetProperty(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible), Value); }
+void TextSpaceComponent::SetIsVirtualVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::IsVirtualVisible), Value); }
 
 BillboardMode TextSpaceComponent::GetBillboardMode() const
 {
@@ -200,6 +212,6 @@ BillboardMode TextSpaceComponent::GetBillboardMode() const
 
 void TextSpaceComponent::SetBillboardMode(BillboardMode Value)
 {
-    SetProperty(static_cast<uint32_t>(TextPropertyKeys::BillboardMode), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(TextPropertyKeys::BillboardMode), static_cast<int64_t>(Value));
 }
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -195,7 +195,7 @@ const csp::common::String& VideoPlayerSpaceComponent::GetName() const
 
 void VideoPlayerSpaceComponent::SetName(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Name_DEPRECATED), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::Name_DEPRECATED), Value);
 }
 
 const csp::common::String& VideoPlayerSpaceComponent::GetVideoAssetId() const
@@ -205,7 +205,7 @@ const csp::common::String& VideoPlayerSpaceComponent::GetVideoAssetId() const
 
 void VideoPlayerSpaceComponent::SetVideoAssetId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::VideoAssetId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::VideoAssetId), Value);
 }
 
 const csp::common::String& VideoPlayerSpaceComponent::GetVideoAssetURL() const
@@ -215,7 +215,7 @@ const csp::common::String& VideoPlayerSpaceComponent::GetVideoAssetURL() const
 
 void VideoPlayerSpaceComponent::SetVideoAssetURL(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::VideoAssetURL), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::VideoAssetURL), Value);
 }
 
 const csp::common::String& VideoPlayerSpaceComponent::GetAssetCollectionId() const
@@ -225,7 +225,7 @@ const csp::common::String& VideoPlayerSpaceComponent::GetAssetCollectionId() con
 
 void VideoPlayerSpaceComponent::SetAssetCollectionId(const csp::common::String& Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AssetCollectionId), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::AssetCollectionId), Value);
 }
 
 /* ITransformComponent */
@@ -237,7 +237,7 @@ const csp::common::Vector3& VideoPlayerSpaceComponent::GetPosition() const
 
 void VideoPlayerSpaceComponent::SetPosition(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Position), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::Position), Value);
 }
 
 const csp::common::Vector4& VideoPlayerSpaceComponent::GetRotation() const
@@ -247,7 +247,7 @@ const csp::common::Vector4& VideoPlayerSpaceComponent::GetRotation() const
 
 void VideoPlayerSpaceComponent::SetRotation(const csp::common::Vector4& Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Rotation), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::Rotation), Value);
 }
 
 const csp::common::Vector3& VideoPlayerSpaceComponent::GetScale() const
@@ -257,7 +257,7 @@ const csp::common::Vector3& VideoPlayerSpaceComponent::GetScale() const
 
 void VideoPlayerSpaceComponent::SetScale(const csp::common::Vector3& Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Scale), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::Scale), Value);
 }
 
 SpaceTransform VideoPlayerSpaceComponent::GetTransform() const
@@ -279,22 +279,31 @@ void VideoPlayerSpaceComponent::SetTransform(const SpaceTransform& InValue)
 
 bool VideoPlayerSpaceComponent::GetIsStateShared() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsStateShared)); }
 
-void VideoPlayerSpaceComponent::SetIsStateShared(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsStateShared), Value); }
+void VideoPlayerSpaceComponent::SetIsStateShared(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsStateShared), Value);
+}
 
 bool VideoPlayerSpaceComponent::GetIsAutoPlay() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsAutoPlay)); }
 
-void VideoPlayerSpaceComponent::SetIsAutoPlay(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsAutoPlay), Value); }
+void VideoPlayerSpaceComponent::SetIsAutoPlay(bool Value) { SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsAutoPlay), Value); }
 
 bool VideoPlayerSpaceComponent::GetIsLoopPlayback() const
 {
     return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsLoopPlayback));
 }
 
-void VideoPlayerSpaceComponent::SetIsLoopPlayback(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsLoopPlayback), Value); }
+void VideoPlayerSpaceComponent::SetIsLoopPlayback(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsLoopPlayback), Value);
+}
 
 bool VideoPlayerSpaceComponent::GetIsAutoResize() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsAutoResize)); }
 
-void VideoPlayerSpaceComponent::SetIsAutoResize(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsAutoResize), Value); }
+void VideoPlayerSpaceComponent::SetIsAutoResize(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsAutoResize), Value);
+}
 
 VideoPlayerPlaybackState VideoPlayerSpaceComponent::GetPlaybackState() const
 {
@@ -303,7 +312,7 @@ VideoPlayerPlaybackState VideoPlayerSpaceComponent::GetPlaybackState() const
 
 void VideoPlayerSpaceComponent::SetPlaybackState(VideoPlayerPlaybackState Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::PlaybackState), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::PlaybackState), static_cast<int64_t>(Value));
 }
 
 float VideoPlayerSpaceComponent::GetCurrentPlayheadPosition() const
@@ -313,12 +322,15 @@ float VideoPlayerSpaceComponent::GetCurrentPlayheadPosition() const
 
 void VideoPlayerSpaceComponent::SetCurrentPlayheadPosition(float Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::CurrentPlayheadPosition), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::CurrentPlayheadPosition), Value);
 }
 
 float VideoPlayerSpaceComponent::GetTimeSincePlay() const { return GetFloatProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::TimeSincePlay)); }
 
-void VideoPlayerSpaceComponent::SetTimeSincePlay(float Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::TimeSincePlay), Value); }
+void VideoPlayerSpaceComponent::SetTimeSincePlay(float Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::TimeSincePlay), Value);
+}
 
 VideoPlayerSourceType VideoPlayerSpaceComponent::GetVideoPlayerSourceType() const
 {
@@ -327,7 +339,7 @@ VideoPlayerSourceType VideoPlayerSpaceComponent::GetVideoPlayerSourceType() cons
 
 void VideoPlayerSpaceComponent::SetVideoPlayerSourceType(VideoPlayerSourceType Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::VideoPlayerSourceType), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::VideoPlayerSourceType), static_cast<int64_t>(Value));
 }
 
 StereoVideoType VideoPlayerSpaceComponent::GetStereoVideoType() const
@@ -337,22 +349,25 @@ StereoVideoType VideoPlayerSpaceComponent::GetStereoVideoType() const
 
 void VideoPlayerSpaceComponent::SetStereoVideoType(StereoVideoType Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::StereoVideoType), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::StereoVideoType), static_cast<int64_t>(Value));
 }
 
 bool VideoPlayerSpaceComponent::GetIsStereoFlipped() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsStereoFlipped)); }
 
-void VideoPlayerSpaceComponent::SetIsStereoFlipped(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsStereoFlipped), Value); }
+void VideoPlayerSpaceComponent::SetIsStereoFlipped(bool Value)
+{
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsStereoFlipped), Value);
+}
 
 /* IVisibleComponent */
 
 bool VideoPlayerSpaceComponent::GetIsVisible() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVisible)); }
 
-void VideoPlayerSpaceComponent::SetIsVisible(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVisible), Value); }
+void VideoPlayerSpaceComponent::SetIsVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVisible), Value); }
 
 bool VideoPlayerSpaceComponent::GetIsARVisible() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible)); }
 
-void VideoPlayerSpaceComponent::SetIsARVisible(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible), Value); }
+void VideoPlayerSpaceComponent::SetIsARVisible(bool Value) { SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsARVisible), Value); }
 
 bool VideoPlayerSpaceComponent::GetIsVirtualVisible() const
 {
@@ -361,7 +376,7 @@ bool VideoPlayerSpaceComponent::GetIsVirtualVisible() const
 
 void VideoPlayerSpaceComponent::SetIsVirtualVisible(bool Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsVirtualVisible), Value);
 }
 
 /* IAudioControlComponent */
@@ -373,7 +388,7 @@ float VideoPlayerSpaceComponent::GetAttenuationRadius() const
 
 void VideoPlayerSpaceComponent::SetAttenuationRadius(float Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AttenuationRadius), Value);
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::AttenuationRadius), Value);
 }
 
 AudioType VideoPlayerSpaceComponent::GetAudioType() const
@@ -383,7 +398,7 @@ AudioType VideoPlayerSpaceComponent::GetAudioType() const
 
 void VideoPlayerSpaceComponent::SetAudioType(AudioType Value)
 {
-    SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::AudioType), static_cast<int64_t>(Value));
+    SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::AudioType), static_cast<int64_t>(Value));
 }
 
 float VideoPlayerSpaceComponent::GetVolume() const { return GetFloatProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Volume)); }
@@ -392,7 +407,7 @@ void VideoPlayerSpaceComponent::SetVolume(float Value)
 {
     if (Value >= 0.f && Value <= 1.f)
     {
-        SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::Volume), Value);
+        SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::Volume), Value);
     }
     else
     {
@@ -407,6 +422,6 @@ void VideoPlayerSpaceComponent::SetVolume(float Value)
 
 bool VideoPlayerSpaceComponent::GetIsEnabled() const { return GetBooleanProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsEnabled)); }
 
-void VideoPlayerSpaceComponent::SetIsEnabled(bool Value) { SetProperty(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsEnabled), Value); }
+void VideoPlayerSpaceComponent::SetIsEnabled(bool Value) { SetPropertyDirect(static_cast<uint32_t>(VideoPlayerPropertyKeys::IsEnabled), Value); }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentScriptInterface.cpp
@@ -94,7 +94,7 @@ std::optional<ComponentScriptInterface::Value> ComponentScriptInterface::GetProp
         return {};
     }
 
-    const auto& MaybeValue = Component->GetProperty(Key);
+    const auto& MaybeValue = Component->GetPropertyDirect(Key);
     if (MaybeValue.GetReplicatedValueType() == csp::common::ReplicatedValueType::InvalidType)
     {
         return std::nullopt;
@@ -198,7 +198,7 @@ void ComponentScriptInterface::SetProperty(uint16_t Key, Value DesiredValue)
 
     if (auto MaybeMappedValue = std::visit(Visitor{}, std::move(DesiredValue)))
     {
-        Component->SetProperty(Key, std::move(*MaybeMappedValue));
+        Component->SetPropertyDirect(Key, std::move(*MaybeMappedValue));
         SendPropertyUpdate();
     }
 }

--- a/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
@@ -50,11 +50,11 @@ public:
     {
         struct Component final
         {
-            void SetProperty(uint16_t Key, csp::common::ReplicatedValue Value) { Ref.SetSchemaProperty(Key, std::move(Value)); }
+            void SetProperty(uint16_t Key, csp::common::ReplicatedValue Value) { Ref.SetProperty(Key, std::move(Value)); }
 
             std::optional<csp::common::ReplicatedValue> GetProperty(uint16_t Key) const
             {
-                const auto* MaybeValue = Ref.GetSchemaProperty(Key);
+                const auto* MaybeValue = Ref.GetProperty(Key);
                 return MaybeValue ? *MaybeValue : std::optional<csp::common::ReplicatedValue>();
             }
 

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -356,7 +356,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponent
     const auto* Component = Entity->GetComponent(0);
     ASSERT_NE(Component, nullptr);
 
-    const auto* Value = Component->GetSchemaProperty(0);
+    const auto* Value = Component->GetProperty(0);
     ASSERT_NE(Value, nullptr);
 
     EXPECT_EQ(Value->GetString(), csp::common::String { "OverriddenValue" });
@@ -387,7 +387,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemComponent
     const auto* Component = Entity->GetComponent(0);
     ASSERT_NE(Component, nullptr);
 
-    const auto* Value = Component->GetSchemaProperty(0);
+    const auto* Value = Component->GetProperty(0);
     ASSERT_NE(Value, nullptr);
 
     EXPECT_EQ(Value->GetString(), csp::common::String { "OverriddenValue" });
@@ -508,7 +508,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, AddComponentFromItemDataAbove
     EXPECT_NE(Entity->GetComponent(0), nullptr);
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetSchemaPropertyReturnsDefaultValue)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetPropertyReturnsDefaultValue)
 {
     auto Fixture = TestFixture({
         Schema {
@@ -526,13 +526,13 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetSchemaPropertyReturnsDefau
     const auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
     ASSERT_NE(Component, nullptr);
 
-    const auto* Value = Component->GetSchemaProperty(0);
+    const auto* Value = Component->GetProperty(0);
     ASSERT_NE(Value, nullptr);
 
     EXPECT_EQ(*Value, "Value");
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetSchemaPropertyReturnsNullptrForUnknownKey)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetPropertyReturnsNullptrForUnknownKey)
 {
     auto Fixture = TestFixture({
         Schema {
@@ -550,10 +550,10 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, GetSchemaPropertyReturnsNullp
     const auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
     ASSERT_NE(Component, nullptr);
 
-    EXPECT_EQ(Component->GetSchemaProperty(999), nullptr);
+    EXPECT_EQ(Component->GetProperty(999), nullptr);
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithMatchingTypeSucceeds)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyWithMatchingTypeSucceeds)
 {
     auto Fixture = TestFixture({
         Schema {
@@ -571,15 +571,15 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithMatching
     auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
     ASSERT_NE(Component, nullptr);
 
-    Component->SetSchemaProperty(0, "NewValue");
+    Component->SetProperty(0, "NewValue");
 
-    const auto* Value = Component->GetSchemaProperty(0);
+    const auto* Value = Component->GetProperty(0);
     ASSERT_NE(Value, nullptr);
 
     EXPECT_EQ(*Value, "NewValue");
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithMismatchedTypeLeavesValueUnchanged)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyWithMismatchedTypeLeavesValueUnchanged)
 {
     auto Fixture = TestFixture({
         Schema {
@@ -597,15 +597,15 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithMismatch
     auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
     ASSERT_NE(Component, nullptr);
 
-    Component->SetSchemaProperty(0, int64_t { 42 });
+    Component->SetProperty(0, int64_t { 42 });
 
-    const auto* Value = Component->GetSchemaProperty(0);
+    const auto* Value = Component->GetProperty(0);
     ASSERT_NE(Value, nullptr);
 
     EXPECT_EQ(*Value, "Value");
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithUnknownKeyHasNoEffect)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyWithUnknownKeyHasNoEffect)
 {
     auto Fixture = TestFixture({
         Schema {
@@ -623,12 +623,12 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWithUnknownK
     auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
     ASSERT_NE(Component, nullptr);
 
-    Component->SetSchemaProperty(999, "SomeValue");
+    Component->SetProperty(999, "SomeValue");
 
-    EXPECT_EQ(Component->GetSchemaProperty(999), nullptr);
+    EXPECT_EQ(Component->GetProperty(999), nullptr);
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWhenParentIsLockedHasNoEffect)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyWhenParentIsLockedHasNoEffect)
 {
     auto Fixture = TestFixture({
         Schema {
@@ -647,15 +647,15 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyWhenParentIs
     ASSERT_NE(Component, nullptr);
 
     Entity->Lock();
-    Component->SetSchemaProperty(0, "NewValue");
+    Component->SetProperty(0, "NewValue");
 
-    const auto* Value = Component->GetSchemaProperty(0);
+    const auto* Value = Component->GetProperty(0);
     ASSERT_NE(Value, nullptr);
 
     EXPECT_EQ(*Value, "Value");
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyReflectsInTypedGetter)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyReflectsInTypedGetter)
 {
     auto Fixture = TestFixture({});
 
@@ -669,12 +669,12 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetSchemaPropertyReflectsInTy
     ASSERT_NE(AudioComponent, nullptr);
 
     const auto NewPosition = csp::common::Vector3 { 1.0f, 2.0f, 3.0f };
-    Component->SetSchemaProperty(static_cast<uint16_t>(csp::multiplayer::AudioPropertyKeys::Position), NewPosition);
+    Component->SetProperty(static_cast<uint16_t>(csp::multiplayer::AudioPropertyKeys::Position), NewPosition);
 
     EXPECT_EQ(AudioComponent->GetPosition(), NewPosition);
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, TypedSetterReflectsInGetSchemaProperty)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, TypedSetterReflectsInGetProperty)
 {
     auto Fixture = TestFixture({});
 
@@ -690,7 +690,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, TypedSetterReflectsInGetSchem
     const auto NewPosition = csp::common::Vector3 { 4.0f, 5.0f, 6.0f };
     AudioComponent->SetPosition(NewPosition);
 
-    const auto* SchemaValue = Component->GetSchemaProperty(static_cast<uint16_t>(csp::multiplayer::AudioPropertyKeys::Position));
+    const auto* SchemaValue = Component->GetProperty(static_cast<uint16_t>(csp::multiplayer::AudioPropertyKeys::Position));
     ASSERT_NE(SchemaValue, nullptr);
 
     EXPECT_EQ(SchemaValue->GetVector3(), NewPosition);

--- a/Tests/src/InternalTests/MCSTests.cpp
+++ b/Tests/src/InternalTests/MCSTests.cpp
@@ -56,7 +56,7 @@ CSP_INTERNAL_TEST(CSPEngine, MCSTests, ComponentPackerPreservesLargeComponentTyp
 
     auto* Component = Entity->AddComponentByTypeId(LargeTypeId);
     ASSERT_NE(Component, nullptr);
-    Component->SetSchemaProperty(0, "hello");
+    Component->SetProperty(0, "hello");
 
     auto Packer = MCSComponentPacker {};
     Packer.WriteValue(Component->GetId(), Component);

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -376,7 +376,7 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, SchemaComponentRoundtrip)
         auto* Component = Entity->AddComponentByTypeId(uint64_t { SchemaTypeId });
         ASSERT_NE(Component, nullptr);
 
-        Component->SetSchemaProperty(0, csp::common::String { "RoundtripValue" });
+        Component->SetProperty(0, csp::common::String { "RoundtripValue" });
 
         Entity->QueueUpdate();
         Engine.ProcessPendingEntityOperations();
@@ -411,7 +411,7 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, SchemaComponentRoundtrip)
         const auto* SchemaComponent = Components->begin()->second;
         ASSERT_EQ(SchemaComponent->GetTypeId(), SchemaTypeId);
 
-        const auto* Value = SchemaComponent->GetSchemaProperty(0);
+        const auto* Value = SchemaComponent->GetProperty(0);
         ASSERT_NE(Value, nullptr);
         EXPECT_EQ(Value->GetString(), csp::common::String { "RoundtripValue" });
 
@@ -492,7 +492,7 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, UpdatedLegacySchemaExposesExtraProper
         ASSERT_NE(Component, nullptr) << Schema.Name.c_str();
 
         const auto ExtraKey = Schema.Properties[Schema.Properties.Size() - 1].Key;
-        const auto* Value = Component->GetSchemaProperty(ExtraKey);
+        const auto* Value = Component->GetProperty(ExtraKey);
         ASSERT_NE(Value, nullptr) << Schema.Name.c_str();
 
         EXPECT_EQ(Value->GetString(), "ExtraDefault") << Schema.Name.c_str();


### PR DESCRIPTION
As discussed in CSP weekly, promote these to `GetProperty` and `SetProperty`, and rename the protected methods of the same name to avoid ambiguity (adding `Direct` suffix, following the naming on `SpaceEntity`)

More info in the individual commits