### PR TITLE
[OB-5315] fix: Deleting a script on remote client continues to execute message subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to this project will be documented in this file. For compile
   Additionally, `Image`, `ExternalLink`, and `FiducialMarker` have also been updated to return the `ComponentName` vs the deprecated name in scripts,
   as these were never updated to do so. This is technically a breaking change (without doing a data migration on the server), but should be low impact
   in practice.
+  
+- [OB-5315] fix: Route remote script updates through the same binding path as local script updates go through. (OnSourceChanged). By @MAG-ElliotMorris
+  Prior to this, we were not clearing the `MessageMap` or `PropertyMap` containers as we should, which meant any `subscribeToMessage`
+  events would keep executing if the script was modified on a remote client.
+  This also causes us to call `ResetContext` when the script is modified, which also seems like the right thing to be doing.
 
 ###  🔨 🔨 Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ All notable changes to this project will be documented in this file. For compile
   - The realtime engine constructors taking `Array<ComponentSchema>` are now `CSP_NO_EXPORT`. Use the `List<String>` JSON overloads instead.
   - No clients had adopted the above, so this shouldn't have any practical impact
 
+### 🐛 🔨 Bug Fixes
+  
+- [OB-5315] fix: Route remote script updates through the same binding path as local script updates go through. (OnSourceChanged). By @MAG-ElliotMorris
+  Prior to this, we were not clearing the `MessageMap` or `PropertyMap` containers as we should, which meant any `subscribeToMessage`
+  events would keep executing if the script was modified on a remote client.
+  This also causes us to call `ResetContext` when the script is modified, which also seems like the right thing to be doing.
+
 ## [6.47.0]
 
 ### 🐛 🔨 Bug Fixes
@@ -33,11 +40,6 @@ All notable changes to this project will be documented in this file. For compile
   Additionally, `Image`, `ExternalLink`, and `FiducialMarker` have also been updated to return the `ComponentName` vs the deprecated name in scripts,
   as these were never updated to do so. This is technically a breaking change (without doing a data migration on the server), but should be low impact
   in practice.
-  
-- [OB-5315] fix: Route remote script updates through the same binding path as local script updates go through. (OnSourceChanged). By @MAG-ElliotMorris
-  Prior to this, we were not clearing the `MessageMap` or `PropertyMap` containers as we should, which meant any `subscribeToMessage`
-  events would keep executing if the script was modified on a remote client.
-  This also causes us to call `ResetContext` when the script is modified, which also seems like the right thing to be doing.
 
 ###  🔨 🔨 Chore
 

--- a/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp
+++ b/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp
@@ -110,9 +110,7 @@ void ScriptSpaceComponent::SetPropertyFromPatch(uint32_t Key, const csp::common:
 
     if (Key == static_cast<uint32_t>(ScriptComponentPropertyKeys::ScriptSource))
     {
-        // CSP_LOG_WARN_FORMAT("ScriptSpaceComponent::SetPropertyFromPatch '%s'", Value.GetString().c_str());
-
-        Parent->GetScript().Bind();
+        Parent->GetScript().OnSourceChanged(Value.GetString());
         Parent->GetScript().Invoke();
     }
 }

