### PR TITLE
[OF-1888] Built-in component schemas defined in JSON (w/ schema addditions)

### DIFF
--- a/Library/include/CSP/Multiplayer/ComponentProperty.h
+++ b/Library/include/CSP/Multiplayer/ComponentProperty.h
@@ -23,6 +23,18 @@
 namespace csp::multiplayer
 {
 
+/// @brief A named value option for a property, pairing a human-readable label with its
+/// corresponding replicated value.
+class CSP_API SchemaOption
+{
+public:
+    csp::common::String Name;
+    csp::common::ReplicatedValue Value;
+
+    bool operator==(const SchemaOption& Other) const;
+    bool operator!=(const SchemaOption& Other) const;
+};
+
 /// @brief Represents an individual data field, or "property", within a component schema,
 /// consisting of a stable ID/key, a type kind and default value (via ReplicatedValue),
 /// and other metadata.
@@ -37,7 +49,7 @@ public:
     /// multiplayer connection.
     KeyType Key;
 
-    /// @brief A human-readable name describing this propery (in `camelCase`).
+    /// @brief A human-readable name describing this property (in `camelCase`).
     /// Must be unique within the component (two properties should not have the same name).
     /// This name will be used for generating script bindings i.e. a property with this name will
     /// be exposed on the component in scripts.
@@ -47,6 +59,30 @@ public:
     /// property, which is considered static i.e. if the value is a `float`, it can't be later
     /// changed to hold a `String`.
     csp::common::ReplicatedValue DefaultValue;
+
+    /// @brief Optional human-readable description of this property.
+    csp::common::String Description;
+
+    /// @brief Whether this property is exposed to scripting. Defaults to true.
+    bool IsScriptable = true;
+
+    /// @brief Whether this property is deprecated.
+    bool IsDeprecated = false;
+
+    /// @brief Whether this key slot is reserved for wire compatibility with no intended API surface.
+    bool IsReserved = false;
+
+    /// @brief Lower bound of the valid range. InvalidType indicates no range is set.
+    csp::common::ReplicatedValue RangeMin;
+
+    /// @brief Upper bound of the valid range. Only meaningful when RangeMin is set.
+    csp::common::ReplicatedValue RangeMax;
+
+    /// @brief Named discrete values for this property. Empty if not enum-valued.
+    csp::common::Array<SchemaOption> Options;
+
+    /// @brief Returns true if a range constraint is set on this property.
+    bool HasRange() const;
 
     bool operator==(const ComponentProperty& Other) const;
     bool operator!=(const ComponentProperty& Other) const;

--- a/Library/include/CSP/Multiplayer/ComponentSchema.h
+++ b/Library/include/CSP/Multiplayer/ComponentSchema.h
@@ -83,10 +83,10 @@ CSP_START_IGNORE
 /// Entries that fail to parse are skipped with a warning; valid entries in the same document are still returned.
 /// @param JsonDocuments One or more JSON documents, each containing an array of schema objects.
 /// The list is a wrapper generator workaround for passing large strings; in practice a single element is expected.
-/// @param LogSystem Logger for reporting skipped entries.
+/// @param LogSystem Optional logger. If provided, logs entries skipped due to parse errors.
 /// @return An array containing all successfully parsed schemas.
 csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
-    const csp::common::List<csp::common::String>& JsonDocuments, csp::common::LogSystem& LogSystem);
+    const csp::common::List<csp::common::String>& JsonDocuments, csp::common::LogSystem* LogSystem = nullptr);
 
 /// @brief Checks whether a schema update is compatible with an existing schema.
 /// @param Original The existing schema to check against.

--- a/Library/include/CSP/Multiplayer/ComponentSchema.h
+++ b/Library/include/CSP/Multiplayer/ComponentSchema.h
@@ -57,6 +57,21 @@ public:
     /// @brief The properties of this component
     csp::common::Array<ComponentProperty> Properties;
 
+    /// @brief Optional human-readable description of this component type.
+    csp::common::String Description;
+
+    /// @brief Whether this component is exposed to scripting. Defaults to true.
+    /// When false, no properties on this component are scriptable regardless of their individual
+    /// @ref ComponentProperty::IsScriptable setting. When true, individual properties may still
+    /// opt out via their own @ref ComponentProperty::IsScriptable flag.
+    bool IsScriptable = true;
+
+    /// @brief Whether this component type slot is reserved for wire compatibility with no intended API surface.
+    bool IsReserved = false;
+
+    /// @brief Whether this component is deprecated.
+    bool IsDeprecated = false;
+
     bool operator==(const ComponentSchema& Other) const;
     bool operator!=(const ComponentSchema& Other) const;
 };

--- a/Library/include/CSP/Multiplayer/Components/AIChatbotComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AIChatbotComponent.h
@@ -50,8 +50,6 @@ enum class AIChatbotVisualState
 class CSP_API AIChatbotSpaceComponent : public ComponentBase, public IPositionComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     AIChatbotSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);
 
     /// @brief Creates an AI chatbot space component using the provided schema if it is compatible with the built-in schema.

--- a/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h
@@ -80,8 +80,6 @@ class CSP_API AnimatedModelSpaceComponent : public ComponentBase,
                                             public IRenderBehaviourComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the animated model space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     AnimatedModelSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/AudioSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AudioSpaceComponent.h
@@ -62,8 +62,6 @@ enum class AudioPropertyKeys : uint16_t
 class CSP_API AudioSpaceComponent : public ComponentBase, public IAudioControlComponent, public IEnableableComponent, public IPositionComponent, public IThirdPartyComponentRef
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the audio space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     AudioSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/AvatarSpaceComponent.h
@@ -58,8 +58,6 @@ enum class AvatarComponentPropertyKeys : uint16_t
 class CSP_API AvatarSpaceComponent : public ComponentBase, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the avatar space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     AvatarSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ButtonSpaceComponent.h
@@ -52,8 +52,6 @@ enum class ButtonPropertyKeys : uint16_t
 class CSP_API ButtonSpaceComponent : public ComponentBase, public IEnableableComponent, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the button space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     ButtonSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h
@@ -58,8 +58,6 @@ class CSP_API CinematicCameraSpaceComponent : public ComponentBase,
                                               public IEnableableComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the CinematicCamera space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     CinematicCameraSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/CollisionSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/CollisionSpaceComponent.h
@@ -67,8 +67,6 @@ enum class CollisionMode
 class CSP_API CollisionSpaceComponent : public ComponentBase, public IThirdPartyComponentRef, public ITransformComponent, public IEnableableComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the collision space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     CollisionSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ConversationSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ConversationSpaceComponent.h
@@ -85,8 +85,6 @@ class CSP_API ConversationSpaceComponent : public ComponentBase, public IPositio
     CSP_END_IGNORE
 
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the conversation component, and associates it with the specified Parent space entity.
     /// This constructor should not be called directly. Instead, use the SpaceEntity::AddComponent function.
     /// @param Parent csp::multiplayer::SpaceEntity* : The Space entity that owns this component. This will also register the component to the entity.

--- a/Library/include/CSP/Multiplayer/Components/CustomSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/CustomSpaceComponent.h
@@ -41,8 +41,6 @@ enum class CustomComponentPropertyKeys : uint16_t
 class CSP_API CustomSpaceComponent : public ComponentBase
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the custom space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     CustomSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ECommerceSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ECommerceSpaceComponent.h
@@ -41,8 +41,6 @@ enum class ECommercePropertyKeys : uint16_t
 class CSP_API ECommerceSpaceComponent : public ComponentBase, public IPositionComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the ECommerce space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     ECommerceSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h
@@ -57,8 +57,6 @@ enum class ExternalLinkPropertyKeys : uint16_t
 class CSP_API ExternalLinkSpaceComponent : public ComponentBase, public IEnableableComponent, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Creates an external link component that can be added to an existing space entity.
     /// @param Parent - The space entity to which this new component will belong to.
     ExternalLinkSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h
@@ -48,8 +48,6 @@ enum class FiducialMarkerPropertyKeys : uint16_t
 class CSP_API FiducialMarkerSpaceComponent : public ComponentBase, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the fiducial marker space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     FiducialMarkerSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/FogSpaceComponent.h
@@ -62,8 +62,6 @@ enum class FogMode
 class CSP_API FogSpaceComponent : public ComponentBase, public IThirdPartyComponentRef, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the fog space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     FogSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h
@@ -61,8 +61,6 @@ class CSP_API GaussianSplatSpaceComponent : public ComponentBase,
 
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the Gaussian Splat component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     GaussianSplatSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/HotspotSpaceComponent.h
@@ -49,8 +49,6 @@ enum class HotspotPropertyKeys : uint16_t
 class CSP_API HotspotSpaceComponent : public ComponentBase, public IPositionComponent, public IRotationComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the Hotspot space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     HotspotSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ImageSpaceComponent.h
@@ -60,8 +60,6 @@ enum class DisplayMode
 class CSP_API ImageSpaceComponent : public ComponentBase, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the image space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     ImageSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/LightSpaceComponent.h
@@ -90,8 +90,6 @@ class CSP_API LightSpaceComponent : public ComponentBase,
                                     public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the light space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     LightSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/PortalSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/PortalSpaceComponent.h
@@ -54,8 +54,6 @@ enum class PortalPropertyKeys : uint16_t
 class CSP_API PortalSpaceComponent : public ComponentBase, public IEnableableComponent, public IPositionComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the portal space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     PortalSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ReflectionSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ReflectionSpaceComponent.h
@@ -55,8 +55,6 @@ enum class ReflectionShape
 class CSP_API ReflectionSpaceComponent : public ComponentBase, public IPositionComponent, public IScaleComponent, public IThirdPartyComponentRef
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the reflection component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     ReflectionSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h
@@ -57,8 +57,6 @@ enum class ScreenSharingPropertyKeys : uint16_t
 class CSP_API ScreenSharingSpaceComponent : public ComponentBase, public IShadowCasterComponent, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the screen sharing component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     ScreenSharingSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/ScriptSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/ScriptSpaceComponent.h
@@ -51,8 +51,6 @@ enum class ScriptComponentPropertyKeys : uint16_t
 class CSP_API ScriptSpaceComponent : public ComponentBase
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the script space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     ScriptSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/SplineSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/SplineSpaceComponent.h
@@ -38,8 +38,6 @@ enum class SplinePropertyKeys : uint16_t
 class CSP_API SplineSpaceComponent : public ComponentBase
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the spline space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     SplineSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/StaticModelSpaceComponent.h
@@ -67,8 +67,6 @@ class CSP_API StaticModelSpaceComponent : public ComponentBase,
 
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the static model space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     StaticModelSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/TextSpaceComponent.h
@@ -53,8 +53,6 @@ enum class TextPropertyKeys : uint16_t
 class CSP_API TextSpaceComponent : public ComponentBase, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the text space component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     TextSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
+++ b/Library/include/CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h
@@ -99,8 +99,6 @@ enum class VideoPlayerPropertyKeys : uint16_t
 class CSP_API VideoPlayerSpaceComponent : public ComponentBase, public IAudioControlComponent, public IEnableableComponent, public ITransformComponent, public IVisibleComponent
 {
 public:
-    CSP_NO_EXPORT static const ComponentSchema& GetSchema();
-
     /// @brief Constructs the video player component, and associates it with the specified Parent space entity.
     /// @param Parent The Space entity that owns this component.
     VideoPlayerSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent);

--- a/Library/src/Multiplayer/ComponentBase.cpp
+++ b/Library/src/Multiplayer/ComponentBase.cpp
@@ -122,6 +122,48 @@ void ComponentBase::SetProperty(uint16_t Key, const csp::common::ReplicatedValue
     if (const auto* Property = FindSchemaProperty(*CachedSchema, Key);
         Property && Value.GetReplicatedValueType() == Property->DefaultValue.GetReplicatedValueType())
     {
+        if (Property->HasRange())
+        {
+            const auto IsWithinRange = std::visit(
+                [&](const auto& DesiredValue) -> bool
+                {
+                    using T = std::decay_t<decltype(DesiredValue)>;
+                    if constexpr (std::is_same_v<T, float> || std::is_same_v<T, int64_t>)
+                    {
+                        return DesiredValue >= std::get<T>(Property->RangeMin.GetValue())
+                            && DesiredValue <= std::get<T>(Property->RangeMax.GetValue());
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                },
+                Value.GetValue());
+
+            if (!IsWithinRange)
+            {
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(csp::common::LogLevel::Warning, "SetProperty: value is outside the valid range");
+                }
+                return;
+            }
+        }
+
+        if (!Property->Options.IsEmpty())
+        {
+            const auto IsKnownOption = [&](const auto& Option) { return Option.Value == Value; };
+
+            if (!std::any_of(Property->Options.begin(), Property->Options.end(), IsKnownOption))
+            {
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(csp::common::LogLevel::Warning, "SetProperty: value is not a valid option");
+                }
+                return;
+            }
+        }
+
         SetPropertyDirect(Key, Value);
     }
 }

--- a/Library/src/Multiplayer/ComponentProperty.cpp
+++ b/Library/src/Multiplayer/ComponentProperty.cpp
@@ -16,12 +16,29 @@
 
 #include "CSP/Multiplayer/ComponentProperty.h"
 
+#include "CSP/Common/ReplicatedValue.h"
+
 namespace csp::multiplayer
 {
 
+bool SchemaOption::operator==(const SchemaOption& Other) const
+{
+    return Name == Other.Name && Value == Other.Value;
+}
+
+bool SchemaOption::operator!=(const SchemaOption& Other) const { return !(*this == Other); }
+
+bool ComponentProperty::HasRange() const
+{
+    const auto Type = DefaultValue.GetReplicatedValueType();
+    return RangeMin.GetReplicatedValueType() == Type && RangeMax.GetReplicatedValueType() == Type;
+}
+
 bool ComponentProperty::operator==(const ComponentProperty& Other) const
 {
-    return Key == Other.Key && Name == Other.Name && DefaultValue == Other.DefaultValue;
+    return Key == Other.Key && Name == Other.Name && DefaultValue == Other.DefaultValue && Description == Other.Description
+        && IsScriptable == Other.IsScriptable && IsDeprecated == Other.IsDeprecated && IsReserved == Other.IsReserved
+        && RangeMin == Other.RangeMin && RangeMax == Other.RangeMax && Options == Other.Options;
 }
 
 bool ComponentProperty::operator!=(const ComponentProperty& Other) const { return !(*this == Other); }

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -762,7 +762,7 @@ csp::common::Optional<ComponentSchema> ComponentSchema::FromJson(const csp::comm
 }
 
 csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
-    const csp::common::List<csp::common::String>& JsonDocuments, csp::common::LogSystem& LogSystem)
+    const csp::common::List<csp::common::String>& JsonDocuments, csp::common::LogSystem* LogSystem)
 {
     auto Collected = std::vector<ComponentSchema> {};
 
@@ -773,17 +773,23 @@ csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
 
         if (Doc.HasParseError() || !Doc.IsArray())
         {
-            LogSystem.LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping document, expected a top-level JSON array");
+            if (LogSystem)
+            {
+                LogSystem->LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping document, expected a top-level JSON array");
+            }
             continue;
         }
 
         for (const auto& Element : Doc.GetArray())
         {
-            const auto Schema = TryParseSchema(Element, &LogSystem);
+            const auto Schema = TryParseSchema(Element, LogSystem);
 
             if (!Schema)
             {
-                LogSystem.LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping entry, failed to parse schema");
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(csp::common::LogLevel::Warning, "ComponentSchemasFromJson: skipping entry, failed to parse schema");
+                }
                 continue;
             }
 

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -86,6 +86,26 @@ namespace
         return std::all_of(Array.begin(), Array.end(), [](const auto& Element) { return Element.IsNumber(); });
     }
 
+    template <typename T> std::optional<T> GetRequired(const rapidjson::Value& Object, const char* Key)
+    {
+        if (!Object.HasMember(Key) || !Object[Key].Is<T>())
+        {
+            return std::nullopt;
+        }
+
+        return Object[Key].Get<T>();
+    }
+
+    template <typename T> T GetOrDefault(const rapidjson::Value& Object, const char* Key, T Default)
+    {
+        if (!Object.HasMember(Key) || !Object[Key].Is<T>())
+        {
+            return std::move(Default);
+        }
+
+        return Object[Key].Get<T>();
+    }
+
     template <typename T> std::optional<csp::common::ReplicatedValue> AsReplicatedValue(std::optional<T> Value)
     {
         if (!Value)
@@ -218,6 +238,76 @@ namespace
         return std::nullopt;
     }
 
+    std::optional<std::pair<csp::common::ReplicatedValue, csp::common::ReplicatedValue>> TryParseRange(
+        const rapidjson::Value& RangeValue, const std::string& Type)
+    {
+        if (!RangeValue.IsObject() || !RangeValue.HasMember("min") || !RangeValue.HasMember("max"))
+        {
+            return std::nullopt;
+        }
+
+        const auto Min = TryParse(Type, RangeValue["min"]);
+        const auto Max = TryParse(Type, RangeValue["max"]);
+
+        if (!Min || !Max)
+        {
+            return std::nullopt;
+        }
+
+        return std::make_pair(*Min, *Max);
+    }
+
+    std::optional<SchemaOption> TryParseOption(const rapidjson::Value& OptionValue, const std::string& Type)
+    {
+        if (!OptionValue.IsObject())
+        {
+            return std::nullopt;
+        }
+
+        const auto Name = GetRequired<const char*>(OptionValue, "name");
+
+        if (!Name)
+        {
+            return std::nullopt;
+        }
+
+        if (!OptionValue.HasMember("value"))
+        {
+            return std::nullopt;
+        }
+
+        const auto Value = TryParse(Type, OptionValue["value"]);
+
+        if (!Value)
+        {
+            return std::nullopt;
+        }
+
+        return SchemaOption {
+            /*Name =*/*Name,
+            /*Value =*/*Value,
+        };
+    }
+
+    std::optional<csp::common::Array<SchemaOption>> TryParseOptions(rapidjson::Value::ConstArray JsonOptions, const std::string& Type)
+    {
+        auto Options = std::vector<SchemaOption> {};
+
+        for (const auto& Element : JsonOptions)
+        {
+            const auto Option = TryParseOption(Element, Type);
+
+            if (!Option)
+            {
+                return std::nullopt;
+            }
+
+            Options.push_back(*Option);
+        }
+
+        return csp::common::Convert(Options);
+    }
+
     std::optional<ComponentProperty> TryParseProperty(const rapidjson::Value& Value, csp::common::LogSystem* LogSystem = nullptr)
     {
         if (!Value.IsObject())
@@ -230,7 +320,9 @@ namespace
             return std::nullopt;
         }
 
-        if (!Value.HasMember("key") || !Value["key"].IsUint())
+        const auto Key = GetRequired<unsigned int>(Value, "key");
+
+        if (!Key)
         {
             if (LogSystem)
             {
@@ -240,7 +332,25 @@ namespace
             return std::nullopt;
         }
 
-        if (!Value.HasMember("name") || !Value["name"].IsString())
+        const auto Description = GetOrDefault<const char*>(Value, "description", "");
+        const auto IsDeprecated = GetOrDefault<bool>(Value, "deprecated", false);
+
+        if (GetOrDefault<bool>(Value, "reserved", false))
+        {
+            return ComponentProperty {
+                /*Key =*/static_cast<ComponentProperty::KeyType>(*Key),
+                /*Name =*/ {},
+                /*DefaultValue =*/ {},
+                /*Description =*/Description,
+                /*IsScriptable =*/false,
+                /*IsDeprecated =*/IsDeprecated,
+                /*IsReserved =*/true,
+            };
+        }
+
+        const auto Name = GetRequired<const char*>(Value, "name");
+
+        if (!Name)
         {
             if (LogSystem)
             {
@@ -250,7 +360,9 @@ namespace
             return std::nullopt;
         }
 
-        if (!Value.HasMember("type") || !Value["type"].IsString())
+        const auto Type = GetRequired<const char*>(Value, "type");
+
+        if (!Type)
         {
             if (LogSystem)
             {
@@ -270,26 +382,109 @@ namespace
             return std::nullopt;
         }
 
-        const auto Key = static_cast<ComponentProperty::KeyType>(Value["key"].GetUint());
-        const auto* Name = Value["name"].GetString();
-        const auto* Type = Value["type"].GetString();
-        const auto DefaultValue = TryParse(Type, Value["defaultValue"]);
+        const auto DefaultValue = TryParse(*Type, Value["defaultValue"]);
 
         if (!DefaultValue)
         {
             if (LogSystem)
             {
                 LogSystem->LogMsg(
-                    csp::common::LogLevel::Warning, fmt::format("TryParseProperty: 'defaultValue' is not valid for type '{}'", Type).c_str());
+                    csp::common::LogLevel::Warning, fmt::format("TryParseProperty: 'defaultValue' is not valid for type '{}'", *Type).c_str());
             }
 
             return std::nullopt;
         }
 
+        const auto IsScriptable = GetOrDefault<bool>(Value, "scripting", true);
+
+        using csp::common::ReplicatedValueType;
+        const auto ValueType = DefaultValue->GetReplicatedValueType();
+
+        auto RangeMin = csp::common::ReplicatedValue {};
+        auto RangeMax = csp::common::ReplicatedValue {};
+
+        if (Value.HasMember("range"))
+        {
+            if (ValueType != ReplicatedValueType::Integer && ValueType != ReplicatedValueType::Float)
+            {
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(
+                        csp::common::LogLevel::Warning, fmt::format("TryParseProperty: 'range' is not supported for type '{}'", *Type).c_str());
+                }
+
+                return std::nullopt;
+            }
+
+            const auto Range = TryParseRange(Value["range"], *Type);
+
+            if (!Range)
+            {
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: 'range' is malformed");
+                }
+
+                return std::nullopt;
+            }
+
+            RangeMin = Range->first;
+            RangeMax = Range->second;
+        }
+
+        auto Options = csp::common::Convert(std::vector<SchemaOption> {});
+
+        if (Value.HasMember("options"))
+        {
+            if (ValueType != ReplicatedValueType::Integer && ValueType != ReplicatedValueType::Float && ValueType != ReplicatedValueType::String)
+            {
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(
+                        csp::common::LogLevel::Warning, fmt::format("TryParseProperty: 'options' is not supported for type '{}'", *Type).c_str());
+                }
+
+                return std::nullopt;
+            }
+
+            const auto JsonOptions = GetRequired<rapidjson::Value::ConstArray>(Value, "options");
+
+            if (!JsonOptions)
+            {
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: 'options' must be an array");
+                }
+
+                return std::nullopt;
+            }
+
+            const auto ParsedOptions = TryParseOptions(*JsonOptions, *Type);
+
+            if (!ParsedOptions)
+            {
+                if (LogSystem)
+                {
+                    LogSystem->LogMsg(csp::common::LogLevel::Warning, "TryParseProperty: 'options' contains an invalid entry");
+                }
+
+                return std::nullopt;
+            }
+
+            Options = *ParsedOptions;
+        }
+
         return ComponentProperty {
-            Key,
-            Name,
-            *DefaultValue,
+            /*Key =*/static_cast<ComponentProperty::KeyType>(*Key),
+            /*Name =*/*Name,
+            /*DefaultValue =*/*DefaultValue,
+            /*Description =*/Description,
+            /*IsScriptable =*/IsScriptable,
+            /*IsDeprecated =*/IsDeprecated,
+            /*IsReserved =*/false,
+            /*RangeMin =*/RangeMin,
+            /*RangeMax =*/RangeMax,
+            /*Options =*/std::move(Options),
         };
     }
 
@@ -325,7 +520,9 @@ namespace
             return std::nullopt;
         }
 
