### PR TITLE
[OF-1882] fix: Guard RealtimeEngine destructor calling NetworkEventBus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file. For compile
   Prior to this, we were not clearing the `MessageMap` or `PropertyMap` containers as we should, which meant any `subscribeToMessage`
   events would keep executing if the script was modified on a remote client.
   This also causes us to call `ResetContext` when the script is modified, which also seems like the right thing to be doing.
+  
+- [OF-1882] fix: Guard RealtimeEngine destruction pathway against null NetworkEventBus, which could cause crashes on out-of-order teardown in GC'd langauges. By @MAG-ElliotMorris
 
 ## [6.47.0]
 

--- a/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
+++ b/Library/src/Multiplayer/OnlineRealtimeEngine.cpp
@@ -15,6 +15,8 @@
  */
 #include "CSP/Multiplayer/OnlineRealtimeEngine.h"
 
+#include "CSP/CSPFoundation.h" //Not great for modularity, wants removed
+
 #include "CSP/Common/List.h"
 #include "CSP/Common/LoginState.h"
 #include "CSP/Common/StringFormat.h"
@@ -1093,7 +1095,15 @@ void OnlineRealtimeEngine::DisableLeaderElection()
 
     if (LeaderElectionManager != nullptr)
     {
-        NetworkEventBus->StopListenCustomNetworkEvent("CSPInternal::ScriptEvent", RemoteRunScriptMessage);
+        /*
+         * This isn't true safety. In threaded destruction contexts, there is still a window where
+         * this remains unsynchronized. Doing this guard closes the window significantly however until we
+         * can actually sort out our initialization and de-initialization to make them bulletproof
+         */
+        if (csp::CSPFoundation::GetIsInitialised())
+        {
+            NetworkEventBus->StopListenCustomNetworkEvent("CSPInternal::ScriptEvent", RemoteRunScriptMessage);
+        }
 
         LeaderElectionManager.reset(nullptr);
     }

--- a/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
+++ b/Tests/src/PublicAPITests/OnlineRealtimeEngineTests.cpp
@@ -816,10 +816,20 @@ CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, ConstructFromJs
 
     EXPECT_CALL(*SignalRMock, Invoke).WillRepeatedly(MakeSingleEntityCreationInvoker());
 
-    auto [Entity] = AWAIT(&Engine, CreateEntity, "SchemaEntity", csp::multiplayer::SpaceTransform {}, csp::common::Optional<uint64_t> {});
+    auto [Entity] = AWAIT(&Engine, CreateEntity, "SchemaEntity", csp::multiplayer::SpaceTransform { }, csp::common::Optional<uint64_t> { });
     ASSERT_NE(Entity, nullptr);
 
     EXPECT_NE(Entity->AddComponentByTypeId(AllPropertyTypesSchemaId), nullptr);
     EXPECT_NE(Entity->AddComponentByTypeId(EmptySchemaId), nullptr);
     EXPECT_EQ(Entity->AddComponentByTypeId(InvalidSchemaId), nullptr);
+}
+
+CSP_PUBLIC_TEST_WITH_MOCKS(CSPEngine, OnlineRealtimeEngineTests, RealtimeEngineCanBeDestructedAfterSystemsShutdown)
+{
+    auto& SystemsManager = csp::systems::SystemsManager::Get();
+    csp::multiplayer::OnlineRealtimeEngine* RealtimeEngine { SystemsManager.MakeOnlineRealtimeEngine() };
+    RealtimeEngine->EnableLeaderElection(); // Neccesary to make LeaderElectionManager not null internally, such that we trigger the appropriate
+                                            // destruction path in realtime engine
+    csp::CSPFoundation::Shutdown();
+    delete RealtimeEngine; // Should not crash
 }


### PR DESCRIPTION
In the case where an online realtime engine was destructed after Shutdown() had been called (not unusual when exiting play mode in an editor with a GC'd language), depending on if leader election was enabled or not, there was a possibility of getting a null dereference.

This adds a guard, breaking modularity, but no more than it already is as the script runner does the exact same thing here. This isn't a true fix, as lack of syncronisation could still cause a crash if action happens to occur between the set of the `isInitialised` bool and the call here, but this radically reduces the window. We still need to make this formally correct, which we can do by changing how we own our connection objects. This closes the window significantly for now though.

Test added reproduces the issue 100% prior to fix, now passes.