### PR TITLE
[OF-1845] ci publish fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,28 +124,29 @@ jobs:
 
     if: |
       always() &&
-        inputs.create_release &&
-        needs.desktop.result == 'success' &&
-        needs.wasm.result == 'success' &&
-        needs.legacy-wasm.result == 'success' &&
-        needs.android.result == 'success' &&
-        needs.ios-visionos.result == 'success' &&
-        (
-          needs.live-desktop-tests.result == 'success' ||
-          needs.live-desktop-tests.result == 'skipped'
-        )
+      inputs.create_release &&
+      (!inputs.build_desktop || needs.desktop.result == 'success') &&
+      (!inputs.build_wasm || needs.wasm.result == 'success') &&
+      (!inputs.build_legacy_wasm || needs.legacy-wasm.result == 'success') &&
+      (!inputs.build_android || needs.android.result == 'success') &&
+      (!inputs.build_ios_visionos || needs.ios-visionos.result == 'success') &&
+      (
+        inputs.skip_tests ||
+        needs.live-desktop-tests.result == 'success'
+      )
 
   publish-npm-sandbox:
     uses: ./.github/workflows/publish-legacy-npm.yml
+
     needs:
-      - legacy-wasm
-      - live-desktop-tests
+    - legacy-wasm
+    - live-desktop-tests
 
     if: |
       always() &&
       inputs.create_release &&
       needs.legacy-wasm.result == 'success' &&
       (
-        needs.live-desktop-tests.result == 'success' ||
-        needs.live-desktop-tests.result == 'skipped'
+        inputs.skip_tests ||
+        needs.live-desktop-tests.result == 'success'
       )

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,7 @@ jobs:
     uses: ./.github/workflows/upload-releases.yml
     with:
       release_number: ${{ inputs.release_number }}
+      upload_legacy_wasm: ${{ inputs.build_legacy_wasm }}
 
     needs:
     - desktop

--- a/.github/workflows/upload-releases.yml
+++ b/.github/workflows/upload-releases.yml
@@ -10,6 +10,10 @@ on:
         type: string
         required: true
 
+      upload_legacy_wasm:
+        type: boolean
+        required: true
+
 jobs:
   upload-release:
     name: Publish Release
@@ -25,6 +29,7 @@ jobs:
           path: release-artifacts
 
       - name: Download npm package artifact
+        if: inputs.upload_legacy_wasm
         uses: actions/download-artifact@v5
         with:
           name: wasm-npm-package
@@ -41,7 +46,7 @@ jobs:
           # Create directory for zipped artifacts
           mkdir -p release-assets
 
-          # Iterate all artifacts and zip them into release-assets dir
+          # Iterate all install artifacts and zip them into release-assets dir
           for artifact_dir in release-artifacts/*-install; do
             if [[ ! -d "$artifact_dir" ]]; then
               continue
@@ -56,11 +61,13 @@ jobs:
             )
           done
 
-          # Package the npm separately.
-          (
-            cd release-artifacts/wasm-npm-package
-            zip -r "../../release-assets/wasm-npm-package.zip" .
-          )
+          # Package the legacy WASM NPM artifact if it was built.
+          if [[ -d "release-artifacts/wasm-npm-package" ]]; then
+            (
+              cd release-artifacts/wasm-npm-package
+              zip -r "../../release-assets/wasm-npm-package.zip" .
+            )
+          fi
 
           echo "Release assets:"
           ls -lh release-assets


### PR DESCRIPTION
This PR contains a couple of publish fixes that i discovered when working on the redistributable CSP that has now been closed. These commits have been cherry-picked from that PR.

There were 2 issues:

- CSP wan't being published properly when certain builds were skipped
- Wasm builds were attempted to be downloaded, even when they were skipped