-        if (!Value.HasMember("typeId") || !Value["typeId"].IsUint64())
+        const auto TypeId = GetRequired<uint64_t>(Value, "typeId");
+
+        if (!TypeId)
         {
             if (LogSystem)
             {
@@ -335,7 +532,26 @@ namespace
             return std::nullopt;
         }
 
-        if (!Value.HasMember("name") || !Value["name"].IsString())
+        const auto IsReserved = GetOrDefault<bool>(Value, "reserved", false);
+        const auto Description = GetOrDefault<const char*>(Value, "description", "");
+        const auto IsScriptable = GetOrDefault<bool>(Value, "scripting", true);
+        const auto IsDeprecated = GetOrDefault<bool>(Value, "deprecated", false);
+
+        if (IsReserved)
+        {
+            return ComponentSchema {
+                /*TypeId =*/*TypeId,
+                /*Name =*/ {},
+                /*Properties =*/ {},
+                /*Description =*/Description,
+                /*IsScriptable =*/false,
+                /*IsReserved =*/true,
+            };
+        }
+
+        const auto Name = GetRequired<const char*>(Value, "name");
+
+        if (!Name)
         {
             if (LogSystem)
             {
@@ -345,7 +561,9 @@ namespace
             return std::nullopt;
         }
 
-        if (!Value.HasMember("properties") || !Value["properties"].IsArray())
+        const auto JsonProperties = GetRequired<rapidjson::Value::ConstArray>(Value, "properties");
+
+        if (!JsonProperties)
         {
             if (LogSystem)
             {
@@ -355,7 +573,7 @@ namespace
             return std::nullopt;
         }
 
-        const auto Properties = TryParseProperties(Value["properties"].GetArray(), LogSystem);
+        const auto Properties = TryParseProperties(*JsonProperties, LogSystem);
 
         if (!Properties)
         {
@@ -363,19 +581,74 @@ namespace
         }
 
         return ComponentSchema {
-            Value["typeId"].GetUint64(),
-            Value["name"].GetString(),
-            *Properties,
+            /*TypeId =*/*TypeId,
+            /*Name =*/*Name,
+            /*Properties =*/*Properties,
+            /*Description =*/Description,
+            /*IsScriptable =*/IsScriptable,
+            /*IsReserved =*/false,
+            /*IsDeprecated =*/IsDeprecated,
         };
     }
 
+    void SerializeReplicatedValueMember(csp::json::JsonSerializer& Serializer, const char* Key, const csp::common::ReplicatedValue& Value)
+    {
+        using csp::common::ReplicatedValueType;
+
+        switch (Value.GetReplicatedValueType())
+        {
+        case ReplicatedValueType::Float:
+            Serializer.SerializeMember(Key, Value.GetFloat());
+            break;
+        case ReplicatedValueType::Integer:
+            Serializer.SerializeMember(Key, Value.GetInt());
+            break;
+        case ReplicatedValueType::String:
+            Serializer.SerializeMember(Key, Value.GetString());
+            break;
+        default:
+            break;
+        }
+    }
+
 } // namespace
+
+struct PropertyRange
+{
+    csp::common::ReplicatedValue Min;
+    csp::common::ReplicatedValue Max;
+};
+
+void ToJson(csp::json::JsonSerializer& Serializer, const PropertyRange& Range)
+{
+    SerializeReplicatedValueMember(Serializer, "min", Range.Min);
+    SerializeReplicatedValueMember(Serializer, "max", Range.Max);
+}
+
+void ToJson(csp::json::JsonSerializer& Serializer, const SchemaOption& Option)
+{
+    Serializer.SerializeMember("name", Option.Name);
+    SerializeReplicatedValueMember(Serializer, "value", Option.Value);
+}
 
 void ToJson(csp::json::JsonSerializer& Serializer, const ComponentProperty& Property)
 {
     using csp::common::ReplicatedValueType;
 
     Serializer.SerializeMember("key", static_cast<uint32_t>(Property.Key));
+
+    if (Property.IsReserved)
+    {
+        Serializer.SerializeMember("reserved", true);
+
+        if (!Property.Description.IsEmpty())
+        {
+            Serializer.SerializeMember("description", Property.Description);
+        }
+
+        return;
+    }
+
     Serializer.SerializeMember("name", Property.Name);
 
     switch (Property.DefaultValue.GetReplicatedValueType())
@@ -404,13 +677,66 @@ void ToJson(csp::json::JsonSerializer& Serializer, const ComponentProperty& Prop
     default:
         break;
     }
+
+    if (!Property.Description.IsEmpty())
+    {
+        Serializer.SerializeMember("description", Property.Description);
+    }
+
+    if (!Property.IsScriptable)
+    {
+        Serializer.SerializeMember("scripting", false);
+    }
+
+    if (Property.IsDeprecated)
+    {
+        Serializer.SerializeMember("deprecated", true);
+    }
+
+    if (Property.HasRange())
+    {
+        Serializer.SerializeMember("range", PropertyRange { Property.RangeMin, Property.RangeMax });
+    }
+
+    if (!Property.Options.IsEmpty())
+    {
+        Serializer.SerializeMember("options", Property.Options);
+    }
 }
 
 void ToJson(csp::json::JsonSerializer& Serializer, const ComponentSchema& Schema)
 {
     Serializer.SerializeMember("typeId", Schema.TypeId);
+
+    if (Schema.IsReserved)
+    {
+        Serializer.SerializeMember("reserved", true);
+
+        if (!Schema.Description.IsEmpty())
+        {
+            Serializer.SerializeMember("description", Schema.Description);
+        }
+
+        return;
+    }
+
     Serializer.SerializeMember("name", Schema.Name);
     Serializer.SerializeMember("properties", Schema.Properties);
+
+    if (!Schema.Description.IsEmpty())
+    {
+        Serializer.SerializeMember("description", Schema.Description);
+    }
+
+    if (!Schema.IsScriptable)
+    {
+        Serializer.SerializeMember("scripting", false);
+    }
+
+    if (Schema.IsDeprecated)
+    {
+        Serializer.SerializeMember("deprecated", true);
+    }
 }
 
 csp::common::String ComponentSchema::ToJson(const ComponentSchema& Schema) { return csp::json::JsonSerializer::Serialize(Schema); }

--- a/Library/src/Multiplayer/ComponentSchema.cpp
+++ b/Library/src/Multiplayer/ComponentSchema.cpp
@@ -470,7 +470,8 @@ csp::common::Array<ComponentSchema> ComponentSchemasFromJson(
 
 bool ComponentSchema::operator==(const ComponentSchema& Other) const
 {
-    return TypeId == Other.TypeId && Name == Other.Name && Properties == Other.Properties;
+    return TypeId == Other.TypeId && Name == Other.Name && Properties == Other.Properties && Description == Other.Description
+        && IsScriptable == Other.IsScriptable && IsReserved == Other.IsReserved && IsDeprecated == Other.IsDeprecated;
 }
 
 bool ComponentSchema::operator!=(const ComponentSchema& Other) const { return !(*this == Other); }

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -56,6 +56,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 1,
+        "deprecated": true,
         "name": "externalResourceAssetId",
         "type": "string",
         "defaultValue": ""
@@ -157,6 +158,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 1,
+        "deprecated": true,
         "name": "externalResourceAssetId",
         "type": "string",
         "defaultValue": ""
@@ -1619,6 +1621,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 8,
+        "deprecated": true,
         "name": "",
         "type": "bool",
         "defaultValue": true

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -112,9 +112,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 8,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       },
       {
         "key": 9,
@@ -237,9 +238,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 12,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       },
       {
         "key": 13,
@@ -475,9 +477,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 23,
-        "name": "",
+        "name": "volume",
         "type": "float",
-        "defaultValue": 1.0
+        "defaultValue": 1.0,
+        "scripting": false
       },
       {
         "key": 24,
@@ -901,13 +904,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 14,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       },
       {
         "key": 15,
-        "name": "",
+        "name": "lightShadowType",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1138,23 +1142,24 @@ constexpr const auto* BuiltinSchemasJson = R"(
   },
   {
     "typeId": 13,
-    "name": "",
+    "name": "Script",
+    "scripting": false,
     "properties": [
       {
         "key": 1,
-        "name": "",
+        "name": "scriptSource",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
-        "name": "",
+        "name": "ownerId",
         "type": "int",
         "defaultValue": 0
       },
       {
         "key": 3,
-        "name": "",
+        "name": "scriptScope",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -1188,9 +1193,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
     "properties": [
       {
         "key": 0,
-        "name": "",
+        "name": "conversationId",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       },
       {
         "key": 1,
@@ -1401,9 +1407,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 8,
-        "name": "",
+        "name": "volume",
         "type": "float",
-        "defaultValue": 1.0
+        "defaultValue": 1.0,
+        "scripting": false
       },
       {
         "key": 9,
@@ -1413,9 +1420,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 10,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       }
     ]
   },
@@ -1426,11 +1434,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   },
   {
     "typeId": 19,
-    "name": "",
+    "name": "Collision",
+    "scripting": false,
     "properties": [
       {
         "key": 0,
-        "name": "",
+        "name": "position",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1440,7 +1449,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 1,
-        "name": "",
+        "name": "rotation",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1451,7 +1460,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 2,
-        "name": "",
+        "name": "scale",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1461,7 +1470,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 3,
-        "name": "",
+        "name": "collisionShape",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1485,7 +1494,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 4,
-        "name": "",
+        "name": "collisionMode",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1501,25 +1510,26 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 5,
-        "name": "",
+        "name": "collisionAssetId",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 6,
-        "name": "",
+        "name": "assetCollectionId",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 7,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       },
       {
         "key": 8,
-        "name": "",
+        "name": "isEnabled",
         "type": "bool",
         "defaultValue": true
       }
@@ -1527,7 +1537,8 @@ constexpr const auto* BuiltinSchemasJson = R"(
   },
   {
     "typeId": 20,
-    "name": "",
+    "name": "Reflection",
+    "scripting": false,
     "properties": [
       {
         "key": 0,
@@ -1536,19 +1547,19 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 1,
-        "name": "",
+        "name": "reflectionAssetId",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
-        "name": "",
+        "name": "assetCollectionId",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
-        "name": "",
+        "name": "position",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1563,7 +1574,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 5,
-        "name": "",
+        "name": "scale",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1573,7 +1584,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 6,
-        "name": "",
+        "name": "reflectionShape",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -1589,9 +1600,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 7,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       }
     ]
   },
@@ -1710,9 +1722,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 13,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       },
       {
         "key": 14,
@@ -1884,9 +1897,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 8,
         "deprecated": true,
-        "name": "",
+        "name": "isShadowCaster",
         "type": "bool",
-        "defaultValue": true
+        "defaultValue": true,
+        "scripting": false
       },
       {
         "key": 9,
@@ -2177,9 +2191,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 12,
-        "name": "",
+        "name": "thirdPartyComponentRef",
         "type": "string",
-        "defaultValue": ""
+        "defaultValue": "",
+        "scripting": false
       },
       {
         "key": 13,

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -16,1510 +16,1973 @@
 
 #include "ComponentSchemaRegistry.h"
 
-#include "CSP/Multiplayer/ComponentBase.h"
-
 #include "CSP/Common/Systems/Log/LogSystem.h"
-#include "CSP/Multiplayer/Components/AIChatbotComponent.h"
-#include "CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h"
-#include "CSP/Multiplayer/Components/AudioSpaceComponent.h"
-#include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ButtonSpaceComponent.h"
-#include "CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h"
-#include "CSP/Multiplayer/Components/CollisionSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ConversationSpaceComponent.h"
-#include "CSP/Multiplayer/Components/CustomSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ECommerceSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h"
-#include "CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h"
-#include "CSP/Multiplayer/Components/FogSpaceComponent.h"
-#include "CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h"
-#include "CSP/Multiplayer/Components/HotspotSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ImageSpaceComponent.h"
-#include "CSP/Multiplayer/Components/LightSpaceComponent.h"
-#include "CSP/Multiplayer/Components/PortalSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ReflectionSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h"
-#include "CSP/Multiplayer/Components/ScriptSpaceComponent.h"
-#include "CSP/Multiplayer/Components/SplineSpaceComponent.h"
-#include "CSP/Multiplayer/Components/StaticModelSpaceComponent.h"
-#include "CSP/Multiplayer/Components/TextSpaceComponent.h"
-#include "CSP/Multiplayer/Components/VideoPlayerSpaceComponent.h"
+#include "CSP/Multiplayer/ComponentSchema.h"
 
 #include <fmt/format.h>
 
+#include <cassert>
 #include <limits>
 #include <type_traits>
 
 namespace csp::multiplayer
 {
 
-namespace
+constexpr const auto* BuiltinSchemasJson = R"(
+[
+  {
+    "typeId": 3,
+    "name": "StaticModel",
+    "properties": [
+      {
+        "key": 1,
+        "name": "externalResourceAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "externalResourceAssetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 7,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 8,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 9,
+        "name": "isShadowCaster",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 11,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 12,
+        "name": "showAsHoldoutInAR",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 13,
+        "name": "showAsHoldoutInVirtual",
+        "type": "bool",
+        "defaultValue": false
+      }
+    ]
+  },
+  {
+    "typeId": 4,
+    "name": "AnimatedModel",
+    "properties": [
+      {
+        "key": 1,
+        "name": "externalResourceAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "externalResourceAssetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "isLoopPlayback",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 7,
+        "name": "isPlaying",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 8,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 10,
+        "name": "animationIndex",
+        "type": "int",
+        "defaultValue": -1
+      },
+      {
+        "key": 11,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 12,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 13,
+        "name": "isShadowCaster",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 15,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 16,
+        "name": "showAsHoldoutInAR",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 17,
+        "name": "showAsHoldoutInVirtual",
+        "type": "bool",
+        "defaultValue": false
+      }
+    ]
+  },
+  {
+    "typeId": 6,
+    "name": "VideoPlayer",
+    "properties": [
+      {
+        "key": 0,
+        "name": "name",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "videoAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "videoAssetURL",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "assetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 4,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 7,
+        "name": "isStateShared",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 8,
+        "name": "isAutoPlay",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 9,
+        "name": "isLoopPlayback",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 10,
+        "name": "isAutoResize",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 11,
+        "name": "attenuationRadius",
+        "type": "float",
+        "defaultValue": 10.0
+      },
+      {
+        "key": 12,
+        "name": "playbackState",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 13,
+        "name": "currentPlayheadPosition",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 14,
+        "name": "timeSincePlay",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 15,
+        "name": "videoPlayerSourceType",
+        "type": "int",
+        "defaultValue": 1
+      },
+      {
+        "key": 16,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 17,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 18,
+        "name": "",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 19,
+        "name": "isEnabled",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 20,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 21,
+        "name": "stereoVideoType",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 22,
+        "name": "isStereoFlipped",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 23,
+        "name": "",
+        "type": "float",
+        "defaultValue": 1.0
+      },
+      {
+        "key": 24,
+        "name": "audioType",
+        "type": "int",
+        "defaultValue": 1
+      }
+    ]
+  },
+  {
+    "typeId": 8,
+    "name": "ExternalLink",
+    "properties": [
+      {
+        "key": 0,
+        "name": "name",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "linkUrl",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 3,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "displayText",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 6,
+        "name": "isEnabled",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 7,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 8,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 9,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 9,
+    "name": "Avatar",
+    "properties": [
+      {
+        "key": 0,
+        "name": "avatarId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "userId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "state",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 3,
+        "name": "",
+        "type": "int",
+        "defaultValue": -1
+      },
+      {
+        "key": 4,
+        "name": "agoraUserId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 5,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 6,
+        "name": "isHandIKEnabled",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 7,
+        "name": "targetHandIKTargetLocation",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 8,
+        "name": "handRotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 9,
+        "name": "headRotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 10,
+        "name": "walkRunBlendPercentage",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 11,
+        "name": "torsoTwistAlpha",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 12,
+        "name": "avatarPlayMode",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 13,
+        "name": "movementDirection",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 14,
+        "name": "locomotionModel",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 15,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 16,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 17,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 18,
+        "name": "avatarUrl",
+        "type": "string",
+        "defaultValue": ""
+      }
+    ]
+  },
+  {
+    "typeId": 10,
+    "name": "Light",
+    "properties": [
+      {
+        "key": 1,
+        "name": "lightType",
+        "type": "int",
+        "defaultValue": 1
+      },
+      {
+        "key": 2,
+        "name": "color",
+        "type": "vec3",
+        "defaultValue": [
+          255.0,
+          255.0,
+          255.0
+        ]
+      },
+      {
+        "key": 3,
+        "name": "Intensity",
+        "type": "float",
+        "defaultValue": 5000.0
+      },
+      {
+        "key": 4,
+        "name": "range",
+        "type": "float",
+        "defaultValue": 1000.0
+      },
+      {
+        "key": 5,
+        "name": "innerConeAngle",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 6,
+        "name": "outerConeAngle",
+        "type": "float",
+        "defaultValue": 0.78539816339
+      },
+      {
+        "key": 7,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 8,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 9,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 10,
+        "name": "cookieAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 11,
+        "name": "cookieAssetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 12,
+        "name": "lightCookieType",
+        "type": "int",
+        "defaultValue": 2
+      },
+      {
+        "key": 13,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 14,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 15,
+        "name": "",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 16,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 11,
+    "name": "Button",
+    "properties": [
+      {
+        "key": 1,
+        "name": "labelText",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "iconAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "assetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 4,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 7,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 8,
+        "name": "isEnabled",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 9,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 10,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 12,
+    "name": "Image",
+    "properties": [
+      {
+        "key": 0,
+        "name": "name",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "imageAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "assetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 7,
+        "name": "billboardMode",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 8,
+        "name": "displayMode",
+        "type": "int",
+        "defaultValue": 1
+      },
+      {
+        "key": 9,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 10,
+        "name": "isEmissive",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 11,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 13,
+    "name": "",
+    "properties": [
+      {
+        "key": 1,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 3,
+        "name": "",
+        "type": "int",
+        "defaultValue": 1
+      }
+    ]
+  },
+  {
+    "typeId": 14,
+    "name": "Custom",
+    "properties": [
+      {
+        "key": 0,
+        "name": "applicationOrigin",
+        "type": "string",
+        "defaultValue": ""
+      }
+    ]
+  },
+  {
+    "typeId": 15,
+    "name": "Conversation",
+    "properties": [
+      {
+        "key": 0,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 2,
+        "name": "isActive",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 3,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "title",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 8,
+        "name": "resolved",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 9,
+        "name": "conversationCameraPosition",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 10,
+        "name": "conversationCameraRotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      }
+    ]
+  },
+  {
+    "typeId": 16,
+    "name": "Portal",
+    "properties": [
+      {
+        "key": 0,
+        "name": "spaceId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 2,
+        "name": "",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 3,
+        "name": "",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 4,
+        "name": "isEnabled",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 5,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "radius",
+        "type": "float",
+        "defaultValue": 1.5
+      }
+    ]
+  },
+  {
+    "typeId": 17,
+    "name": "Audio",
+    "properties": [
+      {
+        "key": 0,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "playbackState",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 2,
+        "name": "audioType",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 3,
+        "name": "audioAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 4,
+        "name": "assetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 5,
+        "name": "attenuationRadius",
+        "type": "float",
+        "defaultValue": 10.0
+      },
+      {
+        "key": 6,
+        "name": "isLoopPlayback",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 7,
+        "name": "timeSincePlay",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 8,
+        "name": "",
+        "type": "float",
+        "defaultValue": 1.0
+      },
+      {
+        "key": 9,
+        "name": "isEnabled",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 10,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      }
+    ]
+  },
+  {
+    "typeId": 18,
+    "name": "Spline",
+    "properties": [
+      {
+        "key": 0,
+        "name": "",
+        "type": "float",
+        "defaultValue": 0.0
+      }
+    ]
+  },
+  {
+    "typeId": 19,
+    "name": "",
+    "properties": [
+      {
+        "key": 0,
+        "name": "",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 2,
+        "name": "",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 3,
+        "name": "",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 4,
+        "name": "",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 5,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 6,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 7,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 8,
+        "name": "",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 20,
+    "name": "",
+    "properties": [
+      {
+        "key": 0,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "",
+        "type": "int",
+        "defaultValue": 1
+      },
+      {
+        "key": 7,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      }
+    ]
+  },
+  {
+    "typeId": 21,
+    "name": "Fog",
+    "properties": [
+      {
+        "key": 0,
+        "name": "fogMode",
+        "type": "int",
+        "defaultValue": 1
+      },
+      {
+        "key": 1,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 2,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 3,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "startDistance",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 5,
+        "name": "endDistance",
+        "type": "float",
+        "defaultValue": 0.0
+      },
+      {
+        "key": 6,
+        "name": "color",
+        "type": "vec3",
+        "defaultValue": [
+          0.8,
+          0.9,
+          1.0
+        ]
+      },
+      {
+        "key": 7,
+        "name": "density",
+        "type": "float",
+        "defaultValue": 0.4
+      },
+      {
+        "key": 8,
+        "name": "heightFalloff",
+        "type": "float",
+        "defaultValue": 0.2
+      },
+      {
+        "key": 9,
+        "name": "maxOpacity",
+        "type": "float",
+        "defaultValue": 1.0
+      },
+      {
+        "key": 10,
+        "name": "isVolumetric",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 11,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 12,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 13,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 14,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 22,
+    "name": "ECommerce",
+    "properties": [
+      {
+        "key": 0,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "productId",
+        "type": "string",
+        "defaultValue": ""
+      }
+    ]
+  },
+  {
+    "typeId": 23,
+    "name": "FiducialMarker",
+    "properties": [
+      {
+        "key": 0,
+        "name": "name",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 1,
+        "name": "markerAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "assetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 7,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 8,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 24,
+    "name": "GaussianSplat",
+    "properties": [
+      {
+        "key": 1,
+        "name": "externalResourceAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "externalResourceAssetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 4,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 7,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 8,
+        "name": "",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 9,
+        "name": "tint",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 10,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 25,
+    "name": "Text",
+    "properties": [
+      {
+        "key": 0,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 2,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 3,
+        "name": "text",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 4,
+        "name": "textColor",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 5,
+        "name": "backgroundColor",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 6,
+        "name": "isBackgroundVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 7,
+        "name": "width",
+        "type": "float",
+        "defaultValue": 1.0
+      },
+      {
+        "key": 8,
+        "name": "height",
+        "type": "float",
+        "defaultValue": 1.0
+      },
+      {
+        "key": 9,
+        "name": "billboardMode",
+        "type": "int",
+        "defaultValue": 0
+      },
+      {
+        "key": 10,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 11,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 12,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 26,
+    "name": "Hotspot",
+    "properties": [
+      {
+        "key": 0,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 2,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "isTeleportPoint",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 4,
+        "name": "isSpawnPoint",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 5,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 6,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 7,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 27,
+    "name": "CinematicCamera",
+    "properties": [
+      {
+        "key": 0,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 2,
+        "name": "isEnabled",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 3,
+        "name": "focalLength",
+        "type": "float",
+        "defaultValue": 0.035
+      },
+      {
+        "key": 4,
+        "name": "aspectRatio",
+        "type": "float",
+        "defaultValue": 1.778
+      },
+      {
+        "key": 5,
+        "name": "sensorSize",
+        "type": "vec2",
+        "defaultValue": [
+          0.036,
+          0.024
+        ]
+      },
+      {
+        "key": 6,
+        "name": "nearClip",
+        "type": "float",
+        "defaultValue": 0.1
+      },
+      {
+        "key": 7,
+        "name": "farClip",
+        "type": "float",
+        "defaultValue": 20000.0
+      },
+      {
+        "key": 8,
+        "name": "iso",
+        "type": "float",
+        "defaultValue": 400.0
+      },
+      {
+        "key": 9,
+        "name": "shutterSpeed",
+        "type": "float",
+        "defaultValue": 0.0167
+      },
+      {
+        "key": 10,
+        "name": "aperture",
+        "type": "float",
+        "defaultValue": 4.0
+      },
+      {
+        "key": 11,
+        "name": "isViewerCamera",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 12,
+        "name": "",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 13,
+        "name": "focusDistance",
+        "type": "float",
+        "defaultValue": 5.0
+      },
+      {
+        "key": 14,
+        "name": "depthOfFieldEnabled",
+        "type": "bool",
+        "defaultValue": false
+      }
+    ]
+  },
+  {
+    "typeId": 28,
+    "name": "ScreenSharing",
+    "properties": [
+      {
+        "key": 0,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "rotation",
+        "type": "vec4",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0,
+          1.0
+        ]
+      },
+      {
+        "key": 2,
+        "name": "scale",
+        "type": "vec3",
+        "defaultValue": [
+          1.0,
+          1.0,
+          1.0
+        ]
+      },
+      {
+        "key": 3,
+        "name": "isVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 4,
+        "name": "isARVisible",
+        "type": "bool",
+        "defaultValue": true
+      },
+      {
+        "key": 5,
+        "name": "isShadowCaster",
+        "type": "bool",
+        "defaultValue": false
+      },
+      {
+        "key": 6,
+        "name": "userId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 7,
+        "name": "defaultImageCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 8,
+        "name": "defaultImageAssetId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 9,
+        "name": "attenuationRadius",
+        "type": "float",
+        "defaultValue": 10.0
+      },
+      {
+        "key": 10,
+        "name": "isVirtualVisible",
+        "type": "bool",
+        "defaultValue": true
+      }
+    ]
+  },
+  {
+    "typeId": 29,
+    "name": "AIChatbot",
+    "properties": [
+      {
+        "key": 0,
+        "name": "position",
+        "type": "vec3",
+        "defaultValue": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      {
+        "key": 1,
+        "name": "voice",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 2,
+        "name": "guardrailAssetCollectionId",
+        "type": "string",
+        "defaultValue": ""
+      },
+      {
+        "key": 3,
+        "name": "visualState",
+        "type": "int",
+        "defaultValue": 0
+      }
+    ]
+  }
+]
+)";
+
+static csp::common::Array<ComponentSchema> ParseBuiltinSchemas()
 {
+    auto Docs = csp::common::List<csp::common::String> {};
+    Docs.Append(BuiltinSchemasJson);
+    const auto Schemas = ComponentSchemasFromJson(Docs);
+    assert(Schemas.Size() == 25 && "Not all built-in schemas could be parsed from JSON");
+    return Schemas;
+}
 
-    const auto AllSchemas = csp::common::Array<ComponentSchema> {
-        // [0] StaticModel
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::StaticModel),
-            "StaticModel",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ExternalResourceAssetId),
-                    "externalResourceAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ExternalResourceAssetCollectionId),
-                    "externalResourceAssetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::MaterialOverrides),
-                    {}, // not exposed to scripting
-                    csp::common::Map<csp::common::String, csp::common::ReplicatedValue>(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4::Identity(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsShadowCaster),
-                    "isShadowCaster",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ShowAsHoldoutInAR),
-                    "showAsHoldoutInAR",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual),
-                    "showAsHoldoutInVirtual",
-                    false,
-                },
-            },
-        },
-        // [1] AnimatedModel
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::AnimatedModel),
-            "AnimatedModel",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ExternalResourceAssetId),
-                    "externalResourceAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ExternalResourceAssetCollectionId),
-                    "externalResourceAssetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::MaterialOverrides),
-                    {}, // not exposed to scripting
-                    csp::common::Map<csp::common::String, csp::common::ReplicatedValue>(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3 { 1, 1, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsLoopPlayback),
-                    "isLoopPlayback",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsPlaying),
-                    "isPlaying",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::AnimationIndex),
-                    "animationIndex",
-                    static_cast<int64_t>(-1),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsShadowCaster),
-                    "isShadowCaster",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR),
-                    "showAsHoldoutInAR",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual),
-                    "showAsHoldoutInVirtual",
-                    false,
-                },
-            },
-        },
-        // [2] VideoPlayer
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::VideoPlayer),
-            "VideoPlayer",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Name_DEPRECATED),
-                    "name",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoAssetId),
-                    "videoAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoAssetURL),
-                    "videoAssetURL",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AssetCollectionId),
-                    "assetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3 { 1, 1, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsStateShared),
-                    "isStateShared",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsAutoPlay),
-                    "isAutoPlay",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsLoopPlayback),
-                    "isLoopPlayback",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsAutoResize),
-                    "isAutoResize",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::PlaybackState),
-                    "playbackState",
-                    static_cast<int64_t>(0),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::CurrentPlayheadPosition),
-                    "currentPlayheadPosition",
-                    0.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::TimeSincePlay),
-                    "timeSincePlay",
-                    0.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AttenuationRadius),
-                    "attenuationRadius",
-                    10.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoPlayerSourceType),
-                    "videoPlayerSourceType",
-                    static_cast<int64_t>(VideoPlayerSourceType::AssetSource),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::StereoVideoType),
-                    "stereoVideoType",
-                    static_cast<int64_t>(StereoVideoType::None),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsStereoFlipped),
-                    "isStereoFlipped",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(0),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsEnabled),
-                    "isEnabled",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Volume),
-                    {}, // not exposed to scripting via schema: we can't express value ranges (min, max) in schemas yet, so manually bind
-                    1.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AudioType),
-                    "audioType",
-                    static_cast<int64_t>(AudioType::Spatial),
-                },
-            },
-        },
-        // [3] ExternalLink
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::ExternalLink),
-            "ExternalLink",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Name_DEPRECATED),
-                    "name",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::LinkUrl),
-                    "linkUrl",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3 { 1, 1, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::DisplayText),
-                    "displayText",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsEnabled),
-                    "isEnabled",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [4] Avatar
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::AvatarData),
-            "Avatar",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarId),
-                    "avatarId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::UserId),
-                    "userId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::State),
-                    "state",
-                    static_cast<int64_t>(AvatarState::Idle),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarMeshIndex_DEPRECATED),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(-1),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AgoraUserId),
-                    "agoraUserId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::CustomAvatarUrl_DEPRECATED),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsHandIKEnabled),
-                    "isHandIKEnabled",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::TargetHandIKTargetLocation),
-                    "targetHandIKTargetLocation",
-                    csp::common::Vector3 { 0.0f, 0.0f, 0.0f },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::HandRotation),
-                    "handRotation",
-                    csp::common::Vector4 { 0.0f, 0.0f, 0.0f, 1.0f },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::HeadRotation),
-                    "headRotation",
-                    csp::common::Vector4 { 0.0f, 0.0f, 0.0f, 1.0f },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::WalkRunBlendPercentage),
-                    "walkRunBlendPercentage",
-                    0.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::TorsoTwistAlpha),
-                    "torsoTwistAlpha",
-                    0.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarPlayMode),
-                    "avatarPlayMode",
-                    static_cast<int64_t>(AvatarPlayMode::Default),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::MovementDirection),
-                    "movementDirection",
-                    csp::common::Vector3 { 0.0f, 0.0f, 0.0f },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::LocomotionModel),
-                    "locomotionModel",
-                    static_cast<int64_t>(LocomotionModel::Grounded),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarUrl),
-                    "avatarUrl",
-                    "",
-                },
-            },
-        },
-        // [5] Light
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Light),
-            "Light",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightType),
-                    "lightType",
-                    static_cast<int64_t>(LightType::Point),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Color),
-                    "color",
-                    csp::common::Vector3 { 255, 255, 255 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Intensity),
-                    "Intensity", // Note: exposed as PascalCase for backwards compatibility (casing was wrong when this property was originally
-                    // exposed)
-                    5000.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Range),
-                    "range",
-                    1000.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::InnerConeAngle),
-                    "innerConeAngle",
-                    0.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::OuterConeAngle),
-                    "outerConeAngle",
-                    0.78539816339f, // Pi / 4
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieAssetId),
-                    "cookieAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieAssetCollectionId),
-                    "cookieAssetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieType),
-                    "lightCookieType",
-                    static_cast<int64_t>(LightCookieType::NoCookie),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightShadowType),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(LightShadowType::None),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [6] Button
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Button),
-            "Button",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::LabelText),
-                    "labelText",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IconAssetId),
-                    "iconAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::AssetCollectionId),
-                    "assetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3 { 1, 1, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsEnabled),
-                    "isEnabled",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [7] Image
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Image),
-            "Image",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Name_DEPRECATED),
-                    "name",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::ImageAssetId),
-                    "imageAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::AssetCollectionId),
-                    "assetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::BillboardMode),
-                    "billboardMode",
-                    static_cast<int64_t>(BillboardMode::Off),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::DisplayMode),
-                    "displayMode",
-                    static_cast<int64_t>(DisplayMode::DoubleSided),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsEmissive),
-                    "isEmissive",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [8] Script
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::ScriptData),
-            {}, // not exposed to scripting
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::ScriptSource),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::OwnerId),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(0),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::ScriptScope),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(ScriptScope::Owner),
-                },
-            },
-        },
-        // [9] Custom
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Custom),
-            "Custom",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(CustomComponentPropertyKeys::ApplicationOrigin),
-                    "applicationOrigin",
-                    "",
-                },
-            },
-        },
-        // [10] Conversation
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Conversation),
-            "Conversation",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationId),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::IsActive),
-                    "isActive",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Title),
-                    "title",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Resolved),
-                    "resolved",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationCameraPosition),
-                    "conversationCameraPosition",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationCameraRotation),
-                    "conversationCameraRotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-            },
-        },
-        // [11] Portal
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Portal),
-            "Portal",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsVisible),
-                    {}, // not exposed to scripting
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsActive),
-                    {}, // not exposed to scripting
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::SpaceId),
-                    "spaceId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsARVisible),
-                    {}, // not exposed to scripting
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsEnabled),
-                    "isEnabled",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::Radius),
-                    "radius",
-                    1.5f,
-                },
-            },
-        },
-        // [12] Audio
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Audio),
-            "Audio",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::PlaybackState),
-                    "playbackState",
-                    static_cast<int64_t>(AudioPlaybackState::Reset),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AudioType),
-                    "audioType",
-                    static_cast<int64_t>(AudioType::Global),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AudioAssetId),
-                    "audioAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AssetCollectionId),
-                    "assetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AttenuationRadius),
-                    "attenuationRadius",
-                    10.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::IsLoopPlayback),
-                    "isLoopPlayback",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::TimeSincePlay),
-                    "timeSincePlay",
-                    0.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::Volume),
-                    {}, // not exposed to scripting via schema: we can't express value ranges (min, max) in schemas yet, so manually bind
-                    1.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::IsEnabled),
-                    "isEnabled",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-            },
-        },
-        // [13] Spline
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Spline),
-            "Spline",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(SplinePropertyKeys::Waypoints),
-                    {}, // not exposed to scripting via an auto-generated property (has a legacy manual getter function)
-                    0.f,
-                },
-            },
-        },
-        // [14] Collision
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Collision),
-            {}, // not exposed to scripting
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Position),
-                    {}, // not exposed to scripting
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Rotation),
-                    {}, // not exposed to scripting
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Scale),
-                    {}, // not exposed to scripting
-                    csp::common::Vector3 { 1, 1, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionShape),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(CollisionShape::Box),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionMode),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(CollisionMode::Collision),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionAssetId),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::AssetCollectionId),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::IsEnabled),
-                    {}, // not exposed to scripting
-                    true,
-                },
-            },
-        },
-        // [15] Reflection
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Reflection),
-            {}, // not exposed to scripting
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Name_DEPRECATED),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ReflectionAssetId),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::AssetCollectionId),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Position),
-                    {}, // not exposed to scripting
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Scale),
-                    {}, // not exposed to scripting
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ReflectionShape),
-                    {}, // not exposed to scripting
-                    static_cast<int64_t>(ReflectionShape::UnitBox),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-            },
-        },
-        // [16] Fog
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Fog),
-            "Fog",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::FogMode),
-                    "fogMode",
-                    static_cast<int64_t>(FogMode::Exponential),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3 { 1, 1, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::StartDistance),
-                    "startDistance",
-                    0.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::EndDistance),
-                    "endDistance",
-                    0.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Color),
-                    "color",
-                    csp::common::Vector3 { 0.8f, 0.9f, 1.0f },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Density),
-                    "density",
-                    0.4f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::HeightFalloff),
-                    "heightFalloff",
-                    0.2f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::MaxOpacity),
-                    "maxOpacity",
-                    1.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVolumetric),
-                    "isVolumetric",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [17] ECommerce
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::ECommerce),
-            "ECommerce",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ECommercePropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3 { 0, 0, 0 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ECommercePropertyKeys::ProductId),
-                    "productId",
-                    "",
-                },
-            },
-        },
-        // [18] FiducialMarker
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::FiducialMarker),
-            "FiducialMarker",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Name_DEPRECATED),
-                    "name",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::MarkerAssetId),
-                    "markerAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::AssetCollectionId),
-                    "assetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [19] GaussianSplat
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::GaussianSplat),
-            "GaussianSplat",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::ExternalResourceAssetId),
-                    "externalResourceAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::ExternalResourceAssetCollectionId),
-                    "externalResourceAssetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4::Identity(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsShadowCaster_DEPRECATED),
-                    {}, // not exposed to scripting: this is a deprecated property that was never exposed to scripting, so no need to start now.
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Tint),
-                    "tint",
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [20] Text
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Text),
-            "Text",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Text),
-                    "text",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::TextColor),
-                    "textColor",
-                    csp::common::Vector3(1.0f, 1.0f, 1.0f),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::BackgroundColor),
-                    "backgroundColor",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsBackgroundVisible),
-                    "isBackgroundVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Width),
-                    "width",
-                    1.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Height),
-                    "height",
-                    1.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::BillboardMode),
-                    "billboardMode",
-                    static_cast<int64_t>(BillboardMode::Off),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [21] Hotspot
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::Hotspot),
-            "Hotspot",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4 { 0, 0, 0, 1 },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Name_DEPRECATED),
-                    {}, // not exposed to scripting
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsTeleportPoint),
-                    "isTeleportPoint",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsSpawnPoint),
-                    "isSpawnPoint",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [22] CinematicCamera
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::CinematicCamera),
-            "CinematicCamera",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4::Identity(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::IsEnabled),
-                    "isEnabled",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FocalLength),
-                    "focalLength",
-                    0.035f,
-                },
-                // 16:9
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::AspectRatio),
-                    "aspectRatio",
-                    1.778f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::SensorSize),
-                    "sensorSize",
-                    csp::common::Vector2 { 0.036f, 0.024f },
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::NearClip),
-                    "nearClip",
-                    0.1f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FarClip),
-                    "farClip",
-                    20000.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Iso),
-                    "iso",
-                    400.0f,
-                },
-                // 60 FPS
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::ShutterSpeed),
-                    "shutterSpeed",
-                    0.0167f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Aperture),
-                    "aperture",
-                    4.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FocusDistance),
-                    "focusDistance",
-                    5.0f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::DepthOfFieldEnabled),
-                    "depthOfFieldEnabled",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::IsViewerCamera),
-                    "isViewerCamera",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::ThirdPartyComponentRef),
-                    {}, // not exposed to scripting
-                    "",
-                },
-            },
-        },
-        // [23] ScreenSharing
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::ScreenSharing),
-            "ScreenSharing",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Rotation),
-                    "rotation",
-                    csp::common::Vector4::Identity(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Scale),
-                    "scale",
-                    csp::common::Vector3::One(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsVisible),
-                    "isVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsARVisible),
-                    "isARVisible",
-                    true,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsShadowCaster),
-                    "isShadowCaster",
-                    false,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::UserId),
-                    "userId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::DefaultImageCollectionId),
-                    "defaultImageCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::DefaultImageAssetId),
-                    "defaultImageAssetId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::AttenuationRadius),
-                    "attenuationRadius",
-                    10.f,
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsVirtualVisible),
-                    "isVirtualVisible",
-                    true,
-                },
-            },
-        },
-        // [24] AIChatbot
-        ComponentSchema {
-            static_cast<ComponentSchema::TypeIdType>(ComponentType::AIChatbot),
-            "AIChatbot",
-            csp::common::Array<ComponentProperty> {
-                {
-                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::Position),
-                    "position",
-                    csp::common::Vector3::Zero(),
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::Voice),
-                    "voice",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::GuardrailAssetCollectionId),
-                    "guardrailAssetCollectionId",
-                    "",
-                },
-                {
-                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::VisualState),
-                    "visualState",
-                    static_cast<int64_t>(0),
-                },
-            },
-        },
-    };
-
-} // namespace
-
-const csp::common::Array<ComponentSchema>& GetAllComponentSchemas() { return AllSchemas; }
+const auto AllSchemas = ParseBuiltinSchemas();
 
 const ComponentSchema& GetStaticModelSchema() { return AllSchemas[0]; }
 const ComponentSchema& GetAnimatedModelSchema() { return AllSchemas[1]; }
