### PR TITLE
[OF-1845] Add custom Conan deployer

### DIFF
--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -68,6 +68,8 @@ runs:
         INPUTS_HOST_PROFILE: ${{ inputs.host_profile }}
         INPUTS_OUTPUT_FOLDER: ${{ inputs.output_folder }}
         INPUTS_BUILD_TYPE: ${{ inputs.build_type }}
+        INPUTS_THIRD_PARTY_LIBS: ${{ inputs.package_third_party_libs }}
+        INPUTS_INSTALL_PREFIX: ${{ inputs.install_prefix }}
       shell: bash
       run: |
         set -euxo pipefail
@@ -87,10 +89,10 @@ runs:
           --profile:host="$PROFILE_PATH"
         )
 
-        if [ "${{ inputs.package_third_party_libs }}" = "true" ]; then
+        if [ "${INPUTS_THIRD_PARTY_LIBS}" = "true" ]; then
           CONAN_ARGS+=(
             --deployer=./conan/csp_deployer.py
-            --deployer-folder="${{ inputs.install_prefix }}/lib/third_party"
+            --deployer-folder="${INPUTS_INSTALL_PREFIX}/lib/third_party"
           )
         fi
 

--- a/.github/actions/build-and-install/action.yml
+++ b/.github/actions/build-and-install/action.yml
@@ -32,6 +32,11 @@ inputs:
     required: false
     default: "install"
 
+  package_third_party_libs:
+    description: "Whether to copy all of csp's third party dependencies into the package."
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
 
@@ -71,12 +76,22 @@ runs:
           exit 1
         fi
 
-        conan install . \
-          -of "${{ inputs.output_folder }}" \
-          -s build_type="${{ inputs.build_type }}" \
-          --build=missing \
+        CONAN_ARGS=(
+          .
+          -of "${{ inputs.output_folder }}"
+          -s build_type="${{ inputs.build_type }}"
+          --build=missing
           --profile:host="$PROFILE_PATH"
+        )
 
+        if [ "${{ inputs.package_third_party_libs }}" = "true" ]; then
+          CONAN_ARGS+=(
+            --deployer=./conan/csp_deployer.py
+            --deployer-folder="${{ inputs.install_prefix }}/lib/third_party"
+          )
+        fi
+
+        conan install "${CONAN_ARGS[@]}"
     - name: Configure CMake
       shell: bash
       run: |

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -79,6 +79,7 @@ jobs:
           output_folder: build/android-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
           build_folder: build/android-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
           install_prefix: install/android/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          package_third_party_libs: ${{ matrix.linkage.name == 'static' && inputs.upload_install }}
 
       - name: Upload install
         if: inputs.upload_install

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -131,6 +131,7 @@ jobs:
           output_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
           build_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
           install_prefix: install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          package_third_party_libs: ${{ matrix.linkage.name == 'static' && inputs.upload_install }}
 
       - name: Upload test build
         if: |

--- a/.github/workflows/ios-visionos-build.yml
+++ b/.github/workflows/ios-visionos-build.yml
@@ -102,6 +102,7 @@ jobs:
           output_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
           build_folder: build/${{ matrix.platform.name }}-${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}/build/${{ matrix.config.build_type }}
           install_prefix: install/${{ matrix.platform.name }}/${{ matrix.config.preset_prefix }}-${{ matrix.linkage.name }}
+          package_third_party_libs: ${{ matrix.linkage.name == 'static' && inputs.upload_install }}
 
       - name: Upload install
         if: inputs.upload_install

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -80,6 +80,7 @@ jobs:
           output_folder: build/wasm-${{ matrix.config.preset_prefix }}
           build_folder: build/wasm-${{ matrix.config.preset_prefix }}/build/${{ matrix.config.build_type }}
           install_prefix: install/wasm/${{ matrix.config.preset_prefix }}
+          package_third_party_libs: ${{ matrix.linkage.name == 'static' && inputs.upload_install }}
 
       - name: Upload install
         if: inputs.upload_install

