### PR TITLE
[OF-1886] feat!: Expose event specializations via network event bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file. For compile
 
 ## [6.46.0]
 
+### 🔌 API Changes
+
+#### NetworkEventBus
+- 🔄 **Updated:** `ListenNetworkEvent(NeworkEventRegistration Registration, NetworkEventCallback Callback)` → `ListenCustomNetworkEvent(String EventReceiverId, String EventName, NetworkEventCallback Callback)`
+- 🔄 **Updated:** `StopListenNetworkEvent(NeworkEventRegistration Registration)` → `StopListenCustomNetworkEvent(String EventReceiverId, String EventName)`
+
+- ➕ **Added:** `ListenAccessControlChangedEvent(String EventReceiverId, AccessControlChangedEventCallback Callback)`
+- ➕ **Added:** `ListenAssetDetailBlobChangedEvent(String EventReceiverId, AssetDetailBlobChangedEventCallback Callback)`
+- ➕ **Added:** `ListenAsyncCallCompletedEvent(String EventReceiverId, String OperationName, AsyncCallCompletedEventCallback Callback)`
+- ➕ **Added:** `ListenConversationEvent(String EventReceiverId, ConversationEventCallback Callback)`
+- ➕ **Added:** `ListenSequenceChangedEvent(String EventReceiverId, SequenceChangedEventCallback Callback)`
+- ➕ **Added:** `StopListenAccessControlChangedEvent(String EventReceiverId)`
+- ➕ **Added:** `StopListenAssetDetailBlobChangedEvent(String EventReceiverId)`
+- ➕ **Added:** `StopListenAsyncCallCompletedEvent(String EventReceiverId, String OperationName)`
+- ➕ **Added:** `StopListenConversationEvent(String EventReceiverId)`
+- ➕ **Added:** `StopListenSequenceChangedEvent(String EventReceiverId)`
+
+#### SpaceSystem
+- ➖ **Removed:** `SetAsyncCallCompletedCallback()`
+- ➖ **Removed:** `OnAsyncCallCompletedEvent()`
+
+### 🔥 ❗Breaking Changes
+
+- [OF-1886] feat!: Expose event specializations via network event bus. By @MAG-AdamThorn
+  Added new dedicated Listen and StopListen methods for our event specializations, as well as dedicated std::unordered_map containers and callbacks for each event type. The existing `ListenNetworkEvent` and `StopListenNetworkEvent` methods have been renamed to `ListenCustomNetworkEvent` and `StopListenNetworkEvent` to better reflect their purpose as a means for clients to register their own custom events. In addition, rather than take a NetworkEventRegistration as an argument they now take EventReceiverId and EventName strings directly. This aligns usage with the new event specialization methods.
+  The `SpaceSystem` has a `DuplicateSpaceAsync` method which fires the AsyncCallCompleted event on completion of the operation. The SpaceSystem had dedicated API for registering a callback with this event and for responding to its firing. Now that the event specializations have been added to the NetworkEventBus, including Listen and StopListen methods for AsyncCallCompleted, the SpaceSystem no longer requires this functionality and it has been removed.
+  The existing NetworkEventBus tests have been updated to reflect the change to the `ListenNetworkEvent` and `StopListenNetworkEvent` method signatures. Tests have also been added to verify that the new Event Specialization methods work correctly. I have elected to test just those related to `AsyncCallCompleted` as they all delegate to shared logic internally.
+  Please see the API Changes section above for further details.
+
+
 ### 💫 💥 Code Refactors
 
 - [NT-0] refac!: Rename `GetSchemaProperty`/`SetSchemaProperty` on `ComponentBase` to `GetProperty`/`SetProperty`. By @mag-lt.

--- a/Library/include/CSP/Common/NetworkEventData.h
+++ b/Library/include/CSP/Common/NetworkEventData.h
@@ -47,7 +47,7 @@ enum class EPermissionChangeType
     Invalid,
 };
 
-/// @brief Data deserialized from a general purpose event. Serves as the base type for all custom deserialized events.
+/// @brief Data deserialized from a custom event. Serves as the base type for all specialized deserialized events.
 class CSP_API NetworkEventData
 {
 public:

--- a/Library/include/CSP/Multiplayer/NetworkEventBus.h
+++ b/Library/include/CSP/Multiplayer/NetworkEventBus.h
@@ -59,9 +59,19 @@ namespace csp::multiplayer
 class EventDeserialiser;
 enum class ErrorCode;
 
-// The callback used to register to listen to events.
+// The callback used to register to listen to custom network events.
 // NetworkEventData lifetime is tied to the callback, do not attempt to store it via reference.
 typedef std::function<void(const csp::common::NetworkEventData& NetworkEventData)> NetworkEventCallback;
+
+// Event listener specializations
+// Callbacks used to register to listen to event specializations.
+// The lifetime of network event data types are tied to the callback, do not attempt to store it via reference.
+typedef std::function<void(const csp::common::AccessControlChangedNetworkEventData& AccessControlChangedEventData)> AccessControlChangedEventCallback;
+typedef std::function<void(const csp::common::AssetDetailBlobChangedNetworkEventData& AssetDetailBlobChangedEventData)>
+    AssetDetailBlobChangedEventCallback;
+typedef std::function<void(const csp::common::AsyncCallCompletedEventData& AsyncCallCompletedEventData)> AsyncCallCompletedEventCallback;
+typedef std::function<void(const csp::common::ConversationNetworkEventData& ConversationNetworkEventData)> ConversationEventCallback;
+typedef std::function<void(const csp::common::SequenceChangedNetworkEventData& SequenceChangedEventData)> SequenceChangedEventCallback;
 
 /*
  * @brief Details about a network event registrations to serve as a key in the event map.
@@ -74,10 +84,10 @@ class CSP_API NetworkEventRegistration
 {
 public:
     /// @brief Construct a NetworkEventRegistration
-    /// @param EventReceiverId csp::common::String : The identifying name for the event receiver, used for management purposes, allowing clients to
+    /// @param EventReceiverId : The identifying name for the event receiver, used for management purposes, allowing clients to
     /// register multiple interests in single events. May be any arbitrary unique string. This is distinct from client ID. A single client/application
     /// may register multiple receivers if they choose.
-    /// @param EventName csp::common::String : The identifying name for the event. May be any arbitrary string.
+    /// @param EventName : The identifying name for the event. May be any arbitrary string.
     NetworkEventRegistration(const csp::common::String& EventReceiverId, const csp::common::String& EventName)
         : EventReceiverId(EventReceiverId)
         , EventName(EventName)
@@ -132,43 +142,105 @@ public:
     typedef std::function<void(csp::multiplayer::ErrorCode)> ErrorCodeCallbackHandler;
 
     /// @brief Sends a network event by EventName to all currently connected clients.
-    /// @param EventName csp::common::String : The identifying name for the event.
-    /// @param Args csp::common::Array<csp::common::ReplicatedValue> : An array of arguments (csp::common::ReplicatedValue) to be passed as part of
+    /// @param EventName : The identifying name for the event.
+    /// @param Args : An array of arguments (csp::common::ReplicatedValue) to be passed as part of
     /// the event payload.
-    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
+    /// @param Callback : a callback with failure state.
     CSP_ASYNC_RESULT void SendNetworkEvent(
         const csp::common::String& EventName, const csp::common::Array<csp::common::ReplicatedValue>& Args, ErrorCodeCallbackHandler Callback);
     CSP_NO_EXPORT async::task<std::optional<csp::multiplayer::ErrorCode>> SendNetworkEvent(
         const csp::common::String& EventName, const csp::common::Array<csp::common::ReplicatedValue>& Args);
 
     /// @brief Sends a network event by EventName, to TargetClientId.
-    /// @param EventName csp::common::String : The identifying name for the event.
-    /// @param Args csp::common::Array<csp::common::ReplicatedValue> : An array of arguments (csp::common::ReplicatedValue) to be passed as part of
+    /// @param EventName : The identifying name for the event.
+    /// @param Args : An array of arguments (csp::common::ReplicatedValue) to be passed as part of
     /// the event payload.
-    /// @param TargetClientId uint64_t : The client ID to send the event to.
-    /// @param Callback ErrorCodeCallbackHandler : a callback with failure state.
+    /// @param TargetClientId : The client ID to send the event to.
+    /// @param Callback : a callback with failure state.
     CSP_ASYNC_RESULT void SendNetworkEventToClient(const csp::common::String& EventName, const csp::common::Array<csp::common::ReplicatedValue>& Args,
         uint64_t TargetClientId, ErrorCodeCallbackHandler Callback);
 
-    /// @brief Register interest in a network event, such that the NetworkEventBus will call the provided callback when it arrives
-    /// @param Registration NetworkEventRegistration : Registration information, containing a ReceiverID and an EventName. Will fail to register if
-    /// identical callback registration already registered.
-    /// @param Callback NetworkEventCallback : Callback to invoke when specified event is received. Will fail to register if null.
-    void ListenNetworkEvent(NetworkEventRegistration Registration, NetworkEventCallback Callback);
+    /// @brief Register interest in a custom network event, such that the NetworkEventBus will call the provided callback when it arrives.
+    /// @note This is for registration of custom events. To register for an event specializations, please use one of the dedicated
+    /// listen methods. Registration will fail if a callback has already been registered with the same ReceiverId and EventName.
+    /// @param ReceiverId : The identifying name for the event receiver, used for management purposes. Allows clients to register multiple receivers
+    /// for the same event if they choose.
+    /// @param EventName : The identifying name for the event. May be any arbitrary string.
+    /// @param Callback : Callback to invoke when the custom event is received. Will fail to register if the callback is null.
+    void ListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName, NetworkEventCallback Callback);
 
-    // Here is where a nice method overload would go that lets you pass 2 strings directly as a convenience, however it can't be done at the moment
-    // due to the wrapper generator (JS), and having a distinct name seems more confusing than anything.
+    /// @brief Register interest in a access control changed network event, such that the NetworkEventBus will call the provided callback when it
+    /// arrives.
+    /// @note Registration will fail if a callback has already been registered with the same ReceiverId.
+    /// @param EventReceiverId : The identifying name for the event receiver, used for management purposes. Allows clients to register multiple
+    /// receivers for the same event if they choose.
+    /// @param Callback : Callback to invoke when a access control changed event is received. Will fail to register if the callback is null.
+    void ListenAccessControlChangedEvent(csp::common::String EventReceiverId, AccessControlChangedEventCallback Callback);
 
-    /// @brief Deregister interest in a network event
-    /// @param Registration NetworkEventRegistration : Registration information of already registered event, containing a ReceiverID and an EventName.
-    void StopListenNetworkEvent(NetworkEventRegistration Registration);
+    /// @brief Register interest in a asset detail blob changed network event, such that the NetworkEventBus will call the provided
+    /// callback when it arrives.
+    /// @note Registration will fail if a callback has already been registered with the same ReceiverId.
+    /// @param EventReceiverId : The identifying name for the event receiver, used for management purposes. Allows clients to register multiple
+    /// receivers for the same event if they choose.
+    /// @param Callback : Callback to invoke when a asset detail blob changed event is received. Will fail to register if the callback is null.
+    void ListenAssetDetailBlobChangedEvent(csp::common::String EventReceiverId, AssetDetailBlobChangedEventCallback Callback);
+
+    /// @brief Register interest in a async call completed network event for a specific operation, such that the NetworkEventBus will call the provided
+    /// callback when it arrives.
+    /// @note Registration will fail if a callback has already been registered with the same ReceiverId and OperationName.
+    /// @param EventReceiverId : The identifying name for the event receiver, used for management purposes. Allows clients to register multiple
+    /// receivers for the same event if they choose.
+    /// @param OperationName : The name of the async call completed operation, eg: 'DuplicateSpaceAsync' or 'CreateSnapshotAsync'.
+    /// @param Callback : Callback to invoke when a async call completed event is received with a specific operation name. Will fail to register if
+    /// the callback is null.
+    void ListenAsyncCallCompletedEvent(
+        csp::common::String EventReceiverId, csp::common::String OperationName, AsyncCallCompletedEventCallback Callback);
+
+    /// @brief Register interest in a conversation network event, such that the NetworkEventBus will call the provided callback when it arrives.
+    /// @note Registration will fail if a callback has already been registered with the same ReceiverId.
+    /// @param EventReceiverId : The identifying name for the event receiver, used for management purposes. Allows clients to register multiple
+    /// receivers for the same event if they choose.
+    /// @param Callback : Callback to invoke when a conversation event is received. Will fail to register if the callback is null.
+    void ListenConversationEvent(csp::common::String EventReceiverId, ConversationEventCallback Callback);
+
+    /// @brief Register interest in a sequence changed network event, such that the NetworkEventBus will call the provided callback when it arrives.
+    /// @note Registration will fail if a callback has already been registered with the same ReceiverId.
+    /// @param EventReceiverId : The identifying name for the event receiver, used for management purposes. Allows clients to register multiple
+    /// receivers for the same event if they choose.
+    /// @param Callback : Callback to invoke when a sequence changed event is received. Will fail to register if the callback is null.
+    void ListenSequenceChangedEvent(csp::common::String EventReceiverId, SequenceChangedEventCallback Callback);
+
+    /// @brief Deregister interest in a custom network event
+    /// @param ReceiverId : The identifying name for the event receiver.
+    /// @param EventName : The identifying name for the event.
+    void StopListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName);
+
+    /// @brief Deregister interest in a access control changed network event
+    /// @param ReceiverId : The identifying name for the event receiver.
+    void StopListenAccessControlChangedEvent(csp::common::String EventReceiverId);
+
+    /// @brief Deregister interest in a asset detail blob changed network event
+    /// @param ReceiverId : The identifying name for the event receiver.
+    void StopListenAssetDetailBlobChangedEvent(csp::common::String EventReceiverId);
+
+    /// @brief Deregister interest in a async call completed network event
+    /// @param ReceiverId : The identifying name for the event receiver.
+    void StopListenAsyncCallCompletedEvent(csp::common::String EventReceiverId, csp::common::String OperationName);
+
+    /// @brief Deregister interest in a conversation network event
+    /// @param ReceiverId : The identifying name for the event receiver.
+    void StopListenConversationEvent(csp::common::String EventReceiverId);
+
+    /// @brief Deregister interest in a sequence changed network event
+    /// @param ReceiverId : The identifying name for the event receiver.
+    void StopListenSequenceChangedEvent(csp::common::String EventReceiverId);
 
     /// @brief Deregister interest in all network events registered to a particular EventReceiverId
-    /// @param EventReceiverId const csp::common::String& : EventReceiverId to deregister.
+    /// @param EventReceiverId : EventReceiverId to deregister.
     void StopListenAllNetworkEvents(const csp::common::String& EventReceiverId);
 
-    /// @brief Get an array of all interests currently registered to the NetworkEventBus
-    /// @return csp::common::Array<csp::multiplayer::NetworkEventRegistration> A container of all currently registered registrations.
+    /// @brief Get an array of all network event registrations currently registered with the NetworkEventBus
+    /// @return An array of all current network event registrations.
     csp::common::Array<NetworkEventRegistration> AllRegistrations() const;
 
     /// @brief Instructs the event bus to start listening to messages
@@ -176,7 +248,8 @@ public:
     bool StartEventMessageListening();
 
     /// @brief NetworkEventBus constructor
-    /// @param InMultiplayerConnection MultiplayerConnection* : the multiplayer connection to construct the event bus with
+    /// @param InMultiplayerConnection : the multiplayer connection to construct the event bus with
+    /// @param LogSystem : Logger such that this system can print status and debug output
     CSP_NO_EXPORT NetworkEventBus(MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem);
 
     /// @brief NetworkEventBus destructor
@@ -228,11 +301,14 @@ private:
 
     CSP_END_IGNORE
 
-    // Map internal event values to the deserializers needed to unpack them
-    CSP_NO_EXPORT std::unique_ptr<csp::common::NetworkEventData> DeserialiseForEventType(
-        NetworkEvent EventType, const std::vector<signalr::value>& EventValues);
-
+    // General purpose event registration.
     std::unordered_map<NetworkEventRegistration, NetworkEventCallback> RegisteredEvents = {};
+    // Registrations for event listener specializations.
+    std::unordered_map<NetworkEventRegistration, AccessControlChangedEventCallback> RegisteredAccessControlChangedEvents = {};
+    std::unordered_map<NetworkEventRegistration, AssetDetailBlobChangedEventCallback> RegisteredAssetDetailBlobChangedEvents = {};
+    std::unordered_map<NetworkEventRegistration, AsyncCallCompletedEventCallback> RegisteredAsyncCallCompletedEvents = {};
+    std::unordered_map<NetworkEventRegistration, ConversationEventCallback> RegisteredConversationEvents = {};
+    std::unordered_map<NetworkEventRegistration, SequenceChangedEventCallback> RegisteredSequenceChangedEvents = {};
 };
 
 } // namespace csp::multiplayer

--- a/Library/include/CSP/Multiplayer/NetworkEventBus.h
+++ b/Library/include/CSP/Multiplayer/NetworkEventBus.h
@@ -61,7 +61,7 @@ enum class ErrorCode;
 
 // The callback used to register to listen to custom network events.
 // NetworkEventData lifetime is tied to the callback, do not attempt to store it via reference.
-typedef std::function<void(const csp::common::NetworkEventData& NetworkEventData)> NetworkEventCallback;
+typedef std::function<void(const csp::common::NetworkEventData& NetworkEventData)> CustomNetworkEventCallback;
 
 // Event listener specializations
 // Callbacks used to register to listen to event specializations.
@@ -167,7 +167,7 @@ public:
     /// for the same event if they choose.
     /// @param EventName : The identifying name for the event. May be any arbitrary string.
     /// @param Callback : Callback to invoke when the custom event is received. Will fail to register if the callback is null.
-    void ListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName, NetworkEventCallback Callback);
+    void ListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName, CustomNetworkEventCallback Callback);
 
     /// @brief Register interest in a access control changed network event, such that the NetworkEventBus will call the provided callback when it
     /// arrives.
@@ -301,8 +301,8 @@ private:
 
     CSP_END_IGNORE
 
-    // General purpose event registration.
-    std::unordered_map<NetworkEventRegistration, NetworkEventCallback> RegisteredEvents = {};
+    // Custom event registration.
+    std::unordered_map<NetworkEventRegistration, CustomNetworkEventCallback> RegisteredCustomEvents = {};
     // Registrations for event listener specializations.
     std::unordered_map<NetworkEventRegistration, AccessControlChangedEventCallback> RegisteredAccessControlChangedEvents = {};
     std::unordered_map<NetworkEventRegistration, AssetDetailBlobChangedEventCallback> RegisteredAssetDetailBlobChangedEvents = {};

--- a/Library/include/CSP/Systems/Assets/AssetSystem.h
+++ b/Library/include/CSP/Systems/Assets/AssetSystem.h
@@ -356,7 +356,7 @@ public:
     void RegisterSystemCallback() override;
     /// @brief Deserialises the event values of the system.
     /// @param EventValues std::vector<signalr::value> : event values to deserialise
-    CSP_NO_EXPORT void OnAssetDetailBlobChangedEvent(const csp::common::NetworkEventData& NetworkEventData);
+    CSP_NO_EXPORT void OnAssetDetailBlobChangedEvent(const csp::common::AssetDetailBlobChangedNetworkEventData& NetworkEventData);
 
 private:
     AssetSystem(); // This constructor is only provided to appease the wrapper generator and should not be used

--- a/Library/include/CSP/Systems/HotspotSequence/HotspotSequenceSystem.h
+++ b/Library/include/CSP/Systems/HotspotSequence/HotspotSequenceSystem.h
@@ -102,7 +102,7 @@ public:
     void RegisterSystemCallback() override;
     /// @brief Deserialises the event values of the system.
     /// @param EventValues std::vector<signalr::value> : event values to deserialise
-    CSP_NO_EXPORT void OnSequenceChangedEvent(const csp::common::NetworkEventData& NetworkEventData);
+    CSP_NO_EXPORT void OnSequenceChangedEvent(const csp::common::SequenceChangedNetworkEventData& NetworkEventData);
 
 private:
     HotspotSequenceSystem(

--- a/Library/include/CSP/Systems/Sequence/SequenceSystem.h
+++ b/Library/include/CSP/Systems/Sequence/SequenceSystem.h
@@ -121,7 +121,7 @@ public:
     void RegisterSystemCallback() override;
     /// @brief Deserialises the event values of the system.
     /// @param EventValues std::vector<signalr::value> : event values to deserialise
-    CSP_NO_EXPORT void OnSequenceChangedEvent(const csp::common::NetworkEventData& NetworkEventData);
+    CSP_NO_EXPORT void OnSequenceChangedEvent(const csp::common::SequenceChangedNetworkEventData& NetworkEventData);
 
 private:
     SequenceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used

--- a/Library/include/CSP/Systems/Spaces/SpaceSystem.h
+++ b/Library/include/CSP/Systems/Spaces/SpaceSystem.h
@@ -363,16 +363,22 @@ public:
         const csp::common::Optional<csp::common::Array<csp::common::String>>& MemberGroupIds, bool ShallowCopy, SpaceResultCallback Callback);
 
     /// @brief Duplicate an existing space and assign it to the current user.
-    /// This is an asynchronous operation. If the user disconnects while waiting for the operation to complete it will continue unaffected. Please
-    /// subscribe to the AsyncCallCompletedCallback via @ref SpaceSystem::SetAsyncCallCompletedCallback() to be notified when the duplication operation
-    /// is complete. The AsyncCallCompletedEventData returned by the AsyncCallCompletedCallback will contain the following information:
+    /// This is a long running asynchronous operation. If the user disconnects while waiting for the operation to complete it will continue
+    /// unaffected. Please subscribe to @ref NetworkEventBus::ListenAsyncCallCompletedEvent() to be notified when the duplication operation is
+    /// complete. The ListenAsyncCallCompletedEvent() method takes the following arguments:
+    /// - EventReceiverId: The identifying name for the event receiver, used for management purposes, allowing clients to register multiple interests
+    /// in a single AsyncCallCompleted operation.
+    /// - OperationName: The identifying name of the async operation. To register interest in **this** operation, OperationName should be set to
+    /// "DuplicateSpaceAsync".
+    ///
+    /// The AsyncCallCompletedEventData returned by the AsyncCallCompletedCallback will contain the following information:
     /// - OperationName: "DuplicateSpaceAsync".
     /// - References: A String map containing the following key:value pairs:
     ///     - "OrignalSpaceId": Id of the original Space.
     ///     - "SpaceId": Id of the newly duplicated Space.
     /// - Success: A boolean value indicating whether the duplication operation was successful.
     /// - StatusReason: This will be an empty string if the operation was successful, but if the operation failed it will contain the failure status.
-    /// 
+    ///
     /// @param SpaceId csp::common::String : Id of the space to duplicate.
     /// @param NewName csp::common::String : A unique name for the duplicated space.
     /// @param NewAttributes csp::systems::SpaceAttributes : Attributes to apply to the duplicated space.
@@ -388,27 +394,6 @@ public:
     // This is required due to a circular dependency between SpaceSystem and MultiplayerSystem.
     // This will be broken when we move enter space logic into RealtimeEngine.
     CSP_NO_EXPORT void SetMultiplayerSystem(csp::systems::MultiplayerSystem& MultiplayerSystem);
-
-    /// @brief The callback for receiving an alert when an async operation is completed.
-    /// Currently this callback is only being used for the DuplicateSpaceAsync operation.
-    /// A callback can be set via @ref SpaceSystem::SetAsyncCallCompletedCallback().
-    typedef std::function<void(const csp::common::AsyncCallCompletedEventData&)> AsyncCallCompletedCallbackHandler;
-
-    /// @brief Sets a callback for the async call completed event. Triggered when an async call to DuplicateSpace is completed.
-    /// @param Callback AsyncCallCompletedCallbackHandler: Callback to receive data concerning the Space duplication.
-    CSP_EVENT void SetAsyncCallCompletedCallback(AsyncCallCompletedCallbackHandler Callback);
-
-    /// @brief Deserialises the AsyncCallCompleted event values.
-    /// The AsyncCallCompletedEventData returned by the AsyncCallCompletedCallback will contain the following information:
-    /// - OperationName: "DuplicateSpaceAsync".
-    /// - References: A String map containing the following key:value pairs:
-    ///     - "OrignalSpaceId": Id of the original Space.
-    ///     - "SpaceId": Id of the newly duplicated Space.
-    /// - Success: A boolean value indicating whether the duplication operation was successful.
-    /// - StatusReason: This will be an empty string if the operation was successful, but if the operation failed it will contain the failure status.
-    /// 
-    /// @param NetworkEventData const csp::common::NetworkEventData& : event values to deserialise
-    CSP_NO_EXPORT void OnAsyncCallCompletedEvent(const csp::common::NetworkEventData& NetworkEventData);
 
 private:
     SpaceSystem(); // This constructor is only provided to appease the wrapper generator and should not be used
@@ -430,8 +415,6 @@ private:
     void RemoveSpaceThumbnail(const csp::common::String& SpaceId, NullResultCallback Callback);
 
     void GetSpaceGeoLocationInternal(const csp::common::String& SpaceId, SpaceGeoLocationResultCallback Callback);
-
-    AsyncCallCompletedCallbackHandler AsyncCallCompletedCallback;
 
     // CreateSpace Continuations
     async::task<SpaceResult> CreateSpaceGroupInfo(const csp::common::String& Name, const csp::common::String& Description, SpaceAttributes Attributes,

--- a/Library/include/CSP/Systems/Users/UserSystem.h
+++ b/Library/include/CSP/Systems/Users/UserSystem.h
@@ -327,7 +327,7 @@ public:
     void RegisterSystemCallback() override;
     /// @brief Deserialises the event values of the system.
     /// @param EventValues std::vector<signalr::value> : event values to deserialise
-    CSP_NO_EXPORT void OnAccessControlChangedEvent(const csp::common::NetworkEventData& NetworkEventData);
+    CSP_NO_EXPORT void OnAccessControlChangedEvent(const csp::common::AccessControlChangedNetworkEventData& NetworkEventData);
 
     /// The IAuthContext object is owned by the UserSystem, and will be destroyed when the UserSystem is destroyed.
     CSP_NO_EXPORT csp::common::IAuthContext& GetAuthContext();

--- a/Library/src/Multiplayer/NetworkEventBus.cpp
+++ b/Library/src/Multiplayer/NetworkEventBus.cpp
@@ -312,7 +312,7 @@ void NetworkEventBus::StopListenSequenceChangedEvent(csp::common::String EventRe
 
 void NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& EventReceiverId)
 {
-    auto StopListenMatchingEventReceivers = [&](const auto& RegisteredEvents, auto StopListenAction) -> size_t
+    auto StopListenMatchingEventReceivers = [&](const auto& RegisteredEvents, auto&& StopListenAction) -> size_t
     {
         std::vector<NetworkEventRegistration> RegistrationsToRemove {};
 

--- a/Library/src/Multiplayer/NetworkEventBus.cpp
+++ b/Library/src/Multiplayer/NetworkEventBus.cpp
@@ -106,7 +106,7 @@ NetworkEventBus::~NetworkEventBus()
 {
     // The NetworkEventBus is owned by the MultiplayerConnection which is one of the last systems to be destroyed by the Systems Manager.
     // Clean up all registered listeners.
-    RegisteredEvents.clear();
+    RegisteredCustomEvents.clear();
     RegisteredAccessControlChangedEvents.clear();
     RegisteredAssetDetailBlobChangedEvents.clear();
     RegisteredAsyncCallCompletedEvents.clear();
@@ -120,7 +120,7 @@ NetworkEventBus::NetworkEventBus(MultiplayerConnection* InMultiplayerConnection,
     MultiplayerConnectionInst = InMultiplayerConnection;
 }
 
-void NetworkEventBus::ListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName, NetworkEventCallback Callback)
+void NetworkEventBus::ListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName, CustomNetworkEventCallback Callback)
 {
     if (EventName.IsEmpty())
     {
@@ -135,7 +135,7 @@ void NetworkEventBus::ListenCustomNetworkEvent(csp::common::String EventReceiver
         return;
     }
 
-    RegisterEventCallback(LogSystem, EventReceiverId, EventName, "ListenCustomNetworkEvent", RegisteredEvents, Callback);
+    RegisterEventCallback(LogSystem, EventReceiverId, EventName, "ListenCustomNetworkEvent", RegisteredCustomEvents, Callback);
 }
 
 void NetworkEventBus::ListenAccessControlChangedEvent(csp::common::String EventReceiverId, AccessControlChangedEventCallback Callback)
@@ -213,7 +213,7 @@ void NetworkEventBus::StopListenCustomNetworkEvent(csp::common::String EventRece
 {
     NetworkEventRegistration Registration(EventReceiverId, EventName);
 
-    size_t RemovedCount = RegisteredEvents.erase(Registration);
+    size_t RemovedCount = RegisteredCustomEvents.erase(Registration);
 
     if (RemovedCount == 0)
     {
@@ -335,7 +335,7 @@ void NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& Even
     size_t RegistrationsToRemoveCount = 0;
 
     RegistrationsToRemoveCount += StopListenMatchingEventReceivers(
-        RegisteredEvents, [&](const auto& EventReceiverId, const auto& EventName) { StopListenCustomNetworkEvent(EventReceiverId, EventName); });
+        RegisteredCustomEvents, [&](const auto& EventReceiverId, const auto& EventName) { StopListenCustomNetworkEvent(EventReceiverId, EventName); });
     RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredAccessControlChangedEvents,
         [&](const auto& EventReceiverId, const auto& /*EventName*/) { StopListenAccessControlChangedEvent(EventReceiverId); });
     RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredAssetDetailBlobChangedEvents,
@@ -366,7 +366,7 @@ void NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& Even
 
 csp::common::Array<NetworkEventRegistration> NetworkEventBus::AllRegistrations() const
 {
-    size_t TotalRegistrationsCount = RegisteredEvents.size() + RegisteredAccessControlChangedEvents.size()
+    size_t TotalRegistrationsCount = RegisteredCustomEvents.size() + RegisteredAccessControlChangedEvents.size()
         + RegisteredAssetDetailBlobChangedEvents.size() + RegisteredAsyncCallCompletedEvents.size() + RegisteredConversationEvents.size()
         + RegisteredSequenceChangedEvents.size();
 
@@ -383,7 +383,7 @@ csp::common::Array<NetworkEventRegistration> NetworkEventBus::AllRegistrations()
         }
     };
 
-    CopyRegistrations(RegisteredEvents);
+    CopyRegistrations(RegisteredCustomEvents);
     CopyRegistrations(RegisteredAccessControlChangedEvents);
     CopyRegistrations(RegisteredAssetDetailBlobChangedEvents);
     CopyRegistrations(RegisteredAsyncCallCompletedEvents);
@@ -579,7 +579,7 @@ bool NetworkEventBus::StartEventMessageListening()
         default:
         case csp::multiplayer::NetworkEventBus::NetworkEvent::GeneralPurposeEvent:
         {
-            if (RegisteredEvents.size() > 0)
+            if (RegisteredCustomEvents.size() > 0)
             {
                 csp::common::NetworkEventData GeneralPurposeEventData;
 
@@ -590,7 +590,7 @@ bool NetworkEventBus::StartEventMessageListening()
                     return;
                 }
 
-                for (auto const& [Registration, Callback] : RegisteredEvents)
+                for (auto const& [Registration, Callback] : RegisteredCustomEvents)
                 {
                     if (Registration.EventName == EventTypeStr)
                     {

--- a/Library/src/Multiplayer/NetworkEventBus.cpp
+++ b/Library/src/Multiplayer/NetworkEventBus.cpp
@@ -36,12 +36,27 @@ namespace
 
 template <typename EventContainer, typename EventCallback>
 void RegisterEventCallback(csp::common::LogSystem& LogSystem, const csp::common::String& EventReceiverId, csp::common::String EventName,
-    const csp::common::String& MethodName, EventContainer& RegisteredEvents, const EventCallback& Callback)
+    EventContainer& RegisteredEvents, const EventCallback& Callback)
 {
+    if (EventName.IsEmpty())
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error, "NetworkEventBus: Expected non-empty name for event registration. Registration denied.");
+
+        return;
+    }
+
     if (EventReceiverId.IsEmpty())
     {
         LogSystem.LogMsg(csp::common::LogLevel::Error,
-            fmt::format("NetworkEventBus::{}: Expected non-empty EventReceiverId. Registration denied.", MethodName).c_str());
+            fmt::format("NetworkEventBus: Expected non-empty EventReceiverId for event {}. Registration denied.", EventName).c_str());
+
+        return;
+    }
+
+    if (!Callback)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error,
+            fmt::format("NetworkEventBus: Expected non-null callback for event {} with EventReceiverId: {}. Registration denied.", EventName, EventReceiverId).c_str());
 
         return;
     }