@@ -1562,31 +2025,10 @@ ComponentSchemaRegistryImpl::ComponentSchemaRegistryImpl(
         }
     };
 
-    AddSchema(GetStaticModelSchema());
-    AddSchema(GetAnimatedModelSchema());
-    AddSchema(GetVideoPlayerSchema());
-    AddSchema(GetExternalLinkSchema());
-    AddSchema(GetAvatarSchema());
-    AddSchema(GetLightSchema());
-    AddSchema(GetButtonSchema());
-    AddSchema(GetImageSchema());
-    AddSchema(GetScriptSchema());
-    AddSchema(GetCustomSchema());
-    AddSchema(GetConversationSchema());
-    AddSchema(GetPortalSchema());
-    AddSchema(GetAudioSchema());
-    AddSchema(GetSplineSchema());
-    AddSchema(GetCollisionSchema());
-    AddSchema(GetReflectionSchema());
-    AddSchema(GetFogSchema());
-    AddSchema(GetECommerceSchema());
-    AddSchema(GetFiducialMarkerSchema());
-    AddSchema(GetGaussianSplatSchema());
-    AddSchema(GetTextSchema());
-    AddSchema(GetHotspotSchema());
-    AddSchema(GetCinematicCameraSchema());
-    AddSchema(GetScreenSharingSchema());
-    AddSchema(GetAIChatbotSchema());
+    for (const auto& Schema : AllSchemas)
+    {
+        AddSchema(Schema);
+    }
 
     for (const auto& Schema : AdditionalComponents)
     {

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -480,7 +480,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "name": "volume",
         "type": "float",
         "defaultValue": 1.0,
-        "scripting": false
+        "range": {
+          "min": 0.0,
+          "max": 1.0
+        }
       },
       {
         "key": 24,
@@ -1410,7 +1413,10 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "name": "volume",
         "type": "float",
         "defaultValue": 1.0,
-        "scripting": false
+        "range": {
+          "min": 0.0,
+          "max": 1.0
+        }
       },
       {
         "key": 9,

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -31,9 +31,29 @@ namespace csp::multiplayer
 constexpr const auto* BuiltinSchemasJson = R"(
 [
   {
+    "typeId": 0,
+    "reserved": true,
+    "description": "Invalid. Sentinel value, not a real component type."
+  },
+  {
+    "typeId": 1,
+    "reserved": true,
+    "description": "Was Core, removed"
+  },
+  {
+    "typeId": 2,
+    "reserved": true,
+    "description": "Was UIController, removed"
+  },
+  {
     "typeId": 3,
     "name": "StaticModel",
     "properties": [
+      {
+        "key": 0,
+        "reserved": true,
+        "description": "Was name, superseded by component-level naming"
+      },
       {
         "key": 1,
         "name": "externalResourceAssetId",
@@ -102,6 +122,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "defaultValue": true
       },
       {
+        "key": 10,
+        "reserved": true,
+        "description": "materialOverrides: Map<String, String>. No equivalent type currently supported."
+      },
+      {
         "key": 11,
         "name": "isVirtualVisible",
         "type": "bool",
@@ -125,6 +150,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
     "typeId": 4,
     "name": "AnimatedModel",
     "properties": [
+      {
+        "key": 0,
+        "reserved": true,
+        "description": "Was name, superseded by component-level naming"
+      },
       {
         "key": 1,
         "name": "externalResourceAssetId",
@@ -187,6 +217,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "defaultValue": true
       },
       {
+        "key": 9,
+        "reserved": true,
+        "description": "Reserved slot in AnimatedModelPropertyKeys"
+      },
+      {
         "key": 10,
         "name": "animationIndex",
         "type": "int",
@@ -211,6 +246,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "defaultValue": true
       },
       {
+        "key": 14,
+        "reserved": true,
+        "description": "materialOverrides: Map<String, String>. No equivalent type currently supported."
+      },
+      {
         "key": 15,
         "name": "isVirtualVisible",
         "type": "bool",
@@ -229,6 +269,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "defaultValue": false
       }
     ]
+  },
+  {
+    "typeId": 5,
+    "reserved": true,
+    "description": "Was MediaSurface, removed"
   },
   {
     "typeId": 6,
@@ -357,9 +402,8 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 18,
-        "name": "",
-        "type": "int",
-        "defaultValue": 0
+        "reserved": true,
+        "description": "Unused key `MeshComponentId` from original `VideoPlayerPropertyKeys` enum"
       },
       {
         "key": 19,
@@ -398,6 +442,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "defaultValue": 1
       }
     ]
+  },
+  {
+    "typeId": 7,
+    "reserved": true,
+    "description": "Was ImageSequencer, removed"
   },
   {
     "typeId": 8,
@@ -502,9 +551,8 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 3,
-        "name": "",
-        "type": "int",
-        "defaultValue": -1
+        "reserved": true,
+        "description": "Was avatarMeshIndex"
       },
       {
         "key": 4,
@@ -514,9 +562,8 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 5,
-        "name": "",
-        "type": "string",
-        "defaultValue": ""
+        "reserved": true,
+        "description": "Was customAvatarUrl"
       },
       {
         "key": 6,
@@ -620,6 +667,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
     "typeId": 10,
     "name": "Light",
     "properties": [
+      {
+        "key": 0,
+        "reserved": true,
+        "description": "Was name, superseded by component-level naming"
+      },
       {
         "key": 1,
         "name": "lightType",
@@ -735,6 +787,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
     "typeId": 11,
     "name": "Button",
     "properties": [
+      {
+        "key": 0,
+        "reserved": true,
+        "description": "Was name, superseded by component-level naming"
+      },
       {
         "key": 1,
         "name": "labelText",
@@ -987,6 +1044,16 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "defaultValue": ""
       },
       {
+        "key": 6,
+        "reserved": true,
+        "description": "Was Date, deprecated and removed"
+      },
+      {
+        "key": 7,
+        "reserved": true,
+        "description": "Was NumberOfReplies, deprecated and removed"
+      },
+      {
         "key": 8,
         "name": "resolved",
         "type": "bool",
@@ -1027,21 +1094,18 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 1,
-        "name": "",
-        "type": "bool",
-        "defaultValue": true
+        "reserved": true,
+        "description": "Was IsVisible, retained for wire compatibility"
       },
       {
         "key": 2,
-        "name": "",
-        "type": "bool",
-        "defaultValue": true
+        "reserved": true,
+        "description": "Was IsActive, retained for wire compatibility"
       },
       {
         "key": 3,
-        "name": "",
-        "type": "bool",
-        "defaultValue": true
+        "reserved": true,
+        "description": "Was IsARVisible, retained for wire compatibility"
       },
       {
         "key": 4,
@@ -1145,15 +1209,8 @@ constexpr const auto* BuiltinSchemasJson = R"(
   },
   {
     "typeId": 18,
-    "name": "Spline",
-    "properties": [
-      {
-        "key": 0,
-        "name": "",
-        "type": "float",
-        "defaultValue": 0.0
-      }
-    ]
+    "reserved": true,
+    "description": "Spline component. Key 0 stores waypoint count, keys 1..N store Vector3 waypoints at runtime. Dynamic keys are not unrepresentable as a static schema."
   },
   {
     "typeId": 19,
@@ -1234,9 +1291,8 @@ constexpr const auto* BuiltinSchemasJson = R"(
     "properties": [
       {
         "key": 0,
-        "name": "",
-        "type": "string",
-        "defaultValue": ""
+        "reserved": true,
+        "description": "Was name, superseded by component-level naming"
       },
       {
         "key": 1,
@@ -1259,6 +1315,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
           0.0,
           0.0
         ]
+      },
+      {
+        "key": 4,
+        "reserved": true,
+        "description": "Was Rotation, reserved as Rotation_NOT_USED in ReflectionPropertyKeys"
       },
       {
         "key": 5,
@@ -1497,6 +1558,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
     "name": "GaussianSplat",
     "properties": [
       {
+        "key": 0,
+        "reserved": true,
+        "description": "Was name, superseded by component-level naming"
+      },
+      {
         "key": 1,
         "name": "externalResourceAssetId",
         "type": "string",
@@ -1707,9 +1773,8 @@ constexpr const auto* BuiltinSchemasJson = R"(
       },
       {
         "key": 2,
-        "name": "",
-        "type": "string",
-        "defaultValue": ""
+        "reserved": true,
+        "description": "Was name, superseded by component-level naming"
       },
       {
         "key": 3,
@@ -1969,6 +2034,11 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "defaultValue": 0
       }
     ]
+  },
+  {
+    "typeId": 56,
+    "reserved": true,
+    "description": "An implementation detail of component deletion on the wire. Not a real component type."
   }
 ]
 )";
@@ -1978,37 +2048,37 @@ static csp::common::Array<ComponentSchema> ParseBuiltinSchemas()
     auto Docs = csp::common::List<csp::common::String> {};
     Docs.Append(BuiltinSchemasJson);
     const auto Schemas = ComponentSchemasFromJson(Docs);
-    assert(Schemas.Size() == 25 && "Not all built-in schemas could be parsed from JSON");
+    assert(Schemas.Size() == 31 && "Not all built-in schemas could be parsed from JSON");
     return Schemas;
 }
 
 const auto AllSchemas = ParseBuiltinSchemas();
 
-const ComponentSchema& GetStaticModelSchema() { return AllSchemas[0]; }
-const ComponentSchema& GetAnimatedModelSchema() { return AllSchemas[1]; }
-const ComponentSchema& GetVideoPlayerSchema() { return AllSchemas[2]; }
-const ComponentSchema& GetExternalLinkSchema() { return AllSchemas[3]; }
-const ComponentSchema& GetAvatarSchema() { return AllSchemas[4]; }
-const ComponentSchema& GetLightSchema() { return AllSchemas[5]; }
-const ComponentSchema& GetButtonSchema() { return AllSchemas[6]; }
-const ComponentSchema& GetImageSchema() { return AllSchemas[7]; }
-const ComponentSchema& GetScriptSchema() { return AllSchemas[8]; }
-const ComponentSchema& GetCustomSchema() { return AllSchemas[9]; }
-const ComponentSchema& GetConversationSchema() { return AllSchemas[10]; }
-const ComponentSchema& GetPortalSchema() { return AllSchemas[11]; }
-const ComponentSchema& GetAudioSchema() { return AllSchemas[12]; }
-const ComponentSchema& GetSplineSchema() { return AllSchemas[13]; }
-const ComponentSchema& GetCollisionSchema() { return AllSchemas[14]; }
-const ComponentSchema& GetReflectionSchema() { return AllSchemas[15]; }
-const ComponentSchema& GetFogSchema() { return AllSchemas[16]; }
-const ComponentSchema& GetECommerceSchema() { return AllSchemas[17]; }
-const ComponentSchema& GetFiducialMarkerSchema() { return AllSchemas[18]; }
-const ComponentSchema& GetGaussianSplatSchema() { return AllSchemas[19]; }
-const ComponentSchema& GetTextSchema() { return AllSchemas[20]; }
-const ComponentSchema& GetHotspotSchema() { return AllSchemas[21]; }
-const ComponentSchema& GetCinematicCameraSchema() { return AllSchemas[22]; }
-const ComponentSchema& GetScreenSharingSchema() { return AllSchemas[23]; }
-const ComponentSchema& GetAIChatbotSchema() { return AllSchemas[24]; }
+const ComponentSchema& GetStaticModelSchema() { return AllSchemas[3]; }
+const ComponentSchema& GetAnimatedModelSchema() { return AllSchemas[4]; }
+const ComponentSchema& GetVideoPlayerSchema() { return AllSchemas[6]; }
+const ComponentSchema& GetExternalLinkSchema() { return AllSchemas[8]; }
+const ComponentSchema& GetAvatarSchema() { return AllSchemas[9]; }
+const ComponentSchema& GetLightSchema() { return AllSchemas[10]; }
+const ComponentSchema& GetButtonSchema() { return AllSchemas[11]; }
+const ComponentSchema& GetImageSchema() { return AllSchemas[12]; }
+const ComponentSchema& GetScriptSchema() { return AllSchemas[13]; }
+const ComponentSchema& GetCustomSchema() { return AllSchemas[14]; }
+const ComponentSchema& GetConversationSchema() { return AllSchemas[15]; }
+const ComponentSchema& GetPortalSchema() { return AllSchemas[16]; }
+const ComponentSchema& GetAudioSchema() { return AllSchemas[17]; }
+const ComponentSchema& GetSplineSchema() { return AllSchemas[18]; }
+const ComponentSchema& GetCollisionSchema() { return AllSchemas[19]; }
+const ComponentSchema& GetReflectionSchema() { return AllSchemas[20]; }
+const ComponentSchema& GetFogSchema() { return AllSchemas[21]; }
+const ComponentSchema& GetECommerceSchema() { return AllSchemas[22]; }
+const ComponentSchema& GetFiducialMarkerSchema() { return AllSchemas[23]; }
+const ComponentSchema& GetGaussianSplatSchema() { return AllSchemas[24]; }
+const ComponentSchema& GetTextSchema() { return AllSchemas[25]; }
+const ComponentSchema& GetHotspotSchema() { return AllSchemas[26]; }
+const ComponentSchema& GetCinematicCameraSchema() { return AllSchemas[27]; }
+const ComponentSchema& GetScreenSharingSchema() { return AllSchemas[28]; }
+const ComponentSchema& GetAIChatbotSchema() { return AllSchemas[29]; }
 
 ComponentSchemaRegistryImpl::ComponentSchemaRegistryImpl(
     csp::common::LogSystem& LogSystem, const csp::common::Array<ComponentSchema>& AdditionalComponents)

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -370,7 +370,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 12,
         "name": "playbackState",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Reset",
+            "value": 0
+          },
+          {
+            "name": "Pause",
+            "value": 1
+          },
+          {
+            "name": "Play",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 13,
@@ -388,7 +402,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 15,
         "name": "videoPlayerSourceType",
         "type": "int",
-        "defaultValue": 1
+        "defaultValue": 1,
+        "options": [
+          {
+            "name": "URLSource",
+            "value": 0
+          },
+          {
+            "name": "AssetSource",
+            "value": 1
+          },
+          {
+            "name": "WowzaStreamSource",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 16,
@@ -423,7 +451,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 21,
         "name": "stereoVideoType",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "None",
+            "value": 0
+          },
+          {
+            "name": "SideBySide",
+            "value": 1
+          },
+          {
+            "name": "TopBottom",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 22,
@@ -441,7 +483,17 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 24,
         "name": "audioType",
         "type": "int",
-        "defaultValue": 1
+        "defaultValue": 1,
+        "options": [
+          {
+            "name": "Global",
+            "value": 0
+          },
+          {
+            "name": "Spatial",
+            "value": 1
+          }
+        ]
       }
     ]
   },
@@ -549,7 +601,33 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 2,
         "name": "state",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Idle",
+            "value": 0
+          },
+          {
+            "name": "Walking",
+            "value": 1
+          },
+          {
+            "name": "Running",
+            "value": 2
+          },
+          {
+            "name": "Flying",
+            "value": 3
+          },
+          {
+            "name": "Jumping",
+            "value": 4
+          },
+          {
+            "name": "Falling",
+            "value": 5
+          }
+        ]
       },
       {
         "key": 3,
@@ -621,7 +699,25 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 12,
         "name": "avatarPlayMode",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Default",
+            "value": 0
+          },
+          {
+            "name": "AR",
+            "value": 1
+          },
+          {
+            "name": "VR",
+            "value": 2
+          },
+          {
+            "name": "Creator",
+            "value": 3
+          }
+        ]
       },
       {
         "key": 13,
@@ -637,7 +733,17 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 14,
         "name": "locomotionModel",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Grounded",
+            "value": 0
+          },
+          {
+            "name": "FreeCamera",
+            "value": 1
+          }
+        ]
       },
       {
         "key": 15,
@@ -678,7 +784,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 1,
         "name": "lightType",
         "type": "int",
-        "defaultValue": 1
+        "defaultValue": 1,
+        "options": [
+          {
+            "name": "Directional",
+            "value": 0
+          },
+          {
+            "name": "Point",
+            "value": 1
+          },
+          {
+            "name": "Spot",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 2,
@@ -757,7 +877,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 12,
         "name": "lightCookieType",
         "type": "int",
-        "defaultValue": 2
+        "defaultValue": 2,
+        "options": [
+          {
+            "name": "ImageCookie",
+            "value": 0
+          },
+          {
+            "name": "VideoCookie",
+            "value": 1
+          },
+          {
+            "name": "NoCookie",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 13,
@@ -775,7 +909,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 15,
         "name": "",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "None",
+            "value": 0
+          },
+          {
+            "name": "Static",
+            "value": 1
+          },
+          {
+            "name": "Realtime",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 16,
@@ -932,13 +1080,41 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 7,
         "name": "billboardMode",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Off",
+            "value": 0
+          },
+          {
+            "name": "Billboard",
+            "value": 1
+          },
+          {
+            "name": "YawLockedBillboard",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 8,
         "name": "displayMode",
         "type": "int",
-        "defaultValue": 1
+        "defaultValue": 1,
+        "options": [
+          {
+            "name": "SingleSided",
+            "value": 0
+          },
+          {
+            "name": "DoubleSided",
+            "value": 1
+          },
+          {
+            "name": "DoubleSidedReversed",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 9,
@@ -980,7 +1156,17 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 3,
         "name": "",
         "type": "int",
-        "defaultValue": 1
+        "defaultValue": 1,
+        "options": [
+          {
+            "name": "Local",
+            "value": 0
+          },
+          {
+            "name": "Owner",
+            "value": 1
+          }
+        ]
       }
     ]
   },
@@ -1151,13 +1337,37 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 1,
         "name": "playbackState",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Reset",
+            "value": 0
+          },
+          {
+            "name": "Pause",
+            "value": 1
+          },
+          {
+            "name": "Play",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 2,
         "name": "audioType",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Global",
+            "value": 0
+          },
+          {
+            "name": "Spatial",
+            "value": 1
+          }
+        ]
       },
       {
         "key": 3,
@@ -1253,13 +1463,41 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 3,
         "name": "",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Box",
+            "value": 0
+          },
+          {
+            "name": "Mesh",
+            "value": 1
+          },
+          {
+            "name": "Capsule",
+            "value": 2
+          },
+          {
+            "name": "Sphere",
+            "value": 3
+          }
+        ]
       },
       {
         "key": 4,
         "name": "",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Collision",
+            "value": 0
+          },
+          {
+            "name": "Trigger",
+            "value": 1
+          }
+        ]
       },
       {
         "key": 5,
@@ -1337,7 +1575,17 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 6,
         "name": "",
         "type": "int",
-        "defaultValue": 1
+        "defaultValue": 1,
+        "options": [
+          {
+            "name": "UnitSphere",
+            "value": 0
+          },
+          {
+            "name": "UnitBox",
+            "value": 1
+          }
+        ]
       },
       {
         "key": 7,
@@ -1355,7 +1603,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 0,
         "name": "fogMode",
         "type": "int",
-        "defaultValue": 1
+        "defaultValue": 1,
+        "options": [
+          {
+            "name": "Linear",
+            "value": 0
+          },
+          {
+            "name": "Exponential",
+            "value": 1
+          },
+          {
+            "name": "Exponential2",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 1,
@@ -1727,7 +1989,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 9,
         "name": "billboardMode",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Off",
+            "value": 0
+          },
+          {
+            "name": "Billboard",
+            "value": 1
+          },
+          {
+            "name": "YawLockedBillboard",
+            "value": 2
+          }
+        ]
       },
       {
         "key": 10,
@@ -2034,7 +2310,29 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 3,
         "name": "visualState",
         "type": "int",
-        "defaultValue": 0
+        "defaultValue": 0,
+        "options": [
+          {
+            "name": "Waiting",
+            "value": 0
+          },
+          {
+            "name": "Listening",
+            "value": 1
+          },
+          {
+            "name": "Thinking",
+            "value": 2
+          },
+          {
+            "name": "Speaking",
+            "value": 3
+          },
+          {
+            "name": "Unknown",
+            "value": 4
+          }
+        ]
       }
     ]
   },

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -48,6 +48,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 3,
     "name": "StaticModel",