--- a/MultiplayerTestRunner/CMakeLists.txt
+++ b/MultiplayerTestRunner/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(MultiplayerTestRunner
         src/InternalUnitTests/Test_RunnableTests.cpp
         src/InternalUnitTests/Test_SpaceRAII.cpp
 
+        src/RunnableTests/ClearScriptSource.cpp
+        src/RunnableTests/ClearScriptSource.h
         src/RunnableTests/CreateAvatar.cpp
         src/RunnableTests/CreateAvatar.h
         src/RunnableTests/CreateConversation.cpp

--- a/MultiplayerTestRunner/include/TestIdentifiers.h
+++ b/MultiplayerTestRunner/include/TestIdentifiers.h
@@ -55,13 +55,15 @@ enum class TestIdentifier
     EVENT_BUS_PING, //"EventBusPing"
     LEADER_ELECTION, //"LeaderElection"
     LEADER_ELECTION_TICK, // "LeaderElectionTick"
-    LEADER_ELECTION_EVENT // "LeaderElectionEvent"
+    LEADER_ELECTION_EVENT, // "LeaderElectionEvent"
+    CLEAR_SCRIPT_SOURCE // "ClearScriptSource"
 };
 
 inline const std::unordered_map<TestIdentifier, std::string> TestIdentifierStringMap { { TestIdentifier::CREATE_AVATAR, "CreateAvatar" },
     { TestIdentifier::CREATE_CONVERSATION, "CreateConversation" }, { TestIdentifier::EVENT_BUS_PING, "EventBusPing" },
     { TestIdentifier::LEADER_ELECTION, "LeaderElection" }, { TestIdentifier::LEADER_ELECTION_TICK, "LeaderElectionTick" },
-    { TestIdentifier::LEADER_ELECTION_EVENT, "LeaderElectionEvent" } };
+    { TestIdentifier::LEADER_ELECTION_EVENT, "LeaderElectionEvent" },
+    { TestIdentifier::CLEAR_SCRIPT_SOURCE, "ClearScriptSource" } };
 
 /*
  * Use `TestIdentifierStringMap` to convert a string to a test identifier, if valid.

--- a/MultiplayerTestRunner/src/Main.cpp
+++ b/MultiplayerTestRunner/src/Main.cpp
@@ -18,6 +18,7 @@
 #include "../include/ProcessDescriptors.h"
 #include "CLIArgs.h"
 #include "LoginRAII.h"
+#include "RunnableTests/ClearScriptSource.h"
 #include "RunnableTests/CreateAvatar.h"
 #include "RunnableTests/CreateConversation.h"
 #include "RunnableTests/EventBusPing.h"
@@ -79,6 +80,9 @@ void RunTest(CLIArgs::RunnerSettings Settings, std::chrono::steady_clock::time_p
         break;
     case TestIdentifier::LEADER_ELECTION_EVENT:
         LeaderElectionEvent::RunTest(SpaceRAII.GetRealtimeEngine());
+        break;
+    case TestIdentifier::CLEAR_SCRIPT_SOURCE:
+        ClearScriptSource::RunTest(SpaceRAII.GetRealtimeEngine());
         break;
     default:
         throw Utils::ExceptionWithCode(

--- a/MultiplayerTestRunner/src/RunnableTests/ClearScriptSource.cpp
+++ b/MultiplayerTestRunner/src/RunnableTests/ClearScriptSource.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ClearScriptSource.h"
+
+#include <CSP/Multiplayer/ComponentBase.h>
+#include <CSP/Multiplayer/Components/ScriptSpaceComponent.h>
+#include <CSP/Multiplayer/OnlineRealtimeEngine.h>
+#include <CSP/Multiplayer/SpaceEntity.h>
+
+#include <iostream>
+#include <stdexcept>
+
+namespace ClearScriptSource
+{
+
+void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine)
+{
+
+    // Must match the name of the entity created in the controlling test
+    csp::multiplayer::SpaceEntity* Entity = RealtimeEngine.FindSpaceEntity("ScriptEntity");
+
+    if (Entity == nullptr)
+    {
+        throw std::runtime_error("Could not find ScriptEntity. The controlling process should create and replicate it before starting this one.");
+    }
+
+    auto* ScriptComponent
+        = static_cast<csp::multiplayer::ScriptSpaceComponent*>(Entity->FindFirstComponentOfType(csp::multiplayer::ComponentType::ScriptData));
+
+    if (ScriptComponent == nullptr)
+    {
+        throw std::runtime_error("ScriptEntity has no ScriptSpaceComponent.");
+    }
+
+    // Just so you know a script was for-sure set and replicated, you can see if it's zero characters.
+    std::cout << "Clearing script source of ScriptEntity, which was " << ScriptComponent->GetScriptSource().Length() << " characters" << std::endl;
+
+    // The thing we're testing, clearing the script source remotely should stop script execution, including registered events (like reacting to ticks)
+    ScriptComponent->SetScriptSource("");
+
+    Entity->QueueUpdate();
+    RealtimeEngine.ProcessPendingEntityOperations();
+}
+
+} // namespace ClearScriptSource

--- a/MultiplayerTestRunner/src/RunnableTests/ClearScriptSource.h
+++ b/MultiplayerTestRunner/src/RunnableTests/ClearScriptSource.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Magnopus LLC
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace csp::multiplayer
+{
+class OnlineRealtimeEngine;
+}
+
+namespace ClearScriptSource
+{
+/*
+ * Clears the script source of an entity created by the controlling process. This entity should be called "ScriptEntity", and should have a Script
+ * Component on it.
+ */
+void RunTest(csp::multiplayer::OnlineRealtimeEngine& RealtimeEngine);
+} // namespace ClearScriptSource

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -26,6 +26,7 @@
 #include "Debug/Logging.h"
 #include "Multiplayer/NetworkEventManagerImpl.h"
 #include "Multiplayer/Script/EntityScriptBinding.h"
+#include "MultiplayerTestRunnerProcess.h"
 #include "RAIIMockLogger.h"
 #include "TestHelpers.h"
 #include "quickjspp.hpp"
@@ -1349,6 +1350,112 @@ TEST_P(ModifyExistingScript, ModifyExistingScriptTest)
     DeleteSpace(SpaceSystem, Space.Id);
 
     // Log out
