### PR TITLE
[OB-5754] fix!: Expose base component name vs deprecated name to scripting for Image, ExternalLink, FiducialMarker, and VideoPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. For compile
 
 ## [6.47.0]
 
+### 🐛 🔨 Bug Fixes
+
+- [OB-5754] fix: Expose base component name vs deprecated name to scripting for VideoPlayer. @mag-lt.
+  This addresses a regression introduced in 6.38.0 made in the context of binding components created w/ Schemas into scripts automatically.
+  The `name` property in scripts accidentally switched back to the older deprecated name property on the video player vs the name corresponding
+  to `ComponentBase::GetComponentName()`/`ComponentBase::SetComponentName()`. This has now been rectified.
+
 ###  🔨 🔨 Chore
 
 - [OF-1835] chore: Remove handling for old AsyncCallCompleted event data structure. By@MAG-AdamThorn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ All notable changes to this project will be documented in this file. For compile
 
 ### 🐛 🔨 Bug Fixes
 
-- [OB-5754] fix: Expose base component name vs deprecated name to scripting for VideoPlayer. @mag-lt.
+- [OB-5754] fix!: Expose base component name vs deprecated name to scripting for Image, ExternalLink, FiducialMarker, and VideoPlayer components. @mag-lt.
   This addresses a regression introduced in 6.38.0 made in the context of binding components created w/ Schemas into scripts automatically.
   The `name` property in scripts accidentally switched back to the older deprecated name property on the video player vs the name corresponding
   to `ComponentBase::GetComponentName()`/`ComponentBase::SetComponentName()`. This has now been rectified.
+  Additionally, `Image`, `ExternalLink`, and `FiducialMarker` have also been updated to return the `ComponentName` vs the deprecated name in scripts,
+  as these were never updated to do so. This is technically a breaking change (without doing a data migration on the server), but should be low impact
+  in practice.
 
 ###  🔨 🔨 Chore
 