@@ -52,9 +67,9 @@ void RegisterEventCallback(csp::common::LogSystem& LogSystem, const csp::common:
     {
         // An event with matching ReceiverId and EventName has already been registered, double registration is not allowed.
         LogSystem.LogMsg(csp::common::LogLevel::Warning,
-            fmt::format("NetworkEventBus::{}: Attempting to register a duplicate {} network event "
+            fmt::format("NetworkEventBus: Attempting to register a duplicate {} network event "
                         "with EventReceiverId: {}. Registration denied.",
-                MethodName, EventName, EventReceiverId)
+                EventName, EventReceiverId)
                 .c_str());
 
         return;
@@ -120,93 +135,39 @@ NetworkEventBus::NetworkEventBus(MultiplayerConnection* InMultiplayerConnection,
     MultiplayerConnectionInst = InMultiplayerConnection;
 }
 
-void NetworkEventBus::ListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName, CustomNetworkEventCallback Callback)
+void NetworkEventBus::ListenCustomNetworkEvent(
+    csp::common::String EventReceiverId, csp::common::String EventName, CustomNetworkEventCallback Callback)
 {
-    if (EventName.IsEmpty())
-    {
-        LogSystem.LogMsg(
-            csp::common::LogLevel::Error, "NetworkEventBus::ListenCustomNetworkEvent: Expected non-empty EventName. Registration denied.");
-        return;
-    }
-
-    if (!Callback)
-    {
-        LogSystem.LogMsg(csp::common::LogLevel::Error, "NetworkEventBus::ListenCustomNetworkEvent: Expected non-null callback. Registration denied.");
-        return;
-    }
-
-    RegisterEventCallback(LogSystem, EventReceiverId, EventName, "ListenCustomNetworkEvent", RegisteredCustomEvents, Callback);
+    RegisterEventCallback(LogSystem, EventReceiverId, EventName, RegisteredCustomEvents, Callback);
 }
 
 void NetworkEventBus::ListenAccessControlChangedEvent(csp::common::String EventReceiverId, AccessControlChangedEventCallback Callback)
 {
-    if (!Callback)
-    {
-        LogSystem.LogMsg(
-            csp::common::LogLevel::Error, "NetworkEventBus::ListenAccessControlChangedEvent: Expected non-null callback. Registration denied.");
-        return;
-    }
-
-    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::AccessControlChanged), "ListenAccessControlChangedEvent",
-        RegisteredAccessControlChangedEvents, Callback);
+    RegisterEventCallback(
+        LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::AccessControlChanged), RegisteredAccessControlChangedEvents, Callback);
 }
 
 void NetworkEventBus::ListenAssetDetailBlobChangedEvent(csp::common::String EventReceiverId, AssetDetailBlobChangedEventCallback Callback)
 {
-    if (!Callback)
-    {
-        LogSystem.LogMsg(
-            csp::common::LogLevel::Error, "NetworkEventBus::ListenAssetDetailBlobChangedEvent: Expected non-null callback. Registration denied.");
-        return;
-    }
-
-    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::AssetDetailBlobChanged),
-        "ListenAssetDetailBlobChangedEvent", RegisteredAssetDetailBlobChangedEvents, Callback);
+    RegisterEventCallback(
+        LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::AssetDetailBlobChanged), RegisteredAssetDetailBlobChangedEvents, Callback);
 }
 
 void NetworkEventBus::ListenAsyncCallCompletedEvent(
     csp::common::String EventReceiverId, csp::common::String OperationName, AsyncCallCompletedEventCallback Callback)
 {
-    if (OperationName.IsEmpty())
-    {
-        LogSystem.LogMsg(
-            csp::common::LogLevel::Error, "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-empty OperationName. Registration denied.");
-        return;
-    }
-
-    if (!Callback)
-    {
-        LogSystem.LogMsg(
-            csp::common::LogLevel::Error, "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-null callback. Registration denied.");
-        return;
-    }
-
-    RegisterEventCallback(LogSystem, EventReceiverId, OperationName, "ListenAsyncCallCompletedEvent", RegisteredAsyncCallCompletedEvents, Callback);
+    RegisterEventCallback(LogSystem, EventReceiverId, OperationName, RegisteredAsyncCallCompletedEvents, Callback);
 }
 
 void NetworkEventBus::ListenConversationEvent(csp::common::String EventReceiverId, ConversationEventCallback Callback)
 {
-    if (!Callback)
-    {
-        LogSystem.LogMsg(csp::common::LogLevel::Error, "NetworkEventBus::ListenConversationEvent: Expected non-null callback. Registration denied.");
-        return;
-    }
-
-    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::Conversation), "ListenConversationEvent",
-        RegisteredConversationEvents, Callback);
+    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::Conversation), RegisteredConversationEvents, Callback);
 }
 
 void NetworkEventBus::ListenSequenceChangedEvent(csp::common::String EventReceiverId, SequenceChangedEventCallback Callback)
 {
-    if (!Callback)
-    {
-        LogSystem.LogMsg(
-            csp::common::LogLevel::Error, "NetworkEventBus::ListenSequenceChangedEvent: Expected non-null callback. Registration denied.");
-        return;
-    }
-
-    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::SequenceChanged), "ListenSequenceChangedEvent",
-        RegisteredSequenceChangedEvents, Callback);
+    RegisterEventCallback(
+        LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::SequenceChanged), RegisteredSequenceChangedEvents, Callback);
 }
 
 void NetworkEventBus::StopListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName)
@@ -334,8 +295,8 @@ void NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& Even
 
     size_t RegistrationsToRemoveCount = 0;
 
-    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(
-        RegisteredCustomEvents, [&](const auto& EventReceiverId, const auto& EventName) { StopListenCustomNetworkEvent(EventReceiverId, EventName); });
+    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredCustomEvents,
+        [&](const auto& EventReceiverId, const auto& EventName) { StopListenCustomNetworkEvent(EventReceiverId, EventName); });
     RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredAccessControlChangedEvents,
         [&](const auto& EventReceiverId, const auto& /*EventName*/) { StopListenAccessControlChangedEvent(EventReceiverId); });
     RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredAssetDetailBlobChangedEvents,

--- a/Library/src/Multiplayer/NetworkEventBus.cpp
+++ b/Library/src/Multiplayer/NetworkEventBus.cpp
@@ -31,6 +31,72 @@
 #include <memory>
 #include <optional>
 
+namespace
+{
+
+template <typename EventContainer, typename EventCallback>
+void RegisterEventCallback(csp::common::LogSystem& LogSystem, const csp::common::String& EventReceiverId, csp::common::String EventName,
+    const csp::common::String& MethodName, EventContainer& RegisteredEvents, const EventCallback& Callback)
+{
+    if (EventReceiverId.IsEmpty())
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error,
+            fmt::format("NetworkEventBus::{}: Expected non-empty EventReceiverId. Registration denied.", MethodName).c_str());
+
+        return;
+    }
+
+    csp::multiplayer::NetworkEventRegistration Registration(EventReceiverId, EventName);
+
+    if (RegisteredEvents.find(Registration) != RegisteredEvents.end())
+    {
+        // An event with matching ReceiverId and EventName has already been registered, double registration is not allowed.
+        LogSystem.LogMsg(csp::common::LogLevel::Warning,
+            fmt::format("NetworkEventBus::{}: Attempting to register a duplicate {} network event "
+                        "with EventReceiverId: {}. Registration denied.",
+                MethodName, EventName, EventReceiverId)
+                .c_str());
+
+        return;
+    }
+
+    LogSystem.LogMsg(
+        csp::common::LogLevel::Verbose, fmt::format("Registering {} network event. EventReceiverId: {}.", EventName, EventReceiverId).c_str());
+
+    RegisteredEvents[Registration] = Callback;
+}
+
+template <typename EventData, typename DeserializeFunc>
+bool TryDeserializeEventData(
+    csp::common::LogSystem& LogSystem, const csp::common::String& EventTypeStr, DeserializeFunc&& Deserialize, EventData& OutEventData)
+{
+    try
+    {
+        OutEventData = Deserialize();
+        return true;
+    }
+    catch (const signalr::signalr_exception& e)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error,
+            fmt::format("NetworkEventBus: SignalR type mismatch encountered in Event {}: {}", EventTypeStr.c_str(), e.what()).c_str());
+    }
+    catch (const csp::common::ReplicatedValueException& e)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error, fmt::format("NetworkEventBus: ReplicatedValue type mismatch: {}", e.what()).c_str());
+    }
+    catch (...)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error, "NetworkEventBus: Unknown error encountered during event deserialisation.");
+    }
+
+    LogSystem.LogMsg(csp::common::LogLevel::Error,
+        fmt::format("NetworkEventBus: Failed to deserialize event '{}'. Registered events will not be fired.", EventTypeStr).c_str());
+
+    return false;
+}
+
+} // namespace
+
 namespace csp::multiplayer
 {
 
@@ -38,13 +104,14 @@ constexpr const uint64_t ALL_CLIENTS_ID = std::numeric_limits<uint64_t>::max();
 
 NetworkEventBus::~NetworkEventBus()
 {
-    // Clean up all registered listeners.
     // The NetworkEventBus is owned by the MultiplayerConnection which is one of the last systems to be destroyed by the Systems Manager.
-    auto Registrations = AllRegistrations();
-    for (const NetworkEventRegistration& Registration : Registrations)
-    {
-        StopListenNetworkEvent(Registration);
-    }
+    // Clean up all registered listeners.
+    RegisteredEvents.clear();
+    RegisteredAccessControlChangedEvents.clear();
+    RegisteredAssetDetailBlobChangedEvents.clear();
+    RegisteredAsyncCallCompletedEvents.clear();
+    RegisteredConversationEvents.clear();
+    RegisteredSequenceChangedEvents.clear();
 }
 
 NetworkEventBus::NetworkEventBus(MultiplayerConnection* InMultiplayerConnection, csp::common::LogSystem& LogSystem)
@@ -53,74 +120,276 @@ NetworkEventBus::NetworkEventBus(MultiplayerConnection* InMultiplayerConnection,
     MultiplayerConnectionInst = InMultiplayerConnection;
 }
 
-void NetworkEventBus::ListenNetworkEvent(NetworkEventRegistration Registration, NetworkEventCallback Callback)
+void NetworkEventBus::ListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName, NetworkEventCallback Callback)
+{
+    if (EventName.IsEmpty())
+    {
+        LogSystem.LogMsg(
+            csp::common::LogLevel::Error, "NetworkEventBus::ListenCustomNetworkEvent: Expected non-empty EventName. Registration denied.");
+        return;
+    }
+
+    if (!Callback)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error, "NetworkEventBus::ListenCustomNetworkEvent: Expected non-null callback. Registration denied.");
+        return;
+    }
+
+    RegisterEventCallback(LogSystem, EventReceiverId, EventName, "ListenCustomNetworkEvent", RegisteredEvents, Callback);
+}
+
+void NetworkEventBus::ListenAccessControlChangedEvent(csp::common::String EventReceiverId, AccessControlChangedEventCallback Callback)
 {
     if (!Callback)
     {
-        LogSystem.LogMsg(csp::common::LogLevel::Error, "Error: Expected non-null callback.");
+        LogSystem.LogMsg(
+            csp::common::LogLevel::Error, "NetworkEventBus::ListenAccessControlChangedEvent: Expected non-null callback. Registration denied.");
         return;
     }
 
-    if (RegisteredEvents.find(Registration) != RegisteredEvents.end())
-    {
-        // We have found an event registered for this event receiver and this event type, double registration is disallowed.
-        LogSystem.LogMsg(csp::common::LogLevel::Warning,
-            fmt::format("Attempting to register a duplicate network event receiver with EventReceiverId: {}, Event: {}. Registration denied.",
-                Registration.EventReceiverId, Registration.EventName)
-                .c_str());
-        return;
-    }
-
-    LogSystem.LogMsg(csp::common::LogLevel::Verbose,
-        fmt::format("Registering network event. EventReceiverId: {}, Event: {}.", Registration.EventReceiverId, Registration.EventName).c_str());
-    RegisteredEvents[Registration] = Callback;
+    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::AccessControlChanged), "ListenAccessControlChangedEvent",
+        RegisteredAccessControlChangedEvents, Callback);
 }
 
-void NetworkEventBus::StopListenNetworkEvent(NetworkEventRegistration Registration)
+void NetworkEventBus::ListenAssetDetailBlobChangedEvent(csp::common::String EventReceiverId, AssetDetailBlobChangedEventCallback Callback)
 {
-    if (RegisteredEvents.find(Registration) == RegisteredEvents.end())
+    if (!Callback)
     {
-        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
-            fmt::format("Could not find network event registration with EventReceiverId: {}, Event: {}. Deregistration denied.",
-                Registration.EventReceiverId, Registration.EventName)
-                .c_str());
+        LogSystem.LogMsg(
+            csp::common::LogLevel::Error, "NetworkEventBus::ListenAssetDetailBlobChangedEvent: Expected non-null callback. Registration denied.");
         return;
     }
 
-    RegisteredEvents.erase(Registration);
+    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::AssetDetailBlobChanged),
+        "ListenAssetDetailBlobChangedEvent", RegisteredAssetDetailBlobChangedEvents, Callback);
+}
+
+void NetworkEventBus::ListenAsyncCallCompletedEvent(
+    csp::common::String EventReceiverId, csp::common::String OperationName, AsyncCallCompletedEventCallback Callback)
+{
+    if (OperationName.IsEmpty())
+    {
+        LogSystem.LogMsg(
+            csp::common::LogLevel::Error, "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-empty OperationName. Registration denied.");
+        return;
+    }
+
+    if (!Callback)
+    {
+        LogSystem.LogMsg(
+            csp::common::LogLevel::Error, "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-null callback. Registration denied.");
+        return;
+    }
+
+    RegisterEventCallback(LogSystem, EventReceiverId, OperationName, "ListenAsyncCallCompletedEvent", RegisteredAsyncCallCompletedEvents, Callback);
+}
+
+void NetworkEventBus::ListenConversationEvent(csp::common::String EventReceiverId, ConversationEventCallback Callback)
+{
+    if (!Callback)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Error, "NetworkEventBus::ListenConversationEvent: Expected non-null callback. Registration denied.");
+        return;
+    }
+
+    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::Conversation), "ListenConversationEvent",
+        RegisteredConversationEvents, Callback);
+}
+
+void NetworkEventBus::ListenSequenceChangedEvent(csp::common::String EventReceiverId, SequenceChangedEventCallback Callback)
+{
+    if (!Callback)
+    {
+        LogSystem.LogMsg(
+            csp::common::LogLevel::Error, "NetworkEventBus::ListenSequenceChangedEvent: Expected non-null callback. Registration denied.");
+        return;
+    }
+
+    RegisterEventCallback(LogSystem, EventReceiverId, StringFromNetworkEvent(NetworkEvent::SequenceChanged), "ListenSequenceChangedEvent",
+        RegisteredSequenceChangedEvents, Callback);
+}
+
+void NetworkEventBus::StopListenCustomNetworkEvent(csp::common::String EventReceiverId, csp::common::String EventName)
+{
+    NetworkEventRegistration Registration(EventReceiverId, EventName);
+
+    size_t RemovedCount = RegisteredEvents.erase(Registration);
+
+    if (RemovedCount == 0)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
+            fmt::format("NetworkEventBus::StopListenCustomNetworkEvent: Could not find custom network event registration with Event ReceiverId: {}, "
+                        "Event: {}. Deregistration denied.",
+                EventReceiverId, EventName)
+                .c_str());
+    }
+}
+
+void NetworkEventBus::StopListenAccessControlChangedEvent(csp::common::String EventReceiverId)
+{
+    NetworkEventRegistration Registration(EventReceiverId, StringFromNetworkEvent(NetworkEvent::AccessControlChanged));
+
+    size_t RemovedCount = RegisteredAccessControlChangedEvents.erase(Registration);
+
+    if (RemovedCount == 0)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
+            fmt::format("NetworkEventBus::StopListenAccessControlChangedEvent: Could not find access control changed network event registration with "
+                        "Event ReceiverId: {}. "
+                        "Deregistration denied.",
+                EventReceiverId)
+                .c_str());
+    }
+}
+
+void NetworkEventBus::StopListenAssetDetailBlobChangedEvent(csp::common::String EventReceiverId)
+{
+    NetworkEventRegistration Registration(EventReceiverId, StringFromNetworkEvent(NetworkEvent::AssetDetailBlobChanged));
+
+    size_t RemovedCount = RegisteredAssetDetailBlobChangedEvents.erase(Registration);
+
+    if (RemovedCount == 0)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
+            fmt::format("NetworkEventBus::StopListenAssetDetailBlobChangedEvent: Could not find asset detail blob changed network event registration "
+                        "with Event "
+                        "ReceiverId: {}. "
+                        "Deregistration denied.",
+                EventReceiverId)
+                .c_str());
+    }
+}
+
+void NetworkEventBus::StopListenAsyncCallCompletedEvent(csp::common::String EventReceiverId, csp::common::String OperationName)
+{
+    NetworkEventRegistration Registration(EventReceiverId, OperationName);
+
+    size_t RemovedCount = RegisteredAsyncCallCompletedEvents.erase(Registration);
+
+    if (RemovedCount == 0)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
+            fmt::format("NetworkEventBus::StopListenAsyncCallCompletedEvent: Could not find async call completed network event for registration with "
+                        "Event ReceiverId: {} for Operation: {}. Deregistration denied.",
+                EventReceiverId, OperationName)
+                .c_str());
+    }
+}
+
+void NetworkEventBus::StopListenConversationEvent(csp::common::String EventReceiverId)
+{
+    NetworkEventRegistration Registration(EventReceiverId, StringFromNetworkEvent(NetworkEvent::Conversation));
+
+    size_t RemovedCount = RegisteredConversationEvents.erase(Registration);
+
+    if (RemovedCount == 0)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
+            fmt::format(
+                "NetworkEventBus::StopListenConversationEvent: Could not find conversation network event registration with Event ReceiverId: {}. "
+                "Deregistration denied.",
+                EventReceiverId)
+                .c_str());
+    }
+}
+
+void NetworkEventBus::StopListenSequenceChangedEvent(csp::common::String EventReceiverId)
+{
+    NetworkEventRegistration Registration(EventReceiverId, StringFromNetworkEvent(NetworkEvent::SequenceChanged));
+
+    size_t RemovedCount = RegisteredSequenceChangedEvents.erase(Registration);
+
+    if (RemovedCount == 0)
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
+            fmt::format("NetworkEventBus::StopListenSequenceChangedEvent: Could not find sequence changed network event registration with Event "
+                        "ReceiverId: {}. "
+                        "Deregistration denied.",
+                EventReceiverId)
+                .c_str());
+    }
 }
 
 void NetworkEventBus::StopListenAllNetworkEvents(const csp::common::String& EventReceiverId)
 {
-    std::vector<NetworkEventRegistration> RegistrationsToRemove {};
-
-    for (std::pair<NetworkEventRegistration, NetworkEventCallback> RegAndCallback : RegisteredEvents)
+    auto StopListenMatchingEventReceivers = [&](const auto& RegisteredEvents, auto StopListenAction) -> size_t
     {
-        if (RegAndCallback.first.EventReceiverId == EventReceiverId)
+        std::vector<NetworkEventRegistration> RegistrationsToRemove {};
+
+        for (const auto& [Registration, Callback] : RegisteredEvents)
         {
-            RegistrationsToRemove.push_back(RegAndCallback.first);
+            if (Registration.EventReceiverId == EventReceiverId)
+            {
+                RegistrationsToRemove.push_back(Registration);
+            }
         }
-    }
 
-    for (const NetworkEventRegistration& RegToRemove : RegistrationsToRemove)
-    {
-        StopListenNetworkEvent(RegToRemove);
-    }
+        for (const NetworkEventRegistration& RegistrationToRemove : RegistrationsToRemove)
+        {
+            StopListenAction(RegistrationToRemove.EventReceiverId, RegistrationToRemove.EventName);
+        }
 
-    // Just be helpful in case the user was expecting to remove something
-    if (RegistrationsToRemove.size() == 0)
+        return RegistrationsToRemove.size();
+    };
+
+    size_t RegistrationsToRemoveCount = 0;
+
+    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(
+        RegisteredEvents, [&](const auto& EventReceiverId, const auto& EventName) { StopListenCustomNetworkEvent(EventReceiverId, EventName); });
+    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredAccessControlChangedEvents,
+        [&](const auto& EventReceiverId, const auto& /*EventName*/) { StopListenAccessControlChangedEvent(EventReceiverId); });
+    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredAssetDetailBlobChangedEvents,
+        [&](const auto& EventReceiverId, const auto& /*EventName*/) { StopListenAssetDetailBlobChangedEvent(EventReceiverId); });
+    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredAsyncCallCompletedEvents,
+        [&](const auto& EventReceiverId, const auto& OperationName) { StopListenAsyncCallCompletedEvent(EventReceiverId, OperationName); });
+    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(
+        RegisteredConversationEvents, [&](const auto& EventReceiverId, const auto& /*EventName*/) { StopListenConversationEvent(EventReceiverId); });
+    RegistrationsToRemoveCount += StopListenMatchingEventReceivers(RegisteredSequenceChangedEvents,
+        [&](const auto& EventReceiverId, const auto& /*EventName*/) { StopListenSequenceChangedEvent(EventReceiverId); });
+
+    if (RegistrationsToRemoveCount == 0)
     {
         LogSystem.LogMsg(csp::common::LogLevel::Log,
-            fmt::format("Could not find any network event registration with EventReceiverId: {}. No events were deregistered.", EventReceiverId)
+            fmt::format("NetworkEventBus::StopListenAllNetworkEvents: Could not find any network events registered with EventReceiverId: {}. No "
+                        "events were deregistered.",
+                EventReceiverId)
+                .c_str());
+    }
+    else
+    {
+        LogSystem.LogMsg(csp::common::LogLevel::Verbose,
+            fmt::format("NetworkEventBus::StopListenAllNetworkEvents: Removed {} network event registration/s with EventReceiverId: {}.",
+                RegistrationsToRemoveCount, EventReceiverId)
                 .c_str());
     }
 }
 
 csp::common::Array<NetworkEventRegistration> NetworkEventBus::AllRegistrations() const
 {
-    csp::common::Array<NetworkEventRegistration> Registrations(RegisteredEvents.size());
-    std::transform(RegisteredEvents.cbegin(), RegisteredEvents.cend(), Registrations.begin(),
-        [](const std::pair<NetworkEventRegistration, NetworkEventCallback>& RegAndCallback) { return RegAndCallback.first; });
+    size_t TotalRegistrationsCount = RegisteredEvents.size() + RegisteredAccessControlChangedEvents.size()
+        + RegisteredAssetDetailBlobChangedEvents.size() + RegisteredAsyncCallCompletedEvents.size() + RegisteredConversationEvents.size()
+        + RegisteredSequenceChangedEvents.size();
+
+    csp::common::Array<NetworkEventRegistration> Registrations(TotalRegistrationsCount);
+
+    auto* RegistrationsIt = Registrations.begin();
+
+    // Copy the NetworkEventRegistration and increment pointer
+    auto CopyRegistrations = [&RegistrationsIt](const auto& EventMap)
+    {
+        for (const auto& [Key, Value] : EventMap)
+        {
+            *RegistrationsIt++ = Key;
+        }
+    };
+
+    CopyRegistrations(RegisteredEvents);
+    CopyRegistrations(RegisteredAccessControlChangedEvents);
+    CopyRegistrations(RegisteredAssetDetailBlobChangedEvents);
+    CopyRegistrations(RegisteredAsyncCallCompletedEvents);
+    CopyRegistrations(RegisteredConversationEvents);
+    CopyRegistrations(RegisteredSequenceChangedEvents);
+
     return Registrations;
 }
 
