### PR TITLE
[NT-0] chore: Create copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+When reviewing pull requests, follow the following directives: 
+
+- Copilot focuses on formal, explicit errors, such as misspellings, use-after-free, race-conditions, iterator invalidation, etc.
+- Architecture and style are not the purview of Copilot and should be left to the judgement of human reviewers.
+- Copilot should not provide formal suggestions unless the fix is trivial and obvious. Focus on explaining the problem over recommending a solution.
+- When the problem is complicated, Copilot provides links to reference material to aid in explanation and comprehension.
+
+Be aware that the connected-spaces-platform library is a C++ library that deploys to many platforms, and is consumed by many different frontend languages. For this reason, it is often under unique constraints and is limited by the capabilities of the various downstream language-interop generators.


### PR DESCRIPTION
On the theme of experimenting with this, thought it might make sense to get a context file in.

This is more of a suggestion than anything else, if folk want to see how the thing works before we steer it, then that's fine too!

https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions#creating-custom-instructions