--- a/conan/csp_deployer.py
+++ b/conan/csp_deployer.py
@@ -1,0 +1,123 @@
+"""
+CSP SDK dependency deployer.
+
+This deploys the third-party dependencies required for csp to be linked
+without requiring Conan in the consumer project.
+
+This can be invoked using the following args at the conan install step:
+--deployer=csp_sdk_deployer --deployer-folder=<output-directory>
+
+This deployer performs the following actions:
+- Copies static libraries
+- Copies dependency license and notices
+
+The output structure of the deployer is:
+
+    output-dir/
+        lib/
+            dependency libraries
+        licenses/
+            package/
+                licence and notice files
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+STATIC_LIBRARY_SUFFIXES = {
+    ".lib",
+    ".a",
+}
+
+# License files can use various conventions, so ensure we don't miss them!
+LICENCE_FILE_PREFIXES = (
+    "license",
+    "licence",
+    "copying",
+    "copyright",
+    "notice",
+    "authors",
+)
+
+# Ensures a file doesn't exist at the destination before copying
+def _copy_file_unique(source: Path, destination: Path) -> Path:
+    destination.mkdir(parents=True, exist_ok=True)
+
+    output = destination / source.name
+
+    if output.exists():
+        if output.read_bytes() != source.read_bytes():
+            raise RuntimeError(
+                f"filename collision:\n"
+                f"  Existing: {output}\n"
+                f"  New:      {source}"
+            )
+
+        return output
+
+    shutil.copy2(source, output)
+    return output
+
+def deploy(graph: Any, output_folder: str, **kwargs: Any) -> None:
+    root_conanfile = graph.root.conanfile
+    output_root = Path(output_folder).resolve()
+
+    library_output = output_root / "lib"
+    licence_output = output_root / "licenses"
+
+    deployed_libraries: list[str] = []
+
+    # Iterate third-party dependencies
+    for dependency in root_conanfile.dependencies.host.values():
+        package_name = dependency.ref.name
+        package_folder_value = dependency.package_folder
+
+        if not package_folder_value:
+            continue
+
+        package_folder = Path(package_folder_value)
+
+        # dependency.cpp_info.libdirs contains the library directories
+        # Search recursively for static libs
+        for library_directory_value in dependency.cpp_info.libdirs:
+            library_directory = Path(library_directory_value)
+
+            if not library_directory.is_dir():
+                continue
+
+            for source in library_directory.rglob("*"):
+                if not source.is_file():
+                    continue
+
+                # Ensure file is a .lib or .a
+                if source.suffix.lower() not in STATIC_LIBRARY_SUFFIXES:
+                    continue
+
+                # Copy into provided deployer-folder
+                # Use # _copy_file_unique to throw if we find libs with the same name
+                deployed = _copy_file_unique(
+                    source,
+                    library_output,
+                )
+
+                deployed_libraries.append(deployed.name)
+
+        # Copy license files
+        for licence_file in package_folder.rglob("*"):
+            if not licence_file.is_file():
+                continue
+            
+            if not licence_file.name.lower().startswith(LICENCE_FILE_PREFIXES):
+                continue
+            
+            print(f"Copying licence: {licence_file}")
+
+            _copy_file_unique(
+                licence_file,
+                licence_output / package_name,
+            )
+
+   

--- a/conan/csp_deployer.py
+++ b/conan/csp_deployer.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 from typing import Any
+import filecmp
 
 STATIC_LIBRARY_SUFFIXES = {
     ".lib",
@@ -52,7 +53,7 @@ def _copy_file_unique(source: Path, destination: Path) -> Path:
     output = destination / source.name
 
     if output.exists():
-        if output.read_bytes() != source.read_bytes():
+        if not filecmp.cmp(output, source, shallow=False):
             raise RuntimeError(
                 f"filename collision:\n"
                 f"  Existing: {output}\n"

--- a/conan/csp_deployer.py
+++ b/conan/csp_deployer.py
@@ -5,7 +5,7 @@ This deploys the third-party dependencies required for csp to be linked
 without requiring Conan in the consumer project.
 
 This can be invoked using the following args at the conan install step:
---deployer=csp_sdk_deployer --deployer-folder=<output-directory>
+--deployer=conan/csp_deployer.py --deployer-folder=<output-directory>
 
 This deployer performs the following actions:
 - Copies static libraries

--- a/conan/csp_deployer.py
+++ b/conan/csp_deployer.py
@@ -42,7 +42,10 @@ LICENCE_FILE_PREFIXES = (
     "authors",
 )
 
-# Ensures a file doesn't exist at the destination before copying
+# Copy a file into the destination directory without overwriting
+# a different file with the same name.
+# If a file with the same name already exists and has identical contents,
+# the existing file is reused. If the contents differ, a RuntimeError is raised.
 def _copy_file_unique(source: Path, destination: Path) -> Path:
     destination.mkdir(parents=True, exist_ok=True)
 
@@ -97,7 +100,6 @@ def deploy(graph: Any, output_folder: str, **kwargs: Any) -> None:
                     continue
 
                 # Copy into provided deployer-folder
-                # Use # _copy_file_unique to throw if we find libs with the same name
                 deployed = _copy_file_unique(
                     source,
                     library_output,

--- a/conanfile.py
+++ b/conanfile.py
@@ -30,7 +30,7 @@ class CSP(ConanFile):
         self.requires("msgpack-cxx/7.0.0")
         self.requires("tinyspline/0.6.0")
         self.requires("glm/1.0.1")
-        self.requires("gtest/1.11.0")
+        self.test_requires("gtest/1.11.0")
         self.requires("sole/1.0.4")
 
         # We use the Emscripten WebSockets API for Emscripten


### PR DESCRIPTION
This PR adds a custom Conan deployer to copy all third-party dependencies in a specified directory. This allows us to create a  static CSP package that can be linked without consumers needing Conan to resolve dependencies.

This also updates our CI to usethe new deployers for releases.