+    "description": "Adds static 3D models to a SpaceEntity. It displays non-animated objects, such as furniture, buildings, or decorative items within a space. The static model defines the visual appearance but has no animations or dynamic behaviors.",
     "properties": [
       {
         "key": 0,
@@ -58,18 +59,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 1,
         "deprecated": true,
         "name": "externalResourceAssetId",
+        "description": "Due to the introduction of LODs it doesn't make sense to set a specific asset anymore",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "externalResourceAssetCollectionId",
+        "description": "To retrieve this component's static asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -80,6 +84,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -91,6 +96,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -101,18 +107,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 7,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 8,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -120,6 +129,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 9,
         "name": "isShadowCaster",
+        "description": "Whether the mesh casts shadows.",
         "type": "bool",
         "defaultValue": true
       },
@@ -131,18 +141,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 11,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 12,
         "name": "showAsHoldoutInAR",
+        "description": "Whether the component is shown as holdout when in AR mode.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 13,
         "name": "showAsHoldoutInVirtual",
+        "description": "Whether the component is shown as holdout when in Virtual mode.",
         "type": "bool",
         "defaultValue": false
       }
@@ -151,6 +164,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 4,
     "name": "AnimatedModel",
+    "description": "Adds animated skeletal meshes to a SpaceEntity. These are used for objects that need to move or act within the space, such as characters or animated props. This component makes it possible to play, pause, or loop animations.",
     "properties": [
       {
         "key": 0,
@@ -161,18 +175,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
         "key": 1,
         "deprecated": true,
         "name": "externalResourceAssetId",
+        "description": "Due to the introduction of LODs it doesn't make sense to set a specific asset anymore",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "externalResourceAssetCollectionId",
+        "description": "To retrieve this component's animated asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -183,6 +200,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -194,6 +212,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -204,18 +223,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "isLoopPlayback",
+        "description": "Whether the animation of this animated model is in loop.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 7,
         "name": "isPlaying",
+        "description": "Whether the animation of this animated model is playing.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 8,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
@@ -227,18 +249,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 10,
         "name": "animationIndex",
+        "description": "Index of the currently active animation.",
         "type": "int",
         "defaultValue": -1
       },
       {
         "key": 11,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 12,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -246,6 +271,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 13,
         "name": "isShadowCaster",
+        "description": "Whether the mesh casts shadows.",
         "type": "bool",
         "defaultValue": true
       },
@@ -257,18 +283,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 15,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 16,
         "name": "showAsHoldoutInAR",
+        "description": "Whether the component is shown as holdout when in AR mode.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 17,
         "name": "showAsHoldoutInVirtual",
+        "description": "Whether the component is shown as holdout when in Virtual mode.",
         "type": "bool",
         "defaultValue": false
       }
@@ -282,6 +311,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 6,
     "name": "VideoPlayer",