--- a/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ExternalLinkSpaceComponent.cpp
@@ -26,7 +26,7 @@ const auto Schema = ComponentSchema {
     csp::common::Array<ComponentProperty> {
         {
             static_cast<ComponentProperty::KeyType>(ExternalLinkPropertyKeys::Name_DEPRECATED),
-            "name",
+            {}, // not exposed to scripting
             "",
         },
         {

--- a/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/FiducialMarkerSpaceComponent.cpp
@@ -27,7 +27,7 @@ const auto Schema = ComponentSchema {
     csp::common::Array<ComponentProperty> {
         {
             static_cast<ComponentProperty::KeyType>(FiducialMarkerPropertyKeys::Name_DEPRECATED),
-            "name",
+            {}, // not exposed to scripting
             "",
         },
         {

--- a/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ImageSpaceComponent.cpp
@@ -26,7 +26,7 @@ const auto Schema = ComponentSchema {
     csp::common::Array<ComponentProperty> {
         {
             static_cast<ComponentProperty::KeyType>(ImagePropertyKeys::Name_DEPRECATED),
-            "name",
+            {}, // not exposed to scripting
             "",
         },
         {

--- a/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/VideoPlayerSpaceComponent.cpp
@@ -38,7 +38,7 @@ const auto Schema = ComponentSchema {
     csp::common::Array<ComponentProperty> {
         {
             static_cast<ComponentProperty::KeyType>(VideoPlayerPropertyKeys::Name_DEPRECATED),
-            "name",
+            {}, // not exposed to scripting
             "",
         },
         {

--- a/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/FiducialMarkerComponentTests.cpp
@@ -189,6 +189,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     CreatedObject->QueueUpdate();
     RealtimeEngine->ProcessPendingEntityOperations();
 
+    EXPECT_EQ(FiducialMarkerComponent->GetComponentName(), "");
     EXPECT_EQ(FiducialMarkerComponent->GetIsVisible(), true);
     EXPECT_EQ(FiducialMarkerComponent->GetMarkerAssetId(), "");
     EXPECT_EQ(FiducialMarkerComponent->GetAssetCollectionId(), "");
@@ -215,7 +216,7 @@ CSP_PUBLIC_TEST(CSPEngine, FiducialMarkerTests, FiducialMarkerScriptInterfaceTes
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
 
-    EXPECT_EQ(FiducialMarkerComponent->GetName(), "Updated_FiducialMarkerScriptName");
+    EXPECT_EQ(FiducialMarkerComponent->GetComponentName(), "Updated_FiducialMarkerScriptName");
     EXPECT_EQ(FiducialMarkerComponent->GetPosition(), csp::common::Vector3::One());
     EXPECT_EQ(FiducialMarkerComponent->GetScale(), csp::common::Vector3(2, 2, 2));
     EXPECT_EQ(FiducialMarkerComponent->GetRotation(), csp::common::Vector4::One());

--- a/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/ImageComponentTests.cpp
@@ -195,7 +195,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     CreatedObject->QueueUpdate();
     RealtimeEngine->ProcessPendingEntityOperations();
 
-    EXPECT_EQ(ImageComponent->GetName(), "");
+    EXPECT_EQ(ImageComponent->GetComponentName(), "");
     EXPECT_EQ(ImageComponent->GetImageAssetId(), "");
     EXPECT_EQ(ImageComponent->GetAssetCollectionId(), "");
     EXPECT_EQ(ImageComponent->GetPosition(), csp::common::Vector3::Zero());
@@ -233,7 +233,7 @@ CSP_PUBLIC_TEST(CSPEngine, ImageTests, ImageScriptInterfaceTest)
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
 
-    EXPECT_EQ(ImageComponent->GetName(), "TestName");
+    EXPECT_EQ(ImageComponent->GetComponentName(), "TestName");
     EXPECT_EQ(ImageComponent->GetImageAssetId(), "TestImageAssetId");
     EXPECT_EQ(ImageComponent->GetAssetCollectionId(), "TestAssetCollectionId");
     EXPECT_EQ(ImageComponent->GetPosition(), csp::common::Vector3::One());

--- a/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/LinkComponentTests.cpp
@@ -175,7 +175,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
     CreatedObject->QueueUpdate();
     RealtimeEngine->ProcessPendingEntityOperations();
 
-    EXPECT_EQ(LinkComponent->GetName(), "");
+    EXPECT_EQ(LinkComponent->GetComponentName(), "");
     EXPECT_EQ(LinkComponent->GetLinkUrl(), "");
     EXPECT_EQ(LinkComponent->GetDisplayText(), "");
     EXPECT_EQ(LinkComponent->GetPosition(), csp::common::Vector3::Zero());
@@ -212,7 +212,7 @@ CSP_PUBLIC_TEST(CSPEngine, LinkTests, ExternalLinkScriptInterfaceTest)
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
 
-    EXPECT_EQ(LinkComponent->GetName(), "TestName");
+    EXPECT_EQ(LinkComponent->GetComponentName(), "TestName");
     EXPECT_EQ(LinkComponent->GetLinkUrl(), "http://youtube.com/avideo");
     EXPECT_EQ(LinkComponent->GetDisplayText(), "TestDisplayText");
     EXPECT_EQ(LinkComponent->GetPosition(), csp::common::Vector3::One());

--- a/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
+++ b/Tests/src/PublicAPITests/ComponentTests/VideoPlayerComponentTests.cpp
@@ -194,6 +194,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     CreatedObject->QueueUpdate();
     RealtimeEngine->ProcessPendingEntityOperations();
 
+    EXPECT_EQ(VideoPlayerComponent->GetComponentName(), "");
     EXPECT_EQ(VideoPlayerComponent->GetPosition(), csp::common::Vector3::Zero());
     EXPECT_EQ(VideoPlayerComponent->GetScale(), csp::common::Vector3::One());
     EXPECT_EQ(VideoPlayerComponent->GetRotation(), csp::common::Vector4::Identity());
@@ -224,6 +225,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
 
 		var video = ThisEntity.getVideoPlayerComponents()[0];
 
+        video.name = "VideoPlayerTest";
         video.position = [1, 1, 1];
         video.scale = [2, 2, 2];
 		video.rotation = [1, 1, 1, 1];
@@ -257,6 +259,7 @@ CSP_PUBLIC_TEST(CSPEngine, VideoTests, VideoPlayerScriptInterfaceTest)
     const bool ScriptHasErrors = CreatedObject->GetScript().HasError();
     EXPECT_FALSE(ScriptHasErrors);
 
+    EXPECT_EQ(VideoPlayerComponent->GetComponentName(), "VideoPlayerTest");
     EXPECT_EQ(VideoPlayerComponent->GetPosition(), csp::common::Vector3::One());
     EXPECT_EQ(VideoPlayerComponent->GetScale(), csp::common::Vector3(2, 2, 2));
     EXPECT_EQ(VideoPlayerComponent->GetRotation(), csp::common::Vector4::One());


### PR DESCRIPTION
This regressed in 289c271103b622e22de83c0f1413511e192200f9.

I had missed when making those changes that the video player component had specific custom handling for exposing the name (introduced as part of the changes landed in a40ea2b5063e956dee4ab6aaceaedaa32c60804e, specifically the `DEFINE_SCRIPT_PROPERTY_STRING_ADAPTNAME` macro [here](https://github.com/magnopus-opensource/connected-spaces-platform/pull/591/changes/387507c66b2ff19cd033a36bc967433a87a6721e#diff-79b320b89915f938f7d35a76573e6f0368cddbf03dac43aeeada2d2062048470R30-R32)), and so mistakenly exposed the deprecated property instead. The solution is to not expose the deprecated property to scripting via the schema, allowing the component to pick up the base class's behaviour for exposing the component name to scripting as `name`.

More details in the fix commit.