### PR TITLE
[NT-0] build: Less optimization for emscripten debug symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file. For compile
 - [OF-1835] chore: Remove handling for old AsyncCallCompleted event data structure. By@MAG-AdamThorn
   Remove backwards compatibility logic for legacy `AsyncCallCompleted` event data structure.
   
+- [NT-0] chore: Add -fstandalone-debug to Emscripten Debug builds. By @MAG-ElliotMorris
+  This should improve symbol availability when debugging in the browser.
+  
 📔 📔 Documentation
 
 - [NT-0] doc: Add additional clarifying docs to EventBus deregistration. By @MAG-ElliotMorris

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,14 @@ target_compile_options(csp-lib
     $<$<PLATFORM_ID:Emscripten>:-pthread;-fwasm-exceptions>
 )
 
+# This causes the clang compiler to output all debug information no matter what.
+# Normally the things it does are fine, as I think it's essentially deduplicating debug symbols,
+# but things don't work as one might expect in WASM land.
+# https://clang.llvm.org/docs/UsersManual.html#cmdoption-fstandalone-debug
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  target_compile_options(csp-lib PRIVATE $<$<CONFIG:Debug>:-fstandalone-debug>)
+endif()
+
 target_link_options(csp-lib PRIVATE
   $<$<PLATFORM_ID:Emscripten>:
     -pthread


### PR DESCRIPTION
We've been having this issue when debugging we builds where only some symbols are available to break on. It's been a bit of a mystery. I found this flag in the clang settings, tried it both here and the web project, and it does seem to improve things (ie, i've not seen any missing symbols since ... but this is a dark art so that doesn't really prove anything).

Figured it can't hurt, is debug only.