+    LogOut(UserSystem);
+}
+
+// Regression test for https://magnopus.atlassian.net/browse/OB-5315
+CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RemoteClearOfScriptSourceStopsScriptTest)
+{
+    SetRandSeed();
+
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    auto* UserSystem = SystemsManager.GetUserSystem();
+    auto* SpaceSystem = SystemsManager.GetSpaceSystem();
+
+    csp::systems::Profile LocalUser = CreateTestUser();
+    csp::systems::Profile RemoteUser = CreateTestUser();
+
+    // Log in local user
+    csp::common::String UserId;
+    LogIn(UserSystem, UserId, LocalUser.Email, GeneratedTestAccountPassword);
+
+    // Create space
+    const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
+    const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
+
+    char UniqueSpaceName[256];
+    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+
+    csp::systems::Space Space;
+    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Public, nullptr, nullptr, nullptr, nullptr, Space);
+
+    std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+
+    // Don't proceed with the test until we've fully entered the space, we want a clean slate for script ticking.
+    std::promise<void> EntityFetchCompletePromise;
+    std::future<void> EntityFetchCompleteFuture = EntityFetchCompletePromise.get_future();
+    RealtimeEngine->SetEntityFetchCompleteCallback([&EntityFetchCompletePromise](uint32_t) { EntityFetchCompletePromise.set_value(); });
+
+    auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
+    ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    EntityFetchCompleteFuture.wait_for(3s);
+
+    // Trailing space is a footgun here, script logger appends a space after every argument for some reason...
+    const csp::common::String ScriptTickStr = "ScriptTick ";
+    // A script that logs on tick, we can assert this via testing the mock logger.
+    const std::string ScriptText = R"xx(
+        globalThis.onTick = () => {
+            CSP.Log('ScriptTick');
+        }
+
+        ThisEntity.subscribeToMessage("entityTick", "onTick");
+    )xx";
+
+    // Name must match the multiplayer test runner test
+    csp::multiplayer::SpaceEntity* Entity = CreateTestObject(RealtimeEngine.get(), "ScriptEntity");
+    ASSERT_TRUE(Entity != nullptr);
+
+    auto* ScriptComponent = static_cast<ScriptSpaceComponent*>(Entity->AddComponent(ComponentType::ScriptData));
+    ScriptComponent->SetScriptSource(ScriptText.c_str());
+    Entity->GetScript().Invoke();
+    ASSERT_FALSE(Entity->GetScript().HasError());
+
+    // Replicate the entity and its script, so the remote client picks it up in its initial fetch.
+    Entity->QueueUpdate();
+    RealtimeEngine->ProcessPendingEntityOperations();
+
+    // Assert the script is actually running
+    {
+        RAIIMockLogger MockLogger;
+        EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Log, ScriptTickStr)).Times(testing::AtLeast(1));
+        csp::CSPFoundation::Tick();
+    }
+
+    // Launch the multiplayer test runner process, it will clear the script source, and we'll recieve the replication back here
+    MultiplayerTestRunnerProcess RemoteClient
+        = MultiplayerTestRunnerProcess(MultiplayerTestRunner::TestIdentifiers::TestIdentifier::CLEAR_SCRIPT_SOURCE)
+              .SetSpaceId(Space.Id.c_str())
+              .SetLoginEmail(RemoteUser.Email.c_str())
+              .SetPassword(GeneratedTestAccountPassword)
+              .SetEndpoint(EndpointBaseURI())
+              .SetTimeoutInSeconds(60);
+
+    std::future<void> RemoteClientReady = RemoteClient.ReadyForAssertionsFuture();
+    RemoteClient.StartProcess();
+
+    // Confirm the empty source has reached us before continuing
+    const bool SourceCleared = ResponseWaiter::WaitFor(
+        [&ScriptComponent]()
+        {
+            csp::CSPFoundation::Tick();
+            return ScriptComponent->GetScriptSource().IsEmpty();
+        },
+        std::chrono::seconds(20));
+
+    ASSERT_TRUE(SourceCleared) << "The remote client's empty ScriptSource patch never arrived.";
+
+    {
+        // A tick should not cause the script behavior
+        RAIIMockLogger MockLogger;
+        EXPECT_CALL(MockLogger.MockLogCallback, Call(csp::common::LogLevel::Log, ScriptTickStr)).Times(0);
+        csp::CSPFoundation::Tick();
+    }
+
+    auto [ExitSpaceResult] = AWAIT_PRE(SpaceSystem, ExitSpace, RequestPredicate);
+    EXPECT_EQ(ExitSpaceResult.GetResultCode(), csp::systems::EResultCode::Success);
+
+    DeleteSpace(SpaceSystem, Space.Id);
     LogOut(UserSystem);
 }
 

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -35,6 +35,7 @@
 #include "CSP/Multiplayer/Components/SplineSpaceComponent.h"
 #include "PublicAPITests/SpaceSystemTestHelpers.h"
 #include "PublicAPITests/UserSystemTestHelpers.h"