@@ -163,66 +432,182 @@ bool NetworkEventBus::StartEventMessageListening()
         }
 
         const csp::common::String EventTypeStr(EventValues[0].as_string().c_str());
+        // For custom events registered via ListenCustomNetworkEvent, the EventTypeStr will be the name of the event. In this case the
+        // NetworkEventFromString() method call below will return NetworkEvent::GeneralPurposeEvent, and the EventTypeStr will be used to look up the
+        // registered callback.
+        auto EventType = NetworkEventFromString(EventTypeStr);
 
-        // Find all registrations that match this network event type.
-        std::vector<NetworkEventRegistration> MatchingRegistrations;
-        for (auto const& [Registration, CB] : RegisteredEvents)
+        bool HasMatchingRegistrations = false;
+
+        switch (EventType)
         {
-            if (Registration.EventName == EventTypeStr)
+        case csp::multiplayer::NetworkEventBus::NetworkEvent::AssetDetailBlobChanged:
+        {
+            if (RegisteredAssetDetailBlobChangedEvents.size() > 0)
             {
-                MatchingRegistrations.push_back(Registration);
+                csp::common::AssetDetailBlobChangedNetworkEventData AssetDetailBlobChangedEventData;
+
+                if (!TryDeserializeEventData(
+                        LogSystem, EventTypeStr, [&] { return csp::multiplayer::DeserializeAssetDetailBlobChangedEvent(EventValues, LogSystem); },
+                        AssetDetailBlobChangedEventData))
+                {
+                    return;
+                }
+
+                for (auto const& [Registration, Callback] : RegisteredAssetDetailBlobChangedEvents)
+                {
+                    Callback(AssetDetailBlobChangedEventData);
+                }
+
+                HasMatchingRegistrations = true;
             }
+
+            break;
+        }
+        case csp::multiplayer::NetworkEventBus::NetworkEvent::Conversation:
+        {
+            if (RegisteredConversationEvents.size() > 0)
+            {
+                csp::common::ConversationNetworkEventData ConversationEventData;
+
+                if (!TryDeserializeEventData(
+                        LogSystem, EventTypeStr, [&] { return csp::multiplayer::DeserializeConversationEvent(EventValues, LogSystem); },
+                        ConversationEventData))
+                {
+                    return;
+                }
+
+                for (auto const& [Registration, Callback] : RegisteredConversationEvents)
+                {
+                    Callback(ConversationEventData);
+                }
+
+                HasMatchingRegistrations = true;
+            }
+
+            break;
+        }
+        case csp::multiplayer::NetworkEventBus::NetworkEvent::SequenceChanged:
+        {
+            if (RegisteredSequenceChangedEvents.size() > 0)
+            {
+                csp::common::SequenceChangedNetworkEventData SequenceChangedEventData;
+
+                if (!TryDeserializeEventData(
+                        LogSystem, EventTypeStr, [&] { return csp::multiplayer::DeserializeSequenceChangedEvent(EventValues, LogSystem); },
+                        SequenceChangedEventData))
+                {
+                    return;
+                }
+
+                const csp::common::String Key = SequenceChangedEventData.Key;
+                const csp::common::String SequenceType = csp::multiplayer::GetSequenceKeyIndex(Key, 0);
+
+                if (SequenceType == "Hotspots")
+                {
+                    SequenceChangedEventData.SequenceType = csp::common::ESequenceType::Hotspot;
+
+                    // If it is a hotspot, the 'key' will contain the following information [SequenceType]:[SpaceId]:[SequenceName]
+                    // eg: Hotspots:abc123456:My-Hotspot-Sequence
+                    csp::common::String OldHotspotSequenceName = csp::multiplayer::GetSequenceKeyIndex(SequenceChangedEventData.Key, 2);
+                    // NewKey will be structured in the same way, eg: Hotspots:abc123456:My-New-Hotspot-Sequence
+                    csp::common::String NewHotspotSequenceName = csp::multiplayer::GetSequenceKeyIndex(SequenceChangedEventData.NewKey, 2);
+
+                    SequenceChangedEventData.SpaceId = csp::multiplayer::GetSequenceKeyIndex(SequenceChangedEventData.Key, 1);
+                    SequenceChangedEventData.Key = OldHotspotSequenceName;
+                    SequenceChangedEventData.NewKey = NewHotspotSequenceName;
+                }
+
+                for (auto const& [Registration, Callback] : RegisteredSequenceChangedEvents)
+                {
+                    Callback(SequenceChangedEventData);
+                }
+
+                HasMatchingRegistrations = true;
+            }
+
+            break;
+        }
+        case csp::multiplayer::NetworkEventBus::NetworkEvent::AccessControlChanged:
+        {
+            if (RegisteredAccessControlChangedEvents.size() > 0)
+            {
+                csp::common::AccessControlChangedNetworkEventData AccessControlChangedEventData;
+
+                if (!TryDeserializeEventData(
+                        LogSystem, EventTypeStr, [&] { return csp::multiplayer::DeserializeAccessControlChangedEvent(EventValues, LogSystem); },
+                        AccessControlChangedEventData))
+                {
+                    return;
+                }
+
+                for (auto const& [Registration, Callback] : RegisteredAccessControlChangedEvents)
+                {
+                    Callback(AccessControlChangedEventData);
+                }
+
+                HasMatchingRegistrations = true;
+            }
+
+            break;
+        }
+        case csp::multiplayer::NetworkEventBus::NetworkEvent::AsyncCallCompleted:
+        {
+            if (RegisteredAsyncCallCompletedEvents.size() > 0)
+            {
+                csp::common::AsyncCallCompletedEventData AsyncCallCompletedEventData;
+
+                if (!TryDeserializeEventData(
+                        LogSystem, EventTypeStr, [&] { return csp::multiplayer::DeserializeAsyncCallCompletedEvent(EventValues, LogSystem); },
+                        AsyncCallCompletedEventData))
+                {
+                    return;
+                }
+
+                for (auto const& [Registration, Callback] : RegisteredAsyncCallCompletedEvents)
+                {
+                    if (Registration.EventName == AsyncCallCompletedEventData.OperationName)
+                    {
+                        Callback(AsyncCallCompletedEventData);
+
+                        HasMatchingRegistrations = true;
+                    }
+                }
+            }
+            break;
+        }
+        default:
+        case csp::multiplayer::NetworkEventBus::NetworkEvent::GeneralPurposeEvent:
+        {
+            if (RegisteredEvents.size() > 0)
+            {
+                csp::common::NetworkEventData GeneralPurposeEventData;
+
+                if (!TryDeserializeEventData(
+                        LogSystem, EventTypeStr, [&] { return csp::multiplayer::DeserializeGeneralPurposeEvent(EventValues, LogSystem); },
+                        GeneralPurposeEventData))
+                {
+                    return;
+                }
+
+                for (auto const& [Registration, Callback] : RegisteredEvents)
+                {
+                    if (Registration.EventName == EventTypeStr)
+                    {
+                        Callback(GeneralPurposeEventData);
+
+                        HasMatchingRegistrations = true;
+                    }
+                }
+            }
+            break;
+        }
         }
 
-        // If we have no registered event matching this string, ignore it entirely.
-        if (MatchingRegistrations.size() == 0)
+        if (!HasMatchingRegistrations)
         {
             LogSystem.LogMsg(
                 csp::common::LogLevel::Verbose, fmt::format("Received event {} has no registrations, discarding...", EventTypeStr).c_str());
-            return;
-        }
-
-        // Deserialize the signalR packets using the appropriate deserialiser.
-        // This only does anything for internal events, external events will always use the base EventDeserializer.
-        // After this, we'll have ReplicatedValues, which serves as our common exchange type.
-        // NOTE: This is not ideal, we'd rather have systems interpret this data directly. However, that would mean breaking the signalr dependency
-        // in the deserialisation, which is very possible, just a bit time consuming, so we'll do it later.
-        // This will be nullptr if the deserialisation fails or throws.
-        std::unique_ptr<csp::common::NetworkEventData> DeserialisedEventData;
-
-        try
-        {
-            DeserialisedEventData = DeserialiseForEventType(NetworkEventFromString(EventTypeStr), EventValues);
-        }
-        catch (const signalr::signalr_exception& e)
-        {
-            LogSystem.LogMsg(csp::common::LogLevel::Error,
-                fmt::format("NetworkEventBus: SignalR type mismatch encountered in Event {}: {}", EventTypeStr.c_str(), e.what()).c_str());
-        }
-        catch (const csp::common::ReplicatedValueException& e)
-        {
-            LogSystem.LogMsg(csp::common::LogLevel::Error, fmt::format("NetworkEventBus: ReplicatedValue type mismatch: {}", e.what()).c_str());
-        }
-        catch (...)
-        {
-            LogSystem.LogMsg(csp::common::LogLevel::Error, "NetworkEventBus: Unknown error encountered during event deserialisation.");
-        }
-        
-        if (DeserialisedEventData == nullptr)
-        {
-            LogSystem.LogMsg(csp::common::LogLevel::Error,
-                fmt::format("NetworkEventBus: Failed to deserialize event '{}'. Registered events will not be fired.", EventTypeStr).c_str());
-            return;
-        }
-
-        // Dispatch the events
-        for (const NetworkEventRegistration& Registration : MatchingRegistrations)
-        {
-            // Pass NetworkEventData object to user ownership
-            // This may be a subtype, the registrar will know what type they are expecting. External users should
-            // only ever register general purpose events, and thus should only ever get an NetworkEventData, so no need to cast.
-            // The user shouldn't expect the scope of this variable to live beyond the callback
-            RegisteredEvents[Registration](*DeserialisedEventData);
         }
     };
 
@@ -283,55 +668,5 @@ NetworkEventBus::NetworkEvent NetworkEventBus::NetworkEventFromString(const csp:
 
     // If we don't recognise the event, it must be a general purpose event
     return NetworkEvent::GeneralPurposeEvent;
-}
-
-std::unique_ptr<csp::common::NetworkEventData> NetworkEventBus::DeserialiseForEventType(
-    NetworkEvent EventType, const std::vector<signalr::value>& EventValues)
-{
-    using namespace csp::common;
-
-    switch (EventType)
-    {
-    case NetworkEvent::AssetDetailBlobChanged:
-        return std::make_unique<AssetDetailBlobChangedNetworkEventData>(
-            csp::multiplayer::DeserializeAssetDetailBlobChangedEvent(EventValues, LogSystem));
-    case NetworkEvent::Conversation:
-        return std::make_unique<ConversationNetworkEventData>(csp::multiplayer::DeserializeConversationEvent(EventValues, LogSystem));
-    case NetworkEvent::SequenceChanged:
-    {
-        std::unique_ptr<SequenceChangedNetworkEventData> SequenceEventData
-            = std::make_unique<SequenceChangedNetworkEventData>(csp::multiplayer::DeserializeSequenceChangedEvent(EventValues, LogSystem));
-
-        const csp::common::String Key = SequenceEventData->Key;
-        const csp::common::String SequenceType = csp::multiplayer::GetSequenceKeyIndex(Key, 0);
-
-        if (SequenceType == "Hotspots")
-        {
-            SequenceEventData->SequenceType = ESequenceType::Hotspot;
-
-            // If it is a hotspot, the 'key' will contain the following information [SequenceType]:[SpaceId]:[SequenceName]
-            // eg: Hotspots:abc123456:My-Hotspot-Sequence
-            String OldHotspotSequenceName = csp::multiplayer::GetSequenceKeyIndex(SequenceEventData->Key, 2);
-            // NewKey will be structured in the same way, eg: Hotspots:abc123456:My-New-Hotspot-Sequence
-            String NewHotspotSequenceName = csp::multiplayer::GetSequenceKeyIndex(SequenceEventData->NewKey, 2);
-
-            SequenceEventData->SpaceId = csp::multiplayer::GetSequenceKeyIndex(SequenceEventData->Key, 1);
-            SequenceEventData->Key = OldHotspotSequenceName;
-            SequenceEventData->NewKey = NewHotspotSequenceName;
-        }
-
-        return SequenceEventData;
-    }
-    case NetworkEvent::AccessControlChanged:
-        return std::make_unique<AccessControlChangedNetworkEventData>(
-            csp::multiplayer::DeserializeAccessControlChangedEvent(EventValues, LogSystem));
-    case NetworkEvent::GeneralPurposeEvent:
-        return std::make_unique<NetworkEventData>(csp::multiplayer::DeserializeGeneralPurposeEvent(EventValues, LogSystem));
-    case NetworkEvent::AsyncCallCompleted:
-        return std::make_unique<AsyncCallCompletedEventData>(csp::multiplayer::DeserializeAsyncCallCompletedEvent(EventValues, LogSystem));
-    default:
-        throw std::invalid_argument(
-            fmt::format("DeserialiseForEventType: unknown enum value {}", static_cast<std::underlying_type_t<NetworkEvent>>(EventType)));
-    }
 }
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/NetworkEventBus.cpp
+++ b/Library/src/Multiplayer/NetworkEventBus.cpp
@@ -333,14 +333,14 @@ csp::common::Array<NetworkEventRegistration> NetworkEventBus::AllRegistrations()
 
     csp::common::Array<NetworkEventRegistration> Registrations(TotalRegistrationsCount);
 
