### PR TITLE
[OF-1835] chore: Remove handling for old AsyncCallCompleted event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. For compiled binaries, deployment packages, and version-specific artifacts, please visit our [GitHub Releases](https://github.com/magnopus-opensource/connected-spaces-platform/releases).
 
+## [6.47.0]
+
+###  🔨 🔨 Chore
+
+- [OF-1835] chore: Remove handling for old AsyncCallCompleted event data structure. By@MAG-AdamThorn
+  Remove backwards compatibility logic for legacy `AsyncCallCompleted` event data structure.
+
 ## [6.46.0]
 
 ### 🔌 API Changes

--- a/Library/include/CSP/Common/NetworkEventData.h
+++ b/Library/include/CSP/Common/NetworkEventData.h
@@ -149,30 +149,8 @@ public:
 class CSP_API AsyncCallCompletedEventData : public NetworkEventData
 {
 public:
-    /*
-    Please note:
-    The structure of the AsyncCallCompleted event has been updated by the backend services to include some additional properties.
-    ReferenceId and ReferenceType are being replaced by a Map called References, and new Status and StatusReason properties have been added.
-    This change is currently behind an backend feature flag, ready to be switched over. As this will be a breaking change we have added these new
-    properties to the event, but will temporarily be keeping the old ones. We will populate both the old and new properties when we deserialise the
-    SignalR event values, which means that Clients will continue to be able to consume the event as before.
-
-    Once this CSP change has been adopted by clients and is confirmed working, we can:
-    - Get the backend services to update the flag and send the new AsyncCallCompletedEvent structure.
-    - Ask client teams to update to use the new event properties.
-    - Remove the old event properties and temporary logic, including this comment - this last step is captured by ticket OF-1835.
-    */
-
     /// @brief The name of the async operation that has been completed.
     csp::common::String OperationName;
-
-    /// @brief An Id related to the async operation that has been completed.
-    /// This could for example be a group Id, if this were an async duplicate group operation.
-    csp::common::String ReferenceId;
-
-    /// @brief The type that the Id represents.
-    /// In the previous example this would be "GroupId".
-    csp::common::String ReferenceType;
 
     /// @brief A string map containing reference information related to this operation.
     /// Each key:value pair in this map represents a reference name and its corresponding Id.

--- a/Library/src/Multiplayer/NetworkEventSerialisation.cpp
+++ b/Library/src/Multiplayer/NetworkEventSerialisation.cpp
@@ -426,52 +426,17 @@ csp::common::AsyncCallCompletedEventData DeserializeAsyncCallCompletedEvent(
     csp::common::AsyncCallCompletedEventData ParsedEvent {};
     PopulateCommonEventData(EventValues, ParsedEvent, LogSystem);
 
-    /*
-    Please note:
-    The structure of the AsyncCallCompleted event has been updated by the backend services to include some additional properties.
-    ReferenceId and ReferenceType are being replaced by a Map called References, and new Status and StatusReason properties have been added.
-    This change is currently behind an backend feature flag, ready to be switched over. As this will be a breaking change we have added these
-    new properties to the event, but will temporarily be keeping the old ones. We are populating both the old and new properties when we
-    deserialise the SignalR event values, which means that Clients will continue to be able to consume the event as before.
-
-    Once this CSP change has been adopted by clients and is confirmed working, we can:
-    - Get the backend services to update the flag and send the new AsyncCallCompletedEvent structure.
-    - Ask client teams to update to use the new event properties.
-    - Remove the old event properties and temporary logic, including this comment - this last step is captured by ticket OF-1835.
-    */
-
     ParsedEvent.OperationName = ParsedEvent.EventValues[0].GetString();
 
-    // Check to see if this event has the new structure that includes a Reference map in place of the old ReferenceId and ReferenceType. As part of
-    // the transition, we will populate both the new and old properties to maintain backwards compatibility with clients.
-    bool IsNewReferenceMapFormat = ParsedEvent.EventValues[1].GetReplicatedValueType() == csp::common::ReplicatedValueType::StringMap;
+    const auto& ReferencesStringMap = ParsedEvent.EventValues[1].GetStringMap();
 
-    if (IsNewReferenceMapFormat)
+    for (const auto& [Key, ReplicatedValue] : ReferencesStringMap)
     {
-        const auto& ReferencesStringMap = ParsedEvent.EventValues[1].GetStringMap();
-
-        for (const auto& [Key, ReplicatedValue] : ReferencesStringMap)
-        {
-            ParsedEvent.References[Key] = ReplicatedValue.GetString();
-
-            // For backwards compatibility, we will also populate the old ReferenceId and ReferenceType properties.
-            // Please note: As part of this change the backend services have changed the ReferenceType from "GroupId" > "SpaceId".
-            if (Key == "SpaceId")
-            {
-                ParsedEvent.ReferenceId = ReplicatedValue.GetString();
-                ParsedEvent.ReferenceType = "GroupId";
-            }
-        }
-
-        ParsedEvent.Success = ParsedEvent.EventValues[2].GetBool();
-        ParsedEvent.StatusReason = ParsedEvent.EventValues[3].GetString();
+        ParsedEvent.References[Key] = ReplicatedValue.GetString();
     }
-    else
-    {
-        // This event uses the old structure with ReferenceId and ReferenceType properties, so we will populate those for backwards compatibility.
-        ParsedEvent.ReferenceId = ParsedEvent.EventValues[1].GetString();
-        ParsedEvent.ReferenceType = ParsedEvent.EventValues[2].GetString();
-    }
+
+    ParsedEvent.Success = ParsedEvent.EventValues[2].GetBool();
+    ParsedEvent.StatusReason = ParsedEvent.EventValues[3].GetString();
 
     return ParsedEvent;
 }

--- a/Tests/src/InternalTests/NetworkEventSerialisationTests.cpp
+++ b/Tests/src/InternalTests/NetworkEventSerialisationTests.cpp
@@ -50,35 +50,7 @@ std::vector<signalr::value> ConstructEventValues(const std::map<uint64_t, signal
 }
 }
 
-CSP_INTERNAL_TEST(CSPEngine, NetworkEventSerialisationTests, DeserializeAsyncCallCompletedEventOldStructureTest)
-{
-    csp::common::LogSystem LogSystem;
-
-    const csp::common::String OperationName("DuplicateSpace");
-    const csp::common::String ReferenceId("new_space-abc-123");
-    const csp::common::String ReferenceType("GroupId");
-
-    // Components map:
-    // 0: OperationName (ItemComponentDataType::STRING)
-    // 1: ReferenceId (ItemComponentDataType::STRING)
-    // 2: ReferenceType (ItemComponentDataType::STRING)
-    std::map<uint64_t, signalr::value> Components;
-
-    Components[0] = ConstructComponentElement(DataTypeString, signalr::value(OperationName.c_str()));
-    Components[1] = ConstructComponentElement(DataTypeString, signalr::value(ReferenceId.c_str()));
-    Components[2] = ConstructComponentElement(DataTypeString, signalr::value(ReferenceType.c_str()));
-
-    // Construct EventValues vector: [ EventName, SenderClientId, Recipient (null), Components map ]
-    std::vector<signalr::value> EventValues = ConstructEventValues(Components);
-
-    csp::common::AsyncCallCompletedEventData Parsed = DeserializeAsyncCallCompletedEvent(EventValues, LogSystem);
-
-    EXPECT_EQ(Parsed.OperationName, OperationName);
-    EXPECT_EQ(Parsed.ReferenceId, ReferenceId);
-    EXPECT_EQ(Parsed.ReferenceType, ReferenceType);
-}
-
-CSP_INTERNAL_TEST(CSPEngine, NetworkEventSerialisationTests, DeserializeAsyncCallCompletedEventNewStructureTest)
+CSP_INTERNAL_TEST(CSPEngine, NetworkEventSerialisationTests, DeserializeAsyncCallCompletedEventTest)
 {
     csp::common::LogSystem LogSystem;
 
@@ -114,7 +86,7 @@ CSP_INTERNAL_TEST(CSPEngine, NetworkEventSerialisationTests, DeserializeAsyncCal
 
     csp::common::AsyncCallCompletedEventData Parsed = DeserializeAsyncCallCompletedEvent(EventValues, LogSystem);
 
-    // Verify new event structure was parsed corrctly
+    // Verify event structure was parsed corrctly
     EXPECT_EQ(Parsed.OperationName, OperationName);
     EXPECT_TRUE(Parsed.Success);
     EXPECT_EQ(Parsed.StatusReason, StatusReason);
@@ -123,9 +95,4 @@ CSP_INTERNAL_TEST(CSPEngine, NetworkEventSerialisationTests, DeserializeAsyncCal
     ASSERT_TRUE(Parsed.References.HasKey("OriginalSpaceId"));
     EXPECT_EQ(Parsed.References["SpaceId"], NewSpaceId);
     EXPECT_EQ(Parsed.References["OriginalSpaceId"], OriginalSpaceId);
-
-    // Check backwards compatibility
-    // If the References map contains the key "SpaceId", the deserializer sets the old ReferenceId and ReferenceType properties
-    EXPECT_EQ(Parsed.ReferenceId, NewSpaceId);
-    EXPECT_EQ(Parsed.ReferenceType, "GroupId"); // The key used to be "GroupId"
 }

--- a/Tests/src/PublicAPITests/SpaceSystemTests.cpp
+++ b/Tests/src/PublicAPITests/SpaceSystemTests.cpp
@@ -3264,14 +3264,14 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceAsyncTest)
 
     // Attempt to duplicate space asynchrously
     {
-        std::promise<std::tuple<String, String, String>> AsyncCallCompletedPromise;
-        std::future<std::tuple<String, String, String>> AsyncCallCompletedFuture = AsyncCallCompletedPromise.get_future();
+        std::promise<std::tuple<String, String>> AsyncCallCompletedPromise;
+        std::future<std::tuple<String, String>> AsyncCallCompletedFuture = AsyncCallCompletedPromise.get_future();
 
         const char* ReceiverId = "TestReceiverId";
         const char* EventName = "DuplicateSpaceAsync";
 
         auto AsyncCallCompletedCallback = [&](const csp::common::AsyncCallCompletedEventData& NetworkEventData)
-        { AsyncCallCompletedPromise.set_value({ NetworkEventData.OperationName, NetworkEventData.ReferenceId, NetworkEventData.ReferenceType }); };
+        { AsyncCallCompletedPromise.set_value({ NetworkEventData.OperationName, NetworkEventData.References["SpaceId"] }); };
 
         SystemsManager.GetEventBus()->ListenAsyncCallCompletedEvent(ReceiverId, EventName, AsyncCallCompletedCallback);
 
@@ -3290,14 +3290,12 @@ CSP_PUBLIC_TEST(CSPEngine, SpaceSystemTests, DuplicateSpaceAsyncTest)
 
         ASSERT_NE(Status, std::future_status::timeout) << "The DuplicateSpaceAsync operation timed out after 30 seconds.";
 
-        std::tuple<String, String, String> AsyncCallResult = AsyncCallCompletedFuture.get();
+        std::tuple<String, String> AsyncCallResult = AsyncCallCompletedFuture.get();
 
         String OperationName = std::get<0>(AsyncCallResult);
-        String ReferenceType = std::get<2>(AsyncCallResult);
         NewSpaceId = std::get<1>(AsyncCallResult);
 
         ASSERT_TRUE(OperationName == "DuplicateSpaceAsync");
-        ASSERT_TRUE(ReferenceType == "GroupId");
     }
 
     // Ensure we can enter the newly duplicated Space


### PR DESCRIPTION
The CHS team updated the `AsyncCallCompleted` event data structure. In order to support both event data structures CSP added backwards compatibility logic. Now that client teams have migrated to the new structure we can remove this backwards compatibility logic.