+#include "fmt/format.h"
 #include "gtest/gtest-param-test.h"
 #include "gtest/gtest.h"
 #include <atomic>
@@ -1373,11 +1374,11 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RemoteClearOfScriptSourceStopsScri
     const char* TestSpaceName = "CSP-UNITTEST-SPACE-MAG";
     const char* TestSpaceDescription = "CSP-UNITTEST-SPACEDESC-MAG";
 
-    char UniqueSpaceName[256];
-    SPRINTF(UniqueSpaceName, "%s-%s", TestSpaceName, GetUniqueString().c_str());
+    const auto UniqueSpaceName = fmt::format("{}-{}", TestSpaceName, GetUniqueString());
 
     csp::systems::Space Space;
-    CreateSpace(SpaceSystem, UniqueSpaceName, TestSpaceDescription, csp::systems::SpaceAttributes::Public, nullptr, nullptr, nullptr, nullptr, Space);
+    CreateSpace(
+        SpaceSystem, UniqueSpaceName.c_str(), TestSpaceDescription, csp::systems::SpaceAttributes::Public, nullptr, nullptr, nullptr, nullptr, Space);
 
     std::unique_ptr<csp::multiplayer::OnlineRealtimeEngine> RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
 

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -1435,7 +1435,10 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RemoteClearOfScriptSourceStopsScri
     std::future<void> RemoteClientReady = RemoteClient.ReadyForAssertionsFuture();
     RemoteClient.StartProcess();
 
-    // Confirm the empty source has reached us before continuing
+    EXPECT_EQ(RemoteClientReady.wait_for(std::chrono::seconds(20)), std::future_status::ready);
+
+    // Confirm the empty source has reached us before continuing. This is a bit paranoid,
+    // it's just that replication goes over the network so we can't be sure it's here even if the remote client has finished.
     const bool SourceCleared = ResponseWaiter::WaitFor(
         [&ScriptComponent]()
         {

--- a/Tests/src/PublicAPITests/ScriptSystemTests.cpp
+++ b/Tests/src/PublicAPITests/ScriptSystemTests.cpp
@@ -1389,7 +1389,7 @@ CSP_PUBLIC_TEST(CSPEngine, ScriptSystemTests, RemoteClearOfScriptSourceStopsScri
     auto [EnterResult] = AWAIT_PRE(SpaceSystem, EnterSpace, RequestPredicate, Space.Id, RealtimeEngine.get());
     ASSERT_EQ(EnterResult.GetResultCode(), csp::systems::EResultCode::Success);
 
-    EntityFetchCompleteFuture.wait_for(3s);
+    ASSERT_EQ(EntityFetchCompleteFuture.wait_for(3s), std::future_status::ready);
 
     // Trailing space is a footgun here, script logger appends a space after every argument for some reason...
     const csp::common::String ScriptTickStr = "ScriptTick ";


### PR DESCRIPTION
There is a divergence in how we update script bindings, depending on if the source of change came from a local or remote client. 

A local client calls [OnSourceChanged](https://github.com/magnopus-opensource/connected-spaces-platform/blob/80a42efece1a456ea5fbe35efa4a12062c978717/Library/src/Multiplayer/Script/EntityScript.cpp#L195), (via [SetScriptSource](https://github.com/magnopus-opensource/connected-spaces-platform/blob/80a42efece1a456ea5fbe35efa4a12062c978717/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp#L82)) whilst a remote update merely calls [Bind and Invoke](https://github.com/magnopus-opensource/connected-spaces-platform/blob/80a42efece1a456ea5fbe35efa4a12062c978717/Library/src/Multiplayer/Components/ScriptSpaceComponent.cpp#L107).

The cause of the bug, where remote script deletions do not stop running scripts, is likely obvious in that context. The clearing of the message buffers is never performed in response to remote updates. Change the implementation such that remote updates call the same binding path as local updates.

This seems like rather a significant fix ... surprised this hasn't come up before. I am a tad worried about Hyrums law style manifestations downstream of this, especially relating to what the resetting of the context might imply. Don't really think we can do much to guard against that right now, script usage tends to be confined within solutions and we don't have a lot of visibility there.

### Testing

One regression test is included in which the multiplayer test runner is used to delete the script source, replicating the reported bug. Prior to the change, this errored on an expectation that no log from the script (logging on a function registered to the tick message) would be received, but after the change, passes as no log is output.