-    auto* RegistrationsIt = Registrations.begin();
+    size_t Index = 0;
 
-    // Copy the NetworkEventRegistration and increment pointer
-    auto CopyRegistrations = [&RegistrationsIt](const auto& EventMap)
+    // Flatten all event containers into a single array of NetworkEventRegistration objects.
+    auto CopyRegistrations = [&Index, &Registrations](const auto& EventMap)
     {
         for (const auto& [Key, Value] : EventMap)
         {
-            *RegistrationsIt++ = Key;
+            Registrations[Index++] = Key;
         }
     };
 

--- a/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
+++ b/Library/src/Multiplayer/NetworkEventManagerImpl.cpp
@@ -27,6 +27,74 @@
 #include <limits>
 #include <signalrclient/signalr_value.h>
 
+namespace
+{
+
+// Serialises a single ReplicatedValue into a [TypeId, [Field]] signalr::value that is expected by the MCS ItemComponentData wire format.
+signalr::value SerialiseReplicatedValueToSignalRValue(const csp::common::ReplicatedValue& Value)
+{
+    using namespace csp::multiplayer;
+
+    switch (Value.GetReplicatedValueType())
+    {
+    case csp::common::ReplicatedValueType::Boolean:
+    {
+        std::vector<signalr::value> Fields { Value.GetBool() };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::NULLABLE_BOOL), Fields };
+    }
+    case csp::common::ReplicatedValueType::Integer:
+    {
+        std::vector<signalr::value> Fields { Value.GetInt() };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::NULLABLE_INT64), Fields };
+    }
+    case csp::common::ReplicatedValueType::Float:
+    {
+        std::vector<signalr::value> Fields { Value.GetFloat() };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::NULLABLE_DOUBLE), Fields };
+    }
+    case csp::common::ReplicatedValueType::String:
+    {
+        std::vector<signalr::value> Fields { Value.GetString().c_str() };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::STRING), Fields };
+    }
+    case csp::common::ReplicatedValueType::Vector2:
+    {
+        auto Vector = Value.GetVector2();
+        std::vector<signalr::value> Fields { std::vector<signalr::value> { Vector.X, Vector.Y } };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::FLOAT_ARRAY), Fields };
+    }
+    case csp::common::ReplicatedValueType::Vector3:
+    {
+        auto Vector = Value.GetVector3();
+        std::vector<signalr::value> Fields { std::vector<signalr::value> { Vector.X, Vector.Y, Vector.Z } };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::FLOAT_ARRAY), Fields };
+    }
+    case csp::common::ReplicatedValueType::Vector4:
+    {
+        auto Vector = Value.GetVector4();
+        std::vector<signalr::value> Fields { std::vector<signalr::value> { Vector.X, Vector.Y, Vector.Z, Vector.W } };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::FLOAT_ARRAY), Fields };
+    }
+    case csp::common::ReplicatedValueType::StringMap:
+    {
+        std::map<std::string, signalr::value> StringMap;
+
+        for (const auto& [Key, MapValue] : Value.GetStringMap())
+        {
+            StringMap[Key.c_str()] = SerialiseReplicatedValueToSignalRValue(MapValue);
+        }
+
+        std::vector<signalr::value> Fields { StringMap };
+        return std::vector<signalr::value> { static_cast<uint64_t>(mcs::ItemComponentDataType::STRING_DICTIONARY), Fields };
+    }
+    default:
+        assert(false && "Argument csp::common::ReplicatedValueType is unsupported.");
+        return signalr::value();
+    }
+}
+
+} // namespace
+
 namespace csp::multiplayer
 {
 
@@ -78,85 +146,7 @@ void NetworkEventManagerImpl::SendNetworkEvent(const csp::common::String& EventN
 
     for (size_t i = 0; i < Arguments.Size(); ++i)
     {
-        switch (Arguments[i].GetReplicatedValueType())
-        {
-        case csp::common::ReplicatedValueType::Boolean:
-        {
-            std::vector<signalr::value> Fields;
-            Fields.push_back(Arguments[i].GetBool());
-
-            std::vector<signalr::value> Component { static_cast<uint64_t>(mcs::ItemComponentDataType::NULLABLE_BOOL), Fields };
-            Components.insert({ i, Component });
-
-            break;
-        }
-        case csp::common::ReplicatedValueType::Integer:
-        {
-            std::vector<signalr::value> Fields;
-            Fields.push_back(Arguments[i].GetInt());
-
-            std::vector<signalr::value> Component { static_cast<uint64_t>(mcs::ItemComponentDataType::NULLABLE_INT64), Fields };
-            Components.insert({ i, Component });
-
-            break;
-        }
-        case csp::common::ReplicatedValueType::Float:
-        {
-            std::vector<signalr::value> Fields;
-            Fields.push_back(Arguments[i].GetFloat());
-
-            std::vector<signalr::value> Component { static_cast<uint64_t>(mcs::ItemComponentDataType::NULLABLE_DOUBLE), Fields };
-            Components.insert({ i, Component });
-
-            break;
-        }
-        case csp::common::ReplicatedValueType::String:
-        {
-            std::vector<signalr::value> Fields;
-            Fields.push_back(Arguments[i].GetString().c_str());
-
-            std::vector<signalr::value> Component { static_cast<uint64_t>(mcs::ItemComponentDataType::STRING), Fields };
-            Components.insert({ i, Component });
-
-            break;
-        }
-        case csp::common::ReplicatedValueType::Vector2:
-        {
-            std::vector<signalr::value> Fields;
-            auto Vector = Arguments[i].GetVector2();
-            Fields.push_back(std::vector<signalr::value> { Vector.X, Vector.Y });
-
-            std::vector<signalr::value> Component { static_cast<uint64_t>(mcs::ItemComponentDataType::FLOAT_ARRAY), Fields };
-            Components.insert({ i, Component });
-
-            break;
-        }
-        case csp::common::ReplicatedValueType::Vector3:
-        {
-            std::vector<signalr::value> Fields;
-            auto Vector = Arguments[i].GetVector3();
-            Fields.push_back(std::vector<signalr::value> { Vector.X, Vector.Y, Vector.Z });
-
-            std::vector<signalr::value> Component { static_cast<uint64_t>(mcs::ItemComponentDataType::FLOAT_ARRAY), Fields };
-            Components.insert({ i, Component });
-
-            break;
-        }
-        case csp::common::ReplicatedValueType::Vector4:
-        {
-            std::vector<signalr::value> Fields;
-            auto Vector = Arguments[i].GetVector4();
-            Fields.push_back(std::vector<signalr::value> { Vector.X, Vector.Y, Vector.Z, Vector.W });
-
-            std::vector<signalr::value> Component { static_cast<uint64_t>(mcs::ItemComponentDataType::FLOAT_ARRAY), Fields };
-            Components.insert({ i, Component });
-
-            break;
-        }
-        default:
-            assert(false && "Argument csp::common::ReplicatedValueType is unsupported.");
-            break;
-        }
+        Components.insert({ i, SerialiseReplicatedValueToSignalRValue(Arguments[i]) });
     }
 
     /*

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -753,8 +753,7 @@ std::function<void(const signalr::value&, std::exception_ptr)> OnlineRealtimeEng
             {
                 // For server-side leader election, we want to listen for script run requests from other clients.
                 // We will receive these if we are the leader and another client modifies a script or sends an event.
-                this->NetworkEventBus->ListenNetworkEvent(
-                    csp::multiplayer::NetworkEventRegistration { "CSPInternal::ScriptEvent", RemoteRunScriptMessage },
+                this->NetworkEventBus->ListenCustomNetworkEvent("CSPInternal::ScriptEvent", RemoteRunScriptMessage,
                     [this](const csp::common::NetworkEventData& EventData) { this->OnRemoteRunScriptEvent(EventData.EventValues); });
 
                 if (ScriptSystemReadyCallback)
@@ -1094,8 +1093,7 @@ void OnlineRealtimeEngine::DisableLeaderElection()
 
     if (LeaderElectionManager != nullptr)
     {
-        NetworkEventBus->StopListenNetworkEvent(
-            csp::multiplayer::NetworkEventRegistration("CSPInternal::ScriptEvent", RemoteRunScriptMessage));
+        NetworkEventBus->StopListenCustomNetworkEvent("CSPInternal::ScriptEvent", RemoteRunScriptMessage);
 
         LeaderElectionManager.reset(nullptr);
     }

--- a/Library/src/Systems/Assets/AssetSystem.cpp
+++ b/Library/src/Systems/Assets/AssetSystem.cpp
@@ -1810,33 +1810,28 @@ void AssetSystem::RegisterSystemCallback()
         return;
     }
 
-    EventBusPtr->ListenNetworkEvent(
-        csp::multiplayer::NetworkEventRegistration("CSPInternal::AssetSystem",
-            csp::multiplayer::NetworkEventBus::StringFromNetworkEvent(csp::multiplayer::NetworkEventBus::NetworkEvent::AssetDetailBlobChanged)),
-        [this](const csp::common::NetworkEventData& NetworkEventData) { this->OnAssetDetailBlobChangedEvent(NetworkEventData); });
+    EventBusPtr->ListenAssetDetailBlobChangedEvent("CSPInternal::AssetSystem",
+        [this](const csp::common::AssetDetailBlobChangedNetworkEventData& NetworkEventData) { this->OnAssetDetailBlobChangedEvent(NetworkEventData); });
 }
 
-void AssetSystem::OnAssetDetailBlobChangedEvent(const csp::common::NetworkEventData& NetworkEventData)
+void AssetSystem::OnAssetDetailBlobChangedEvent(const csp::common::AssetDetailBlobChangedNetworkEventData& NetworkEventData)
 {
     if (!AssetDetailBlobChangedCallback && !MaterialChangedCallback)
     {
         return;
     }
 
-    const csp::common::AssetDetailBlobChangedNetworkEventData& AssetDetailBlobChangedNetworkEventData
-        = static_cast<const csp::common::AssetDetailBlobChangedNetworkEventData&>(NetworkEventData);
-
     if (AssetDetailBlobChangedCallback)
     {
-        AssetDetailBlobChangedCallback(AssetDetailBlobChangedNetworkEventData);
+        AssetDetailBlobChangedCallback(NetworkEventData);
     }
 
-    if (AssetDetailBlobChangedNetworkEventData.AssetType == systems::EAssetType::MATERIAL && MaterialChangedCallback)
+    if (NetworkEventData.AssetType == systems::EAssetType::MATERIAL && MaterialChangedCallback)
     {
         csp::common::MaterialChangedParams MaterialParams;
-        MaterialParams.ChangeType = AssetDetailBlobChangedNetworkEventData.ChangeType;
-        MaterialParams.MaterialCollectionId = AssetDetailBlobChangedNetworkEventData.AssetCollectionId;
-        MaterialParams.MaterialId = AssetDetailBlobChangedNetworkEventData.AssetId;
+        MaterialParams.ChangeType = NetworkEventData.ChangeType;
+        MaterialParams.MaterialCollectionId = NetworkEventData.AssetCollectionId;
+        MaterialParams.MaterialId = NetworkEventData.AssetId;
 
         MaterialChangedCallback(MaterialParams);
     }

--- a/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
+++ b/Library/src/Systems/Conversation/ConversationSystemInternal.cpp
@@ -1139,18 +1139,14 @@ void ConversationSystemInternal::RegisterSystemCallback()
         return;
     }
 
-    EventBusPtr->ListenNetworkEvent(
-        csp::multiplayer::NetworkEventRegistration("CSPInternal::ConversationSystemInternal",
-            csp::multiplayer::NetworkEventBus::StringFromNetworkEvent(csp::multiplayer::NetworkEventBus::NetworkEvent::Conversation)),
-        [this](const csp::common::NetworkEventData& NetworkEventData)
+    EventBusPtr->ListenConversationEvent("CSPInternal::ConversationSystemInternal",
+        [this](const csp::common::ConversationNetworkEventData& NetworkEventData)
         {
-            const csp::common::ConversationNetworkEventData& ConversationNetworkEventData
-                = static_cast<const csp::common::ConversationNetworkEventData&>(NetworkEventData);
-            if (TrySendEvent(ConversationNetworkEventData) == false)
+            if (TrySendEvent(NetworkEventData) == false)
             {
                 // If component doesn't exist, add it to the queue for processing later
                 std::unique_ptr<csp::common::ConversationNetworkEventData> EventDataCopy
-                    = std::make_unique<csp::common::ConversationNetworkEventData>(ConversationNetworkEventData);
+                    = std::make_unique<csp::common::ConversationNetworkEventData>(NetworkEventData);
                 Events.push_back(std::move(EventDataCopy));
             }
         });

--- a/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
+++ b/Library/src/Systems/HotspotSequence/HotspotSequenceSystem.cpp
@@ -424,21 +424,17 @@ void HotspotSequenceSystem::RegisterSystemCallback()
         return;
     }
 
-    EventBusPtr->ListenNetworkEvent(
-        csp::multiplayer::NetworkEventRegistration("CSPInternal::HotspotSequenceSystem",
-            csp::multiplayer::NetworkEventBus::StringFromNetworkEvent(csp::multiplayer::NetworkEventBus::NetworkEvent::SequenceChanged)),
-        [this](const csp::common::NetworkEventData& NetworkEventData) { this->OnSequenceChangedEvent(NetworkEventData); });
+    EventBusPtr->ListenSequenceChangedEvent("CSPInternal::HotspotSequenceSystem",
+        [this](const csp::common::SequenceChangedNetworkEventData& NetworkEventData) { this->OnSequenceChangedEvent(NetworkEventData); });
 }
 
-void HotspotSequenceSystem::OnSequenceChangedEvent(const csp::common::NetworkEventData& NetworkEventData)
+void HotspotSequenceSystem::OnSequenceChangedEvent(const csp::common::SequenceChangedNetworkEventData& NetworkEventData)
 {
-    // This event may either represent a default sequence or a hotspot sequence. Here we are only concerned with hotspot sequences.
-    const auto& SequenceEvent = static_cast<const csp::common::SequenceChangedNetworkEventData&>(NetworkEventData);
-
-    if (SequenceEvent.SequenceType == csp::common::ESequenceType::Hotspot && HotspotSequenceChangedCallback)
+    // This event may either represent a default sequence or a hotspot sequence. Here we are only concerned with Hotspot sequences.
+    if (NetworkEventData.SequenceType == csp::common::ESequenceType::Hotspot && HotspotSequenceChangedCallback)
     {
         // We can cast directly, we're sure we're the correct type.
-        HotspotSequenceChangedCallback(SequenceEvent);
+        HotspotSequenceChangedCallback(NetworkEventData);
     }
 }
 

--- a/Library/src/Systems/Sequence/SequenceSystem.cpp
+++ b/Library/src/Systems/Sequence/SequenceSystem.cpp
@@ -333,21 +333,17 @@ void SequenceSystem::RegisterSystemCallback()
         return;
     }
 
-    EventBusPtr->ListenNetworkEvent(
-        csp::multiplayer::NetworkEventRegistration("CSPInternal::SequenceSystem",
-            csp::multiplayer::NetworkEventBus::StringFromNetworkEvent(csp::multiplayer::NetworkEventBus::NetworkEvent::SequenceChanged)),
-        [this](const csp::common::NetworkEventData& NetworkEventData) { this->OnSequenceChangedEvent(NetworkEventData); });
+    EventBusPtr->ListenSequenceChangedEvent("CSPInternal::SequenceSystem",
+        [this](const csp::common::SequenceChangedNetworkEventData& NetworkEventData) { this->OnSequenceChangedEvent(NetworkEventData); });
 }
 
-void SequenceSystem::OnSequenceChangedEvent(const csp::common::NetworkEventData& NetworkEventData)
+void SequenceSystem::OnSequenceChangedEvent(const csp::common::SequenceChangedNetworkEventData& NetworkEventData)
 {
     // This event may either represent a default sequence or a hotspot sequence. Here we are only concerned with default sequences.
-    const auto& SequenceEvent = static_cast<const csp::common::SequenceChangedNetworkEventData&>(NetworkEventData);
-
-    if (SequenceEvent.SequenceType == csp::common::ESequenceType::Default && SequenceChangedCallback)
+    if (NetworkEventData.SequenceType == csp::common::ESequenceType::Default && SequenceChangedCallback)
     {
         // We can cast directly, we're sure we're the correct type.
-        SequenceChangedCallback(SequenceEvent);
+        SequenceChangedCallback(NetworkEventData);
     }
 }
 

--- a/Library/src/Systems/Spaces/SpaceSystem.cpp
+++ b/Library/src/Systems/Spaces/SpaceSystem.cpp
@@ -2070,35 +2070,5 @@ void SpaceSystem::DuplicateSpaceAsync(const String& SpaceId, const String& NewNa
     );
 }
 
-void SpaceSystem::SetAsyncCallCompletedCallback(AsyncCallCompletedCallbackHandler Callback)
-{
-    AsyncCallCompletedCallback = std::move(Callback);
-
-    if (!AsyncCallCompletedCallback)
-    {
-        CSP_LOG_ERROR_MSG("Error: The AsyncCallCompletedCallback handler has not been set and the SpaceSystem has not been registered with the "
-                          "AsyncCallCompleted event. Please call 'SetAsyncCallCompletedCallback()' with a valid AsyncCallCompletedCallbackHandler.");
-        return;
-    }
-
-    EventBusPtr->ListenNetworkEvent(
-        csp::multiplayer::NetworkEventRegistration("CSPInternal::SpaceSystem",
-            csp::multiplayer::NetworkEventBus::StringFromNetworkEvent(csp::multiplayer::NetworkEventBus::NetworkEvent::AsyncCallCompleted)),
-        [this](const csp::common::NetworkEventData& NetworkEventData) { this->OnAsyncCallCompletedEvent(NetworkEventData); });
-}
-
-void SpaceSystem::OnAsyncCallCompletedEvent(const csp::common::NetworkEventData& NetworkEventData)
-{
-    if (!AsyncCallCompletedCallback)
-    {
-        return;
-    }
-
-    const csp::common::AsyncCallCompletedEventData& AsyncCallCompletedEventData
-        = static_cast<const csp::common::AsyncCallCompletedEventData&>(NetworkEventData);
-
-    AsyncCallCompletedCallback(AsyncCallCompletedEventData);
-}
-
 void SpaceSystem::SetMultiplayerSystem(csp::systems::MultiplayerSystem& InMultiplayerSystem) { MultiplayerSystem = &InMultiplayerSystem; }
 } // namespace csp::systems

--- a/Library/src/Systems/Users/UserSystem.cpp
+++ b/Library/src/Systems/Users/UserSystem.cpp
@@ -1168,23 +1168,18 @@ void UserSystem::RegisterSystemCallback()
         return;
     }
 
-    EventBusPtr->ListenNetworkEvent(
-        csp::multiplayer::NetworkEventRegistration("CSPInternal::UserSystem",
-            csp::multiplayer::NetworkEventBus::StringFromNetworkEvent(csp::multiplayer::NetworkEventBus::NetworkEvent::AccessControlChanged)),
-        [this](const csp::common::NetworkEventData& NetworkEventData) { this->OnAccessControlChangedEvent(NetworkEventData); });
+    EventBusPtr->ListenAccessControlChangedEvent("CSPInternal::UserSystem",
+        [this](const csp::common::AccessControlChangedNetworkEventData& NetworkEventData) { this->OnAccessControlChangedEvent(NetworkEventData); });
 }
 
-void UserSystem::OnAccessControlChangedEvent(const csp::common::NetworkEventData& NetworkEventData)
+void UserSystem::OnAccessControlChangedEvent(const csp::common::AccessControlChangedNetworkEventData& NetworkEventData)
 {
     if (!UserPermissionsChangedCallback)
     {
         return;
     }
 
-    const csp::common::AccessControlChangedNetworkEventData& AccessControlChangedNetworkEventData
-        = static_cast<const csp::common::AccessControlChangedNetworkEventData&>(NetworkEventData);
-
-    UserPermissionsChangedCallback(AccessControlChangedNetworkEventData);
+    UserPermissionsChangedCallback(NetworkEventData);
 }
 
 csp::common::IAuthContext& UserSystem::GetAuthContext() { return Auth; }

--- a/MultiplayerTestRunner/src/RunnableTests/EventBusPing.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/EventBusPing.cpp
@@ -27,7 +27,7 @@ namespace EventBusPing
 void RunTest()
 {
     // Listen for an event, then ping it back to the client that sent it.
-    csp::systems::SystemsManager::Get().GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration("Receiver", "EventPingRequest"),
+    csp::systems::SystemsManager::Get().GetEventBus()->ListenCustomNetworkEvent("Receiver", "EventPingRequest",
         [](const csp::common::NetworkEventData& NetworkEventData)
         {
             csp::systems::SystemsManager::Get().GetEventBus()->SendNetworkEventToClient(

--- a/Tests/src/PublicAPITests/EventBusTests.cpp
+++ b/Tests/src/PublicAPITests/EventBusTests.cpp
@@ -80,18 +80,41 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterDeregister)
     const char* EventName = "TestEventName";
 
     const csp::common::Array<NetworkEventRegistration> InitialRegisteredEvents = SystemsManager.GetEventBus()->AllRegistrations();
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId, EventName }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
     const csp::common::Array<NetworkEventRegistration> AddedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
 
     EXPECT_TRUE(AddedRegistration.Size() == InitialRegisteredEvents.Size() + 1);
     EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, EventName }));
 
-    SystemsManager.GetEventBus()->StopListenNetworkEvent(NetworkEventRegistration { ReceiverId, EventName });
+    SystemsManager.GetEventBus()->StopListenCustomNetworkEvent(ReceiverId, EventName);
 
     const csp::common::Array<NetworkEventRegistration> RemovedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
     EXPECT_TRUE(RemovedRegistration.Size() == InitialRegisteredEvents.Size());
     EXPECT_FALSE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, EventName }));
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterDeregisterAsyncCallCompleted)
+{
+    using namespace csp::multiplayer;
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* OperationName = "DuplicateSpaceAsync";
+
+    const csp::common::Array<NetworkEventRegistration> InitialRegisteredEvents = SystemsManager.GetEventBus()->AllRegistrations();
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId, OperationName, [](const csp::common::AsyncCallCompletedEventData& /*NetworkEventData*/) { });
+    const csp::common::Array<NetworkEventRegistration> AddedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+
+    EXPECT_TRUE(AddedRegistration.Size() == InitialRegisteredEvents.Size() + 1);
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName }));
+
+    SystemsManager.GetEventBus()->StopListenAsyncCallCompletedEvent(ReceiverId, OperationName);
+
+    const csp::common::Array<NetworkEventRegistration> RemovedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+    EXPECT_TRUE(RemovedRegistration.Size() == InitialRegisteredEvents.Size());
+    EXPECT_FALSE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName }));
 }
 
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterDeregisterMulti)
@@ -108,18 +131,14 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterDeregisterMulti)
     const char* EventName3 = "TestEventName3";
 
     const csp::common::Array<NetworkEventRegistration> InitialRegisteredEvents = SystemsManager.GetEventBus()->AllRegistrations();
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId, EventName }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId, EventName2 }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId, EventName3 }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId2, EventName }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId2, EventName2 }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId2, EventName3 }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName2, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName3, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId2, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(
+        ReceiverId2, EventName2, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(
+        ReceiverId2, EventName3, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
     const csp::common::Array<NetworkEventRegistration> AddedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
 
     EXPECT_TRUE(AddedRegistration.Size() == InitialRegisteredEvents.Size() + 6);
@@ -130,7 +149,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterDeregisterMulti)
     EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, EventName2 }));
     EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, EventName3 }));
 