+    "description": "Enables the playback of video content within the space. You can use it to stream videos from a URL or play videos stored as assets in CSP, allowing users to watch videos directly within the virtual environment.",
     "properties": [
       {
         "key": 0,
@@ -292,24 +322,28 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "videoAssetId",
+        "description": "ID of the video asset associated with this video player.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "videoAssetURL",
+        "description": "URL of the video asset associated with this video player.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "assetCollectionId",
+        "description": "To retrieve this component's video asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 4,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -320,6 +354,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -331,6 +366,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -341,36 +377,42 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 7,
         "name": "isStateShared",
+        "description": "Whether playback state is shared with other users through replication.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 8,
         "name": "isAutoPlay",
+        "description": "Whether the video plays automatically on load.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 9,
         "name": "isLoopPlayback",
+        "description": "Whether the video loops (i.e. starts over on end).",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 10,
         "name": "isAutoResize",
+        "description": "Whether the video auto-resizes if its frame has different dimensions.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 11,
         "name": "attenuationRadius",
+        "description": "Attenuation for the audio when a spatial audio type. The radius is the minimum distance between the origin of this audio component and the position of the player, from within which the player can start hearing the spatial audio in range. The radius is expressed in meters.",
         "type": "float",
         "defaultValue": 10.0
       },
       {
         "key": 12,
         "name": "playbackState",
+        "description": "Playback state of the video of this component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -391,18 +433,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 13,
         "name": "currentPlayheadPosition",
+        "description": "Current playhead position of the played video.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 14,
         "name": "timeSincePlay",
+        "description": "Time in Unix timestamp format that identifies the moment when the video started to play.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 15,
         "name": "videoPlayerSourceType",
+        "description": "Type of source the video of this component uses.",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -423,12 +468,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 16,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 17,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
@@ -440,18 +487,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 19,
         "name": "isEnabled",
+        "description": "Whether the component is enabled.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 20,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 21,
         "name": "stereoVideoType",
+        "description": "Type of stereo the video of this component uses.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -472,12 +522,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 22,
         "name": "isStereoFlipped",
+        "description": "Whether the stereo video left and right are flipped.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 23,
         "name": "volume",
+        "description": "Volume of the audio in a ratio between 0 and 1. Volume 1 represents the full volume of the audio clip of this component.",
         "type": "float",
         "defaultValue": 1.0,
         "range": {
@@ -488,6 +540,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 24,
         "name": "audioType",
+        "description": "Type of the audio of this audio component.",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -511,6 +564,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 8,
     "name": "ExternalLink",
+    "description": "Used to handle external URLs that can be opened from within a space.",
     "properties": [
       {
         "key": 0,
@@ -521,12 +575,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "linkUrl",
+        "description": "URL address to which this external link component redirects the user on trigger.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -537,6 +593,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -548,6 +605,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -558,30 +616,35 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "displayText",
+        "description": "Text that will be displayed by the component as hyperlink to the URL it redirects to.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 6,
         "name": "isEnabled",
+        "description": "Whether the component is enabled.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 7,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 8,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 9,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -590,22 +653,26 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 9,
     "name": "Avatar",
+    "description": "Data representation of an AvatarSpaceComponent.",
     "properties": [
       {
         "key": 0,
         "name": "avatarId",
+        "description": "Used for selecting a specific avatar depending on the user's preferences.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 1,
         "name": "userId",
+        "description": "ID of the user that controls this avatar.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "state",
+        "description": "State of the current avatar.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -643,6 +710,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "agoraUserId",
+        "description": "ID of the Agora user bounded to this avatar. When using voice chat, an Agora user is associated with a specific avatar component, so that it is possible to associate the person speaking via the Agora voice chat through the relative avatar.",
         "type": "string",
         "defaultValue": ""
       },
@@ -654,12 +722,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "isHandIKEnabled",
+        "description": "Whether the Hands Inverse Kinematics (IK) are enabled for this avatar. Intended for use in VR or with virtual hands controllers.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 7,
         "name": "targetHandIKTargetLocation",
+        "description": "Location of the target used for the hands IK. Used in combination with hand IK if enabled.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -670,6 +740,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 8,
         "name": "handRotation",
+        "description": "Rotation of the avatar hand.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -681,6 +752,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 9,
         "name": "headRotation",
+        "description": "Rotation of the avatar head.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -692,18 +764,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 10,
         "name": "walkRunBlendPercentage",
+        "description": "Blending between walk and run states expressed in percentage. When 0 the avatar is fully walking, when 100 the avatar is fully running.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 11,
         "name": "torsoTwistAlpha",
+        "description": "Angle to use to twist the avatar's torso. Positive value if the torso is turning right, negative if avatar is turning left.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 12,
         "name": "avatarPlayMode",
+        "description": "Play mode used by this avatar.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -728,6 +803,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 13,
         "name": "movementDirection",
+        "description": "A vector that represents the movement direction of the avatar.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -738,6 +814,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 14,
         "name": "locomotionModel",
+        "description": "Specifies which locomotion model this avatar component is using.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -754,24 +831,28 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 15,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 16,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 17,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 18,
         "name": "avatarUrl",
+        "description": "URL of a mesh for this avatar. This is intended for use with external avatar managers, such as ReadyPlayerMe.",
         "type": "string",
         "defaultValue": ""
       }
@@ -780,6 +861,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 10,
     "name": "Light",
+    "description": "Adds various types of lighting to a SpaceEntity, such as directional, point, or spotlights. This component is essential for creating realistic lighting effects and controlling how objects are illuminated within the space.",
     "properties": [
       {
         "key": 0,
@@ -789,6 +871,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "lightType",
+        "description": "Type of light of this light component.",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -809,6 +892,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 2,
         "name": "color",
+        "description": "Color of the light of this component.",
         "type": "vec3",
         "defaultValue": [
           255.0,
@@ -819,30 +903,35 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "Intensity",
+        "description": "Intensity of the light of this component.",
         "type": "float",
         "defaultValue": 5000.0
       },
       {
         "key": 4,
         "name": "range",
+        "description": "Range within which the light of this component affects the surrounding 3D scene.",
         "type": "float",
         "defaultValue": 1000.0
       },
       {
         "key": 5,
         "name": "innerConeAngle",
+        "description": "Angle of the inner cone in a spotlight.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 6,
         "name": "outerConeAngle",
+        "description": "Angle of the outer cone in a spotlight.",
         "type": "float",
         "defaultValue": 0.78539816339
       },
       {
         "key": 7,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -853,6 +942,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 8,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -864,24 +954,28 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 9,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 10,
         "name": "cookieAssetId",
+        "description": "ID of the asset used for the light cookie of this light component.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 11,
         "name": "cookieAssetCollectionId",
+        "description": "ID of the asset collection used for the light cookie of this light component.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 12,
         "name": "lightCookieType",
+        "description": "Type of the light cookie used by this light component.",
         "type": "int",
         "defaultValue": 2,
         "options": [
@@ -902,12 +996,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 13,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 14,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -915,6 +1011,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 15,
         "name": "lightShadowType",
+        "description": "Type of light shadow of this light component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -935,6 +1032,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 16,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -943,6 +1041,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 11,
     "name": "Button",
+    "description": "Add a clickable button to your space. Button click events can be responded to via scripts.",
     "properties": [
       {
         "key": 0,
@@ -952,24 +1051,28 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "labelText",
+        "description": "Text of the label of this button.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "iconAssetId",
+        "description": "ID of the icon asset associated with the button of this component. This is used to show a specific icon on the button by ID.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "assetCollectionId",
+        "description": "To retrieve this component's button asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 4,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -980,6 +1083,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -991,6 +1095,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1001,24 +1106,28 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 7,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 8,
         "name": "isEnabled",
+        "description": "Whether the component is enabled.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 9,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 10,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -1027,6 +1136,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 12,
     "name": "Image",
+    "description": "Add an image to your space.",
     "properties": [
       {
         "key": 0,
@@ -1037,18 +1147,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "imageAssetId",
+        "description": "ID of the image asset this image component refers to.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "assetCollectionId",
+        "description": "To retrieve this component's image asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1059,6 +1172,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1070,6 +1184,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1080,12 +1195,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 7,
         "name": "billboardMode",
+        "description": "Billboard mode used by this image component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1106,6 +1223,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 8,
         "name": "displayMode",
+        "description": "Display mode used by this image component.",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -1126,18 +1244,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 9,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 10,
         "name": "isEmissive",
+        "description": "Whether the image of this image component is emissive.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 11,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -1146,23 +1267,27 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 13,
     "name": "Script",
+    "description": "Enables custom behavior through scripting. This component allows developers to author scripts that control how entities and components behave based on specific conditions or user actions. Scripts can modify entity properties, trigger events, or respond to user inputs.",
     "scripting": false,
     "properties": [
       {
         "key": 1,
         "name": "scriptSource",
+        "description": "Source of the script of this script component.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "ownerId",
+        "description": "ID of the owner of this script component.",
         "type": "int",
         "defaultValue": 0
       },
       {
         "key": 3,
         "name": "scriptScope",
+        "description": "Scope within which this script operates.",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -1181,10 +1306,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 14,
     "name": "Custom",
+    "description": "Can be used to prototype new component types or to support the replication of custom data. This still requires using the CustomSpaceComponent class, as user-defined properties are stored at dynamic hash-derived ids that aren't statically representable in a schema.",
     "properties": [
       {
         "key": 0,
         "name": "applicationOrigin",
+        "description": "The application origin for which this component has been generated.",
         "type": "string",
         "defaultValue": ""
       }
@@ -1193,6 +1320,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 15,
     "name": "Conversation",
+    "description": "Add a conversation with comment thread to your space. These conversations have a spatial representation.",
     "properties": [
       {
         "key": 0,
@@ -1216,6 +1344,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1226,6 +1355,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1237,6 +1367,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "title",
+        "description": "Title of the conversation.",
         "type": "string",
         "defaultValue": ""
       },
@@ -1253,12 +1384,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 8,
         "name": "resolved",
+        "description": "Resolved value of the conversation.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 9,
         "name": "conversationCameraPosition",
+        "description": "Camera position of the conversation.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1269,6 +1402,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 10,
         "name": "conversationCameraRotation",
+        "description": "Camera rotation of the conversation.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1282,10 +1416,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 16,
     "name": "Portal",
+    "description": "Add a portal to your space that can be used to teleport users to another configured Space. To ensure the connection to the new space is successful, clients should: 1. Store the new space Id by calling PortalSpaceComponent::GetSpaceId(). 2. Exit the current space via the space system. 3. Enter the new one (also via the space system).",
     "properties": [
       {
         "key": 0,
         "name": "spaceId",
+        "description": "Space ID that this portal points to. When the user uses the portal, it should be able to leave the current space and enter the one identified by this property.",
         "type": "string",
         "defaultValue": ""
       },
@@ -1307,12 +1443,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "isEnabled",
+        "description": "Whether the component is enabled.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 5,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1323,6 +1461,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "radius",
+        "description": "Radius of this portal.",
         "type": "float",
         "defaultValue": 1.5
       }
@@ -1331,10 +1470,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 17,
     "name": "Audio",
+    "description": "Adds spatial audio to a SpaceEntity. This component creates immersive soundscapes by playing audio that reacts to the user's position in the space. Whether it's background music, sound effects, or voiceovers, the AudioSpaceComponent makes sound more engaging by positioning it in 3D space.",
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1345,6 +1486,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "playbackState",
+        "description": "Current playback state of the audio of this audio component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1365,6 +1507,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 2,
         "name": "audioType",
+        "description": "Type of the audio of this audio component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1381,36 +1524,42 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "audioAssetId",
+        "description": "Asset ID for this audio asset.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 4,
         "name": "assetCollectionId",
+        "description": "To retrieve this component's audio asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 5,
         "name": "attenuationRadius",
+        "description": "Attenuation for the audio when a spatial audio type. The radius is the minimum distance between the origin of this audio component and the position of the player, from within which the player can start hearing the spatial audio in range. The radius is expressed in meters.",
         "type": "float",
         "defaultValue": 10.0
       },
       {
         "key": 6,
         "name": "isLoopPlayback",
+        "description": "Whether the audio playback is looping. True if the audio loops (i.e. starts from the beginning when ended), false otherwise.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 7,
         "name": "timeSincePlay",
+        "description": "Timestamp recorded from the moment when the audio clip started playing, in Unix timestamp format.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 8,
         "name": "volume",
+        "description": "Volume of the audio in a ratio between 0 and 1. Volume 1 represents the full volume of the audio clip of this component.",
         "type": "float",
         "defaultValue": 1.0,
         "range": {
@@ -1421,12 +1570,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 9,
         "name": "isEnabled",
+        "description": "Whether the component is enabled.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 10,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -1441,11 +1592,13 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 19,
     "name": "Collision",
+    "description": "Add box, mesh, capsule and sphere colliders to objects in your Space. These colliders can act as triggers, which can be used in conjunction with Scripts to drive behavior.",
     "scripting": false,
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1456,6 +1609,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1467,6 +1621,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 2,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1477,6 +1632,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "collisionShape",
+        "description": "Collision shape used by this collision component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1501,6 +1657,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "collisionMode",
+        "description": "Collision mode used by this collision component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -1517,18 +1674,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "collisionAssetId",
+        "description": "ID of the collision asset used by this collision component.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 6,
         "name": "assetCollectionId",
+        "description": "To retrieve this component's collision asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 7,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -1536,6 +1696,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 8,
         "name": "isEnabled",
+        "description": "Whether the component is enabled.",
         "type": "bool",
         "defaultValue": true
       }
@@ -1544,6 +1705,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 20,
     "name": "Reflection",
+    "description": "Add sphere and box reflection captures to your Space which can be used by objects with reflective materials.",
     "scripting": false,
     "properties": [
       {
@@ -1554,18 +1716,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "reflectionAssetId",
+        "description": "Asset Id for the Reflection texture asset.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "assetCollectionId",
+        "description": "To retrieve this component's reflection asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1581,6 +1746,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1591,6 +1757,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "reflectionShape",
+        "description": "UnitBox: Projects a texture in a planar fashion from all six directions (like an inward facing cube). UnitSphere: Warps the texture into a spherical shape and projects it onto a surface.",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -1607,6 +1774,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 7,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -1616,10 +1784,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 21,
     "name": "Fog",
+    "description": "Add a depth-based fog volume to your space.",
     "properties": [
       {
         "key": 0,
         "name": "fogMode",
+        "description": "Type of fog currently used by this fog component.",
         "type": "int",
         "defaultValue": 1,
         "options": [
@@ -1640,6 +1810,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1650,6 +1821,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 2,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1661,6 +1833,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1671,18 +1844,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "startDistance",
+        "description": "Start distance. Distance from camera that the fog will start. 0 = this property has no effect.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 5,
         "name": "endDistance",
+        "description": "End distance. Objects passed this distance will not be affected by fog. 0 = this property has no effect.",
         "type": "float",
         "defaultValue": 0.0
       },
       {
         "key": 6,
         "name": "color",
+        "description": "Fog color.",
         "type": "vec3",
         "defaultValue": [
           0.8,
@@ -1693,42 +1869,49 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 7,
         "name": "density",
+        "description": "Global density factor.",
         "type": "float",
         "defaultValue": 0.4
       },
       {
         "key": 8,
         "name": "heightFalloff",
+        "description": "Height density factor. Controls how the density increases and height decreases. Smaller values make the visible transition larger.",
         "type": "float",
         "defaultValue": 0.2
       },
       {
         "key": 9,
         "name": "maxOpacity",
+        "description": "Maximum opacity of the fog. 1 = fog becomes fully opaque at a distance and replaces the scene colour completely. 0 = fog colour will have no impact.",
         "type": "float",
         "defaultValue": 1.0
       },
       {
         "key": 10,
         "name": "isVolumetric",
+        "description": "Whether fog is volumetric.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 11,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 12,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 13,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -1736,6 +1919,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 14,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -1744,10 +1928,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 22,
     "name": "ECommerce",
+    "description": "Can be used alongside CSP's Stripe integration to add e-commerce to your space. This component is used to represent physical objects that can be purchased as virtual items in the environment.",
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1758,6 +1944,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "productId",
+        "description": "Product ID associated with the ECommerce component.",
         "type": "string",
         "defaultValue": ""
       }
@@ -1766,6 +1953,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 23,
     "name": "FiducialMarker",
+    "description": "As an alternative to cloud-based anchors, fiducial markers can be used to anchor your space to a physical location.",
     "properties": [
       {
         "key": 0,
@@ -1776,18 +1964,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "markerAssetId",
+        "description": "ID of the image asset this fiducial marker component refers to.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "assetCollectionId",
+        "description": "To retrieve this component's image asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1798,6 +1989,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1809,6 +2001,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1819,18 +2012,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 7,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 8,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -1839,6 +2035,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 24,
     "name": "GaussianSplat",
+    "description": "Add Gaussian Splats to your space. Gaussian Splatting is a technique for real-time 3D reconstruction and rendering of an object or environment using images taken from multiple points of view. Rather than representing the object as a mesh of triangles, it is instead represented as a volume comprising a point cloud of splats, each of which has a position, colour (with alpha) and covariance.",
     "properties": [
       {
         "key": 0,
@@ -1848,18 +2045,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "externalResourceAssetId",
+        "description": "To retrieve this component's gaussian splat asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "externalResourceAssetCollectionId",
+        "description": "To retrieve this component's gaussian splat asset, both the Asset ID and the Asset Collection ID are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1870,6 +2070,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 4,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1881,6 +2082,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1891,12 +2093,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 7,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
@@ -1911,6 +2115,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 9,
         "name": "tint",
+        "description": "Tint that should be globally applied to the Gaussian Splat associated with this component. Expected to be in RGB color space, with each value normalised between 0 and 1.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1921,6 +2126,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 10,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -1929,10 +2135,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 25,
     "name": "Text",
+    "description": "Add a spatial representation of text to your space.",
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -1943,6 +2151,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -1954,6 +2163,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 2,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1964,12 +2174,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "text",
+        "description": "Text this text component refers to.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 4,
         "name": "textColor",
+        "description": "Text color. Expected to be in RGB color space, with each value normalised between 0 and 1.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -1980,6 +2192,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 5,
         "name": "backgroundColor",
+        "description": "Background color applied to the text component. Expected to be in RGB color space, with each value normalised between 0 and 1.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -2008,6 +2221,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 9,
         "name": "billboardMode",
+        "description": "Billboard mode used by this text component.",
         "type": "int",
         "defaultValue": 0,
         "options": [
@@ -2028,18 +2242,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 10,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 11,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 12,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -2048,10 +2265,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 26,
     "name": "Hotspot",
+    "description": "Data representation of an HotspotSpaceComponent.",
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -2062,6 +2281,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -2078,30 +2298,35 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "isTeleportPoint",
+        "description": "Whether this Hotspot is a teleport point.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 4,
         "name": "isSpawnPoint",
+        "description": "Whether this Hotspot is a spawn point.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 5,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 6,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 7,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -2110,10 +2335,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 27,
     "name": "CinematicCamera",
+    "description": "Data representation of a CinematicCameraSpaceComponent.",
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -2124,6 +2351,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -2135,24 +2363,28 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 2,
         "name": "isEnabled",
+        "description": "Whether the component is enabled.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 3,
         "name": "focalLength",
+        "description": "Focal length. Used alongside sensorSize and aspectRatio to compute field of view (historically exposed as GetFov()).",
         "type": "float",
         "defaultValue": 0.035
       },
       {
         "key": 4,
         "name": "aspectRatio",
+        "description": "Current aspect ratio.",
         "type": "float",
         "defaultValue": 1.778
       },
       {
         "key": 5,
         "name": "sensorSize",
+        "description": "Sensor size.",
         "type": "vec2",
         "defaultValue": [
           0.036,
@@ -2162,42 +2394,49 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 6,
         "name": "nearClip",
+        "description": "Near clip. On platforms that don't support reversedZ, near clip should be used to control the clipping distance.",
         "type": "float",
         "defaultValue": 0.1
       },
       {
         "key": 7,
         "name": "farClip",
+        "description": "Far clip. On platforms that don't support reversedZ, far clip should be used to control the clipping distance.",
         "type": "float",
         "defaultValue": 20000.0
       },
       {
         "key": 8,
         "name": "iso",
+        "description": "ISO sensitivity for controlling exposure.",
         "type": "float",
         "defaultValue": 400.0
       },
       {
         "key": 9,
         "name": "shutterSpeed",
+        "description": "Shutter speed.",
         "type": "float",
         "defaultValue": 0.0167
       },
       {
         "key": 10,
         "name": "aperture",
+        "description": "Aperture.",
         "type": "float",
         "defaultValue": 4.0
       },
       {
         "key": 11,
         "name": "isViewerCamera",
+        "description": "Whether this camera acts as the viewer camera.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 12,
         "name": "thirdPartyComponentRef",
+        "description": "Third party component reference.",
         "type": "string",
         "defaultValue": "",
         "scripting": false
@@ -2205,12 +2444,14 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 13,
         "name": "focusDistance",
+        "description": "Focus distance.",
         "type": "float",
         "defaultValue": 5.0
       },
       {
         "key": 14,
         "name": "depthOfFieldEnabled",
+        "description": "Whether depth of field is enabled.",
         "type": "bool",
         "defaultValue": false
       }
@@ -2219,10 +2460,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 28,
     "name": "ScreenSharing",
+    "description": "Enables screen sharing within the space. The component provides properties to define a default image to be displayed when no users are sharing their screen, as well as a UserId property to store the Id of the user currently sharing their screen.",
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -2233,6 +2476,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "rotation",
+        "description": "Rotation of this component's origin as a quaternion, expressed in radians. Right handed coordinate system, positive rotation is counterclockwise. North: +Z, East: -X, South: -Z, West: +X.",
         "type": "vec4",
         "defaultValue": [
           0.0,
@@ -2244,6 +2488,7 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 2,
         "name": "scale",
+        "description": "Scale of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           1.0,
@@ -2254,48 +2499,56 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 3,
         "name": "isVisible",
+        "description": "Whether the component is visible when in default mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 4,
         "name": "isARVisible",
+        "description": "Whether the component is visible when in AR mode.",
         "type": "bool",
         "defaultValue": true
       },
       {
         "key": 5,
         "name": "isShadowCaster",
+        "description": "Whether the mesh casts shadows.",
         "type": "bool",
         "defaultValue": false
       },
       {
         "key": 6,
         "name": "userId",
+        "description": "ID of the user who is currently sharing their screen to this component. An empty string means that no user is currently sharing their screen.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 7,
         "name": "defaultImageCollectionId",
+        "description": "To retrieve this component's default image, both the DefaultImageCollectionId and the DefaultImageAssetId are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 8,
         "name": "defaultImageAssetId",
+        "description": "To retrieve this component's default image, both the DefaultImageCollectionId and the DefaultImageAssetId are required.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 9,
         "name": "attenuationRadius",
+        "description": "Radius from this component origin within which the audio of this video can be heard by the user. Only when the user position is within this radius should the audio be heard.",
         "type": "float",
         "defaultValue": 10.0
       },
       {
         "key": 10,
         "name": "isVirtualVisible",
+        "description": "Whether the component is visible when in Virtual mode.",
         "type": "bool",
         "defaultValue": true
       }
@@ -2304,10 +2557,12 @@ constexpr const auto* BuiltinSchemasJson = R"(
   {
     "typeId": 29,
     "name": "AIChatbot",
+    "description": "AI chatbot component with text-to-speech voice capability and configurable guardrails.",
     "properties": [
       {
         "key": 0,
         "name": "position",
+        "description": "Position of this component's origin in world space. The coordinate system used follows the glTF 2.0 specification, in meters. Right handed coordinate system, +Y is UP, +X is left (facing forward), +Z is forward.",
         "type": "vec3",
         "defaultValue": [
           0.0,
@@ -2318,18 +2573,21 @@ constexpr const auto* BuiltinSchemasJson = R"(
       {
         "key": 1,
         "name": "voice",
+        "description": "Voice name of the TTS model associated with this AI chatbot.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 2,
         "name": "guardrailAssetCollectionId",
+        "description": "ID of the guardrail asset collection associated with this AI chatbot.",
         "type": "string",
         "defaultValue": ""
       },
       {
         "key": 3,
         "name": "visualState",
+        "description": "Visual state of the AI chatbot for this component.",
         "type": "int",
         "defaultValue": 0,
         "options": [

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.cpp
@@ -53,6 +53,1500 @@
 namespace csp::multiplayer
 {
 
+namespace
+{
+
+    const auto AllSchemas = csp::common::Array<ComponentSchema> {
+        // [0] StaticModel
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::StaticModel),
+            "StaticModel",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ExternalResourceAssetId),
+                    "externalResourceAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ExternalResourceAssetCollectionId),
+                    "externalResourceAssetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::MaterialOverrides),
+                    {}, // not exposed to scripting
+                    csp::common::Map<csp::common::String, csp::common::ReplicatedValue>(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4::Identity(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsShadowCaster),
+                    "isShadowCaster",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ShowAsHoldoutInAR),
+                    "showAsHoldoutInAR",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual),
+                    "showAsHoldoutInVirtual",
+                    false,
+                },
+            },
+        },
+        // [1] AnimatedModel
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::AnimatedModel),
+            "AnimatedModel",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ExternalResourceAssetId),
+                    "externalResourceAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ExternalResourceAssetCollectionId),
+                    "externalResourceAssetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::MaterialOverrides),
+                    {}, // not exposed to scripting
+                    csp::common::Map<csp::common::String, csp::common::ReplicatedValue>(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3 { 1, 1, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsLoopPlayback),
+                    "isLoopPlayback",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsPlaying),
+                    "isPlaying",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::AnimationIndex),
+                    "animationIndex",
+                    static_cast<int64_t>(-1),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsShadowCaster),
+                    "isShadowCaster",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR),
+                    "showAsHoldoutInAR",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual),
+                    "showAsHoldoutInVirtual",
+                    false,
+                },
+            },
+        },
+        // [2] VideoPlayer
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::VideoPlayer),
+            "VideoPlayer",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Name_DEPRECATED),
+                    "name",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoAssetId),
+                    "videoAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoAssetURL),
+                    "videoAssetURL",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AssetCollectionId),
+                    "assetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3 { 1, 1, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsStateShared),
+                    "isStateShared",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsAutoPlay),
+                    "isAutoPlay",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsLoopPlayback),
+                    "isLoopPlayback",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsAutoResize),
+                    "isAutoResize",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::PlaybackState),
+                    "playbackState",
+                    static_cast<int64_t>(0),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::CurrentPlayheadPosition),
+                    "currentPlayheadPosition",
+                    0.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::TimeSincePlay),
+                    "timeSincePlay",
+                    0.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AttenuationRadius),
+                    "attenuationRadius",
+                    10.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoPlayerSourceType),
+                    "videoPlayerSourceType",
+                    static_cast<int64_t>(VideoPlayerSourceType::AssetSource),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::StereoVideoType),
+                    "stereoVideoType",
+                    static_cast<int64_t>(StereoVideoType::None),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsStereoFlipped),
+                    "isStereoFlipped",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(0),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsEnabled),
+                    "isEnabled",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Volume),
+                    {}, // not exposed to scripting via schema: we can't express value ranges (min, max) in schemas yet, so manually bind
+                    1.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AudioType),
+                    "audioType",
+                    static_cast<int64_t>(AudioType::Spatial),
+                },
+            },
+        },
+        // [3] ExternalLink
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::ExternalLink),
+            "ExternalLink",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Name_DEPRECATED),
+                    "name",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::LinkUrl),
+                    "linkUrl",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3 { 1, 1, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::DisplayText),
+                    "displayText",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsEnabled),
+                    "isEnabled",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [4] Avatar
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::AvatarData),
+            "Avatar",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarId),
+                    "avatarId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::UserId),
+                    "userId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::State),
+                    "state",
+                    static_cast<int64_t>(AvatarState::Idle),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarMeshIndex_DEPRECATED),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(-1),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AgoraUserId),
+                    "agoraUserId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::CustomAvatarUrl_DEPRECATED),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsHandIKEnabled),
+                    "isHandIKEnabled",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::TargetHandIKTargetLocation),
+                    "targetHandIKTargetLocation",
+                    csp::common::Vector3 { 0.0f, 0.0f, 0.0f },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::HandRotation),
+                    "handRotation",
+                    csp::common::Vector4 { 0.0f, 0.0f, 0.0f, 1.0f },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::HeadRotation),
+                    "headRotation",
+                    csp::common::Vector4 { 0.0f, 0.0f, 0.0f, 1.0f },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::WalkRunBlendPercentage),
+                    "walkRunBlendPercentage",
+                    0.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::TorsoTwistAlpha),
+                    "torsoTwistAlpha",
+                    0.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarPlayMode),
+                    "avatarPlayMode",
+                    static_cast<int64_t>(AvatarPlayMode::Default),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::MovementDirection),
+                    "movementDirection",
+                    csp::common::Vector3 { 0.0f, 0.0f, 0.0f },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::LocomotionModel),
+                    "locomotionModel",
+                    static_cast<int64_t>(LocomotionModel::Grounded),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarUrl),
+                    "avatarUrl",
+                    "",
+                },
+            },
+        },
+        // [5] Light
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Light),
+            "Light",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightType),
+                    "lightType",
+                    static_cast<int64_t>(LightType::Point),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Color),
+                    "color",
+                    csp::common::Vector3 { 255, 255, 255 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Intensity),
+                    "Intensity", // Note: exposed as PascalCase for backwards compatibility (casing was wrong when this property was originally
+                    // exposed)
+                    5000.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Range),
+                    "range",
+                    1000.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::InnerConeAngle),
+                    "innerConeAngle",
+                    0.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::OuterConeAngle),
+                    "outerConeAngle",
+                    0.78539816339f, // Pi / 4
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieAssetId),
+                    "cookieAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieAssetCollectionId),
+                    "cookieAssetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieType),
+                    "lightCookieType",
+                    static_cast<int64_t>(LightCookieType::NoCookie),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightShadowType),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(LightShadowType::None),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [6] Button
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Button),
+            "Button",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::LabelText),
+                    "labelText",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IconAssetId),
+                    "iconAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::AssetCollectionId),
+                    "assetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3 { 1, 1, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsEnabled),
+                    "isEnabled",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [7] Image
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Image),
+            "Image",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Name_DEPRECATED),
+                    "name",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::ImageAssetId),
+                    "imageAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::AssetCollectionId),
+                    "assetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::BillboardMode),
+                    "billboardMode",
+                    static_cast<int64_t>(BillboardMode::Off),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::DisplayMode),
+                    "displayMode",
+                    static_cast<int64_t>(DisplayMode::DoubleSided),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsEmissive),
+                    "isEmissive",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [8] Script
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::ScriptData),
+            {}, // not exposed to scripting
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::ScriptSource),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::OwnerId),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(0),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::ScriptScope),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(ScriptScope::Owner),
+                },
+            },
+        },
+        // [9] Custom
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Custom),
+            "Custom",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(CustomComponentPropertyKeys::ApplicationOrigin),
+                    "applicationOrigin",
+                    "",
+                },
+            },
+        },
+        // [10] Conversation
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Conversation),
+            "Conversation",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationId),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::IsActive),
+                    "isActive",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Title),
+                    "title",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Resolved),
+                    "resolved",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationCameraPosition),
+                    "conversationCameraPosition",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationCameraRotation),
+                    "conversationCameraRotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+            },
+        },
+        // [11] Portal
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Portal),
+            "Portal",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsVisible),
+                    {}, // not exposed to scripting
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsActive),
+                    {}, // not exposed to scripting
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::SpaceId),
+                    "spaceId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsARVisible),
+                    {}, // not exposed to scripting
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsEnabled),
+                    "isEnabled",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::Radius),
+                    "radius",
+                    1.5f,
+                },
+            },
+        },
+        // [12] Audio
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Audio),
+            "Audio",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::PlaybackState),
+                    "playbackState",
+                    static_cast<int64_t>(AudioPlaybackState::Reset),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AudioType),
+                    "audioType",
+                    static_cast<int64_t>(AudioType::Global),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AudioAssetId),
+                    "audioAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AssetCollectionId),
+                    "assetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AttenuationRadius),
+                    "attenuationRadius",
+                    10.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::IsLoopPlayback),
+                    "isLoopPlayback",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::TimeSincePlay),
+                    "timeSincePlay",
+                    0.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::Volume),
+                    {}, // not exposed to scripting via schema: we can't express value ranges (min, max) in schemas yet, so manually bind
+                    1.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::IsEnabled),
+                    "isEnabled",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+            },
+        },
+        // [13] Spline
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Spline),
+            "Spline",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(SplinePropertyKeys::Waypoints),
+                    {}, // not exposed to scripting via an auto-generated property (has a legacy manual getter function)
+                    0.f,
+                },
+            },
+        },
+        // [14] Collision
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Collision),
+            {}, // not exposed to scripting
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Position),
+                    {}, // not exposed to scripting
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Rotation),
+                    {}, // not exposed to scripting
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Scale),
+                    {}, // not exposed to scripting
+                    csp::common::Vector3 { 1, 1, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionShape),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(CollisionShape::Box),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionMode),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(CollisionMode::Collision),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionAssetId),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::AssetCollectionId),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::IsEnabled),
+                    {}, // not exposed to scripting
+                    true,
+                },
+            },
+        },
+        // [15] Reflection
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Reflection),
+            {}, // not exposed to scripting
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Name_DEPRECATED),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ReflectionAssetId),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::AssetCollectionId),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Position),
+                    {}, // not exposed to scripting
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Scale),
+                    {}, // not exposed to scripting
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ReflectionShape),
+                    {}, // not exposed to scripting
+                    static_cast<int64_t>(ReflectionShape::UnitBox),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+            },
+        },
+        // [16] Fog
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Fog),
+            "Fog",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::FogMode),
+                    "fogMode",
+                    static_cast<int64_t>(FogMode::Exponential),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3 { 1, 1, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::StartDistance),
+                    "startDistance",
+                    0.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::EndDistance),
+                    "endDistance",
+                    0.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Color),
+                    "color",
+                    csp::common::Vector3 { 0.8f, 0.9f, 1.0f },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Density),
+                    "density",
+                    0.4f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::HeightFalloff),
+                    "heightFalloff",
+                    0.2f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::MaxOpacity),
+                    "maxOpacity",
+                    1.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVolumetric),
+                    "isVolumetric",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [17] ECommerce
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::ECommerce),
+            "ECommerce",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ECommercePropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3 { 0, 0, 0 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ECommercePropertyKeys::ProductId),
+                    "productId",
+                    "",
+                },
+            },
+        },
+        // [18] FiducialMarker
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::FiducialMarker),
+            "FiducialMarker",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Name_DEPRECATED),
+                    "name",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::MarkerAssetId),
+                    "markerAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::AssetCollectionId),
+                    "assetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [19] GaussianSplat
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::GaussianSplat),
+            "GaussianSplat",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::ExternalResourceAssetId),
+                    "externalResourceAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::ExternalResourceAssetCollectionId),
+                    "externalResourceAssetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4::Identity(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsShadowCaster_DEPRECATED),
+                    {}, // not exposed to scripting: this is a deprecated property that was never exposed to scripting, so no need to start now.
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Tint),
+                    "tint",
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [20] Text
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Text),
+            "Text",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Text),
+                    "text",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::TextColor),
+                    "textColor",
+                    csp::common::Vector3(1.0f, 1.0f, 1.0f),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::BackgroundColor),
+                    "backgroundColor",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsBackgroundVisible),
+                    "isBackgroundVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Width),
+                    "width",
+                    1.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Height),
+                    "height",
+                    1.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::BillboardMode),
+                    "billboardMode",
+                    static_cast<int64_t>(BillboardMode::Off),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [21] Hotspot
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::Hotspot),
+            "Hotspot",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4 { 0, 0, 0, 1 },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Name_DEPRECATED),
+                    {}, // not exposed to scripting
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsTeleportPoint),
+                    "isTeleportPoint",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsSpawnPoint),
+                    "isSpawnPoint",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [22] CinematicCamera
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::CinematicCamera),
+            "CinematicCamera",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4::Identity(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::IsEnabled),
+                    "isEnabled",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FocalLength),
+                    "focalLength",
+                    0.035f,
+                },
+                // 16:9
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::AspectRatio),
+                    "aspectRatio",
+                    1.778f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::SensorSize),
+                    "sensorSize",
+                    csp::common::Vector2 { 0.036f, 0.024f },
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::NearClip),
+                    "nearClip",
+                    0.1f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FarClip),
+                    "farClip",
+                    20000.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Iso),
+                    "iso",
+                    400.0f,
+                },
+                // 60 FPS
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::ShutterSpeed),
+                    "shutterSpeed",
+                    0.0167f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Aperture),
+                    "aperture",
+                    4.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FocusDistance),
+                    "focusDistance",
+                    5.0f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::DepthOfFieldEnabled),
+                    "depthOfFieldEnabled",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::IsViewerCamera),
+                    "isViewerCamera",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::ThirdPartyComponentRef),
+                    {}, // not exposed to scripting
+                    "",
+                },
+            },
+        },
+        // [23] ScreenSharing
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::ScreenSharing),
+            "ScreenSharing",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Rotation),
+                    "rotation",
+                    csp::common::Vector4::Identity(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Scale),
+                    "scale",
+                    csp::common::Vector3::One(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsVisible),
+                    "isVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsARVisible),
+                    "isARVisible",
+                    true,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsShadowCaster),
+                    "isShadowCaster",
+                    false,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::UserId),
+                    "userId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::DefaultImageCollectionId),
+                    "defaultImageCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::DefaultImageAssetId),
+                    "defaultImageAssetId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::AttenuationRadius),
+                    "attenuationRadius",
+                    10.f,
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsVirtualVisible),
+                    "isVirtualVisible",
+                    true,
+                },
+            },
+        },
+        // [24] AIChatbot
+        ComponentSchema {
+            static_cast<ComponentSchema::TypeIdType>(ComponentType::AIChatbot),
+            "AIChatbot",
+            csp::common::Array<ComponentProperty> {
+                {
+                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::Position),
+                    "position",
+                    csp::common::Vector3::Zero(),
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::Voice),
+                    "voice",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::GuardrailAssetCollectionId),
+                    "guardrailAssetCollectionId",
+                    "",
+                },
+                {
+                    static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::VisualState),
+                    "visualState",
+                    static_cast<int64_t>(0),
+                },
+            },
+        },
+    };
+
+} // namespace
+
+const csp::common::Array<ComponentSchema>& GetAllComponentSchemas() { return AllSchemas; }
+
+const ComponentSchema& GetStaticModelSchema() { return AllSchemas[0]; }
+const ComponentSchema& GetAnimatedModelSchema() { return AllSchemas[1]; }
+const ComponentSchema& GetVideoPlayerSchema() { return AllSchemas[2]; }
+const ComponentSchema& GetExternalLinkSchema() { return AllSchemas[3]; }
+const ComponentSchema& GetAvatarSchema() { return AllSchemas[4]; }
+const ComponentSchema& GetLightSchema() { return AllSchemas[5]; }
+const ComponentSchema& GetButtonSchema() { return AllSchemas[6]; }
+const ComponentSchema& GetImageSchema() { return AllSchemas[7]; }
+const ComponentSchema& GetScriptSchema() { return AllSchemas[8]; }
+const ComponentSchema& GetCustomSchema() { return AllSchemas[9]; }
+const ComponentSchema& GetConversationSchema() { return AllSchemas[10]; }
+const ComponentSchema& GetPortalSchema() { return AllSchemas[11]; }
+const ComponentSchema& GetAudioSchema() { return AllSchemas[12]; }
+const ComponentSchema& GetSplineSchema() { return AllSchemas[13]; }
+const ComponentSchema& GetCollisionSchema() { return AllSchemas[14]; }
+const ComponentSchema& GetReflectionSchema() { return AllSchemas[15]; }
+const ComponentSchema& GetFogSchema() { return AllSchemas[16]; }
+const ComponentSchema& GetECommerceSchema() { return AllSchemas[17]; }
+const ComponentSchema& GetFiducialMarkerSchema() { return AllSchemas[18]; }
+const ComponentSchema& GetGaussianSplatSchema() { return AllSchemas[19]; }
+const ComponentSchema& GetTextSchema() { return AllSchemas[20]; }
+const ComponentSchema& GetHotspotSchema() { return AllSchemas[21]; }
+const ComponentSchema& GetCinematicCameraSchema() { return AllSchemas[22]; }
+const ComponentSchema& GetScreenSharingSchema() { return AllSchemas[23]; }
+const ComponentSchema& GetAIChatbotSchema() { return AllSchemas[24]; }
+
 ComponentSchemaRegistryImpl::ComponentSchemaRegistryImpl(
     csp::common::LogSystem& LogSystem, const csp::common::Array<ComponentSchema>& AdditionalComponents)
 {
@@ -68,31 +1562,31 @@ ComponentSchemaRegistryImpl::ComponentSchemaRegistryImpl(
         }
     };
 
