### PR TITLE
[NT-0] ci: Fix quoting issue in CI preventing GTEST_FILTER from being expanded

### DIFF
--- a/.github/workflows/live-mcs-tests-run.yml
+++ b/.github/workflows/live-mcs-tests-run.yml
@@ -32,5 +32,5 @@ jobs:
 
           chmod +x ./MultiplayerTestRunner/MultiplayerTestRunner
           chmod +x ./csp-tests
-          ./csp-tests --gtest_filter='${INPUTS_GTEST_FILTER}'
+          ./csp-tests --gtest_filter="${INPUTS_GTEST_FILTER}"
    

--- a/.github/workflows/local-mcs-tests-run.yml
+++ b/.github/workflows/local-mcs-tests-run.yml
@@ -89,6 +89,6 @@ jobs:
 
           chmod +x ./MultiplayerTestRunner/MultiplayerTestRunner
           chmod +x ./csp-tests
-          ./csp-tests --gtest_filter='${INPUTS_GTEST_FILTER}'
+          ./csp-tests --gtest_filter="${INPUTS_GTEST_FILTER}"
         env:
           INPUTS_GTEST_FILTER: ${{ inputs.gtest_filter }}


### PR DESCRIPTION
We haven't been running tests for the last few days, since that zizmor change that hoisted variables.

Our test invocations, uniquely, used single quoted strings,. Double quoted strings are necessary for variable expansion in bash. This is actually why it's more secure (I think), as previously it was the github actions pre-processor doing this substitution, which is less restrictive.

You can see the tests run now : https://github.com/magnopus-opensource/connected-spaces-platform/actions/runs/32732542048/job/97456344385?pr=1022