### PR TITLE
[Of-1840] feat: Add legacy emscripten build and tests to ci

### DIFF
--- a/.github/actions/build-legacy-emscripten/action.yml
+++ b/.github/actions/build-legacy-emscripten/action.yml
@@ -1,0 +1,75 @@
+name: "Build and Install"
+description: "Fetch dependencies with Conan, configure CMake, build, and install"
+
+inputs:
+
+  build_type:
+    description: "CMake build type [Debug, Release, RelWithDebInfo]"
+    required: true
+
+  configure_preset:
+    description: "CMake configure preset to use. Run cmake --list-presets to list available presets."
+    required: true
+
+  build_preset:
+    description: "CMake build preset to use. Run cmake --build --list-presets to list available presets."
+    required: true
+
+  build_folder:
+    description: "CMake build directory to install from. This can change depending on the generator used."
+    required: true
+
+  output_folder:
+    description: "Conan output folder"
+    required: true
+    default: ""
+
+runs:
+  using: "composite"
+
+  steps:
+
+    - name: Generate wrapper
+      shell: bash
+      run: |
+        set -euxo pipefail
+
+        pip install chevron
+        pip install jinja2
+        python Tools/WrapperGenerator/WrapperGenerator.py --generate_typescript
+
+    - name: Install Conan
+      uses: conan-io/setup-conan@v1
+
+    - name: Conan install
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+      shell: bash
+      run: |
+        set -euxo pipefail
+
+        conan install . \
+          -of "${{ inputs.output_folder }}" \
+          -s build_type="${{ inputs.build_type }}" \
+          --build=missing \
+          --profile:host=profiles/host/emscripten
+
+    - name: Configure CMake
+      shell: bash
+      run: |
+        set -euxo pipefail
+        cmake --preset "${{ inputs.configure_preset }}" -DCSP_BUILD_LEGACY_EMSCRIPTEN=1 -DWASM_WITH_NODE=1 -DUSE_LEGACY_WRAPPER_GEN=1
+
+    - name: Build
+      shell: bash
+      run: |
+        set -euxo pipefail
+        cmake --build --preset "${{ inputs.build_preset }}"
+
+    - name: Create Package
+      shell: bash
+      run: |
+        set -euxo pipefail
+        ./LegacyEmscriptenWrapper/GenerateLegacyEmscriptenPackage.sh \
+          "${{ inputs.build_type }}" \
+          "${{ inputs.build_folder }}"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -324,3 +324,56 @@ jobs:
           chmod +x ./MultiplayerTestRunner/MultiplayerTestRunner
           chmod +x ./csp-tests
           ./csp-tests