-    AddSchema(StaticModelSpaceComponent::GetSchema());
-    AddSchema(AnimatedModelSpaceComponent::GetSchema());
-    AddSchema(VideoPlayerSpaceComponent::GetSchema());
-    AddSchema(ImageSpaceComponent::GetSchema());
-    AddSchema(ExternalLinkSpaceComponent::GetSchema());
-    AddSchema(AvatarSpaceComponent::GetSchema());
-    AddSchema(LightSpaceComponent::GetSchema());
-    AddSchema(ScriptSpaceComponent::GetSchema());
-    AddSchema(ButtonSpaceComponent::GetSchema());
-    AddSchema(CustomSpaceComponent::GetSchema());
-    AddSchema(PortalSpaceComponent::GetSchema());
-    AddSchema(ConversationSpaceComponent::GetSchema());
-    AddSchema(AudioSpaceComponent::GetSchema());
-    AddSchema(SplineSpaceComponent::GetSchema());
-    AddSchema(CollisionSpaceComponent::GetSchema());
-    AddSchema(ReflectionSpaceComponent::GetSchema());
-    AddSchema(FogSpaceComponent::GetSchema());
-    AddSchema(ECommerceSpaceComponent::GetSchema());
-    AddSchema(CinematicCameraSpaceComponent::GetSchema());
-    AddSchema(FiducialMarkerSpaceComponent::GetSchema());
-    AddSchema(GaussianSplatSpaceComponent::GetSchema());
-    AddSchema(TextSpaceComponent::GetSchema());
-    AddSchema(HotspotSpaceComponent::GetSchema());
-    AddSchema(ScreenSharingSpaceComponent::GetSchema());
-    AddSchema(AIChatbotSpaceComponent::GetSchema());
+    AddSchema(GetStaticModelSchema());
+    AddSchema(GetAnimatedModelSchema());
+    AddSchema(GetVideoPlayerSchema());
+    AddSchema(GetExternalLinkSchema());
+    AddSchema(GetAvatarSchema());
+    AddSchema(GetLightSchema());
+    AddSchema(GetButtonSchema());
+    AddSchema(GetImageSchema());
+    AddSchema(GetScriptSchema());
+    AddSchema(GetCustomSchema());
+    AddSchema(GetConversationSchema());
+    AddSchema(GetPortalSchema());
+    AddSchema(GetAudioSchema());
+    AddSchema(GetSplineSchema());
+    AddSchema(GetCollisionSchema());
+    AddSchema(GetReflectionSchema());
+    AddSchema(GetFogSchema());
+    AddSchema(GetECommerceSchema());
+    AddSchema(GetFiducialMarkerSchema());
+    AddSchema(GetGaussianSplatSchema());
+    AddSchema(GetTextSchema());
+    AddSchema(GetHotspotSchema());
+    AddSchema(GetCinematicCameraSchema());
+    AddSchema(GetScreenSharingSchema());
+    AddSchema(GetAIChatbotSchema());
 
     for (const auto& Schema : AdditionalComponents)
     {

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.h
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.h
@@ -34,8 +34,6 @@ std::optional<ComponentType> ToComponentType(uint64_t TypeId);
 
 bool IsLegacyComponentTypeId(uint64_t TypeId);
 
-const csp::common::Array<ComponentSchema>& GetAllComponentSchemas();
-
 const ComponentSchema& GetStaticModelSchema();
 const ComponentSchema& GetAnimatedModelSchema();
 const ComponentSchema& GetVideoPlayerSchema();

--- a/Library/src/Multiplayer/ComponentSchemaRegistry.h
+++ b/Library/src/Multiplayer/ComponentSchemaRegistry.h
@@ -34,6 +34,34 @@ std::optional<ComponentType> ToComponentType(uint64_t TypeId);
 
 bool IsLegacyComponentTypeId(uint64_t TypeId);
 
+const csp::common::Array<ComponentSchema>& GetAllComponentSchemas();
+
+const ComponentSchema& GetStaticModelSchema();
+const ComponentSchema& GetAnimatedModelSchema();
+const ComponentSchema& GetVideoPlayerSchema();
+const ComponentSchema& GetExternalLinkSchema();
+const ComponentSchema& GetAvatarSchema();
+const ComponentSchema& GetLightSchema();
+const ComponentSchema& GetButtonSchema();
+const ComponentSchema& GetImageSchema();
+const ComponentSchema& GetScriptSchema();
+const ComponentSchema& GetCustomSchema();
+const ComponentSchema& GetConversationSchema();
+const ComponentSchema& GetPortalSchema();
+const ComponentSchema& GetAudioSchema();
+const ComponentSchema& GetSplineSchema();
+const ComponentSchema& GetCollisionSchema();
+const ComponentSchema& GetReflectionSchema();
+const ComponentSchema& GetFogSchema();
+const ComponentSchema& GetECommerceSchema();
+const ComponentSchema& GetFiducialMarkerSchema();
+const ComponentSchema& GetGaussianSplatSchema();
+const ComponentSchema& GetTextSchema();
+const ComponentSchema& GetHotspotSchema();
+const ComponentSchema& GetCinematicCameraSchema();
+const ComponentSchema& GetScreenSharingSchema();
+const ComponentSchema& GetAIChatbotSchema();
+
 class ComponentSchemaRegistryImpl final : public IComponentSchemaRegistry
 {
 public:

--- a/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
+++ b/Library/src/Multiplayer/Components/AIChatbotComponent.cpp
@@ -16,49 +16,20 @@
 
 #include "CSP/Multiplayer/Components/AIChatbotComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::AIChatbot),
-    "AIChatbot",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::Voice),
-            "voice",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::GuardrailAssetCollectionId),
-            "guardrailAssetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AIChatbotPropertyKeys::VisualState),
-            "visualState",
-            static_cast<int64_t>(0),
-        },
-    },
-};
-
-const ComponentSchema& AIChatbotSpaceComponent::GetSchema() { return Schema; }
-
 csp::multiplayer::AIChatbotSpaceComponent::AIChatbotSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : AIChatbotSpaceComponent(Schema, LogSystem, Parent)
+    : AIChatbotSpaceComponent(GetAIChatbotSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<AIChatbotSpaceComponent> AIChatbotSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(AIChatbotSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetAIChatbotSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AnimatedModelSpaceComponent.cpp
@@ -16,111 +16,22 @@
 
 #include "CSP/Multiplayer/Components/AnimatedModelSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 #include <memory>
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::AnimatedModel),
-    "AnimatedModel",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ExternalResourceAssetId),
-            "externalResourceAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ExternalResourceAssetCollectionId),
-            "externalResourceAssetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::MaterialOverrides),
-            {}, // not exposed to scripting
-            csp::common::Map<csp::common::String, csp::common::ReplicatedValue>(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3 { 1, 1, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsLoopPlayback),
-            "isLoopPlayback",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsPlaying),
-            "isPlaying",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::AnimationIndex),
-            "animationIndex",
-            static_cast<int64_t>(-1),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsShadowCaster),
-            "isShadowCaster",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ShowAsHoldoutInAR),
-            "showAsHoldoutInAR",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AnimatedModelPropertyKeys::ShowAsHoldoutInVirtual),
-            "showAsHoldoutInVirtual",
-            false,
-        },
-    },
-};
-
-const ComponentSchema& AnimatedModelSpaceComponent::GetSchema() { return Schema; }
-
 AnimatedModelSpaceComponent::AnimatedModelSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : AnimatedModelSpaceComponent(Schema, LogSystem, Parent)
+    : AnimatedModelSpaceComponent(GetAnimatedModelSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<AnimatedModelSpaceComponent> AnimatedModelSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(AnimatedModelSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetAnimatedModelSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AudioSpaceComponent.cpp
@@ -17,95 +17,23 @@
 #include "CSP/Multiplayer/Components/AudioSpaceComponent.h"
 #include "CSP/Common/Systems/Log/LogSystem.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/AudioSpaceComponentScriptInterface.h"
 
 #include <fmt/format.h>
 
-namespace
-{
-
-constexpr const float DefaultAttenuationRadius = 10.f; // Distance in meters
-constexpr const float DefaultVolume = 1.f;
-
-} // namespace
-
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Audio),
-    "Audio",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::PlaybackState),
-            "playbackState",
-            static_cast<int64_t>(AudioPlaybackState::Reset),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AudioType),
-            "audioType",
-            static_cast<int64_t>(AudioType::Global),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AudioAssetId),
-            "audioAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AssetCollectionId),
-            "assetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::AttenuationRadius),
-            "attenuationRadius",
-            DefaultAttenuationRadius,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::IsLoopPlayback),
-            "isLoopPlayback",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::TimeSincePlay),
-            "timeSincePlay",
-            0.f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::Volume),
-            {}, // not exposed to scripting via schema: we can't express value ranges (min, max) in schemas yet, so manually bind
-            DefaultVolume,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::IsEnabled),
-            "isEnabled",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AudioPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting
-            "",
-        },
-    },
-};
-
-const ComponentSchema& AudioSpaceComponent::GetSchema() { return Schema; }
-
 AudioSpaceComponent::AudioSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : AudioSpaceComponent(Schema, LogSystem, Parent)
+    : AudioSpaceComponent(GetAudioSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<AudioSpaceComponent> AudioSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(AudioSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetAudioSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/AvatarSpaceComponent.cpp
@@ -15,124 +15,20 @@
  */
 #include "CSP/Multiplayer/Components/AvatarSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::AvatarData),
-    "Avatar",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarId),
-            "avatarId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::UserId),
-            "userId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::State),
-            "state",
-            static_cast<int64_t>(AvatarState::Idle),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarMeshIndex_DEPRECATED),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(-1),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AgoraUserId),
-            "agoraUserId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::CustomAvatarUrl_DEPRECATED),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsHandIKEnabled),
-            "isHandIKEnabled",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::TargetHandIKTargetLocation),
-            "targetHandIKTargetLocation",
-            csp::common::Vector3 { 0.0f, 0.0f, 0.0f },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::HandRotation),
-            "handRotation",
-            csp::common::Vector4 { 0.0f, 0.0f, 0.0f, 1.0f },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::HeadRotation),
-            "headRotation",
-            csp::common::Vector4 { 0.0f, 0.0f, 0.0f, 1.0f },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::WalkRunBlendPercentage),
-            "walkRunBlendPercentage",
-            0.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::TorsoTwistAlpha),
-            "torsoTwistAlpha",
-            0.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarPlayMode),
-            "avatarPlayMode",
-            static_cast<int64_t>(AvatarPlayMode::Default),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::MovementDirection),
-            "movementDirection",
-            csp::common::Vector3 { 0.0f, 0.0f, 0.0f },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::LocomotionModel),
-            "locomotionModel",
-            static_cast<int64_t>(LocomotionModel::Grounded),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(AvatarComponentPropertyKeys::AvatarUrl),
-            "avatarUrl",
-            "",
-        },
-    },
-};
-
-const ComponentSchema& AvatarSpaceComponent::GetSchema() { return Schema; }
-
 AvatarSpaceComponent::AvatarSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : AvatarSpaceComponent(Schema, LogSystem, Parent)
+    : AvatarSpaceComponent(GetAvatarSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<AvatarSpaceComponent> AvatarSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(AvatarSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetAvatarSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ButtonSpaceComponent.cpp
@@ -15,79 +15,20 @@
  */
 #include "CSP/Multiplayer/Components/ButtonSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Button),
-    "Button",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::LabelText),
-            "labelText",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IconAssetId),
-            "iconAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::AssetCollectionId),
-            "assetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3 { 1, 1, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsEnabled),
-            "isEnabled",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ButtonPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& ButtonSpaceComponent::GetSchema() { return Schema; }
-
 ButtonSpaceComponent::ButtonSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ButtonSpaceComponent(Schema, LogSystem, Parent)
+    : ButtonSpaceComponent(GetButtonSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ButtonSpaceComponent> ButtonSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ButtonSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetButtonSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CinematicCameraSpaceComponent.cpp
@@ -16,7 +16,7 @@
 
 #include "CSP/Multiplayer/Components/CinematicCameraSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/CinematicCameraSpaceComponentScriptInterface.h"
 
 #include <cmath>
@@ -24,101 +24,15 @@
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::CinematicCamera),
-    "CinematicCamera",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4::Identity(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::IsEnabled),
-            "isEnabled",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FocalLength),
-            "focalLength",
-            0.035f,
-        },
-        // 16:9
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::AspectRatio),
-            "aspectRatio",
-            1.778f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::SensorSize),
-            "sensorSize",
-            csp::common::Vector2 { 0.036f, 0.024f },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::NearClip),
-            "nearClip",
-            0.1f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FarClip),
-            "farClip",
-            20000.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Iso),
-            "iso",
-            400.0f,
-        },
-        // 60 FPS
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::ShutterSpeed),
-            "shutterSpeed",
-            0.0167f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::Aperture),
-            "aperture",
-            4.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::FocusDistance),
-            "focusDistance",
-            5.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::DepthOfFieldEnabled),
-            "depthOfFieldEnabled",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::IsViewerCamera),
-            "isViewerCamera",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CinematicCameraPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting,
-            "",
-        },
-    },
-};
-
-const ComponentSchema& CinematicCameraSpaceComponent::GetSchema() { return Schema; }
-
 CinematicCameraSpaceComponent::CinematicCameraSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : CinematicCameraSpaceComponent(Schema, LogSystem, Parent)