-    SystemsManager.GetEventBus()->StopListenNetworkEvent(NetworkEventRegistration { ReceiverId, EventName });
+    SystemsManager.GetEventBus()->StopListenCustomNetworkEvent(ReceiverId, EventName);
 
     const csp::common::Array<NetworkEventRegistration> RemovedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
     EXPECT_TRUE(RemovedRegistration.Size() == InitialRegisteredEvents.Size() + 5);
@@ -153,6 +172,129 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterDeregisterMulti)
     EXPECT_FALSE(RemovedAllTestReceivedOneRegistrations.ToList().Contains(NetworkEventRegistration { ReceiverId2, EventName3 }));
 }
 
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterDeregisterMultiAsyncCallCompleted)
+{
+    using namespace csp::multiplayer;
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* OperationName1 = "DuplicateSpaceAsync";
+
+    const char* ReceiverId2 = "TestReceiverId2";
+    const char* OperationName2 = "CreateSnapshotAsync";
+
+    const char* OperationName3 = "OtherAsyncOperation";
+
+    const csp::common::Array<NetworkEventRegistration> InitialRegisteredEvents = SystemsManager.GetEventBus()->AllRegistrations();
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId, OperationName1, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId, OperationName2, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId, OperationName3, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId2, OperationName1, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId2, OperationName2, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId2, OperationName3, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+
+    const csp::common::Array<NetworkEventRegistration> AddedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+
+    EXPECT_TRUE(AddedRegistration.Size() == InitialRegisteredEvents.Size() + 6);
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName1 }));
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName2 }));
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName3 }));
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName1 }));
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName2 }));
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName3 }));
+
+    SystemsManager.GetEventBus()->StopListenAsyncCallCompletedEvent(ReceiverId, OperationName1);
+
+    const csp::common::Array<NetworkEventRegistration> RemovedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+
+    EXPECT_TRUE(RemovedRegistration.Size() == InitialRegisteredEvents.Size() + 5);
+    EXPECT_FALSE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName1 }));
+    EXPECT_TRUE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName2 }));
+    EXPECT_TRUE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName3 }));
+    EXPECT_TRUE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName1 }));
+    EXPECT_TRUE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName2 }));
+    EXPECT_TRUE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName3 }));
+
+    SystemsManager.GetEventBus()->StopListenAsyncCallCompletedEvent(ReceiverId2, OperationName1);
+
+    const csp::common::Array<NetworkEventRegistration> RemovedAllTestReceivedOneRegistrations = SystemsManager.GetEventBus()->AllRegistrations();
+
+    EXPECT_TRUE(RemovedAllTestReceivedOneRegistrations.Size() == InitialRegisteredEvents.Size() + 4);
+    EXPECT_FALSE(RemovedAllTestReceivedOneRegistrations.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName1 }));
+    EXPECT_TRUE(RemovedAllTestReceivedOneRegistrations.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName2 }));
+    EXPECT_TRUE(RemovedAllTestReceivedOneRegistrations.ToList().Contains(NetworkEventRegistration { ReceiverId, OperationName3 }));
+    EXPECT_FALSE(RemovedAllTestReceivedOneRegistrations.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName1 }));
+    EXPECT_TRUE(RemovedAllTestReceivedOneRegistrations.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName2 }));
+    EXPECT_TRUE(RemovedAllTestReceivedOneRegistrations.ToList().Contains(NetworkEventRegistration { ReceiverId2, OperationName3 }));
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterStopAll)
+{
+    using namespace csp::multiplayer;
+
+    RAIIMockLogger MockLogger {};
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* EventName = "TestEventName";
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const csp::common::String SuccessLog = fmt::format("Registering {} network event. EventReceiverId: {}.", EventName, ReceiverId).c_str();
+    const csp::common::String VerboseLog
+        = fmt::format("NetworkEventBus::StopListenAllNetworkEvents: Removed 1 network event registration/s with EventReceiverId: {}.", ReceiverId)
+              .c_str();
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, SuccessLog)).Times(1);
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, VerboseLog)).Times(1);
+
+    const csp::common::Array<NetworkEventRegistration> InitialRegisteredEvents = SystemsManager.GetEventBus()->AllRegistrations();
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    const csp::common::Array<NetworkEventRegistration> AddedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+
+    EXPECT_TRUE(AddedRegistration.Size() == InitialRegisteredEvents.Size() + 1);
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, EventName }));
+
+    SystemsManager.GetEventBus()->StopListenAllNetworkEvents(ReceiverId);
+
+    const csp::common::Array<NetworkEventRegistration> RemovedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+    EXPECT_TRUE(RemovedRegistration.Size() == InitialRegisteredEvents.Size());
+    EXPECT_FALSE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId, EventName }));
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterMultiStopAll)
+{
+    using namespace csp::multiplayer;
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    
+    const char* ReceiverId1 = "TestReceiverId1";
+    const char* EventName = "TestEventName";
+    const char* OperationName = "TestEventName";
+
+    const csp::common::Array<NetworkEventRegistration> InitialRegisteredEvents = SystemsManager.GetEventBus()->AllRegistrations();
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId1, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId1, OperationName, [](const csp::common::AsyncCallCompletedEventData& /*NetworkEventData*/) { });
+    const csp::common::Array<NetworkEventRegistration> AddedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+
+    EXPECT_TRUE(AddedRegistration.Size() == InitialRegisteredEvents.Size() + 2);
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId1, EventName }));
+    EXPECT_TRUE(AddedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId1, OperationName }));
+
+    SystemsManager.GetEventBus()->StopListenAllNetworkEvents(ReceiverId1);
+
+    const csp::common::Array<NetworkEventRegistration> RemovedRegistration = SystemsManager.GetEventBus()->AllRegistrations();
+    EXPECT_TRUE(RemovedRegistration.Size() == InitialRegisteredEvents.Size());
+    EXPECT_FALSE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId1, EventName }));
+    EXPECT_FALSE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId1, OperationName }));
+}
+
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEvent)
 {
     using namespace csp::multiplayer;
@@ -161,14 +303,58 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEvent)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    const csp::common::String Error = "Error: Expected non-null callback.";
+    const csp::common::String Error = "NetworkEventBus::ListenCustomNetworkEvent: Expected non-null callback. Registration denied.";
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
 
     const char* ReceiverId = "TestReceiverId";
     const char* EventName = "TestEventName";
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(NetworkEventRegistration { ReceiverId, EventName }, nullptr);
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName, nullptr);
     auto AllRegistrations = SystemsManager.GetEventBus()->AllRegistrations();
+    EXPECT_FALSE(std::any_of(AllRegistrations.begin(), AllRegistrations.end(),
+        [ReceiverId](const NetworkEventRegistration& Registration) { return Registration.EventReceiverId == ReceiverId; }));
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEventAsyncCallCompleted)
+{
+    using namespace csp::multiplayer;
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const csp::common::String Error = "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-null callback. Registration denied.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* OperationName = "DuplicateSpaceAsync";
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, OperationName, nullptr);
+
+    auto AllRegistrations = SystemsManager.GetEventBus()->AllRegistrations();
+
+    EXPECT_FALSE(std::any_of(AllRegistrations.begin(), AllRegistrations.end(),
+        [ReceiverId](const NetworkEventRegistration& Registration) { return Registration.EventReceiverId == ReceiverId; }));
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNoOperationNameAsyncCallCompleted)
+{
+    using namespace csp::multiplayer;
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const csp::common::String Error = "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-empty OperationName. Registration denied.";
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* InvalidOperationName = "";
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, InvalidOperationName, nullptr);
+
+    auto AllRegistrations = SystemsManager.GetEventBus()->AllRegistrations();
+
     EXPECT_FALSE(std::any_of(AllRegistrations.begin(), AllRegistrations.end(),
         [ReceiverId](const NetworkEventRegistration& Registration) { return Registration.EventReceiverId == ReceiverId; }));
 }
@@ -187,35 +373,79 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectDuplicateRegistration)
     const char* ReceiverId2 = "TestReceiverId2";
     const char* EventName2 = "TestEventName2";
 
-    const csp::common::String Success1 = fmt::format("Registering network event. EventReceiverId: {}, Event: {}.", ReceiverId, EventName).c_str();
-    const csp::common::String Success2 = fmt::format("Registering network event. EventReceiverId: {}, Event: {}.", ReceiverId2, EventName).c_str();
-    const csp::common::String Success3 = fmt::format("Registering network event. EventReceiverId: {}, Event: {}.", ReceiverId, EventName2).c_str();
+    const csp::common::String Success1 = fmt::format("Registering {} network event. EventReceiverId: {}.", EventName, ReceiverId).c_str();
+    const csp::common::String Success2 = fmt::format("Registering {} network event. EventReceiverId: {}.", EventName, ReceiverId2).c_str();
+    const csp::common::String Success3 = fmt::format("Registering {} network event. EventReceiverId: {}.", EventName2, ReceiverId).c_str();
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success1)).Times(1);
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success2)).Times(1);
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success3)).Times(1);
+
+    const csp::common::String Error = fmt::format("NetworkEventBus::ListenCustomNetworkEvent: Attempting to register a duplicate {} network event "
+                                                  "with EventReceiverId: {}. Registration denied.",
+        EventName, ReceiverId2)
+                                          .c_str();
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Warning, Error)).Times(1);
+
+    const auto StartSize = SystemsManager.GetEventBus()->AllRegistrations().Size();
+
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 1);
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId2, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 2);
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName2, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 3);
+
+    // This one should be rejected
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId2, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 3);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectDuplicateRegistrationAsyncCallCompleted)
+{
+    using namespace csp::multiplayer;
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* OperationName1 = "DuplicateSpaceAsync";
+
+    const char* ReceiverId2 = "TestReceiverId2";
+    const char* OperationName2 = "CreateSnapshotAsync";
+
+    const csp::common::String Success1 = fmt::format("Registering {} network event. EventReceiverId: {}.", OperationName1, ReceiverId).c_str();
+    const csp::common::String Success2 = fmt::format("Registering {} network event. EventReceiverId: {}.", OperationName1, ReceiverId2).c_str();
+    const csp::common::String Success3 = fmt::format("Registering {} network event. EventReceiverId: {}.", OperationName2, ReceiverId).c_str();
+
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success1)).Times(1);
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success2)).Times(1);
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success3)).Times(1);
 
     const csp::common::String Error