+
+  build-and-run-legacy-emscripten:
+    name: Build legacy emscripten ${{ matrix.config.build_type }}
+    runs-on: windows-latest
+    
+    env:
+      EMSDK_VERSION: 3.1.40
+    
+    strategy:
+      fail-fast: false
+      
+      matrix:
+        config:
+          - build_type: Debug
+            preset_prefix: debug
+
+          - build_type: Release
+            preset_prefix: release
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Ensure we fetch tags so our automatic versioning script picks up the version.
+          fetch-tags: true
+
+      - name: Set up MSVC (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup emsdk
+        uses: emscripten-core/setup-emsdk@v15
+        with:
+          version: ${{ env.EMSDK_VERSION }}
+          actions-cache-folder: 'emsdk-cache'
+
+      - name: Build Emscripten
+        uses: ./.github/actions/build-legacy-emscripten
+        with:
+          build_type: ${{ matrix.config.build_type }}
+          configure_preset: ${{ matrix.config.preset_prefix }}-static
+          build_preset: ${{ matrix.config.preset_prefix }}-static
+          output_folder: build/emscripten-${{ matrix.config.preset_prefix }}
+          build_folder: build/emscripten-${{ matrix.config.preset_prefix }}/build/${{ matrix.config.build_type }}
+
+      - name: Run Tests
+        if: matrix.config.build_type == 'Debug'
+        env:
+          MCS_X_WAF_BYPASS: ${{ secrets.MCS_BYPASS }}
+        shell: bash
+        run: |
+          cd WasmTesting
+          ./run-csp-wasm-tests.cmd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,14 @@ configure_file(
     ${CSP_INCLUDE_DIR}/CSP/version.h
 )
 
+# Temporary define until we remove the legacy wrapper gen
+if(USE_LEGACY_WRAPPER_GEN)
+    target_compile_definitions(csp-lib
+        PRIVATE
+            USE_LEGACY_WRAPPER_GEN=1
+    )
+endif()
+
 # Legacy Emscripten wrapper ---------------------------------------
 
   option(CSP_BUILD_LEGACY_EMSCRIPTEN "Build legacy emscripten project" OFF)

--- a/LegacyEmscriptenWrapper/GenerateLegacyEmscriptenPackage.sh
+++ b/LegacyEmscriptenWrapper/GenerateLegacyEmscriptenPackage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copies the generated TypeScript wrapper files and Emscripten build outputs
+# into the package/wasm directory, matching the layout used by the legacy scripts.
+
+set -euo pipefail
+
+CONFIG="${1:-Debug}"
+BUILD_DIR="${2:-build/Debug}"
+
+case "$CONFIG" in
+    Debug|Release|RelWithDebInfo)
+        ;;
+    debug)
+        CONFIG="Debug"
+        ;;
+    release)
+        CONFIG="Release"
+        ;;
+    relwithdebinfo)
+        CONFIG="RelWithDebInfo"
+        ;;
+    *)
+        echo "Error: CONFIG must be one of: Debug, Release, RelWithDebInfo"
+        echo "Usage: $0 <Config> <BuildDir>"
+        echo "Example: $0 Debug build/Debug"
+        exit 1
+        ;;
+esac
+
+OUTPUT_DIR="./Library/Binaries/package/wasm/connected-spaces-platform.web"
+CONFIG_OUTPUT_DIR="$OUTPUT_DIR/$CONFIG"
+
+WRAPPER_BUILD_DIR="./$BUILD_DIR/LegacyEmscriptenWrapper"
+TYPESCRIPT_OUTPUT_DIR="Tools/WrapperGenerator/Output/TypeScript"
+
+mkdir -p "$CONFIG_OUTPUT_DIR"
+
+# Copy specific Emscripten output files into the config folder
+cp "$WRAPPER_BUILD_DIR/ConnectedSpacesPlatform_WASM.js" "$CONFIG_OUTPUT_DIR/"
+cp "$WRAPPER_BUILD_DIR/ConnectedSpacesPlatform_WASM.wasm" "$CONFIG_OUTPUT_DIR/"
+cp "$WRAPPER_BUILD_DIR/ConnectedSpacesPlatform_WASM.worker.js" "$CONFIG_OUTPUT_DIR/"
+
+if [ "$CONFIG" = "Debug" ]; then
+    cp "$WRAPPER_BUILD_DIR/ConnectedSpacesPlatform_WASM.wasm.debug.wasm" "$CONFIG_OUTPUT_DIR/"
+fi
+
+# Copy all generated TypeScript output into the package folder
+cp -R "$TYPESCRIPT_OUTPUT_DIR"/. "$OUTPUT_DIR/"

--- a/LegacyEmscriptenWrapper/GenerateLegacyEmscriptenPackage.sh
+++ b/LegacyEmscriptenWrapper/GenerateLegacyEmscriptenPackage.sh
@@ -34,6 +34,8 @@ CONFIG_OUTPUT_DIR="$OUTPUT_DIR/$CONFIG"
 WRAPPER_BUILD_DIR="./$BUILD_DIR/LegacyEmscriptenWrapper"
 TYPESCRIPT_OUTPUT_DIR="Tools/WrapperGenerator/Output/TypeScript"
 
+python ./teamcity/BuildNPMWebPackage.py --npm_publish_flag=False
+
 mkdir -p "$CONFIG_OUTPUT_DIR"
 
 # Copy specific Emscripten output files into the config folder


### PR DESCRIPTION
This PR adds support for our existing Wasm builds on CI. This PR adds:

- A new action to build the csp legacy wasm project
- A new workflow step to build and run tests
- A new script to generate the wasm package by copying wrapper files and binaries into the package folder

Ive decided to leave RelWithDebInfo out of this work, as it will require additional work to the wrapper gen, which us unnecessary for now. This can be added with the  new binding layer.