+    : CinematicCameraSpaceComponent(GetCinematicCameraSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<CinematicCameraSpaceComponent> CinematicCameraSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(CinematicCameraSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetCinematicCameraSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/CollisionSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CollisionSpaceComponent.cpp
@@ -16,7 +16,7 @@
 
 #include "CSP/Multiplayer/Components/CollisionSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/CollisionSpaceComponentScriptInterface.h"
 
 namespace
@@ -31,69 +31,15 @@ constexpr const float DefaultCapsuleHalfHeight = 1.f;
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Collision),
-    {}, // not exposed to scripting
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Position),
-            {}, // not exposed to scripting
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Rotation),
-            {}, // not exposed to scripting
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::Scale),
-            {}, // not exposed to scripting
-            csp::common::Vector3 { 1, 1, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionShape),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(CollisionShape::Box),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionMode),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(CollisionMode::Collision),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::CollisionAssetId),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::AssetCollectionId),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(CollisionPropertyKeys::IsEnabled),
-            {}, // not exposed to scripting
-            true,
-        },
-    },
-};
-
-const ComponentSchema& CollisionSpaceComponent::GetSchema() { return Schema; }
-
 CollisionSpaceComponent::CollisionSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : CollisionSpaceComponent(Schema, LogSystem, Parent)
+    : CollisionSpaceComponent(GetCollisionSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<CollisionSpaceComponent> CollisionSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(CollisionSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetCollisionSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ConversationSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ConversationSpaceComponent.cpp
@@ -16,7 +16,7 @@
 
 #include "CSP/Multiplayer/Components/ConversationSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "Systems/Conversation/ConversationSystemInternal.h"
@@ -49,69 +49,15 @@ namespace
     }
 }
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Conversation),
-    "Conversation",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationId),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::IsActive),
-            "isActive",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Title),
-            "title",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::Resolved),
-            "resolved",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationCameraPosition),
-            "conversationCameraPosition",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ConversationPropertyKeys::ConversationCameraRotation),
-            "conversationCameraRotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-    },
-};
-
-const ComponentSchema& ConversationSpaceComponent::GetSchema() { return Schema; }
-
 csp::multiplayer::ConversationSpaceComponent::ConversationSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ConversationSpaceComponent(Schema, LogSystem, Parent)
+    : ConversationSpaceComponent(GetConversationSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ConversationSpaceComponent> ConversationSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ConversationSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetConversationSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/CustomSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/CustomSpaceComponent.cpp
@@ -16,7 +16,7 @@
 #include "CSP/Multiplayer/Components/CustomSpaceComponent.h"
 
 #include "CSP/Common/Systems/Log/LogSystem.h"
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/CustomSpaceComponentScriptInterface.h"
 
 #include <algorithm>
@@ -25,29 +25,15 @@
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Custom),
-    "Custom",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(CustomComponentPropertyKeys::ApplicationOrigin),
-            "applicationOrigin",
-            "",
-        },
-    },
-};
-
-const ComponentSchema& CustomSpaceComponent::GetSchema() { return Schema; }
-
 CustomSpaceComponent::CustomSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : CustomSpaceComponent(Schema, LogSystem, Parent)
+    : CustomSpaceComponent(GetCustomSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<CustomSpaceComponent> CustomSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(CustomSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetCustomSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ECommerceSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ECommerceSpaceComponent.cpp
@@ -16,39 +16,20 @@
 
 #include "CSP/Multiplayer/Components/ECommerceSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::ECommerce),
-    "ECommerce",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ECommercePropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ECommercePropertyKeys::ProductId),
-            "productId",
-            "",
-        },
-    },
-};
-
-const ComponentSchema& ECommerceSpaceComponent::GetSchema() { return Schema; }
-
 ECommerceSpaceComponent::ECommerceSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ECommerceSpaceComponent(Schema, LogSystem, Parent)
+    : ECommerceSpaceComponent(GetECommerceSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ECommerceSpaceComponent> ECommerceSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ECommerceSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetECommerceSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
@@ -15,79 +15,20 @@
  */
 #include "CSP/Multiplayer/Components/ExternalLinkSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::ExternalLink),
-    "ExternalLink",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Name_DEPRECATED),
-            "name",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::LinkUrl),
-            "linkUrl",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3 { 1, 1, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::DisplayText),
-            "displayText",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsEnabled),
-            "isEnabled",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& ExternalLinkSpaceComponent::GetSchema() { return Schema; }
-
 ExternalLinkSpaceComponent::ExternalLinkSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ExternalLinkSpaceComponent(Schema, LogSystem, Parent)
+    : ExternalLinkSpaceComponent(GetExternalLinkSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ExternalLinkSpaceComponent> ExternalLinkSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ExternalLinkSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetExternalLinkSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
@@ -16,74 +16,20 @@
 
 #include "CSP/Multiplayer/Components/FiducialMarkerSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::FiducialMarker),
-    "FiducialMarker",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Name_DEPRECATED),
-            "name",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::MarkerAssetId),
-            "markerAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::AssetCollectionId),
-            "assetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& FiducialMarkerSpaceComponent::GetSchema() { return Schema; }
-
 FiducialMarkerSpaceComponent::FiducialMarkerSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : FiducialMarkerSpaceComponent(Schema, LogSystem, Parent)
+    : FiducialMarkerSpaceComponent(GetFiducialMarkerSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<FiducialMarkerSpaceComponent> FiducialMarkerSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(FiducialMarkerSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetFiducialMarkerSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FogSpaceComponent.cpp
@@ -15,103 +15,19 @@
  */
 #include "CSP/Multiplayer/Components/FogSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Fog),
-    "Fog",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::FogMode),
-            "fogMode",
-            static_cast<int64_t>(FogMode::Exponential),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3 { 1, 1, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::StartDistance),
-            "startDistance",
-            0.f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::EndDistance),
-            "endDistance",
-            0.f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Color),
-            "color",
-            csp::common::Vector3 { 0.8f, 0.9f, 1.0f },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::Density),
-            "density",
-            0.4f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::HeightFalloff),
-            "heightFalloff",
-            0.2f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::MaxOpacity),
-            "maxOpacity",
-            1.f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVolumetric),
-            "isVolumetric",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(FogPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& FogSpaceComponent::GetSchema() { return Schema; }
-
 FogSpaceComponent::FogSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : FogSpaceComponent(Schema, LogSystem, Parent)
+    : FogSpaceComponent(GetFogSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<FogSpaceComponent> FogSpaceComponent::TryMake(const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(FogSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetFogSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/GaussianSplatSpaceComponent.cpp
@@ -16,79 +16,20 @@
 
 #include "CSP/Multiplayer/Components/GaussianSplatSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::GaussianSplat),
-    "GaussianSplat",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::ExternalResourceAssetId),
-            "externalResourceAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::ExternalResourceAssetCollectionId),
-            "externalResourceAssetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4::Identity(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsShadowCaster_DEPRECATED),
-            {}, // not exposed to scripting: this is a deprecated property that was never exposed to scripting, so no need to start now.
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::Tint),
-            "tint",
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(GaussianSplatPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& GaussianSplatSpaceComponent::GetSchema() { return Schema; }
-
 GaussianSplatSpaceComponent::GaussianSplatSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : GaussianSplatSpaceComponent(Schema, LogSystem, Parent)
+    : GaussianSplatSpaceComponent(GetGaussianSplatSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<GaussianSplatSpaceComponent> GaussianSplatSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(GaussianSplatSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetGaussianSplatSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/HotspotSpaceComponent.cpp
@@ -15,71 +15,22 @@
  */
 #include "CSP/Multiplayer/Components/HotspotSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/HotspotSpaceComponentScriptInterface.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Hotspot),
-    "Hotspot",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::Name_DEPRECATED),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsTeleportPoint),
-            "isTeleportPoint",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsSpawnPoint),
-            "isSpawnPoint",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(HotspotPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& HotspotSpaceComponent::GetSchema() { return Schema; }
-
 HotspotSpaceComponent::HotspotSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : HotspotSpaceComponent(Schema, LogSystem, Parent)
+    : HotspotSpaceComponent(GetHotspotSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<HotspotSpaceComponent> HotspotSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(HotspotSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetHotspotSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
@@ -15,89 +15,20 @@
  */
 #include "CSP/Multiplayer/Components/ImageSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Image),
-    "Image",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Name_DEPRECATED),
-            "name",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::ImageAssetId),
-            "imageAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::AssetCollectionId),
-            "assetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::BillboardMode),
-            "billboardMode",
-            static_cast<int64_t>(BillboardMode::Off),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::DisplayMode),
-            "displayMode",
-            static_cast<int64_t>(DisplayMode::DoubleSided),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsEmissive),
-            "isEmissive",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& ImageSpaceComponent::GetSchema() { return Schema; }
-
 ImageSpaceComponent::ImageSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ImageSpaceComponent(Schema, LogSystem, Parent)
+    : ImageSpaceComponent(GetImageSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ImageSpaceComponent> ImageSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ImageSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetImageSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/LightSpaceComponent.cpp
@@ -15,109 +15,20 @@
  */
 #include "CSP/Multiplayer/Components/LightSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Light),
-    "Light",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightType),
-            "lightType",
-            static_cast<int64_t>(LightType::Point),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Color),
-            "color",
-            csp::common::Vector3 { 255, 255, 255 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Intensity),
-            "Intensity", // Note: exposed as PascalCase for backwards compatibility (casing was wrong when this property was originally exposed)
-            5000.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Range),
-            "range",
-            1000.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::InnerConeAngle),
-            "innerConeAngle",
-            0.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::OuterConeAngle),
-            "outerConeAngle",
-            0.78539816339f, // Pi / 4
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieAssetId),
-            "cookieAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieAssetCollectionId),
-            "cookieAssetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightCookieType),
-            "lightCookieType",
-            static_cast<int64_t>(LightCookieType::NoCookie),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::LightShadowType),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(LightShadowType::None),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(LightPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& LightSpaceComponent::GetSchema() { return Schema; }
-
 LightSpaceComponent::LightSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : LightSpaceComponent(Schema, LogSystem, Parent)
+    : LightSpaceComponent(GetLightSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<LightSpaceComponent> LightSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(LightSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetLightSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/PortalSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/PortalSpaceComponent.cpp
@@ -15,64 +15,20 @@
  */
 #include "CSP/Multiplayer/Components/PortalSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Portal),
-    "Portal",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsVisible),
-            {}, // not exposed to scripting
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsActive),
-            {}, // not exposed to scripting
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::SpaceId),
-            "spaceId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsARVisible),
-            {}, // not exposed to scripting
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::IsEnabled),
-            "isEnabled",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(PortalPropertyKeys::Radius),
-            "radius",
-            1.5f,
-        },
-    },
-};
-
-const ComponentSchema& PortalSpaceComponent::GetSchema() { return Schema; }
-
 PortalSpaceComponent::PortalSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : PortalSpaceComponent(Schema, LogSystem, Parent)
+    : PortalSpaceComponent(GetPortalSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<PortalSpaceComponent> PortalSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(PortalSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetPortalSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ReflectionSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ReflectionSpaceComponent.cpp
@@ -16,65 +16,21 @@
 
 #include "CSP/Multiplayer/Components/ReflectionSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/ReflectionSpaceComponentScriptInterface.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Reflection),
-    {}, // not exposed to scripting
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Name_DEPRECATED),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ReflectionAssetId),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::AssetCollectionId),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Position),
-            {}, // not exposed to scripting
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::Scale),
-            {}, // not exposed to scripting
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ReflectionShape),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(ReflectionShape::UnitBox),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ReflectionPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting
-            "",
-        },
-    },
-};
-
-const ComponentSchema& ReflectionSpaceComponent::GetSchema() { return Schema; }
-
 ReflectionSpaceComponent::ReflectionSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ReflectionSpaceComponent(Schema, LogSystem, Parent)
+    : ReflectionSpaceComponent(GetReflectionSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ReflectionSpaceComponent> ReflectionSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ReflectionSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetReflectionSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScreenSharingSpaceComponent.cpp
@@ -15,90 +15,21 @@
  */
 #include "CSP/Multiplayer/Components/ScreenSharingSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
-
-namespace
-{
-constexpr const float DefaultAttenuationRadius = 10.f; // Distance in meters
-}
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::ScreenSharing),
-    "ScreenSharing",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4::Identity(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsShadowCaster),
-            "isShadowCaster",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::UserId),
-            "userId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::DefaultImageCollectionId),
-            "defaultImageCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::DefaultImageAssetId),
-            "defaultImageAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::AttenuationRadius),
-            "attenuationRadius",
-            DefaultAttenuationRadius,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScreenSharingPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& ScreenSharingSpaceComponent::GetSchema() { return Schema; }
-
 ScreenSharingSpaceComponent::ScreenSharingSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ScreenSharingSpaceComponent(Schema, LogSystem, Parent)
+    : ScreenSharingSpaceComponent(GetScreenSharingSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ScreenSharingSpaceComponent> ScreenSharingSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ScreenSharingSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetScreenSharingSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp
@@ -18,44 +18,20 @@
 #include "CSP/Multiplayer/Script/EntityScript.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::ScriptData),
-    {}, // not exposed to scripting
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::ScriptSource),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::OwnerId),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(0),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(ScriptComponentPropertyKeys::ScriptScope),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(ScriptScope::Owner),
-        },
-    },
-};
-
-const ComponentSchema& ScriptSpaceComponent::GetSchema() { return Schema; }
-
 ScriptSpaceComponent::ScriptSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : ScriptSpaceComponent(Schema, LogSystem, Parent)
+    : ScriptSpaceComponent(GetScriptSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<ScriptSpaceComponent> ScriptSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(ScriptSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetScriptSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/SplineSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/SplineSpaceComponent.cpp
@@ -17,7 +17,7 @@
 #include "CSP/Common/Systems/Log/LogSystem.h"
 #include "CSP/Common/fmt_Formatters.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/SplineSpaceComponentScriptInterface.h"
 
 #include "tinyspline.h"
@@ -39,29 +39,15 @@ namespace
     };
 }
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Spline),
-    "Spline",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(SplinePropertyKeys::Waypoints),
-            {}, // not exposed to scripting via an auto-generated property (has a legacy manual getter function)
-            0.f,
-        },
-    },
-};
-
-const ComponentSchema& SplineSpaceComponent::GetSchema() { return Schema; }
-
 SplineSpaceComponent::SplineSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : SplineSpaceComponent(Schema, LogSystem, Parent)
+    : SplineSpaceComponent(GetSplineSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<SplineSpaceComponent> SplineSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(SplineSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetSplineSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/StaticModelSpaceComponent.cpp
@@ -16,96 +16,22 @@
 
 #include "CSP/Multiplayer/Components/StaticModelSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 #include <memory>
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::StaticModel),
-    "StaticModel",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ExternalResourceAssetId),
-            "externalResourceAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ExternalResourceAssetCollectionId),
-            "externalResourceAssetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::MaterialOverrides),
-            {}, // not exposed to scripting
-            csp::common::Map<csp::common::String, csp::common::ReplicatedValue>(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4::Identity(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ThirdPartyComponentRef),
-            {}, // not exposed to scripting
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsShadowCaster),
-            "isShadowCaster",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ShowAsHoldoutInAR),
-            "showAsHoldoutInAR",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(StaticModelPropertyKeys::ShowAsHoldoutInVirtual),
-            "showAsHoldoutInVirtual",
-            false,
-        },
-    },
-};
-
-const ComponentSchema& StaticModelSpaceComponent::GetSchema() { return Schema; }
-
 StaticModelSpaceComponent::StaticModelSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : StaticModelSpaceComponent(Schema, LogSystem, Parent)
+    : StaticModelSpaceComponent(GetStaticModelSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<StaticModelSpaceComponent> StaticModelSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(StaticModelSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetStaticModelSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/TextSpaceComponent.cpp
@@ -15,94 +15,20 @@
  */
 #include "CSP/Multiplayer/Components/TextSpaceComponent.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::Text),
-    "Text",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Position),
-            "position",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3::One(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Text),
-            "text",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::TextColor),
-            "textColor",
-            csp::common::Vector3(1.0f, 1.0f, 1.0f),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::BackgroundColor),
-            "backgroundColor",
-            csp::common::Vector3::Zero(),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsBackgroundVisible),
-            "isBackgroundVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Width),
-            "width",
-            1.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::Height),
-            "height",
-            1.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::BillboardMode),
-            "billboardMode",
-            static_cast<int64_t>(BillboardMode::Off),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(TextPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-    },
-};
-
-const ComponentSchema& TextSpaceComponent::GetSchema() { return Schema; }
-
 TextSpaceComponent::TextSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : TextSpaceComponent(Schema, LogSystem, Parent)
+    : TextSpaceComponent(GetTextSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<TextSpaceComponent> TextSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(TextSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetTextSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -18,163 +18,23 @@
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 #include "CSP/Multiplayer/SpaceEntity.h"
 
-#include "CSP/Multiplayer/ComponentSchema.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "Multiplayer/Script/ComponentBinding/VideoPlayerSpaceComponentScriptInterface.h"
 
 #include <fmt/format.h>
 
-namespace
-{
-constexpr const float DefaultAttenuationRadius = 10.f; // Distance in meters
-constexpr const float DefaultVolume = 1.f;
-}
-
 namespace csp::multiplayer
 {
 
-const auto Schema = ComponentSchema {
-    static_cast<ComponentSchema::TypeIdType>(ComponentType::VideoPlayer),
-    "VideoPlayer",
-    csp::common::Array<ComponentProperty> {
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Name_DEPRECATED),
-            "name",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoAssetId),
-            "videoAssetId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoAssetURL),
-            "videoAssetURL",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AssetCollectionId),
-            "assetCollectionId",
-            "",
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Position),
-            "position",
-            csp::common::Vector3 { 0, 0, 0 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Rotation),
-            "rotation",
-            csp::common::Vector4 { 0, 0, 0, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Scale),
-            "scale",
-            csp::common::Vector3 { 1, 1, 1 },
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsStateShared),
-            "isStateShared",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsAutoPlay),
-            "isAutoPlay",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsLoopPlayback),
-            "isLoopPlayback",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsAutoResize),
-            "isAutoResize",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::PlaybackState),
-            "playbackState",
-            static_cast<int64_t>(0),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::CurrentPlayheadPosition),
-            "currentPlayheadPosition",
-            0.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::TimeSincePlay),
-            "timeSincePlay",
-            0.0f,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AttenuationRadius),
-            "attenuationRadius",
-            DefaultAttenuationRadius,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::VideoPlayerSourceType),
-            "videoPlayerSourceType",
-            static_cast<int64_t>(VideoPlayerSourceType::AssetSource),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::StereoVideoType),
-            "stereoVideoType",
-            static_cast<int64_t>(StereoVideoType::None),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsStereoFlipped),
-            "isStereoFlipped",
-            false,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsVisible),
-            "isVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsARVisible),
-            "isARVisible",
-            true,
-        },
-        {
-            static_cast<uint16_t>(VideoPlayerPropertyKeys::MeshComponentId),
-            {}, // not exposed to scripting
-            static_cast<int64_t>(0),
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsEnabled),
-            "isEnabled",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::IsVirtualVisible),
-            "isVirtualVisible",
-            true,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Volume),
-            {}, // not exposed to scripting via schema: we can't express value ranges (min, max) in schemas yet, so manually bind
-            DefaultVolume,
-        },
-        {
-            static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::AudioType),
-            "audioType",
-            static_cast<int64_t>(AudioType::Spatial),
-        },
-    },
-};
-
-const ComponentSchema& VideoPlayerSpaceComponent::GetSchema() { return Schema; }
-
 VideoPlayerSpaceComponent::VideoPlayerSpaceComponent(csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
-    : VideoPlayerSpaceComponent(Schema, LogSystem, Parent)
+    : VideoPlayerSpaceComponent(GetVideoPlayerSchema(), LogSystem, Parent)
 {
 }
 
 std::unique_ptr<VideoPlayerSpaceComponent> VideoPlayerSpaceComponent::TryMake(
     const ComponentSchema& InSchema, csp::common::LogSystem* LogSystem, SpaceEntity* Parent)
 {
-    if (!IsCompatible(VideoPlayerSpaceComponent::GetSchema(), InSchema))
+    if (!IsCompatible(GetVideoPlayerSchema(), InSchema))
     {
         return nullptr;
     }

--- a/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OfflineRealtimeEngine.cpp
@@ -120,7 +120,7 @@ OfflineRealtimeEngine::OfflineRealtimeEngine(csp::common::LogSystem& LogSystem, 
 
 OfflineRealtimeEngine::OfflineRealtimeEngine(
     csp::common::LogSystem& LogSystem, csp::common::IJSScriptRunner& RemoteScriptRunner, const csp::common::List<csp::common::String>& JsonSchemas)
-    : OfflineRealtimeEngine(LogSystem, RemoteScriptRunner, ComponentSchemasFromJson(JsonSchemas, LogSystem))
+    : OfflineRealtimeEngine(LogSystem, RemoteScriptRunner, ComponentSchemasFromJson(JsonSchemas, &LogSystem))
 {
 }
 

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -190,7 +190,7 @@ OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerC
 OnlineRealtimeEngine::OnlineRealtimeEngine(MultiplayerConnection& InMultiplayerConnection, csp::common::LogSystem& LogSystem,
     csp::multiplayer::NetworkEventBus& NetworkEventBus, csp::common::IJSScriptRunner& ScriptRunner,
     const csp::common::List<csp::common::String>& JsonSchemas)
-    : OnlineRealtimeEngine(InMultiplayerConnection, LogSystem, NetworkEventBus, ScriptRunner, ComponentSchemasFromJson(JsonSchemas, LogSystem))
+    : OnlineRealtimeEngine(InMultiplayerConnection, LogSystem, NetworkEventBus, ScriptRunner, ComponentSchemasFromJson(JsonSchemas, &LogSystem))
 {
 }
 

--- a/Library/src/Multiplayer/Script/ComponentScriptHelpers.h
+++ b/Library/src/Multiplayer/Script/ComponentScriptHelpers.h
@@ -71,7 +71,12 @@ inline bool IsScriptable(const csp::common::String& Name) { return !Name.IsEmpty
 
 inline bool IsScriptable(const ComponentProperty& Property)
 {
-    return IsScriptable(Property.Name)
+    if (Property.IsReserved)
+    {
+        return false;
+    }
+
+    return Property.IsScriptable && IsScriptable(Property.Name)
         && std::visit(
             [](const auto& V)
             {
@@ -83,10 +88,15 @@ inline bool IsScriptable(const ComponentProperty& Property)
 
 inline bool IsScriptable(const ComponentSchema& Schema)
 {
+    if (Schema.IsReserved)
+    {
+        return false;
+    }
+
     const auto HasScriptableProperties = [&](const auto& Properties)
     { return std::any_of(Properties.begin(), Properties.end(), [](const auto& Property) { return IsScriptable(Property); }); };
 
-    return IsScriptable(Schema.Name) && HasScriptableProperties(Schema.Properties);
+    return Schema.IsScriptable && IsScriptable(Schema.Name) && HasScriptableProperties(Schema.Properties);
 }
 
 } // namespace csp::multiplayer

--- a/Library/src/Multiplayer/Script/ComponentScriptInterface.cpp
+++ b/Library/src/Multiplayer/Script/ComponentScriptInterface.cpp
@@ -198,7 +198,7 @@ void ComponentScriptInterface::SetProperty(uint16_t Key, Value DesiredValue)
 
     if (auto MaybeMappedValue = std::visit(Visitor{}, std::move(DesiredValue)))
     {
-        Component->SetPropertyDirect(Key, std::move(*MaybeMappedValue));
+        Component->SetProperty(Key, std::move(*MaybeMappedValue));
         SendPropertyUpdate();
     }
 }

--- a/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
+++ b/Library/src/Multiplayer/Script/EntityScriptBinding.cpp
@@ -446,11 +446,6 @@ void EntityScriptBinding::RemoveBinding(EntityScriptBinding* InEntityBinding, cs
 
 void BindComponents(qjs::Context::Module* Module)
 {
-    Module->class_<VideoPlayerSpaceComponentScriptInterface>("VideoPlayerSpaceComponent")
-        .constructor<>()
-        .base<ComponentScriptInterface>()
-        .PROPERTY_GET_SET(VideoPlayerSpaceComponent, Volume, "volume"); // we can't express value ranges (min, max) in schemas yet, so manually bind
-
     Module->class_<CinematicCameraSpaceComponentScriptInterface>("CinematicCameraSpaceComponent")
         .constructor<>()
         .base<ComponentScriptInterface>()
@@ -472,11 +467,6 @@ void BindComponents(qjs::Context::Module* Module)
         .fun<&SplineSpaceComponentScriptInterface::SetWaypoints>("setWaypoints")
         .fun<&SplineSpaceComponentScriptInterface::GetWaypoints>("getWaypoints")
         .fun<&SplineSpaceComponentScriptInterface::GetLocationAlongSpline>("getLocationAlongSpline");
-
-    Module->class_<AudioSpaceComponentScriptInterface>("AudioSpaceComponent")
-        .constructor<>()
-        .base<ComponentScriptInterface>()
-        .PROPERTY_GET_SET(AudioSpaceComponent, Volume, "volume"); // we can't express value ranges (min, max) in schemas yet, so manually bind
 
     Module->class_<HotspotSpaceComponentScriptInterface>("HotspotSpaceComponent")
         .constructor<>()

--- a/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaScriptBindingTests.cpp
@@ -812,7 +812,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleScriptab
     EXPECT_TRUE(Fixture.InvokeScript(Entity, ScriptText));
 }
 
-CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleSchemaComponentsOneNonScriptable)
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleSchemaComponentsSomeNonScriptable)
 {
     auto Fixture = TestFixture({
         Schema {
@@ -835,7 +835,30 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleSchemaCo
                     "value",
                     "Hello",
                 },
+                {
+                    1,
+                    "nonScriptableProperty",
+                    "Hidden",
+                    /*.Description =*/ {},
+                    /*.IsScriptable =*/false,
+                },
+                {
+                    2,
+                    {},
+                    {},
+                    /*.Description =*/"Was a property, now reserved",
+                    /*.IsScriptable =*/false,
+                    /*.IsDeprecated =*/false,
+                    /*.IsReserved =*/true,
+                },
             },
+        },
+        Schema {
+            Schema::TypeIdType { 456 },
+            "NonScriptable",
+            {},
+            /*.Description =*/ {},
+            /*.IsScriptable =*/false,
         },
     });
 
@@ -849,6 +872,10 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleSchemaCo
                 Schema::TypeIdType { 321 },
                 TestFixture::Entity::ComponentCreationArgs::InstanceCount { 1 },
             },
+            TestFixture::Entity::ComponentCreationArgs {
+                Schema::TypeIdType { 456 },
+                TestFixture::Entity::ComponentCreationArgs::InstanceCount { 1 },
+            },
         });
 
     // Test script ensures that getScriptableComponents still gets registered despite a