-        = fmt::format("Attempting to register a duplicate network event receiver with EventReceiverId: {}, Event: {}. Registration "
-                      "denied.",
-            ReceiverId2, EventName)
+        = fmt::format("NetworkEventBus::ListenAsyncCallCompletedEvent: Attempting to register a duplicate {} network event "
+                      "with EventReceiverId: {}. Registration denied.",
+            OperationName1, ReceiverId2)
               .c_str();
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Warning, Error)).Times(1);
 
     const auto StartSize = SystemsManager.GetEventBus()->AllRegistrations().Size();
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId, EventName }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId, OperationName1, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
     EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 1);
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId2, EventName }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId2, OperationName1, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
     EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 2);
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId, EventName2 }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId, OperationName2, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
     EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 3);
 
     // This one should be rejected
-    SystemsManager.GetEventBus()->ListenNetworkEvent(
-        NetworkEventRegistration { ReceiverId2, EventName }, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(
+        ReceiverId2, OperationName1, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
     EXPECT_EQ(SystemsManager.GetEventBus()->AllRegistrations().Size(), StartSize + 3);
 }
 
@@ -231,14 +461,49 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectUnknownDeregistration)
     const char* EventName = "TestEventName";
 
     const csp::common::String Error
-        = fmt::format("Could not find network event registration with EventReceiverId: {}, Event: {}. Deregistration denied.", ReceiverId, EventName)
+        = fmt::format("NetworkEventBus::StopListenCustomNetworkEvent: Could not find custom network event registration with Event ReceiverId: {}, "
+                      "Event: {}. Deregistration denied.",
+            ReceiverId, EventName)
               .c_str();
     const csp::common::String Error1
-        = fmt::format("Could not find any network event registration with EventReceiverId: {}. No events were deregistered.", ReceiverId).c_str();
+        = fmt::format("NetworkEventBus::StopListenAllNetworkEvents: Could not find any network events registered with EventReceiverId: {}. No "
+                      "events were deregistered.",
+            ReceiverId)
+              .c_str();
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Error)).Times(1);
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Log, Error1)).Times(1);
 
-    SystemsManager.GetEventBus()->StopListenNetworkEvent(NetworkEventRegistration { ReceiverId, EventName });
+    SystemsManager.GetEventBus()->StopListenCustomNetworkEvent(ReceiverId, EventName);
+    SystemsManager.GetEventBus()->StopListenAllNetworkEvents(ReceiverId);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectUnknownDeregistrationAsyncCallCompleted)
+{
+    using namespace csp::multiplayer;
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* OperationName = "DuplicateSpaceAsync";
+
+    const csp::common::String Error
+        = fmt::format("NetworkEventBus::StopListenAsyncCallCompletedEvent: Could not find async call completed network event for registration with "
+                        "Event ReceiverId: {} for Operation: {}. Deregistration denied.",
+            ReceiverId, OperationName)
+              .c_str();
+
+    const csp::common::String Error1
+        = fmt::format("NetworkEventBus::StopListenAllNetworkEvents: Could not find any network events registered with EventReceiverId: {}. No "
+                      "events were deregistered.",
+            ReceiverId)
+              .c_str();
+
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Error)).Times(1);
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Log, Error1)).Times(1);
+
+    SystemsManager.GetEventBus()->StopListenAsyncCallCompletedEvent(ReceiverId, OperationName);
     SystemsManager.GetEventBus()->StopListenAllNetworkEvents(ReceiverId);
 }
 
@@ -269,7 +534,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SingleEventSingleReciever)
     const csp::common::Array<csp::common::ReplicatedValue> ValsToSend
         = { csp::common::ReplicatedValue { TestValValue }, csp::common::ReplicatedValue { 1.0f } };
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration(ReceiverId, EventName),
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName,
         [&NetworkEventPromise](const csp::common::NetworkEventData& NetworkEventData)
         { NetworkEventPromise.set_value(NetworkEventData.EventValues); });
 
@@ -281,6 +546,56 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SingleEventSingleReciever)
     EXPECT_EQ(ReceivedVals[1].GetReplicatedValueType(), csp::common::ReplicatedValueType::Float);
     EXPECT_EQ(ReceivedVals[0].GetString(), TestValValue);
     EXPECT_EQ(ReceivedVals[1].GetFloat(), 1.0f);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SingleEventSingleRecieverAsyncCallCompleted)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* EventName = "AsyncCallCompleted";
+
+    const char* OperationName = "DuplicateSpaceAsync";
+    const auto ReferencesStringMap
+        = csp::common::Map<csp::common::String, csp::common::ReplicatedValue> { { "SpaceId", csp::common::ReplicatedValue { "TestSpaceId" } } };
+    bool Success = true;
+    const char* StatusReason = "";
+
+    // Log in
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    auto [FlagSetResult] = AWAIT(Connection, SetAllowSelfMessagingFlag, true);
+
+    CreateTestSpaceAndEnterScope(SystemsManager.GetSpaceSystem(), Connection);
+
+    auto ErrorCallback = [](ErrorCode Error) { ASSERT_EQ(Error, ErrorCode::None); };
+
+    std::promise<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventPromise;
+    std::future<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventFuture = NetworkEventPromise.get_future();
+
+    const csp::common::Array<csp::common::ReplicatedValue> ValsToSend
+        = { csp::common::ReplicatedValue { OperationName }, csp::common::ReplicatedValue { ReferencesStringMap },
+              csp::common::ReplicatedValue { Success }, csp::common::ReplicatedValue { StatusReason } };
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, OperationName,
+        [&NetworkEventPromise](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
+        { NetworkEventPromise.set_value(NetworkEventData.EventValues); });
+
+    SystemsManager.GetEventBus()->SendNetworkEventToClient(EventName, ValsToSend, Connection->GetClientId(), ErrorCallback);
+
+    const csp::common::Array<csp::common::ReplicatedValue> ReceivedVals = NetworkEventFuture.get();
+    EXPECT_EQ(ReceivedVals.Size(), 4);
+    EXPECT_EQ(ReceivedVals[0].GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(ReceivedVals[1].GetReplicatedValueType(), csp::common::ReplicatedValueType::StringMap);
+    EXPECT_EQ(ReceivedVals[2].GetReplicatedValueType(), csp::common::ReplicatedValueType::Boolean);
+    EXPECT_EQ(ReceivedVals[3].GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(ReceivedVals[0].GetString(), OperationName);
+    EXPECT_EQ(ReceivedVals[1].GetStringMap(), ReferencesStringMap);
+    EXPECT_EQ(ReceivedVals[2].GetBool(), Success);
+    EXPECT_EQ(ReceivedVals[3].GetString(), StatusReason);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SingleEventMultiReciever)
@@ -312,14 +627,14 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SingleEventMultiReciever)
     const csp::common::Array<csp::common::ReplicatedValue> ValsToSend
         = { csp::common::ReplicatedValue { TestValValue }, csp::common::ReplicatedValue { 1.0f } };
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration(ReceiverId, EventName),
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName,
         [&NetworkEventPromise](const csp::common::NetworkEventData& NetworkEventData)
         { NetworkEventPromise.set_value(NetworkEventData.EventValues); });
 
     std::promise<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventPromise1;
     std::future<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventFuture1 = NetworkEventPromise1.get_future();
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration(ReceiverId2, EventName),
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId2, EventName,
         [&NetworkEventPromise1](const csp::common::NetworkEventData& NetworkEventData)
         { NetworkEventPromise1.set_value(NetworkEventData.EventValues); });
 
@@ -333,6 +648,67 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SingleEventMultiReciever)
     EXPECT_EQ(ReceivedVals[1].GetReplicatedValueType(), ReceivedVals1[1].GetReplicatedValueType());
     EXPECT_EQ(ReceivedVals[0].GetString(), ReceivedVals1[0].GetString());
     EXPECT_EQ(ReceivedVals[1].GetFloat(), ReceivedVals1[1].GetFloat());
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, SingleEventMultiRecieverAsyncCallCompleted)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* EventName = "AsyncCallCompleted";
+
+    const char* ReceiverId2 = "TestReceiverId2";
+
+    const char* OperationName = "DuplicateSpaceAsync";
+    const auto ReferencesStringMap
+        = csp::common::Map<csp::common::String, csp::common::ReplicatedValue> { { "SpaceId", csp::common::ReplicatedValue { "TestSpaceId" } } };
+    bool Success = true;
+    const char* StatusReason = "";
+
+    // Log in
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    auto [FlagSetResult] = AWAIT(Connection, SetAllowSelfMessagingFlag, true);
+
+    CreateTestSpaceAndEnterScope(SystemsManager.GetSpaceSystem(), Connection);
+
+    auto ErrorCallback = [](ErrorCode Error) { ASSERT_EQ(Error, ErrorCode::None); };
+
+    std::promise<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventPromise;
+    std::future<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventFuture = NetworkEventPromise.get_future();
+
+    const csp::common::Array<csp::common::ReplicatedValue> ValsToSend
+        = { csp::common::ReplicatedValue { OperationName }, csp::common::ReplicatedValue { ReferencesStringMap },
+              csp::common::ReplicatedValue { Success }, csp::common::ReplicatedValue { StatusReason } };
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, OperationName,
+        [&NetworkEventPromise](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
+        { NetworkEventPromise.set_value(NetworkEventData.EventValues); });
+
+    std::promise<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventPromise1;
+    std::future<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventFuture1 = NetworkEventPromise1.get_future();
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId2, OperationName,
+        [&NetworkEventPromise1](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
+        { NetworkEventPromise1.set_value(NetworkEventData.EventValues); });
+
+    SystemsManager.GetEventBus()->SendNetworkEventToClient(EventName, ValsToSend, Connection->GetClientId(), ErrorCallback);
+
+    // Both recievers should recieve this event
+    const csp::common::Array<csp::common::ReplicatedValue> ReceivedVals = NetworkEventFuture.get();
+    const csp::common::Array<csp::common::ReplicatedValue> ReceivedVals1 = NetworkEventFuture1.get();
+    EXPECT_EQ(ReceivedVals.Size(), ReceivedVals1.Size());
+    EXPECT_EQ(ReceivedVals[0].GetReplicatedValueType(), ReceivedVals1[0].GetReplicatedValueType());
+    EXPECT_EQ(ReceivedVals[1].GetReplicatedValueType(), ReceivedVals1[1].GetReplicatedValueType());
+    EXPECT_EQ(ReceivedVals[2].GetReplicatedValueType(), ReceivedVals1[2].GetReplicatedValueType());
+    EXPECT_EQ(ReceivedVals[3].GetReplicatedValueType(), ReceivedVals1[3].GetReplicatedValueType());
+    EXPECT_EQ(ReceivedVals[0].GetString(), ReceivedVals1[0].GetString());
+    EXPECT_EQ(ReceivedVals[1].GetStringMap(), ReceivedVals1[1].GetStringMap());
+    EXPECT_EQ(ReceivedVals[2].GetBool(), ReceivedVals1[2].GetBool());
+    EXPECT_EQ(ReceivedVals[3].GetString(), ReceivedVals1[3].GetString());
 }
 
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, MultiEventSingleReceiver)
@@ -367,10 +743,10 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, MultiEventSingleReceiver)
     const csp::common::Array<csp::common::ReplicatedValue> ValsToSend
         = { csp::common::ReplicatedValue { TestValValue }, csp::common::ReplicatedValue { 1.0f } };
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration(ReceiverId, EventName),
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName,
         [&NetworkEventPromise](const csp::common::NetworkEventData& NetworkEventData)
         { NetworkEventPromise.set_value(NetworkEventData.EventValues); });
-    SystemsManager.GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration(ReceiverId, EventName2),
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName2,
         [&NetworkEventPromise1](const csp::common::NetworkEventData& NetworkEventData)
         { NetworkEventPromise1.set_value(NetworkEventData.EventValues); });
 
@@ -389,6 +765,85 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, MultiEventSingleReceiver)
     SystemsManager.GetEventBus()->SendNetworkEventToClient(EventName2, ValsToSend, Connection->GetClientId(), ErrorCallback);
     const csp::common::Array<csp::common::ReplicatedValue> ReceivedVals1 = NetworkEventFuture1.get();
     EXPECT_EQ(ReceivedVals1.Size(), 2);
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, MultiAsyncCallCompletedEventSingleReceiver)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* Connection = SystemsManager.GetMultiplayerConnection();
+
+    const char* ReceiverId = "TestReceiverId";
+    const char* EventName = "AsyncCallCompleted";
+
+    const char* OperationName1 = "DuplicateSpaceAsync";
+    const char* OperationName2 = "CreateSnapshotAsync";
+
+    const auto ReferencesStringMap
+        = csp::common::Map<csp::common::String, csp::common::ReplicatedValue> { { "SpaceId", csp::common::ReplicatedValue { "TestSpaceId" } } };
+    bool Success = true;
+    const char* StatusReason = "";
+
+    // Log in
+    csp::common::String UserId;
+    LogInAsNewTestUser(UserSystem, UserId);
+
+    auto [FlagSetResult] = AWAIT(Connection, SetAllowSelfMessagingFlag, true);
+
+    CreateTestSpaceAndEnterScope(SystemsManager.GetSpaceSystem(), Connection);
+
+    auto ErrorCallback = [](ErrorCode Error) { ASSERT_EQ(Error, ErrorCode::None); };
+
+    std::promise<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventPromise;
+    std::future<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventFuture = NetworkEventPromise.get_future();
+
+    std::promise<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventPromise1;
+    std::future<csp::common::Array<csp::common::ReplicatedValue>> NetworkEventFuture1 = NetworkEventPromise1.get_future();
+
+    const csp::common::Array<csp::common::ReplicatedValue> Event1ValsToSend
+        = { csp::common::ReplicatedValue { OperationName1 }, csp::common::ReplicatedValue { ReferencesStringMap },
+              csp::common::ReplicatedValue { Success }, csp::common::ReplicatedValue { StatusReason } };
+
+    const csp::common::Array<csp::common::ReplicatedValue> Event2ValsToSend
+        = { csp::common::ReplicatedValue { OperationName2 }, csp::common::ReplicatedValue { ReferencesStringMap },
+              csp::common::ReplicatedValue { Success }, csp::common::ReplicatedValue { StatusReason } };
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, OperationName1,
+        [&NetworkEventPromise](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
+        { NetworkEventPromise.set_value(NetworkEventData.EventValues); });
+
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, OperationName2,
+        [&NetworkEventPromise1](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
+        { NetworkEventPromise1.set_value(NetworkEventData.EventValues); });
+
+    SystemsManager.GetEventBus()->SendNetworkEventToClient(EventName, Event1ValsToSend, Connection->GetClientId(), ErrorCallback);
+
+    const csp::common::Array<csp::common::ReplicatedValue> ReceivedVals = NetworkEventFuture.get();
+    EXPECT_EQ(ReceivedVals.Size(), 4);
+    EXPECT_EQ(ReceivedVals[0].GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(ReceivedVals[1].GetReplicatedValueType(), csp::common::ReplicatedValueType::StringMap);
+    EXPECT_EQ(ReceivedVals[2].GetReplicatedValueType(), csp::common::ReplicatedValueType::Boolean);
+    EXPECT_EQ(ReceivedVals[3].GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(ReceivedVals[0].GetString(), OperationName1);
+    EXPECT_EQ(ReceivedVals[1].GetStringMap(), ReferencesStringMap);
+    EXPECT_EQ(ReceivedVals[2].GetBool(), Success);
+    EXPECT_EQ(ReceivedVals[3].GetString(), StatusReason);
+
+    // The other event should not have been recieved as it has not been fired
+    EXPECT_TRUE(NetworkEventFuture1.wait_for(std::chrono::milliseconds { 0 }) != std::future_status::ready);
+
+    SystemsManager.GetEventBus()->SendNetworkEventToClient(EventName, Event2ValsToSend, Connection->GetClientId(), ErrorCallback);
+
+    const csp::common::Array<csp::common::ReplicatedValue> ReceivedVals1 = NetworkEventFuture1.get();
+    EXPECT_EQ(ReceivedVals1.Size(), 4);
+    EXPECT_EQ(ReceivedVals1[0].GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(ReceivedVals1[1].GetReplicatedValueType(), csp::common::ReplicatedValueType::StringMap);
+    EXPECT_EQ(ReceivedVals1[2].GetReplicatedValueType(), csp::common::ReplicatedValueType::Boolean);
+    EXPECT_EQ(ReceivedVals1[3].GetReplicatedValueType(), csp::common::ReplicatedValueType::String);
+    EXPECT_EQ(ReceivedVals1[0].GetString(), OperationName2);
+    EXPECT_EQ(ReceivedVals1[1].GetStringMap(), ReferencesStringMap);
+    EXPECT_EQ(ReceivedVals1[2].GetBool(), Success);
+    EXPECT_EQ(ReceivedVals1[3].GetString(), StatusReason);
 }
 
 CSP_PUBLIC_TEST(CSPEngine, EventBusTests, TestNoConnectionRegistration)
@@ -459,7 +914,7 @@ CSP_PUBLIC_TEST(DISABLED_CSPEngine, EventBusTests, TestMulticastEventToAllClient
     const char* PintRequestEventName = "EventPingRequest";
     const char* PingResponseEventName = "EventPingResponse";
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration(ReceiverId, PingResponseEventName),
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, PingResponseEventName,
         [&ReceivedPings, &TwoPingsResponsePromise](const csp::common::NetworkEventData& /*NetworkEventData*/)
         {
             std::cout << "Received Event Bus Ping." << std::endl;
@@ -488,11 +943,12 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventDispatchReplicatedValueException)
     // Ensure the MockLogger will ignore all logs except the one we care about
     EXPECT_CALL(MockLogger.MockLogCallback, Call(::testing::_, ::testing::_)).Times(::testing::AnyNumber());
 
-    const csp::common::String Error = "NetworkEventBus: Failed to deserialize event 'AsyncCallCompleted'. Registered events will not be fired.";
-    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
-
     const char* ReceiverId = "TestReceiverId";
     const char* EventName = "AsyncCallCompleted";
+
+    const csp::common::String Error
+        = fmt::format("NetworkEventBus: Failed to deserialize event '{}'. Registered events will not be fired.", EventName).c_str();
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
 
     int64_t TestValue = 5;
 
@@ -518,13 +974,12 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, EventDispatchReplicatedValueException)
     // Note: There is currently no way to observe the error with the current api and so we are having to check for the error log instead.
     const csp::common::Array<csp::common::ReplicatedValue> EventData = { csp::common::ReplicatedValue { TestValue } };
 
-    SystemsManager.GetEventBus()->ListenNetworkEvent(csp::multiplayer::NetworkEventRegistration(ReceiverId, EventName),
-        [&NetworkEventPromise](const csp::common::NetworkEventData& NetworkEventData)
-        {
-            NetworkEventPromise.set_value(NetworkEventData.EventValues);
-        });
+    SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, EventName,
+        [&NetworkEventPromise](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
+        { NetworkEventPromise.set_value(NetworkEventData.EventValues); });
 
     SystemsManager.GetEventBus()->SendNetworkEventToClient(EventName, EventData, Connection->GetClientId(), ErrorCallback);
 
-    EXPECT_NE(NetworkEventFuture.wait_for(5s), std::future_status::ready) << "Network Event will not be sent due to ReplicatedValueException being thrown for invalid ReplicatedValue type.";
+    EXPECT_NE(NetworkEventFuture.wait_for(5s), std::future_status::ready)
+        << "Network Event will not be sent due to ReplicatedValueException being thrown for invalid ReplicatedValue type.";
 }

--- a/Tests/src/PublicAPITests/EventBusTests.cpp
+++ b/Tests/src/PublicAPITests/EventBusTests.cpp
@@ -272,7 +272,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterMultiStopAll)
     using namespace csp::multiplayer;
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
-    
+
     const char* ReceiverId1 = "TestReceiverId1";
     const char* EventName = "TestEventName";
     const char* OperationName = "TestEventName";