@@ -856,7 +883,12 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaScriptBindingTests, MultipleSchemaCo
     constexpr auto ScriptText = R"(
         import { assert } from "CSPTest";
 
-        assert(typeof ThisEntity.getScriptableComponents === "function", "Scriptable component getter exists");
+        assert(typeof ThisEntity.getScriptableComponents === "function", "getScriptableComponents should exist");
+        assert(typeof ThisEntity.getNonScriptableComponents === "undefined", "getNonScriptableComponents should not exist");
+
+        const scriptable = ThisEntity.getScriptableComponents()[0];
+        assert("value" in scriptable, "value should be exposed");
+        assert(!("nonScriptableProperty" in scriptable), "nonScriptableProperty should not be exposed");
     )";
 
     EXPECT_TRUE(Fixture.InvokeScript(Entity, ScriptText));

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -1179,6 +1179,8 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonParsesAllPropertyType
 
 CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, JsonSerializationRoundTrip)
 {
+    using Option = csp::multiplayer::SchemaOption;
+
     const auto Original = Schema {
         Schema::TypeIdType { 123 },
         "Example",
@@ -1188,7 +1190,55 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, JsonSerializationRoundTrip)
                 "stringProperty",
                 "value",
             },
+            {
+                1,
+                "intProp",
+                int64_t { 0 },
+                /*.Description =*/"A description.",
+                /*.IsScriptable =*/true,
+                /*.IsDeprecated =*/false,
+                /*.IsReserved =*/false,
+                /*.RangeMin =*/ {},
+                /*.RangeMax =*/ {},
+                /*.Options =*/
+                csp::common::Array<Option> {
+                    { "Off", int64_t { 0 } },
+                    { "On", int64_t { 1 } },
+                },
+            },
+            {
+                2,
+                "floatProp",
+                1.0f,
+                /*.Description =*/"Another description.",
+                /*.IsScriptable =*/false,
+                /*.IsDeprecated =*/false,
+                /*.IsReserved =*/false,
+                /*.RangeMin =*/0.0f,
+                /*.RangeMax =*/1.0f,
+            },
+            {
+                3,
+                "stringProp",
+                csp::common::String { "" },
+                /*.Description =*/ {},
+                /*.IsScriptable =*/true,
+                /*.IsDeprecated =*/true,
+            },
+            {
+                4,
+                {},
+                {},
+                /*.Description =*/"Was prop, removed",
+                /*.IsScriptable =*/false,
+                /*.IsDeprecated =*/false,
+                /*.IsReserved =*/true,
+            },
         },
+        /*.Description =*/"A component description.",
+        /*.IsScriptable =*/false,
+        /*.IsReserved =*/false,
+        /*.IsDeprecated =*/true,
     };
 
     const auto Json = Schema::ToJson(Original);
@@ -1451,6 +1501,382 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsVec4PropertyWi
     })";
     const auto Result = Schema::FromJson(csp::common::String { RawJson });
     EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonParsesPropertyMetadata)
+{
+    using Option = csp::multiplayer::SchemaOption;
+
+    constexpr auto RawJson = R"({
+        "typeId": 123,
+        "name": "Example",
+        "properties": [
+            {
+                "key": 0,
+                "name": "intProp",
+                "type": "int",
+                "defaultValue": 0,
+                "description": "A description.",
+                "scripting": false,
+                "options": [
+                    { "name": "Off", "value": 0 },
+                    { "name": "On", "value": 1 }
+                ]
+            },
+            {
+                "key": 1,
+                "name": "floatProp",
+                "type": "float",
+                "defaultValue": 1.0,
+                "scripting": false,
+                "range": { "min": 0.0, "max": 1.0 }
+            },
+            {
+                "key": 2,
+                "name": "stringProp",
+                "type": "string",
+                "defaultValue": "",
+                "deprecated": true
+            }
+        ]
+    })";
+
+    const auto Expected = Schema {
+        Schema::TypeIdType { 123 },
+        "Example",
+        {
+            {
+                0,
+                "intProp",
+                int64_t { 0 },
+                /*.Description =*/"A description.",
+                /*.IsScriptable =*/false,
+                /*.IsDeprecated =*/false,
+                /*.IsReserved =*/false,
+                /*.RangeMin =*/ {},
+                /*.RangeMax =*/ {},
+                /*.Options =*/
+                csp::common::Array<Option> {
+                    { "Off", int64_t { 0 } },
+                    { "On", int64_t { 1 } },
+                },
+            },
+            {
+                1,
+                "floatProp",
+                1.0f,
+                /*.Description =*/ {},
+                /*.IsScriptable =*/false,
+                /*.IsDeprecated =*/false,
+                /*.IsReserved =*/false,
+                /*.RangeMin =*/0.0f,
+                /*.RangeMax =*/1.0f,
+            },
+            {
+                2,
+                "stringProp",
+                csp::common::String { "" },
+                /*.Description =*/ {},
+                /*.IsScriptable =*/true,
+                /*.IsDeprecated =*/true,
+            },
+        },
+    };
+
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+
+    ASSERT_TRUE(Result.HasValue());
+    EXPECT_EQ(*Result, Expected);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonParsesReservedProperty)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123,
+        "name": "Example",
+        "properties": [
+            {
+                "key": 0,
+                "name": "prop",
+                "type": "string",
+                "defaultValue": ""
+            },
+            {
+                "key": 1,
+                "reserved": true,
+                "description": "Was prop, removed"
+            }
+        ]
+    })";
+
+    const auto Expected = Schema {
+        Schema::TypeIdType { 123 },
+        "Example",
+        {
+            {
+                0,
+                "prop",
+                csp::common::String { "" },
+            },
+            {
+                1,
+                {},
+                {},
+                /*.Description =*/"Was prop, removed",
+                /*.IsScriptable =*/false,
+                /*.IsDeprecated =*/false,
+                /*.IsReserved =*/true,
+            },
+        },
+    };
+
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+
+    ASSERT_TRUE(Result.HasValue());
+    EXPECT_EQ(*Result, Expected);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonParsesReservedSchema)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 5,
+        "reserved": true,
+        "description": "Was Example, removed"
+    })";
+
+    const auto Expected = Schema {
+        Schema::TypeIdType { 5 },
+        /*.Name =*/ {},
+        /*.Properties =*/ {},
+        /*.Description =*/"Was Example, removed",
+        /*.IsScriptable =*/false,
+        /*.IsReserved =*/true,
+    };
+
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+
+    ASSERT_TRUE(Result.HasValue());
+    EXPECT_EQ(*Result, Expected);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, JsonSerializationRoundTripReservedSchema)
+{
+    const auto Original = Schema {
+        Schema::TypeIdType { 5 },
+        /*.Name =*/ {},
+        /*.Properties =*/ {},
+        /*.Description =*/"Was Example, removed",
+        /*.IsScriptable =*/false,
+        /*.IsReserved =*/true,
+    };
+
+    const auto Json = Schema::ToJson(Original);
+    const auto Result = Schema::FromJson(Json);
+
+    ASSERT_TRUE(Result.HasValue());
+    EXPECT_EQ(*Result, Original);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsPropertyWithMalformedRange)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123,
+        "name": "Example",
+        "properties": [
+            {
+                "key": 0,
+                "name": "floatProp",
+                "type": "float",
+                "defaultValue": 1.0,
+                "range": { "min": "low", "max": "high" }
+            }
+        ]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsPropertyWithMalformedOption)
+{
+    constexpr auto RawJson = R"({
+        "typeId": 123,
+        "name": "Example",
+        "properties": [
+            {
+                "key": 0,
+                "name": "intProp",
+                "type": "int",
+                "defaultValue": 0,
+                "options": [
+                    { "name": "Off", "value": 0 },
+                    { "name": "On" }
+                ]
+            }
+        ]
+    })";
+    const auto Result = Schema::FromJson(csp::common::String { RawJson });
+    EXPECT_FALSE(Result.HasValue());
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsOptionsOnUnsupportedPropertyTypes)
+{
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "bool",
+                    "defaultValue": false,
+                    "options": [{ "name": "Off", "value": false }, { "name": "On", "value": true }]
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "vec2",
+                    "defaultValue": [0.0, 0.0],
+                    "options": [{ "name": "Zero", "value": [0.0, 0.0] }]
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "vec3",
+                    "defaultValue": [0.0, 0.0, 0.0],
+                    "options": [{ "name": "Zero", "value": [0.0, 0.0, 0.0] }]
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "vec4",
+                    "defaultValue": [0.0, 0.0, 0.0, 1.0],
+                    "options": [{ "name": "Identity", "value": [0.0, 0.0, 0.0, 1.0] }]
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, FromJsonRejectsRangeOnUnsupportedPropertyTypes)
+{
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "string",
+                    "defaultValue": "",
+                    "range": { "min": "a", "max": "z" }
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "bool",
+                    "defaultValue": false,
+                    "range": { "min": false, "max": true }
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "vec2",
+                    "defaultValue": [0.0, 0.0],
+                    "range": { "min": 0.0, "max": 1.0 }
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "vec3",
+                    "defaultValue": [0.0, 0.0, 0.0],
+                    "range": { "min": 0.0, "max": 1.0 }
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
+    {
+        constexpr auto RawJson = R"({
+            "typeId": 123,
+            "name": "Example",
+            "properties": [
+                {
+                    "key": 0,
+                    "name": "prop",
+                    "type": "vec4",
+                    "defaultValue": [0.0, 0.0, 0.0, 1.0],
+                    "range": { "min": 0.0, "max": 1.0 }
+                }
+            ]
+        })";
+        const auto Result = Schema::FromJson(csp::common::String { RawJson });
+        EXPECT_FALSE(Result.HasValue());
+    }
 }
 
 CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, IsCompatibleReturnsTrueForValidUpdate)

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -699,6 +699,7 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, TypedSetterReflectsInGetPrope
 CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, ComponentPropertyEquality)
 {
     using Property = csp::multiplayer::ComponentProperty;
+    using Option = csp::multiplayer::SchemaOption;
 
     {
         const auto A = Property {
@@ -749,6 +750,134 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, ComponentPropertyEquality)
             0,
             "name",
             "other",
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/"a description",
+        };
+        const auto B = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/ {},
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/ {},
+            /*.IsScriptable =*/false,
+        };
+        const auto B = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/true,
+        };
+        const auto B = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/false,
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/false,
+            /*.IsReserved =*/true,
+        };
+        const auto B = Property {
+            0,
+            "name",
+            "value",
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/false,
+            /*.IsReserved =*/false,
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            1.0f,
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/false,
+            /*.IsReserved =*/false,
+            /*.RangeMin =*/0.0f,
+            /*.RangeMax =*/1.0f,
+        };
+        const auto B = Property {
+            0,
+            "name",
+            1.0f,
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/false,
+            /*.IsReserved =*/false,
+            /*.RangeMin =*/ {},
+            /*.RangeMax =*/ {},
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Property {
+            0,
+            "name",
+            int64_t { 0 },
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/false,
+            /*.IsReserved =*/false,
+            /*.RangeMin =*/ {},
+            /*.RangeMax =*/ {},
+            /*.Options =*/
+            csp::common::Array<Option> {
+                { "Off", int64_t { 0 } },
+                { "On", int64_t { 1 } },
+            },
+        };
+        const auto B = Property {
+            0,
+            "name",
+            int64_t { 0 },
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsDeprecated =*/false,
+            /*.IsReserved =*/false,
+            /*.RangeMin =*/ {},
+            /*.RangeMax =*/ {},
+            /*.Options =*/ {},
         };
         EXPECT_NE(A, B);
     }
@@ -872,6 +1001,78 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, ComponentSchemaEquality)
                     "other",
                 },
             },
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/"A description.",
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/ {},
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/ {},
+            /*.IsScriptable =*/false,
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/ {},
+            /*.IsScriptable =*/false,
+            /*.IsReserved =*/true,
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/ {},
+            /*.IsScriptable =*/false,
+            /*.IsReserved =*/false,
+        };
+        EXPECT_NE(A, B);
+    }
+    {
+        const auto A = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsReserved =*/false,
+            /*.IsDeprecated =*/true,
+        };
+        const auto B = Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {},
+            /*.Description =*/ {},
+            /*.IsScriptable =*/true,
+            /*.IsReserved =*/false,
+            /*.IsDeprecated =*/false,
         };
         EXPECT_NE(A, B);
     }

--- a/Tests/src/InternalTests/ComponentSchemaTests.cpp
+++ b/Tests/src/InternalTests/ComponentSchemaTests.cpp
@@ -655,6 +655,85 @@ CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyWhenParentIsLocked
     EXPECT_EQ(*Value, "Value");
 }
 
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyIgnoresValueOutsideRange)
+{
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "floatProp",
+                    0.5f,
+                    /*.Description =*/ {},
+                    /*.IsScriptable =*/true,
+                    /*.IsDeprecated =*/false,
+                    /*.IsReserved =*/false,
+                    /*.RangeMin =*/0.0f,
+                    /*.RangeMax =*/1.0f,
+                },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    Component->SetProperty(0, 2.0f);
+
+    const auto* Value = Component->GetProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(*Value, 0.5f);
+}
+
+CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyIgnoresValueNotInOptions)
+{
+    using Option = csp::multiplayer::SchemaOption;
+
+    auto Fixture = TestFixture({
+        Schema {
+            Schema::TypeIdType { 123 },
+            "Example",
+            {
+                {
+                    0,
+                    "intProp",
+                    int64_t { 0 },
+                    /*.Description =*/ {},
+                    /*.IsScriptable =*/true,
+                    /*.IsDeprecated =*/false,
+                    /*.IsReserved =*/false,
+                    /*.RangeMin =*/ {},
+                    /*.RangeMax =*/ {},
+                    /*.Options =*/
+                    csp::common::Array<Option> {
+                        { "Off", int64_t { 0 } },
+                        { "On", int64_t { 1 } },
+                    },
+                },
+            },
+        },
+    });
+
+    auto* Entity = Fixture.MakeEntity("Test Entity");
+    ASSERT_NE(Entity, nullptr);
+
+    auto* Component = Entity->AddComponentByTypeId(uint64_t { 123 });
+    ASSERT_NE(Component, nullptr);
+
+    Component->SetProperty(0, int64_t { 2 });
+
+    const auto* Value = Component->GetProperty(0);
+    ASSERT_NE(Value, nullptr);
+
+    EXPECT_EQ(*Value, int64_t { 0 });
+}
+
 CSP_INTERNAL_TEST(CSPEngine, ComponentSchemaTests, SetPropertyReflectsInTypedGetter)
 {
     auto Fixture = TestFixture({});

--- a/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ComponentTests.cpp
@@ -50,6 +50,7 @@
 #include "CSP/Systems/Script/ScriptSystem.h"
 #include "CSP/Systems/SystemsManager.h"
 #include "Common/Convert.h"
+#include "Multiplayer/ComponentSchemaRegistry.h"
 #include "TestHelpers.h"
 
 #include "gtest/gtest.h"
@@ -453,31 +454,31 @@ CSP_PUBLIC_TEST(CSPEngine, ComponentTests, UpdatedLegacySchemaExposesExtraProper
     };
 
     const auto AllUpdated = std::vector<csp::multiplayer::ComponentSchema> {
-        WithExtraProperty(csp::multiplayer::StaticModelSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::AnimatedModelSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::VideoPlayerSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ImageSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ExternalLinkSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::AvatarSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::LightSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ScriptSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ButtonSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::CustomSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::PortalSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ConversationSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::AudioSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::SplineSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::CollisionSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ReflectionSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::FogSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ECommerceSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::CinematicCameraSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::FiducialMarkerSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::GaussianSplatSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::TextSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::HotspotSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::ScreenSharingSpaceComponent::GetSchema()),
-        WithExtraProperty(csp::multiplayer::AIChatbotSpaceComponent::GetSchema()),
+        WithExtraProperty(csp::multiplayer::GetStaticModelSchema()),
+        WithExtraProperty(csp::multiplayer::GetAnimatedModelSchema()),
+        WithExtraProperty(csp::multiplayer::GetVideoPlayerSchema()),
+        WithExtraProperty(csp::multiplayer::GetImageSchema()),
+        WithExtraProperty(csp::multiplayer::GetExternalLinkSchema()),
+        WithExtraProperty(csp::multiplayer::GetAvatarSchema()),
+        WithExtraProperty(csp::multiplayer::GetLightSchema()),
+        WithExtraProperty(csp::multiplayer::GetScriptSchema()),
+        WithExtraProperty(csp::multiplayer::GetButtonSchema()),
+        WithExtraProperty(csp::multiplayer::GetCustomSchema()),
+        WithExtraProperty(csp::multiplayer::GetPortalSchema()),
+        WithExtraProperty(csp::multiplayer::GetConversationSchema()),
+        WithExtraProperty(csp::multiplayer::GetAudioSchema()),
+        WithExtraProperty(csp::multiplayer::GetSplineSchema()),
+        WithExtraProperty(csp::multiplayer::GetCollisionSchema()),
+        WithExtraProperty(csp::multiplayer::GetReflectionSchema()),
+        WithExtraProperty(csp::multiplayer::GetFogSchema()),
+        WithExtraProperty(csp::multiplayer::GetECommerceSchema()),
+        WithExtraProperty(csp::multiplayer::GetCinematicCameraSchema()),
+        WithExtraProperty(csp::multiplayer::GetFiducialMarkerSchema()),
+        WithExtraProperty(csp::multiplayer::GetGaussianSplatSchema()),
+        WithExtraProperty(csp::multiplayer::GetTextSchema()),
+        WithExtraProperty(csp::multiplayer::GetHotspotSchema()),
+        WithExtraProperty(csp::multiplayer::GetScreenSharingSchema()),
+        WithExtraProperty(csp::multiplayer::GetAIChatbotSchema()),
     };
 
     auto& SystemsManager = csp::systems::SystemsManager::Get();


### PR DESCRIPTION
[WIP]

In support of eventually removing the C++ component classes, this PR centralises schema definitions for the components and expresses them as JSON (this same JSON will be provided externally in the short/mid term future, but whilst we still maintain the hardcoded components we need an internal reference schema to compare against, so we stamp it out as JSON now to prove out representing these components). In support of that, there are some additions to the schema to cater for cases that were otherwise unrepresentable.

The additions are as follows:
* `description`: at the component and property level, an optional text string. Essentially comments.
* `reserved`: at the component and property level. A way of marking an id/key as "taken".
  * There are a few cases where component or properties have been removed. In the existing C++ there are a few different naming conventions for marking these gaps. `reserved` in the schema is a way to explicitly document this. A `description` can also give context. This can also be used for cases where we can't currently fully represent a component/property in the data schema, and so until we can, we can mark it `reserved`.
* `deprecated`: at the component and property level. Distinct from `reserved`. The component or property is still available for use, but is discouraged or has been superseded but is not yet removed.
* `scripting`: at the component and property level. A boolean flag, whether to expose to the script system. true by default. Disabling at the component level takes precedent over any property-level flag
* `range`: for `int`, `float` properties, a way to constrain the value to a given range.
* `options`: a solution to documenting the cases for properties that were represented as enums, but a bit more flexible. Can be used for `int`, `float`, `string` properties, and could be used to drive a UI, where only distinct options are provided

Most of these are just additional metadata and not actually used for anything in the code. However, `range` and `options` are used for validation checks on `SetProperty`.

Following this work, there are still some cases that have not been handled:
* Computed properties: Some components have C++ helper methods (`CinematicCamera::GetFov`, `Spline::GetLocationAlongSpline`). Clients can continue to use the component classes for now, or they can do these calculations themselves. As follow up work we could provide alternative pure library functions that perform the calculations given the data.
* Components with behaviour: mainly `Conversation` component is coupled with an internal system, and has various async methods (mostly CRUD, i.e. `CreateConversation`, `DeleteConversation` etc). These interact with an internal subsystem (`ConversationSystemInternal`), which we might consider exposing instead.
* Dynamic properties: `SplineSpaceComponent` currently works around limitations in the wire format to dynamicly write nested arrays into component slots. `CustomSpaceComponent` similarily dynamic creates keys (hashed strings). These can't be represented in a static schema. So for now, those component classes will still have to be used.
* Material overrides: This is a `Map<String, String>`. Supporting this in some way may not be too difficult, but representing it properly (i.e. what do we want `type` to be in the schema? Presumably strict? so `map<string, string>` vs an untyped `dict`/`object` or something?). Implies more work for general containers, and ideally anything that can be expressed in the schema can automatically be bound into the script system. Is quite a bit of work in itself.

More info in the individual commits.