@@ -295,7 +295,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RegisterMultiStopAll)
     EXPECT_FALSE(RemovedRegistration.ToList().Contains(NetworkEventRegistration { ReceiverId1, OperationName }));
 }
 
-CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEvent)
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullReceiverIdForEventRegistration)
 {
     using namespace csp::multiplayer;
 
@@ -303,11 +303,35 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEvent)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    const csp::common::String Error = "NetworkEventBus::ListenCustomNetworkEvent: Expected non-null callback. Registration denied.";
+    const char* ReceiverId = "";
+    const char* EventName = "TestEventName";
+
+    const csp::common::String Error
+        = fmt::format("NetworkEventBus: Expected non-empty EventReceiverId for event {}. Registration denied.", EventName)
+              .c_str();
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
+
+    SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName, [](const csp::common::NetworkEventData& /*NetworkEventData*/) { });
+    auto AllRegistrations = SystemsManager.GetEventBus()->AllRegistrations();
+    EXPECT_FALSE(std::any_of(AllRegistrations.begin(), AllRegistrations.end(),
+        [ReceiverId](const NetworkEventRegistration& Registration) { return Registration.EventReceiverId == ReceiverId; }));
+}
+
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullCallback)
+{
+    using namespace csp::multiplayer;
+
+    RAIIMockLogger MockLogger {};
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
 
     const char* ReceiverId = "TestReceiverId";
     const char* EventName = "TestEventName";
+
+    const csp::common::String Error
+        = fmt::format("NetworkEventBus: Expected non-null callback for event {} with EventReceiverId: {}. Registration denied.", EventName, ReceiverId)
+              .c_str();
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
 
     SystemsManager.GetEventBus()->ListenCustomNetworkEvent(ReceiverId, EventName, nullptr);
     auto AllRegistrations = SystemsManager.GetEventBus()->AllRegistrations();
@@ -315,7 +339,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEvent)
         [ReceiverId](const NetworkEventRegistration& Registration) { return Registration.EventReceiverId == ReceiverId; }));
 }
 
-CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEventAsyncCallCompleted)
+CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullCallbackAsyncCallCompleted)
 {
     using namespace csp::multiplayer;
 
@@ -323,11 +347,13 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNullEventAsyncCallCompleted)
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    const csp::common::String Error = "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-null callback. Registration denied.";
-    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
-
     const char* ReceiverId = "TestReceiverId";
     const char* OperationName = "DuplicateSpaceAsync";
+
+    const csp::common::String Error
+        = fmt::format("NetworkEventBus: Expected non-null callback for event {} with EventReceiverId: {}. Registration denied.", OperationName, ReceiverId)
+              .c_str();
+    EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
 
     SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, OperationName, nullptr);
 
@@ -345,7 +371,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectNoOperationNameAsyncCallComplete
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();
 
-    const csp::common::String Error = "NetworkEventBus::ListenAsyncCallCompletedEvent: Expected non-empty OperationName. Registration denied.";
+    const csp::common::String Error = "NetworkEventBus: Expected non-empty name for event registration. Registration denied.";
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Error, Error)).Times(1);
 
     const char* ReceiverId = "TestReceiverId";
@@ -380,7 +406,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectDuplicateRegistration)
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success2)).Times(1);
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success3)).Times(1);
 
-    const csp::common::String Error = fmt::format("NetworkEventBus::ListenCustomNetworkEvent: Attempting to register a duplicate {} network event "
+    const csp::common::String Error = fmt::format("NetworkEventBus: Attempting to register a duplicate {} network event "
                                                   "with EventReceiverId: {}. Registration denied.",
         EventName, ReceiverId2)
                                           .c_str();
@@ -423,8 +449,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectDuplicateRegistrationAsyncCallCo
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Verbose, Success3)).Times(1);
 
     const csp::common::String Error
-        = fmt::format("NetworkEventBus::ListenAsyncCallCompletedEvent: Attempting to register a duplicate {} network event "
-                      "with EventReceiverId: {}. Registration denied.",
+        = fmt::format("NetworkEventBus: Attempting to register a duplicate {} network event with EventReceiverId: {}. Registration denied.",
             OperationName1, ReceiverId2)
               .c_str();
     EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Warning, Error)).Times(1);
@@ -490,7 +515,7 @@ CSP_PUBLIC_TEST(CSPEngine, EventBusTests, RejectUnknownDeregistrationAsyncCallCo
 
     const csp::common::String Error
         = fmt::format("NetworkEventBus::StopListenAsyncCallCompletedEvent: Could not find async call completed network event for registration with "
-                        "Event ReceiverId: {} for Operation: {}. Deregistration denied.",
+                      "Event ReceiverId: {} for Operation: {}. Deregistration denied.",
             ReceiverId, OperationName)
               .c_str();
 

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -19,6 +19,7 @@
 #include "CSP/Common/SharedEnums.h"
 #include "CSP/Multiplayer/MultiPlayerConnection.h"
 #include "CSP/Multiplayer/MultiplayerHubMethods.h"
+#include "CSP/Multiplayer/NetworkEventBus.h"
 #include "CSP/Systems/Assets/AssetSystem.h"
 #include "CSP/Systems/Spaces/SpaceSystem.h"
 #include "CSP/Systems/SystemsManager.h"
@@ -602,7 +603,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBufferWithThumbnailT
 
     auto UploadFileData = OpenFile("assets/OKO.png");
     ASSERT_NE(UploadFileData, std::nullopt);
-    
+
     BufferAssetDataSource SpaceThumbnail;
     SpaceThumbnail.Buffer = UploadFileData->data();
     SpaceThumbnail.BufferLength = UploadFileData->size();
@@ -669,7 +670,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithInvalidBufferWithThu
 
     auto UploadFileData = OpenFile("assets/OKO.png");
     ASSERT_NE(UploadFileData, std::nullopt);
-    
+
     BufferAssetDataSource BufferSource;
     BufferSource.Buffer = UploadFileData->data();
     BufferSource.BufferLength = UploadFileData->size();
@@ -724,10 +725,10 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, CreateSpaceWithBufferWithBulkInvite
 
     // Log in
     LogInAsNewTestUser(UserSystem, UserId);
-    
+
     auto UploadFileData = OpenFile("assets/OKO.png");
     ASSERT_NE(UploadFileData, std::nullopt);
-    
+
     BufferAssetDataSource BufferSource;
     BufferSource.Buffer = UploadFileData->data();
     BufferSource.BufferLength = UploadFileData->size();
@@ -1488,7 +1489,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, UpdateUserRolesTest)
     // Ensure alt test account can join space
     {
         std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
@@ -2126,7 +2127,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetAcceptedUserInvitesTest)
     LogIn(UserSystem, User1Id, User1.Email, GeneratedTestAccountPassword);
 
     std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     ASSERT_EQ(EnterSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
@@ -2228,7 +2229,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, GetPublicSpaceMetadataTest)
     LogIn(UserSystem, AltUserId, AltUser.Email, GeneratedTestAccountPassword);
 
     std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     auto [Result] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
 
@@ -2535,7 +2536,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
         EXPECT_FALSE(SpaceSystem->IsInSpace());
 
         std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
@@ -2556,7 +2557,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceTest)
 
     {
         std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
@@ -2601,7 +2602,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsNonModeratorTest)
 
     {
         std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
@@ -2659,7 +2660,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, EnterSpaceAsModeratorTest)
     // Note the space is now out of date and does not have the new user in its lists
     {
         std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
@@ -3199,7 +3200,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceTest)
 
         // Ensure we can enter the newly duplicated Space
         std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, NewSpace.Id, RealtimeEngine.get());
         ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
@@ -3266,11 +3267,13 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceAsyncTest)
         std::promise<std::tuple<String, String, String>> AsyncCallCompletedPromise;
         std::future<std::tuple<String, String, String>> AsyncCallCompletedFuture = AsyncCallCompletedPromise.get_future();
 
-        auto AsyncCallCompletedCallback = [&](const csp::common::AsyncCallCompletedEventData& NetworkEventData) {
-            AsyncCallCompletedPromise.set_value({ NetworkEventData.OperationName, NetworkEventData.ReferenceId, NetworkEventData.ReferenceType });
-        };
+        const char* ReceiverId = "TestReceiverId";
+        const char* EventName = "DuplicateSpaceAsync";
 
-        SpaceSystem->SetAsyncCallCompletedCallback(AsyncCallCompletedCallback);
+        auto AsyncCallCompletedCallback = [&](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
+        { AsyncCallCompletedPromise.set_value({ NetworkEventData.OperationName, NetworkEventData.ReferenceId, NetworkEventData.ReferenceType }); };
+
+        SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, EventName, AsyncCallCompletedCallback);
 
         SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
 
@@ -3300,7 +3303,7 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceAsyncTest)
     // Ensure we can enter the newly duplicated Space
     {
         std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, NewSpaceId, RealtimeEngine.get());
         ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
@@ -3361,7 +3364,7 @@ TEST_P(ExitSpaceRealtimeEngine, ExitSpaceRealtimeEngineTest)
     }
 
     std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType) };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     auto [Result] = AWAIT(SpaceSystem, EnterSpace, Space.Id, RealtimeEngine.get());
 
@@ -3449,7 +3452,7 @@ TEST_P(EnterSpaceWhenGuest, EnterSpaceWhenGuestTest)
     LogInAsGuest(UserSystem, GuestUserId);
 
     std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType::Online) };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
@@ -3502,7 +3505,7 @@ TEST_P(EnterSpaceWhenUninvited, EnterSpaceWhenUninvitedTest)
     LogIn(UserSystem, UninvitedUserId, UninvitedUser.Email, GeneratedTestAccountPassword);
 
     std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType::Online) };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
@@ -3561,7 +3564,7 @@ TEST_P(EnterSpaceWhenInvited, EnterSpaceWhenInvitedTest)
     LogIn(UserSystem, InvitedUserId, InvitedUser.Email, GeneratedTestAccountPassword);
 
     std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType::Online) };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
@@ -3607,7 +3610,7 @@ TEST_P(EnterSpaceWhenCreator, EnterSpaceWhenCreatorTest)
     CreateSpace(SpaceSystem, UniqueSpaceName.c_str(), TestSpaceDescription, SpacePermission, nullptr, nullptr, nullptr, nullptr, CreatedSpace);
 
     std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType::Online) };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();
@@ -3664,7 +3667,7 @@ TEST_P(EnterSpaceWhenBanned, EnterSpaceWhenBannedTest)
 
     {
         std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType::Online) };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         // In order to ban the user, they have to have entered the space. (This seems like an underthought limitation)
         auto [EnterSpaceResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
@@ -3684,7 +3687,7 @@ TEST_P(EnterSpaceWhenBanned, EnterSpaceWhenBannedTest)
         LogIn(UserSystem, BannedUserId, BannedUser.Email, GeneratedTestAccountPassword);
 
         std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType::Online) };
-        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+        RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
         testing::internal::CaptureStderr();
         auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, CreatedSpace.Id, RealtimeEngine.get());
@@ -3815,7 +3818,7 @@ TEST_P(EnterSpaceOnlineOffline, EnterSpaceOnlineOfflineTest)
     LogInAsGuest(UserSystem, GuestUserId, LoginWithMultiplayerConnection);
 
     std::unique_ptr<csp::common::IRealtimeEngine> RealtimeEngine { SystemsManager.MakeRealtimeEngine(RealtimeEngineType) };
-    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) {});
+    RealtimeEngine->SetEntityFetchCompleteCallback([](uint32_t) { });
 
     // Attempt to enter the space and check the expected result
     testing::internal::CaptureStderr();

--- a/WasmTesting/html_tests/SendReceiveNetworkEvent.html
+++ b/WasmTesting/html_tests/SendReceiveNetworkEvent.html
@@ -67,14 +67,13 @@
                  
         const receiverId = "Id";
         const eventName = "EventName";
-        const networkEventRegistration = Multiplayer.NetworkEventRegistration.create_eventReceiverId_eventName(receiverId, eventName);
-
+        
         const replicatedValues = Common.Array.ofcsp_common_ReplicatedValue()
  
         function sendAndWaitForEvent() {
           return new Promise((resolve, reject) => {
             // Register for "EventName" event
-            const success = eventBus.listenNetworkEvent(networkEventRegistration, (ab, networkEventData) => {
+            const success = eventBus.listenCustomNetworkEvent(receiverId, eventName, (ab, networkEventData) => {
                 console.log("Received event:", eventName);
                 resolve(networkEventData);
               }


### PR DESCRIPTION
NetworkEventBus
Add new dedicated Listen and StopListen methods for our event specializations, as well as dedicated std::unordered_map containers and callbacks for each event type.

Event Specializations are:
- `AccessControlChanged`
- `AssetDetailBlobChanged`
- `AsyncCallCompleted`
- `Conversation`
- `SequenceChanged`

The existing `ListenNetworkEvent` and `StopListenNetworkEvent` methods have been renamed to `ListenCustomNetworkEvent` and `StopListenNetworkEvent` to better reflect their purpose as a means for clients to register their own custom events. In addition, rather than take a `NetworkEventRegistration` as an argument they now take `EventReceiverId` and `EventName` strings directly. This aligns usage with the new event specialization methods.

The `NetworkEventBus` is used internally by several of our systems. These were all using the old `ListenNetworkEvent` method and then casting the resultant `NetworkEventData` to the appropriate event data type. These systems have been updated to call the new event specialization methods directly, removing the need to perform a static cast.

The `SpaceSystem` has a `DuplicateSpaceAsync` method which fires the `AsyncCallCompleted` event on completion of the operation. The `SpaceSystem` had dedicated API for registering a callback with this event and for responding to its firing. Now that the event specializations have been added to the `NetworkEventBus`, including Listen and StopListen methods for `AsyncCallCompleted`, the `SpaceSystem` no longer requires this functionality and it has been removed.

The existing `NetworkEventBus` tests have been updated to reflect the change to the `ListenNetworkEvent` and `StopListenNetworkEvent` method signatures. New tests have also been added to verify that the new Event Specialization methods work correctly. I have elected to test just those related to `AsyncCallCompleted` as they all delegate to shared logic internally.

In addition to the above I have:
- updated the `NetworkEventManagerImpl::SendNetworkEvent()` method to add support for deserialising the `StringMap` replicated value type.
- updated one of the `SpaceSystem` tests which was using the legacy AsyncCallCompleted methods.

**Breaking changes:**
- The NetworkEventBus `ListenNetworkEvent(NeworkEventRegistration)` > `ListenCustomNetworkEvent(String EventReceiverId, String EventName)`.
- The NetworkEventBus `StopListenNeworkEvent(NeworkEventRegistration)` > `StopListenNeworkEvent(String EventReceiverId, String EventName)`.
- Removed the `SetAsyncCallCompletedCallback()` and `OnAsyncCallCompletedEvent()` methods from the `SpaceSystem`.